### PR TITLE
fix(torch_fsdp): get ddp_config failed when use torch_fsdp

### DIFF
--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -303,6 +303,8 @@ class MegatronTrainer(BaseTrainer, BaseModule):
         log_kv_rank_0(f"-world_size", f"{args.world_size}")
 
         ###################################################cuda
+        if not args.use_torch_fsdp2:
+            os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
 
         ###################################################checkpoint
         ckpt_path = os.path.abspath(os.path.join(exp_root_path, "checkpoints"))


### PR DESCRIPTION
get_megatron_optimizer will use the ddp_config, while megatron-lm's torch_fsdp not hold the ddp_config