### PR TITLE
[Fix] fp8 option not work

### DIFF
--- a/primus/configs/modules/megatron/trainer_base.yaml
+++ b/primus/configs/modules/megatron/trainer_base.yaml
@@ -52,7 +52,7 @@ accumulate_allreduce_grads_in_fp32: false
 fp16_lm_cross_entropy: false
 
 # fp8
-fp8_format: null # e4m3, hybrid
+fp8: null # e4m3, hybrid
 fp8_margin: 0
 fp8_interval: 1 # deprecated
 fp8_amax_history_len: 1024


### PR DESCRIPTION
Fix `fp8_format` option not work. 
https://github.com/NVIDIA/Megatron-LM/blob/47b99b6ca0132a8d7c5321ac16a32a0ec9f9e192/megatron/core/transformer/transformer_config.py#L255-L258