### PR TITLE
test:Add model-specific Megatron trainer test cases with isolated test config

### DIFF
--- a/examples/megatron/run_pretrain.sh
+++ b/examples/megatron/run_pretrain.sh
@@ -8,6 +8,7 @@
 
 # available models: primus/configs/models/megatron
 export MODEL_CONFIG=${MODEL_CONFIG:-deepseek_v2_lite}
+export EXP=${EXP:-"examples/megatron/exp_pretrain.yaml"}
 
 export MASTER_ADDR=${MASTER_ADDR:-localhost}
 export MASTER_PORT=${MASTER_PORT:-1234}
@@ -221,10 +222,13 @@ pushd "${MEGATRON_PATH}/megatron/core/datasets" && make && popd || exit 1
 # env
 
 torchrun "${DISTRIBUTED_ARGS[@]}" examples/megatron/pretrain.py \
-    --exp examples/megatron/exp_pretrain.yaml 2>&1 | tee $TRAIN_LOG
+    --exp $EXP 2>&1 | tee $TRAIN_LOG
+exit_code=${PIPESTATUS[0]}
 
 if [ "$PRIMUS_HIPBLASLT_TUNING_STAGE" -eq 1 ]; then
     echo "[PRIMUS_HIPBLASLT_TUNING_STAGE-1]: HipBlasLT gemm shape dump is finished, " \
          "please set PRIMUS_HIPBLASLT_TUNING_STAGE to 2, " \
          "and tune the gemm with a single node."
 fi
+
+exit $exit_code

--- a/tests/trainer/test_megatron_trainer.py
+++ b/tests/trainer/test_megatron_trainer.py
@@ -25,13 +25,72 @@ class TestMegatronTrainer(PrimusUT):
     def tearDown(self):
         pass
 
-    def test_pretrain(self):
+    def test_llama2_7B(self):
+        self._run_script(
+            "llama2_7B",
+            env_override={
+                "MODEL_CONFIG": "llama2_7B",
+                "PRIMUS_GLOBAL_BATCH_SIZE": "8",
+                "PRIMUS_NUM_LAYERS": "4",
+            },
+        )
+
+    def test_llama3_8B(self):
+        self._run_script(
+            "llama3_8B",
+            env_override={
+                "MODEL_CONFIG": "llama3_8B",
+                "PRIMUS_GLOBAL_BATCH_SIZE": "8",
+                "PRIMUS_NUM_LAYERS": "4",
+            },
+        )
+
+    def test_llama3_70B(self):
+        self._run_script(
+            "llama3_70B",
+            env_override={
+                "MODEL_CONFIG": "llama3_70B",
+                "PRIMUS_GLOBAL_BATCH_SIZE": "8",
+                "PRIMUS_NUM_LAYERS": "4",
+            },
+        )
+
+    def test_deepseek_v2_lite(self):
+        self._run_script(
+            "deepseek_v2_lite",
+            env_override={
+                "MODEL_CONFIG": "deepseek_v2_lite",
+                "PRIMUS_GLOBAL_BATCH_SIZE": "8",
+                "PRIMUS_MOE_LAYER_FREQ": "[0]*1+[1]*3",
+                "PRIMUS_EP": "8",
+                "PRIMUS_NUM_LAYERS": "4",
+            },
+        )
+
+    def test_deepseek_v3(self):
+        self._run_script(
+            "deepseek_v3",
+            env_override={
+                "MODEL_CONFIG": "deepseek_v3",
+                "PRIMUS_GLOBAL_BATCH_SIZE": "8",
+                "PRIMUS_MOE_LAYER_FREQ": "[0]*3+[1]*1",
+                "PRIMUS_EP": "8",
+                "PRIMUS_NUM_LAYERS": "4",
+            },
+        )
+
+    def _run_script(self, tag: str, env_override: dict = None):
         shell_entry = "examples/megatron/run_pretrain.sh"
+        env = os.environ.copy()
+        if env_override:
+            env.update(env_override)
+        env["EXP"] = "tests/trainer/test_megatron_trainer.yaml"
+
         do_print_at_runtime = False
         run_stdout = subprocess.PIPE if not do_print_at_runtime else sys.stdout
         run_stderr = subprocess.PIPE if not do_print_at_runtime else sys.stderr
         try:
-            logger.info(f"Begin run {shell_entry}...")
+            logger.info(f"Begin run {tag}...")
             start = time.time()
             result = subprocess.run(
                 ["bash", f"{shell_entry}"],
@@ -39,8 +98,9 @@ class TestMegatronTrainer(PrimusUT):
                 stdout=run_stdout,
                 stderr=run_stderr,
                 text=True,
+                env=env,
             )
-            logger.info(f"End run {shell_entry}, time={time.time()-start:.3f} s")
+            logger.info(f"End run {tag}, time={time.time()-start:.3f} s")
             if not do_print_at_runtime:
                 ut_log_path = os.environ.get("UT_LOG_PATH", "ut_out")
                 logger.info(f"Training log path: {ut_log_path}/logs/UT-{self.__class__.__name__}")

--- a/tests/trainer/test_megatron_trainer.yaml
+++ b/tests/trainer/test_megatron_trainer.yaml
@@ -1,0 +1,80 @@
+work_group: ${TEAM:amd}
+user_name: ${USER:root}
+exp_name: &exp_name ${EXP:exp-deepseek-pretrain}
+workspace: ./output
+
+platform:
+  config: platform_azure.yaml
+  overrides:
+    master_sink_level: INFO
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    model: ${MODEL_CONFIG:deepseek_v2_lite}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_test_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      num_layers: 4
+      moe_layer_freq: "[0]*1+[1]*3"
+
+      # optimizer: adam
+      moe_router_force_load_balancing: true
+      moe_router_dtype: fp32
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 5
+
+      # hyber parameters
+      train_iters: 3
+      micro_batch_size: 1
+      global_batch_size: 8
+      seq_length: 4096
+      max_position_embeddings: 4096
+      lr: 1.0e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:1}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # fusion
+      # 20250321: need latest megatron docker image
+      moe_permute_fusion: false
+      # 20250317: need latest apex in docker image
+      gradient_accumulation_fusion: false
+      # 20250317: TE grouped gemm has numerical issue
+      moe_use_legacy_grouped_gemm: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: true
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch


### PR DESCRIPTION
This PR improves the Megatron trainer's test framework by introducing:

1. ✅ Multiple model test cases for:
    - llama2_7B
    - llama3_8B
    - llama3_70B
    - deepseek_v2_lite
    - deepseek_v3
2. ✅ A new test-only config file: test_megatron_trainer.yaml
    - This isolates test logic from production EXP files and ensures each model is tested with simplified settings for faster execution.