### PR TITLE
fix fast async checkpoint on ROCm

### DIFF
--- a/primus/backends/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/primus/backends/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -1,0 +1,33 @@
+import torch
+from megatron.core.dist_checkpointing.strategies.filesystem_async import (
+    FileSystemWriterAsync,
+)
+
+from primus.modules.module_utils import log_rank_0, warning_rank_0
+
+
+class PrimusFileSystemWriterAsync(FileSystemWriterAsync):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def preload_tensors(*args, **kwargs):
+        # (limou)
+        # change argument non_blocking to False on HIP platform
+        # the tensors will be stored in pinned memory if non_blocking=True
+        # currently on the ROCm platform
+        # forking a subprocess afterward with pinned_memory=True will trigger segmentation fault
+        if torch.version.hip:
+            log_rank_0("HIP env detected, change argument non_blocking in FileSystemWriterAsync to False")
+            if "non_blocking" in kwargs:
+                kwargs["non_blocking"] = False
+            elif len(args) > 0 and type(args[-1]) == type(True):
+                # TODO (limou)
+                # non_blocking may NOT always be the last argument in the future
+                args = args[:-1] + (False,)
+            else:
+                warning_rank_0("found argument non_blocking failed")
+
+        return super(PrimusFileSystemWriterAsync, PrimusFileSystemWriterAsync).preload_tensors(
+            *args, **kwargs
+        )

--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -377,6 +377,7 @@ class MegatronTrainer(BaseTrainer, BaseModule):
         # monkey patch modules
         self.patch_topk_router()
         self.patch_torch_fsdp()
+        self.patch_file_system_writer()
 
         self.app_metrics = {}
 
@@ -422,6 +423,21 @@ class MegatronTrainer(BaseTrainer, BaseModule):
             raise RuntimeError("Failed to patch torch_FSDP2: missing dependencies") from e
         except Exception as e:
             raise RuntimeError("Unexpected error occurred during FSDP patching") from e
+
+    def patch_file_system_writer(self):
+        warning_rank_0("MegatronTrainer: Patching FileSystemWriterAsync...")
+        try:
+            import megatron.core.dist_checkpointing.strategies.filesystem_async as filesystem_async_module
+
+            from primus.backends.megatron.core.dist_checkpointing.strategies.filesystem_async import (
+                PrimusFileSystemWriterAsync,
+            )
+
+            filesystem_async_module.FileSystemWriterAsync = PrimusFileSystemWriterAsync
+        except Exception:
+            warning_rank_0("MegatronTrainer: Patch FileSystemWriterAsync failed.")
+        else:
+            warning_rank_0("MegatronTrainer: Patch FileSystemWriterAsync successfully.")
 
     def init(self, *init_args, **kwargs):
         allowed_keys = {


### PR DESCRIPTION
fix fast && async checkpoint bug on ROCm
to enable fast checkpoint, change these arguments in yaml:
1) ckpt_format : torch_dist
2) ckpt_fully_parallel_save : true
3) async_save : true

bug details:
https://amd.atlassian.net/wiki/spaces/~712020ea4fade82ae94a95b7c0ba1cb554d2a8/pages/925498804/fatal+BUG+on+ROCm+platform+with+dist_checkpointing
