### PR TITLE
Update mixtral pretrain configs

### DIFF
--- a/examples/megatron/configs/mixtral_8x22B_v0.1-pretrain.yaml
+++ b/examples/megatron/configs/mixtral_8x22B_v0.1-pretrain.yaml
@@ -28,9 +28,9 @@ modules:
       # hyber parameters
       train_iters: 3
       micro_batch_size: 2
-      global_batch_size: 256
-      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
-      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      global_batch_size: 128
+      seq_length: ${PRIMUS_SEQ_LENGTH:8192}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:8192}
       lr: 1.0e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -44,11 +44,16 @@ modules:
       norm_epsilon: 1.0e-6
 
       # parallel
-      tensor_model_parallel_size: ${PRIMUS_TP:2}
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
       pipeline_model_parallel_size: ${PRIMUS_PP:4}
       expert_model_parallel_size: ${PRIMUS_EP:4}
       overlap_grad_reduce: true
       overlap_param_gather: true
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 56 # int
 
       # data
       train_data_path: ${TOKENIZED_DATA_PATH:null}

--- a/examples/megatron/configs/mixtral_8x7B_v0.1-pretrain.yaml
+++ b/examples/megatron/configs/mixtral_8x7B_v0.1-pretrain.yaml
@@ -27,8 +27,8 @@ modules:
 
       # hyber parameters
       train_iters: 3
-      micro_batch_size: 6
-      global_batch_size: 768
+      micro_batch_size: 2
+      global_batch_size: 128
       seq_length: ${PRIMUS_SEQ_LENGTH:4096}
       max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1.0e-5
@@ -44,9 +44,9 @@ modules:
       norm_epsilon: 1.0e-6
 
       # parallel
-      tensor_model_parallel_size: ${PRIMUS_TP:2}
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
       pipeline_model_parallel_size: ${PRIMUS_PP:1}
-      expert_model_parallel_size: ${PRIMUS_EP:4}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
       overlap_grad_reduce: true
       overlap_param_gather: true
 

--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -1973,6 +1973,7 @@ class MegatronTrainer(BaseTrainer, BaseModule):
                 total_loss_dict=total_loss_dict,
                 per_layer_logging=args.moe_per_layer_logging,
                 moe_layer_freq=args.moe_layer_freq,
+                num_layers=args.num_layers,
             )
 
         if iteration % args.log_interval == 0:


### PR DESCRIPTION
1. updated mixtral-8x7B config, TFLOPS per gpu improves from 260 to 390 on 4 nodes
2. updated mextral-8x22B config, TFLOPS per gpu improves from 220 to 290 on 4 nodes
3. fixed function call to track_moe_metrics in trainer.py