### PR TITLE
opt(UT): add num_workers=1 in UT yaml to save most of the time on exit

### DIFF
--- a/tests/trainer/test_megatron_trainer.yaml
+++ b/tests/trainer/test_megatron_trainer.yaml
@@ -56,7 +56,7 @@ modules:
       overlap_param_gather: true
 
       # data
-      num_workers: 8
+      num_workers: 1
       train_data_path: ${TOKENIZED_DATA_PATH:null}
       valid_data_path: null
       test_data_path: null


### PR DESCRIPTION
Add `num_workers=1` in `test_megatron_trainer.yaml` to save most of the time on exit of the UTs, where the exiting time can decrease from about 60s-100s to 20s-30s, saving 240s of the total UT time from 810s to 570s.
Related existing torch dataloader issue: https://github.com/pytorch/data/issues/701