### PR TITLE
feat: Add run_k8s_pretrain interface for Kubernetes workload submission

### DIFF
--- a/examples/run_k8s_pretrain.sh
+++ b/examples/run_k8s_pretrain.sh
@@ -44,8 +44,8 @@ Other:
 Examples:
 
     # Create a workload with custom resources and paths
-    $0 --url http://api.example.com create --replica 2 --cpu 96 --gpu 4 \\
-        --exp examples/megatron/configs/llama2_7B-pretrain.yaml --data_path /mnt/data/train \\
+    $0 --url http://api.example.com create --replica 2 --cpu 96 --gpu 4\
+        --exp examples/megatron/configs/llama2_7B-pretrain.yaml --data_path /mnt/data/train\
         --image docker.io/custom/image:latest --hf_token myhf_token
 
     # Get workload details


### PR DESCRIPTION
This PR adds a new function run_k8s_pretrain to support launching training jobs on Kubernetes via REST API.

### Create a workload with custom resources and paths
    examples/run_k8s_pretrain.sh --url http://api.example.com create --replica 2 --cpu 96 --gpu 4 \
        --exp examples/megatron/configs/llama2_7B-pretrain.yaml --data_path /mnt/data/train \
        --image docker.io/custom/image:latest --hf_token myhf_token

### Get workload details
    examples/run_k8s_pretrain.sh --url http://api.example.com get --workload-id abc123

### Delete a workload
    examples/run_k8s_pretrain.sh --url http://api.example.com delete --workload-id abc123

### List all workloads
    examples/run_k8s_pretrain.sh --url http://api.example.com list