### PR TITLE
feat(run_k8s_pretrain): support --workspace and improve job spec defaults

### DIFF
--- a/examples/run_k8s_pretrain.sh
+++ b/examples/run_k8s_pretrain.sh
@@ -171,7 +171,7 @@ ENTRY_POINT="cd $CUR_DIR; NNODES=\$PET_NNODES NODE_RANK=\$PET_NODE_RANK bash ./e
 read -r -d '' INLINE_JSON <<EOF || true
 {
     "workspace": "$WORKSPACE",
-    "displayName": "primus-pretrain",
+    "displayName": "pretrain",
     "groupVersionKind": {
         "kind": "PyTorchJob",
         "group": "kubeflow.org",


### PR DESCRIPTION
This PR introduces the following updates to `examples/run_k8s_pretrain.sh`:
- ✅ **Added `--workspace` argument** to specify the target workspace for the job
- ✅ **Printed full inline JSON** before submission for better visibility and debugging
- ✅ **Added `ttlSecondsAfterFinished: 36000`** to auto-clean finished jobs after 10h
- 🔧 **Reduced default CPU allocation** from `192` → `96` to better align with typical clusters