### PR TITLE
llama3.1_405B model config

### DIFF
--- a/examples/megatron/exp_pretrain.yaml
+++ b/examples/megatron/exp_pretrain.yaml
@@ -44,8 +44,8 @@ modules:
 
       # hyber parameters
       train_iters: 3
-      micro_batch_size: 6
-      global_batch_size: 768
+      micro_batch_size: 1
+      global_batch_size: 16
       seq_length: ${PRIMUS_SEQ_LENGTH:4096}
       max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1.0e-5

--- a/primus/backends/transformer_engine/pytorch/cpp_extensions/gemm.py
+++ b/primus/backends/transformer_engine/pytorch/cpp_extensions/gemm.py
@@ -1,3 +1,10 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+#################################################################################
+
+
 from typing import Optional, Tuple, Union
 
 import torch

--- a/primus/backends/transformer_engine/pytorch/module/base.py
+++ b/primus/backends/transformer_engine/pytorch/module/base.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+#################################################################################
+
 from typing import Optional, Union
 
 import torch

--- a/primus/backends/transformer_engine/transformer_engine_torch/__init__.py
+++ b/primus/backends/transformer_engine/transformer_engine_torch/__init__.py
@@ -1,2 +1,8 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+#################################################################################
+
 from .comm_overlap import CommOverlap, CommOverlapBase, CommOverlapP2P
 from .comm_overlap_type import CommOverlapAlgo, CommOverlapType

--- a/primus/backends/transformer_engine/transformer_engine_torch/comm_overlap.py
+++ b/primus/backends/transformer_engine/transformer_engine_torch/comm_overlap.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+#################################################################################
+
 import operator
 from functools import reduce
 from typing import Dict, List, Optional, Union

--- a/primus/backends/transformer_engine/transformer_engine_torch/comm_overlap_type.py
+++ b/primus/backends/transformer_engine/transformer_engine_torch/comm_overlap_type.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+#################################################################################
+
 from enum import Enum
 
 

--- a/primus/configs/models/megatron/llama3.1_405B.yaml
+++ b/primus/configs/models/megatron/llama3.1_405B.yaml
@@ -1,0 +1,11 @@
+bases:
+  - llama3_base.yaml
+
+tokenizer_type: Llama3Tokenizer
+tokenizer_model: meta-llama/Llama-3.1-405B
+
+ffn_hidden_size: 53248
+hidden_size: 16384
+num_attention_heads: 128
+num_layers: 126
+num_query_groups: 8

--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -373,6 +373,9 @@ class MegatronTrainer(BaseTrainer, BaseModule):
         self.app_metrics = {}
 
     def patch_te_tp_overlap(self):
+        if not self.module_config.tp_comm_overlap:
+            return
+
         import transformer_engine as te
         import transformer_engine_torch as tex
 

--- a/tests/distributed/test_tp_overlap.py
+++ b/tests/distributed/test_tp_overlap.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+#################################################################################
+
 from contextlib import contextmanager
 
 import torch


### PR DESCRIPTION
- Add llama3.1_405B model configuration
- Add license header to Python source files (tp overlap extension)
- Add check for TP overlap option to prevent import errors when primus-turbo is unavailable