### PR TITLE
feat(megatron): add attn warmup to save iter1's time when pp is used

### DIFF
--- a/primus/configs/modules/megatron/trainer_base.yaml
+++ b/primus/configs/modules/megatron/trainer_base.yaml
@@ -3,6 +3,9 @@ includes:
 
 trainable: true
 
+# perf
+attn_warmup: false # set to true to decrease iter-1 time when using pp
+
 # logging
 disable_tensorboard: true
 disable_wandb: true

--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -1272,7 +1272,7 @@ class MegatronTrainer(BaseTrainer, BaseModule):
         one_logger = get_one_logger()
         args = get_args()
 
-        if os.environ.get("PRIMUS_WARMUP_ATTN", "0") == "1":
+        if args.attn_warmup:
             from .utils import warmup_attn
 
             log_rank_0(

--- a/tests/trainer/test_megatron_trainer.py
+++ b/tests/trainer/test_megatron_trainer.py
@@ -95,7 +95,6 @@ class TestMegatronTrainer(PrimusUT):
                 "PRIMUS_PP": "4",
                 "PRIMUS_VPP": "2",
                 "PRIMUS_NUM_LAYERS": "8",
-                "PRIMUS_WARMUP_ATTN": "1",
             },
         )
 


### PR DESCRIPTION
- Currently the first iteration is too slow when pipeline parallelism is used, where it could be decreased from minutes to seconds by setting `args.attn_warmup=true` to run an additional attn fwd/bwd in parallel before training
  - e.g. in `dsv2_hs1024_layer64_pp8_gpu8` config, **190s (without warmup) --> 10s (with warmup)**
- [TODO] The root cause is that the initialization of the attention fwd/bwd of the first layer is too slow and need in-depth analysis