### PR TITLE
Add deepseek v2 config

### DIFF
--- a/examples/megatron/configs/deepseek_v2-pretrain.yaml
+++ b/examples/megatron/configs/deepseek_v2-pretrain.yaml
@@ -1,0 +1,83 @@
+work_group: ${TEAM:amd}
+user_name: ${USER:root}
+exp_name: ${EXP_NAME:deepseek_v2-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:deepseek_v2}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyber parameters
+      train_iters: 50
+      micro_batch_size: 1
+      global_batch_size: 256
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1.0e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 14 # int
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:4}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # fusion
+      # 20250321: need latest megatron docker image
+      moe_permute_fusion: false
+      # 20250317: need latest apex in docker image
+      gradient_accumulation_fusion: true
+      # 20250317: TE grouped gemm has numerical issue
+      moe_use_legacy_grouped_gemm: true
+      # fused topk router with aux score
+      moe_use_fused_router_with_aux_score: false
+      # pad 192/128 for deepseek attention
+      fused_padded_mla_attention: false
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0

--- a/examples/megatron/configs/deepseek_v2_lite-pretrain.yaml
+++ b/examples/megatron/configs/deepseek_v2_lite-pretrain.yaml
@@ -21,7 +21,7 @@ modules:
       log_avg_reset_interval: 50
 
       # hyber parameters
-      train_iters: 8
+      train_iters: 50
       micro_batch_size: 4
       global_batch_size: 640
       seq_length: ${PRIMUS_SEQ_LENGTH:4096}

--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -86,6 +86,10 @@ bash "${PRIMUS_PATH}"/tools/docker/docker_podman_proxy.sh run --rm \
     --env DATA_PATH="${DATA_PATH}" \
     --env TRAIN_LOG="${TRAIN_LOG}" \
     --env HSA_NO_SCRATCH_RECLAIM="${HSA_NO_SCRATCH_RECLAIM}" \
+    --env GLOO_SOCKET_IFNAME="${GLOO_SOCKET_IFNAME}" \
+    --env NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME}" \
+    --env REBUILD_BNXT="${REBUILD_BNXT}" \
+    --env PATH_TO_BNXT_TAR_PACKAGE="${PATH_TO_BNXT_TAR_PACKAGE}" \
     "${ENV_ARGS[@]}" \
     --ipc=host --network=host \
     --device=/dev/kfd --device=/dev/dri \

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -204,6 +204,7 @@ export NVTE_CK_USES_BWD_V3=0
 export NVTE_DEBUG=0 # 0, 1
 export NVTE_DEBUG_LEVEL=0 # 0, 1, 2
 export NVTE_FUSED_ATTN_LOG_CONFIG=0 # 0, 1
+export PATCH_TE_FLASH_ATTN=${PATCH_TE_FLASH_ATTN:-0}
 
 LOG_INFO_RANK0 "==========Performance tuning=========="
 LOG_INFO_RANK0 "GPU_MAX_HW_QUEUES: $GPU_MAX_HW_QUEUES"
@@ -212,11 +213,34 @@ LOG_INFO_RANK0 "TORCH_NCCL_HIGH_PRIORITY: $TORCH_NCCL_HIGH_PRIORITY"
 LOG_INFO_RANK0 "NVTE_CK_USES_BWD_V3: $NVTE_CK_USES_BWD_V3"
 LOG_INFO_RANK0 "NVTE_USE_CAST_TRANSPOSE_TRITON: $NVTE_USE_CAST_TRANSPOSE_TRITON"
 LOG_INFO_RANK0 "NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE: $NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE"
-LOG_INFO_RANK0 'Patching _flash_attn_max_version in attention.py...'
-sed -i 's/_flash_attn_max_version = PkgVersion(\".*\")/_flash_attn_max_version = PkgVersion(\"3.0.0.post1\")/' \
-    /opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformer_engine/pytorch/attention.py
-LOG_INFO_RANK0 'Patch complete.'
+if [[ "$PATCH_TE_FLASH_ATTN" == "1" ]]; then
+    LOG_INFO_RANK0 'Patching _flash_attn_max_version in attention.py...'
+    sed -i 's/_flash_attn_max_version = PkgVersion(\".*\")/_flash_attn_max_version = PkgVersion(\"3.0.0.post1\")/' \
+        /opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformer_engine/pytorch/attention.py
+    LOG_INFO_RANK0 'Patch complete.'
+fi
 LOG_INFO_RANK0 ""
+
+# ----------------- Rebuild nbxt -----------------
+export REBUILD_BNXT=${REBUILD_BNXT:-0}
+export PATH_TO_BNXT_TAR_PACKAGE=${PATH_TO_BNXT_TAR_PACKAGE}
+
+if [[ "$REBUILD_BNXT" == "1" && -f "$PATH_TO_BNXT_TAR_PACKAGE" ]]; then
+    LOG_INFO "Rebuilding bnxt from $PATH_TO_BNXT_TAR_PACKAGE ..." && \
+    tar xzf "${PATH_TO_BNXT_TAR_PACKAGE}" -C /tmp/ && \
+    mv /tmp/libbnxt_re-* /tmp/libbnxt && \
+    mv /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so /usr/lib/x86_64-linux-gnu/libibverbs/libbnxt_re-rdmav34.so.inbox && \
+    cd /tmp/libbnxt/ && sh ./autogen.sh && ./configure && \
+    make -C /tmp/libbnxt clean all install && \
+    echo '/usr/local/lib' > /etc/ld.so.conf.d/libbnxt_re.conf && \
+    ldconfig && \
+    cp -f /tmp/libbnxt/bnxt_re.driver /etc/libibverbs.d/ && \
+    cd "${PRIMUS_PATH}" && \
+    LOG_INFO "Rebuilding libbnxt done."
+else
+  LOG_INFO "Skip bnxt rebuild. REBUILD_BNXT=$REBUILD_BNXT, PATH_TO_BNXT_TAR_PACKAGE=$PATH_TO_BNXT_TAR_PACKAGE"
+fi
+
 
 
 # -------------------- HipBLASLt Tuning --------------------

--- a/examples/run_slurm_pretrain.sh
+++ b/examples/run_slurm_pretrain.sh
@@ -56,5 +56,9 @@ srun -N "${NNODES}" \
           export NODE_RANK=\${SLURM_PROCID}
           export GPUS_PER_NODE=\${SLURM_GPUS_ON_NODE}
           export HSA_NO_SCRATCH_RECLAIM=\${HSA_NO_SCRATCH_RECLAIM}
+          export GLOO_SOCKET_IFNAME=\${GLOO_SOCKET_IFNAME}
+          export NCCL_SOCKET_IFNAME=\${NCCL_SOCKET_IFNAME}
+          export REBUILD_BNXT=\${REBUILD_BNXT}
+          export PATH_TO_BNXT_TAR_PACKAGE=\${PATH_TO_BNXT_TAR_PACKAGE}
           bash ${SCRIPT_DIR}/run_local_pretrain.sh \"\$@\" 2>&1 | tee ${LOG_FILE}
      " bash "$@"

--- a/primus/configs/models/megatron/llama2_base.yaml
+++ b/primus/configs/models/megatron/llama2_base.yaml
@@ -6,7 +6,5 @@ rotary_base: 10000
 norm_epsilon: 1.0e-05
 init_method_std: 0.02
 
-# multi_latent_attention does not support apply_rope_fusion
 apply_rope_fusion: true
-
 masked_softmax_fusion: false

--- a/primus/configs/models/megatron/llama3_base.yaml
+++ b/primus/configs/models/megatron/llama3_base.yaml
@@ -7,6 +7,5 @@ rotary_base: 500000
 norm_epsilon: 1.0e-05
 init_method_std: 0.02
 
-apply_rope_fusion: false
-
+apply_rope_fusion: true
 masked_softmax_fusion: false


### PR DESCRIPTION
1. Added training configuration for DeepSeek V2
New config files to support training of DeepSeek V2 models.

3. Renamed config file
deepseekv2_lite-pretrain.yaml → deepseek_v2_lite-pretrain.yaml
For consistent naming style across all model configs.

4. Disabled TE flash attention max version patch by default
The TE version patching logic is now off by default to avoid unexpected override of version constraints.

5. Introduced REBUILD_BNXT environment variable
When enabled and provided with a valid tarball path (PATH_TO_BNXT_TAR_PACKAGE), Primus will rebuild BNXT to ensure IB communication works properly on clusters where default drivers don't suffice.

6. Enabled apply_rope_fusion for LLaMA3 base model
Improves performance by applying rope fusion optimization during training.