### PR TITLE
add te fused cross entropy argument

### DIFF
--- a/primus/configs/models/megatron/language_model.yaml
+++ b/primus/configs/models/megatron/language_model.yaml
@@ -68,6 +68,7 @@ attention_softmax_in_fp32: false
 # fusion
 bias_gelu_fusion: true
 cross_entropy_loss_fusion: False
+cross_entropy_fusion_impl: "native" # "native", "te"
 bias_swiglu_fusion: true
 masked_softmax_fusion: true
 no_persist_layer_norm: false


### PR DESCRIPTION
This PR enables fused cross entropy with the following configuration:

```yaml
cross_entropy_loss_fusion: true
cross_entropy_fusion_impl: "te"
```  

Simple test with DeepSeekV2 Lite (GBS=32, 8 GPUs):
Fusion | Memory Usage | Throughput
-- | -- | --
Enabled | 121.64 GB | 215.3 TFLOPS
Disabled | 127.66 GB | 210.7 TFLOPS