### PR TITLE
chore: update default rocm/megatron-lm image to v25.8_py310

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Primus leverages AMD’s ROCm Docker images to provide a consistent, ready-to-ru
 1. Pull the latest Docker image
 
     ```bash
-    docker pull docker.io/rocm/megatron-lm:v25.7_py310
+    docker pull docker.io/rocm/megatron-lm:v25.8_py310
 
     ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ We recommend using the official [rocm/megatron-lm Docker image](https://hub.dock
 
 ```bash
 # Pull the latest Docker image
-docker pull docker.io/rocm/megatron-lm:v25.7_py310
+docker pull docker.io/rocm/megatron-lm:v25.8_py310
 
 ```
 
@@ -114,7 +114,7 @@ Multi-node training is launched via **SLURM**.
 Specify the number of nodes and the model config:
 
 ```bash
-export DOCKER_IMAGE="docker.io/rocm/megatron-lm:v25.7_py310"
+export DOCKER_IMAGE="docker.io/rocm/megatron-lm:v25.8_py310"
 export NNODES=8
 
 # Example for megatron llama3.1_8B
@@ -273,7 +273,7 @@ When using the `create` command to start a new training workload, the following 
 | `--gpu`        | Number of GPUs                                       | 8                                        |
 | `--exp`        | Path to experiment (training config) file (required) | —                                        |
 | `--data_path`  | Path to training data                                | —                                        |
-| `--image`      | Docker image to use                                  | `docker.io/rocm/megatron-lm:v25.7_py310` |
+| `--image`      | Docker image to use                                  | `docker.io/rocm/megatron-lm:v25.8_py310` |
 | `--hf_token`   | HuggingFace token                                    | Read from env var `HF_TOKEN`             |
 | `--workspace`  | Workspace name                                       | `primus-safe-pretrain`                   |
 | `--nodelist`   | Comma-separated list of node hostnames to run on     | —                                        |

--- a/examples/run_k8s_pretrain.sh
+++ b/examples/run_k8s_pretrain.sh
@@ -15,7 +15,7 @@ GPU="8"
 EXP_PATH=""
 DATA_PATH=""
 BACKEND="megatron"
-IMAGE="docker.io/rocm/megatron-lm:v25.7_py310"
+IMAGE="docker.io/rocm/megatron-lm:v25.8_py310"
 HF_TOKEN="${HF_TOKEN:-}"
 WORKSPACE="primus-safe-pretrain"
 NODELIST=""
@@ -38,7 +38,7 @@ Options for create:
     --backend <name>            Training backend, e.g. megatron | torchtitan(default: megatron)
     --exp <exp_path>            Path to EXP config (optional)
     --data_path <data_path>     Data path (optional)
-    --image <docker_image>      Docker image to use (default: docker.io/rocm/megatron-lm:v25.7_py310)
+    --image <docker_image>      Docker image to use (default: docker.io/rocm/megatron-lm:v25.8_py310)
     --hf_token <token>          HuggingFace token (default: from env HF_TOKEN)
     --workspace <workspace>     Workspace name (default: safe-cluster-dev)
     --nodelist <node1,node2>    Comma-separated list of node names to run on (optional)

--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -16,7 +16,7 @@ Usage: bash run_local_pretrain.sh
 This script launches a Primus pretraining task inside a Docker/Podman container.
 
 Environment Variables:
-    DOCKER_IMAGE   Docker image to use [Default: docker.io/rocm/megatron-lm:v25.7_py310]
+    DOCKER_IMAGE   Docker image to use [Default: docker.io/rocm/megatron-lm:v25.8_py310]
     MASTER_ADDR    Master node IP or hostname [Default: localhost]
     MASTER_PORT    Master node port [Default: 1234]
     NNODES         Total number of nodes [Default: 1]
@@ -39,7 +39,7 @@ fi
 EXP=${EXP:-"examples/megatron/exp_pretrain.yaml"}
 
 # Default docker image
-DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/megatron-lm:v25.7_py310"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/megatron-lm:v25.8_py310"}
 
 # Project root
 PRIMUS_PATH=$(realpath "$(dirname "$0")/..")

--- a/tools/docker/start_container.sh
+++ b/tools/docker/start_container.sh
@@ -6,7 +6,7 @@
 ###############################################################################
 
 PRIMUS_PATH=$(realpath "$(dirname "$0")/../..")
-DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/megatron-lm:v25.7_py310"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/megatron-lm:v25.8_py310"}
 DATA_PATH=${DATA_PATH:-"${PRIMUS_PATH}/data"}
 
 bash "${PRIMUS_PATH}"/tools/docker/docker_podman_proxy.sh run -d \

--- a/tools/preflight/run_preflight.sh
+++ b/tools/preflight/run_preflight.sh
@@ -135,7 +135,7 @@ if [ "$RUN_ENV" = "torchrun" ]; then
         2>&1 | tee $PREFLIGHT_LOG
 
 elif [ "$RUN_ENV" = "slurm" ]; then
-    export DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/megatron-lm:v25.7_py310"}
+    export DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/megatron-lm:v25.8_py310"}
 
     bash "${PRIMUS_PATH}"/tools/docker/docker_podman_proxy.sh run --rm \
         --env SLURM_MASTER_ADDR=$SLURM_MASTER_ADDR \


### PR DESCRIPTION
This PR updates the default Docker image reference from `v25.7_py310` to `v25.8_py310` across documentation, examples, and tooling scripts.
