### PR TITLE
perf(aiter): add AITER_JIT_DIR env for cached build to speed up re-compilation

### DIFF
--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -95,6 +95,22 @@ if [ ! -f "${EXP}" ]; then
     exit 1
 fi
 
+TMP_BUILD_DIR="${PRIMUS_PATH}/build/${HOSTNAME}"
+mkdir -p "$TMP_BUILD_DIR"
+# Collect environment info for cache tagging
+OS_VER=$(grep ^PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d '"' | tr ' ' '_' | tr -d '()')
+PY_VER=$(python3 -c 'import platform; print(platform.python_version())')
+ROCM_VER=$(/opt/rocm/bin/rocminfo | grep 'ROCm version' | head -1 | awk '{print $NF}' | tr -d '()')
+if [[ -f /proc/driver/amdgpu/version ]]; then
+    AMDGPU_VER=$(head -1 < /proc/driver/amdgpu/version | awk '{print $3}' | tr -d '()')
+else
+    AMDGPU_VER="unknown"
+fi
+KERNEL_VER=$(uname -r | tr '.' '_' | tr '-' '_')
+
+CACHE_TAG="${OS_VER}_py${PY_VER}_rocm${ROCM_VER}_amdgpu${AMDGPU_VER}_kernel${KERNEL_VER}_${HOSTNAME}"
+export AITER_JIT_DIR="${TMP_BUILD_DIR}/${CACHE_TAG}_aiter_cache"
+
 
 TRAIN_LOG=${TRAIN_LOG:-"output/log_torchrun_pretrain_$(basename "$EXP" .yaml).txt"}
 


### PR DESCRIPTION
## Summary
This PR introduces the `AITER_JIT_DIR` environment variable in `examples/run_pretrain.sh` to accelerate **aiter** module builds by reusing cached compilation artifacts across runs.

## Changes
- Added per-host temporary build directory under `${PRIMUS_PATH}/build/${HOSTNAME}`  
- Constructed a unique `CACHE_TAG` based on:
  - OS version  
  - Python version  
  - ROCm version  
  - AMDGPU driver version  
  - Kernel version  
  - Hostname  
- Exported `AITER_JIT_DIR=${TMP_BUILD_DIR}/${CACHE_TAG}_aiter_cache`  

## Motivation
- Improve developer productivity by avoiding redundant aiter JIT rebuilds on subsequent runs  
- Ensure cache isolation across different environments, avoiding conflicts by tagging with system info  
