### PR TITLE
Megatron: compatibility update (model_provider / gpt_builder / FSDP) & new args

### DIFF
--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -18,7 +18,7 @@ from megatron.core.parallel_state import (
     get_hierarchical_context_parallel_groups,
     get_tensor_model_parallel_group,
 )
-from megatron.core.process_groups_config import ModelCommProcessGroups
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.moe.experts import GroupedMLP
@@ -178,7 +178,7 @@ class PrimusTurboAttention(te.pytorch.DotProductAttention):
         k_channels: Optional[int] = None,
         v_channels: Optional[int] = None,
         cp_comm_type: str = "p2p",
-        model_comm_pgs: ModelCommProcessGroups = None,
+        pg_collection: ProcessGroupCollection = None,
     ):
         self.config = config
         self.qkv_format: str = "sbhd"
@@ -191,24 +191,24 @@ class PrimusTurboAttention(te.pytorch.DotProductAttention):
         else:
             self.attn = pt.ops.flash_attn_func
             self.attention_backend = "ck"
-        if model_comm_pgs is None:
+        if pg_collection is None:
             # For backward compatibility, remove in v0.14 and raise error
-            # raise ValueError("TEDotProductAttention was called without ModelCommProcessGroups")
-            model_comm_pgs = ModelCommProcessGroups(
+            # raise ValueError("TEDotProductAttention was called without ProcessGroupCollection")
+            pg_collection = ProcessGroupCollection(
                 tp=get_tensor_model_parallel_group(check_initialized=False),
                 cp=get_context_parallel_group(check_initialized=False),
                 hcp=get_hierarchical_context_parallel_groups(check_initialized=False),
             )
         else:
-            assert hasattr(model_comm_pgs, "tp"), "TEDotProductAttention model_comm_pgs must have tp pg"
-            assert hasattr(model_comm_pgs, "cp"), "TEDotProductAttention model_comm_pgs must have cp pg"
+            assert hasattr(pg_collection, "tp"), "TEDotProductAttention pg_collection must have tp pg"
+            assert hasattr(pg_collection, "cp"), "TEDotProductAttention pg_collection must have cp pg"
             if cp_comm_type == "a2a+p2p":
                 assert hasattr(
-                    model_comm_pgs, "hcp"
-                ), "TEDotProductAttention model_comm_pgs must have hierarchical cp pg"
+                    pg_collection, "hcp"
+                ), "TEDotProductAttention pg_collection must have hierarchical cp pg"
         self.cp_param_bundle = None
         if self.config.context_parallel_size > 1:
-            self.cp_param_bundle = {"cp_group": model_comm_pgs.cp, "cp_comm_type": cp_comm_type}
+            self.cp_param_bundle = {"cp_group": pg_collection.cp, "cp_comm_type": cp_comm_type}
 
         assert config.window_size is None, "primus_turbo does not support sliding window attention"
         # Check version
@@ -232,7 +232,7 @@ class PrimusTurboAttention(te.pytorch.DotProductAttention):
             sequence_parallel=self.config.sequence_parallel,
             tp_size=self.config.tensor_model_parallel_size,
             get_rng_state_tracker=None,
-            tp_group=model_comm_pgs.tp,
+            tp_group=pg_collection.tp,
             layer_number=layer_number,
             attention_type=attention_type,
             # cp is not support
@@ -669,12 +669,12 @@ class PrimusTurboGroupedMLP(GroupedMLP):
         self,
         num_local_experts: int,
         config: TransformerConfig,
-        model_comm_pgs: Optional[ModelCommProcessGroups] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
     ):
         super().__init__(
             num_local_experts,
             config,
-            model_comm_pgs,
+            pg_collection,
         )
         self.grouped_gemm = pt.ops.grouped_gemm
 

--- a/primus/backends/megatron/core/transformer/multi_latent_attention.py
+++ b/primus/backends/megatron/core/transformer/multi_latent_attention.py
@@ -8,7 +8,7 @@
 from typing import Optional
 
 import torch.nn.functional as F
-from megatron.core.process_groups_config import ModelCommProcessGroups
+from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core.transformer.multi_latent_attention import (
     MLASelfAttention,
@@ -44,7 +44,7 @@ class PaddedMLASelfAttention(MLASelfAttention):
         layer_number: int,
         attn_mask_type=AttnMaskType.padding,
         cp_comm_type: Optional[str] = None,
-        model_comm_pgs: ModelCommProcessGroups = None,
+        pg_collection: ProcessGroupCollection = None,
     ):
         super().__init__(
             config=config,
@@ -52,7 +52,7 @@ class PaddedMLASelfAttention(MLASelfAttention):
             layer_number=layer_number,
             attn_mask_type=attn_mask_type,
             cp_comm_type=cp_comm_type,
-            model_comm_pgs=model_comm_pgs,
+            pg_collection=pg_collection,
         )
 
         if self.q_head_dim > self.config.v_head_dim:
@@ -66,7 +66,7 @@ class PaddedMLASelfAttention(MLASelfAttention):
                 k_channels=self.q_head_dim,
                 v_channels=self.q_head_dim,  # pad self.config.v_head_dim,
                 cp_comm_type=cp_comm_type,
-                model_comm_pgs=self.model_comm_pgs,
+                pg_collection=self.pg_collection,
             )
 
     def forward(

--- a/primus/configs/models/megatron/language_model.yaml
+++ b/primus/configs/models/megatron/language_model.yaml
@@ -16,6 +16,7 @@ num_attention_heads: 16
 attention_backend: auto
 group_query_attention: false
 qk_layernorm: false
+qk_l2_norm: false
 num_query_groups: null
 add_position_embedding: false
 position_embedding_type: learned_absolute
@@ -32,6 +33,7 @@ apply_residual_connection_post_layernorm: false
 add_bias_linear: false
 add_qkv_bias: false
 swiglu: true
+quick_geglu: false
 openai_gelu: false
 squared_relu: false
 rotary_base: 10000
@@ -42,6 +44,8 @@ use_rotary_position_embeddings: null
 use_rope_scaling: false # Apply rope scaling as used in llama3.x
 rope_scaling_factor: 8.0 # float, Rope scaling factor in llama3.x models
 transformer_impl: transformer_engine
+
+rope_type: null # rope, yarn
 
 # tokenizer
 # 'BertWordPieceLowerCase', 'BertWordPieceCase', 'GPT2BPETokenizer',
@@ -130,14 +134,15 @@ moe_z_loss_coeff: null # 1.0e-03 would be a good start value for z-loss
 moe_input_jitter_eps: null
 moe_token_dispatcher_type: allgather # str: 'allgather', 'alltoall', 'flex', 'alltoall_seq'
 moe_enable_deepep: false
-moe_per_layer_logging: False
+moe_per_layer_logging: false
 moe_expert_capacity_factor: null
-moe_pad_expert_input_to_capacity: False
+moe_pad_expert_input_to_capacity: false
 moe_token_drop_policy: probs
-moe_layer_recompute: False
-moe_extended_tp: False
+moe_layer_recompute: false
+moe_extended_tp: false
 moe_use_upcycling: false
 moe_permute_fusion: false
+delay_wgrad_compute: false
 
 # Model parallelism
 model_parallel_size: null
@@ -148,6 +153,7 @@ cp_comm_type: p2p # p2p, a2a, allgather or a2a+p2p
 hierarchical_context_parallel_sizes: null
 
 pipeline_model_parallel_size: 1
+pipeline_model_parallel_layout: null
 pipeline_model_parallel_comm_backend: null # str: nccl, ucc
 encoder_pipeline_model_parallel_size: 0
 pipeline_model_parallel_split_rank: null
@@ -159,6 +165,9 @@ microbatch_group_size_per_vp_stage: null # int
 sequence_parallel: true
 expert_model_parallel_size: 1
 expert_tensor_parallel_size: null # int
+
+high_priority_stream_groups: []         # List of group names to assign high priority
+use_te_activation_func: false           # Whether to use Transformer Engine's activation kernel
 
 # Initialization
 perform_initialization: true

--- a/primus/configs/modules/megatron/trainer_base.yaml
+++ b/primus/configs/modules/megatron/trainer_base.yaml
@@ -57,6 +57,11 @@ fp8_param_gather: false
 te_rng_tracker: false
 inference_rng_tracker: false
 
+# fp4
+fp4: null
+fp4_recipe: nvfp4
+fp4_param: false
+
 first_last_layers_bf16: false
 num_layers_at_start_in_bf16: 1
 num_layers_at_end_in_bf16: 1
@@ -101,9 +106,11 @@ pin_cpu_params: true
 # checkpointing arguments
 save: null
 save_interval: 20000
+save_retain_interval: null
 no_save_optim: null
 no_save_rng: null
 load: null
+load_main_params_from_ckpt: false
 no_load_optim: null
 no_load_rng: null
 finetune: false
@@ -158,7 +165,10 @@ account_for_loss_in_pipeline_split: false
 empty_unused_memory_level: 0
 standalone_embedding_stage: false
 use_distributed_optimizer: false
+use_sharp: false
+sharp_enabled_group: null  # options: [dp, dp_replica]
 use_custom_fsdp: false
+use_megatron_fsdp: false
 init_model_with_meta_device: false
 data_parallel_sharding_strategy: no_shard # 'no_shard', 'optim', 'optim_grads', 'optim_grads_params'
 gradient_reduce_div_fusion: true
@@ -175,8 +185,10 @@ deterministic_mode: false
 check_weight_hash_across_dp_replicas_interval: null
 
 train_iters: null
-eval_iters: 32
-eval_interval: 2000
+eval_iters: 100
+full_validation: false
+multiple_validation_sets: false
+eval_interval: 1000
 skip_train: false
 train_sync_interval: null # int
 
@@ -274,10 +286,22 @@ error_injection_rate: 0 # int
 error_injection_type: transient_error # str: 'correct_result', 'transient_error', 'persistent_error'
 rerun_mode: disabled # str: 'disabled', 'validate_results', 'report_stats'
 
-# experimental
+# Experimental features
+enable_experimental: false
+
+# Hybrid model configuration
 hybrid_attention_ratio: 0.0 # float range [0,0, 1.0]
 hybrid_mlp_ratio: 0.0 # float range [0,0, 1.0]
 hybrid_override_pattern: null # str
+is_hybrid_model: false
+
+# Mamba layer configuration
+mamba_state_dim: 128
+mamba_head_dim: 64
+mamba_num_groups: 8
+mamba_num_heads: null
+disable_mamba_mem_eff_path: false
+
 # Args of precision-aware optimizer
 use_precision_aware_optimizer: false
 main_grads_dtype: fp32 # str: fp32, bf16
@@ -369,9 +393,33 @@ parallel_output: false
 enable_ft_package: false
 calc_ft_timeouts: false
 run_workload_inspector_server: false
-is_hybrid_model: false
 
 
 heterogeneous_layers_config_path: null
 heterogeneous_layers_config_encoded_json: null
 inprocess_restart: false
+
+# rl_args
+perform_rl_step: false
+rl_prompts_per_eval: 32
+grpo_prompts_per_step: 32
+grpo_group_size: 2
+grpo_iterations: 2
+grpo_clamp_eps_lower: 0.01
+grpo_clamp_eps_upper: 0.01
+grpo_kl_beta: 0.001
+grpo_entropy_term_weight: 0.0
+grpo_filter_groups_with_same_reward: false
+grpo_default_temperature: 1.0
+grpo_default_top_p: 0
+langrl_inference_server_type: inplace_megatron
+langrl_inference_server_conversation_template: null
+langrl_env_config: null
+rl_offload_optimizer_during_inference: false
+rl_offload_kv_cache_during_training: false
+rl_remove_kv_cache_during_training: false
+rl_reset_cuda_graphs: false
+rl_partial_rollouts: false
+rl_inference_logprobs_is_correction: false
+rl_importance_sampling_truncation_coef: null
+rl_calculate_intra_group_similarity: false

--- a/primus/core/utils/import_utils.py
+++ b/primus/core/utils/import_utils.py
@@ -1,0 +1,72 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+import importlib
+from functools import partial
+
+from primus.modules.module_utils import log_rank_0
+
+
+def lazy_import(paths, symbol, log_prefix="[Primus]"):
+    """
+    Try to import a symbol from a list of module paths.
+
+    Args:
+        paths (list[str]): candidate module paths
+        symbol (str): the attribute/class/function name
+        log_prefix (str): prefix for logging
+
+    Returns:
+        The imported symbol
+
+    Raises:
+        ImportError: if symbol not found in any given path
+    """
+    for path in paths:
+        try:
+            mod = importlib.import_module(path)
+            log_rank_0(f"{log_prefix} Loaded {symbol} from {path}")
+            return getattr(mod, symbol)
+        except ImportError:
+            continue
+    raise ImportError(f"{log_prefix} {symbol} not found in any of: {paths}")
+
+
+def get_model_provider():
+    """
+    Resolve model_provider across Megatron versions.
+
+    - New:   model_provider + gpt_builder
+    - Mid:   model_provider only
+    - Old:   pretrain_gpt.model_provider
+    """
+    # Try to import model_provider
+    model_provider = lazy_import(
+        ["model_provider", "pretrain_gpt"], "model_provider", log_prefix="[Primus][MegatronCompat]"
+    )
+
+    # Try to import gpt_builder (only exists in newer versions)
+    try:
+        gpt_builder = lazy_import(["gpt_builders"], "gpt_builder", log_prefix="[Primus][MegatronCompat]")
+        return partial(model_provider, gpt_builder)
+    except ImportError:
+        return model_provider
+
+
+def get_custom_fsdp():
+    """
+    Resolve FullyShardedDataParallel across Megatron versions.
+
+    - New: megatron.core.distributed.fsdp.mcore_fsdp_adapter.FullyShardedDataParallel
+    - Old: megatron.core.distributed.custom_fsdp.FullyShardedDataParallel
+    """
+    return lazy_import(
+        [
+            "megatron.core.distributed.fsdp.mcore_fsdp_adapter",
+            "megatron.core.distributed.custom_fsdp",
+        ],
+        "FullyShardedDataParallel",
+        log_prefix="[Primus][MegatronCompat]",
+    )


### PR DESCRIPTION
## Background & Motivation  
- Megatron has diverging import paths and call signatures across versions (e.g., `model_provider` moved from `pretrain_gpt` → `model_provider`, and newer versions require a `gpt_builder` argument).  
- FSDP has also changed import locations (`custom_fsdp` → `fsdp.mcore_fsdp_adapter`).  
- Current code tightly couples to one version, requiring manual edits whenever switching/upgrading Megatron.  
- This PR introduces a compatibility layer plus parameter defaults to reduce maintenance cost and provide consistent configuration.

## Key Changes  
1. **Compatibility layer (compat)**  
   - Added `primus/core/utils/import_utils.py`: a general `lazy_import(paths, symbol, log_prefix)` utility.  
   - Added `primus/backends/megatron/utils/compat.py`:  
     - `get_model_provider()`:  
       - Prefer `model_provider` + `gpt_builder` (wrapped with `partial`).  
       - Fallback to plain `model_provider`.  
       - Fallback to `pretrain_gpt.model_provider`.  
       - Logs which version is used.  
     - `get_custom_fsdp()`:  
       - Supports both `megatron.core.distributed.fsdp.mcore_fsdp_adapter.FullyShardedDataParallel` (new) and `megatron.core.distributed.custom_fsdp.FullyShardedDataParallel` (old).  

2. **Trainer integration**  
   - Replaced hard-coded imports with:  
     ```python
     from primus.backends.megatron.utils.compat import get_model_provider, get_custom_fsdp
     provider = get_model_provider()
     custom_FSDP = get_custom_fsdp()
     ```
   - `setup_model_and_optimizer(...)` now automatically adapts to whether `gpt_builder` is required.  

3. **Argument defaults**  
   - Added structured defaults (aligned with argparse behavior) for evaluation and regularization:  
     ```yaml
     full_validation: false
     multiple_validation_sets: false
     eval_iters: 100
     eval_interval: 1000
     test_mode: false
     skip_train: false
     qk-layernorm: false
     qk-l2-norm: false
     rope-type: null   # choices: [rope, yarn]
     ```

4. **Logging**  
   - Rank-0 logs now indicate which path/version is selected, e.g.:  
     - `[Primus][MegatronCompat] Using model_provider with gpt_builder (new version)`  
     - `[Primus][MegatronCompat] Loaded FullyShardedDataParallel from ...`  

## Impact & Compatibility  
- **Backward compatible**: works with older Megatron versions using `pretrain_gpt.model_provider` or `custom_fsdp`.  
- **Forward ready**: supports new Megatron releases with `gpt_builder` and `mcore_fsdp_adapter`.  
- **Improved maintainability**: future path changes require edits only in the compat layer, not scattered across Trainer code.  