### PR TITLE
feat(CLI): add unified shell entry scripts for Slurm, container, and direct modes

### DIFF
--- a/bin/primus-cli
+++ b/bin/primus-cli
@@ -1,0 +1,103 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+set -euo pipefail
+
+print_usage() {
+cat << EOF
+Primus Unified Launcher CLI
+
+Usage:
+    primus-cli <mode> [mode-args] -- [primus-commands and args]
+
+Description:
+    The unified entry point for all Primus workflows: distributed launch, containerization, and direct host training.
+    Use '--' to separate mode-specific arguments from Primus Python CLI commands (train, benchmark, etc).
+
+Supported modes:
+    slurm      Launch distributed workflows via Slurm cluster (srun/sbatch)
+    container  Launch workflows in a managed Docker/Podman container
+    direct     Launch workflows directly on the current host or container
+
+Mode-specific help:
+    primus-cli slurm --help         Show usage for slurm mode
+    primus-cli container --help     Show usage for container mode (single node or debugging)
+    primus-cli direct --help        Show usage for direct mode (host/container)
+
+Examples:
+    # Distributed GEMM benchmark using srun on 4 nodes:
+    primus-cli slurm srun -N 4 -- benchmark gemm -M 4096 -N 4096 -K 4096
+
+    # Distributed pretrain using sbatch on partition "AIG_Model":
+    primus-cli slurm sbatch -N 8 -p AIG_Model -- train pretrain --config exp.yaml
+
+    # Run GEMM benchmark in a managed container (single node):
+    primus-cli container -- benchmark gemm -M 4096 -N 4096 -K 4096
+
+    # Run pretrain directly on the host or inside an existing container:
+    primus-cli direct -- train pretrain --config exp.yaml
+
+    # [Advanced] Specify --container or --host for explicit entry (slurm mode only):
+    primus-cli slurm srun --container -N 2 -- benchmark gemm ...
+    primus-cli slurm sbatch --host -N 1 -- train pretrain ...
+
+Notes:
+- [--] is required: it separates Primus launcher options (mode/mode-args) from Python CLI arguments.
+- All arguments after [--] are passed to the Primus Python CLI (see 'primus-cli direct -- --help').
+- For detailed documentation on each mode, use the '--help' flag after the mode name.
+- Primus CLI supports both training and benchmarking with Megatron, TorchTitan, and ROCm-optimized backends.
+
+To see all supported Primus Python CLI commands and options:
+    primus-cli direct -- --help
+EOF
+}
+
+# Show help if called with -h, --help, or no arguments
+if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
+    print_usage
+    exit 0
+fi
+
+# Resolve script directory robustly (handles symlinks)
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
+# Try PATH first, fallback to local ./bin directory
+run_subscript() {
+    local script="$1"
+    shift
+    if command -v "$script" >/dev/null 2>&1; then
+        echo "[primus-cli] Executing from PATH: $script $*"
+        exec "$script" "$@"
+    elif [[ -x "$SCRIPT_DIR/$script" ]]; then
+        echo "[primus-cli] Executing from local repo: $SCRIPT_DIR/$script $*"
+        exec bash "$SCRIPT_DIR/$script" "$@"
+    else
+        echo "[primus-cli][ERROR] Subscript not found: $script" >&2
+        exit 2
+    fi
+}
+
+# # Check argument count, print usage if not enough arguments
+[[ $# -ge 1 ]] || { echo "Usage: primus-cli <mode> [mode-args] -- [primus-commands and args]"; exit 2; }
+mode="$1"; shift
+
+case "$mode" in
+    slurm)
+        run_subscript "primus-cli-slurm.sh" "$@"
+        ;;
+    container)
+        run_subscript "primus-cli-container.sh" "$@"
+        ;;
+    direct)
+        run_subscript "primus-cli-entrypoint.sh" "$@"
+        ;;
+    *)
+        echo "[primus-cli][ERROR] Unknown mode: $mode" >&2
+        print_usage
+        exit 2
+        ;;
+esac

--- a/bin/primus-cli-container.sh
+++ b/bin/primus-cli-container.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+print_usage() {
+cat <<EOF
+Usage: bash primus-run-container.sh [OPTIONS] -- [SCRIPT_ARGS...]
+
+Launch a Primus task (train / benchmark / preflight / etc.) in a Docker/Podman container.
+
+Options:
+    --image <DOCKER_IMAGE>      Docker image to use [default: \$DOCKER_IMAGE or rocm/megatron-lm:v25.5_py310]
+    --mount <HOST[:CONTAINER]>  Mount a host directory into the container.
+                                 - If only HOST is given, mounts to same path inside container.
+                                 - If HOST:CONTAINER is given, mounts host directory to container path.
+                                 (repeatable; for data, output, cache, etc.)
+    --primus-path <HOST_PATH>   Use this Primus repo instead of the image default. The path will be mounted
+                                into the container and installed in editable mode.
+    --clean                     Remove all containers before launch
+    --help                      Show this message and exit
+
+Examples:
+    primus-cli container --mount /mnt/data -- train --config /mnt/data/exp.yaml --data-path /mnt/data
+    primus-cli container --mount /mnt/profile_out -- benchmark gemm --output /mnt/profile_out/result.txt
+
+    # Mounts and installs your local Primus repo into the container.
+    primus-cli container --primus-path ~/workspace/Primus -- train pretrain --config /data/exp.yaml
+EOF
+}
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    print_usage
+    exit 0
+fi
+
+HOSTNAME=$(hostname)
+
+# Default Values
+PRIMUS_PATH="/workspace/Primus"
+
+# Parse CLI options
+DOCKER_IMAGE=""
+CLEAN_DOCKER_CONTAINER=0
+MOUNTS=()
+POSITIONAL_ARGS=()
+
+VERBOSE=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)
+            DOCKER_IMAGE="$2"
+            shift 2
+            ;;
+        --mount)
+            MOUNTS+=("$2")
+            shift 2
+            ;;
+        --primus-path)
+            raw_path="$2"
+            full_path="$(realpath -m "$raw_path")"
+            PRIMUS_PATH="$full_path"
+            MOUNTS+=("$full_path")
+            # PRIMUS_PATH="$2"
+            # MOUNTS+=("$2")
+            shift 2
+            ;;
+        --clean)
+            CLEAN_DOCKER_CONTAINER=1
+            shift
+            ;;
+        --no-verbose)
+            VERBOSE=0
+            shift
+            ;;
+        --verbose)
+            VERBOSE=1
+            shift
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        --)
+            shift
+            POSITIONAL_ARGS+=("$@")
+            break
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Defaults (fallback)
+DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/megatron-lm:v25.5_py310"}
+
+# ----------------- Volume Mounts -----------------
+# Mount the project root and dataset directory into the container
+VOLUME_ARGS=()
+for mnt in "${MOUNTS[@]}"; do
+    # Parse --mount argument (HOST[:CONTAINER])
+    if [[ "$mnt" == *:* ]]; then
+        host_path="${mnt%%:*}"
+        container_path="${mnt#*:}"
+        # Check that the host path exists and is a directory
+        if [[ ! -d "$host_path" ]]; then
+            echo "[primus-cli-container][${HOSTNAME}][ERROR] --mount $host_path does not exist or is not a directory. Please check your path." >&2
+            exit 1
+        fi
+        VOLUME_ARGS+=(-v "$(realpath "$host_path")":"$container_path")
+    else
+        # Mount to same path inside container
+        if [[ ! -d "$mnt" ]]; then
+            echo "[primus-cli-container][${HOSTNAME}][ERROR] --mount $mnt does not exist or is not a directory. Please check your path." >&2
+            exit 1
+        fi
+        abs_path="$(realpath "$mnt")"
+        VOLUME_ARGS+=(-v "$abs_path":"$abs_path")
+    fi
+done
+
+
+
+
+# ------------------ Optional Container Cleanup ------------------
+if command -v podman >/dev/null 2>&1; then
+    DOCKER_CLI="podman"
+elif command -v docker >/dev/null 2>&1; then
+    DOCKER_CLI="docker"
+else
+    echo "[primus-cli-container][${HOSTNAME}][ERROR] Neither Docker nor Podman found!" >&2
+    exit 1
+fi
+
+if [[ "$CLEAN_DOCKER_CONTAINER" == "1" ]]; then
+    echo "[primus-cli-container][${HOSTNAME}][INFO] Cleaning up existing containers..."
+    CONTAINERS="$($DOCKER_CLI ps -aq)"
+    if [[ -n "$CONTAINERS" ]]; then
+        printf '%s\n' "$CONTAINERS" | xargs -r -n1 "$DOCKER_CLI" rm -f
+        echo "[primus-cli-container][${HOSTNAME}][INFO] Removed containers: $CONTAINERS"
+    else
+        echo "[primus-cli-container][${HOSTNAME}][INFO] No containers to remove."
+    fi
+fi
+
+ARGS=("${POSITIONAL_ARGS[@]}")
+
+# ------------------ Print Info ------------------
+if [[ "$VERBOSE" == "1" ]]; then
+    echo "[prinus-cli-container][${HOSTNAME}][INFO] ========== Launch Info =========="
+    echo "[prinus-cli-container][${HOSTNAME}][INFO]  HOSTNAME: $HOSTNAME"
+    echo "[prinus-cli-container][${HOSTNAME}][INFO]  VOLUME_ARGS:"
+    for ((i = 0; i < ${#VOLUME_ARGS[@]}; i+=2)); do
+        echo "[prinus-cli-container][${HOSTNAME}][INFO]      ${VOLUME_ARGS[i]} ${VOLUME_ARGS[i+1]}"
+    done
+    echo "[prinus-cli-container][${HOSTNAME}][INFO]  LAUNCH ARGS:"
+    echo "[prinus-cli-container][${HOSTNAME}][INFO]      ${ARGS[*]}"
+    echo
+fi
+
+
+# ------------------ Launch Training Container ------------------
+"${DOCKER_CLI}" run --rm \
+    --ipc=host \
+    --network=host \
+    --device=/dev/kfd \
+    --device=/dev/dri \
+    --cap-add=SYS_PTRACE \
+    --cap-add=CAP_SYS_ADMIN \
+    --security-opt seccomp=unconfined \
+    --group-add video \
+    --privileged \
+    --device=/dev/infiniband \
+    "${VOLUME_ARGS[@]}" \
+    "$DOCKER_IMAGE" /bin/bash -c "\
+        echo '[primus-cli-container][${HOSTNAME}][INFO]: container started at $(date +"%Y.%m.%d %H:%M:%S")' && \
+        cd $PRIMUS_PATH && pip install -e . && bin/primus-cli-entrypoint.sh \"\$@\" 2>&1 && \
+        echo '[primus-cli-container][${HOSTNAME}][INFO]: container finished at $(date +"%Y.%m.%d %H:%M:%S")'
+    " bash "${ARGS[@]}"

--- a/bin/primus-cli-entrypoint.sh
+++ b/bin/primus-cli-entrypoint.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+print_usage() {
+cat << EOF
+Primus Direct Launcher
+
+Usage:
+    primus-cli direct [--env KEY=VALUE ...] -- <primus-args>
+
+Description:
+    Launch Primus training, benchmarking, or preflight directly on the host (or inside a container).
+    Distributed settings can be controlled by either exporting environment variables in advance,
+    or by specifying them inline using --env KEY=VALUE.
+
+Distributed Environment Variables:
+    NNODES        Number of nodes participating in distributed run        [default: 1]
+    NODE_RANK     Rank of the current node (unique integer per node)      [default: 0]
+    GPUS_PER_NODE Number of GPUs to use per node                          [default: 8]
+    MASTER_ADDR   Hostname or IP of master node                           [default: localhost]
+    MASTER_PORT   Port of master node                                     [default: 1234]
+
+You can set these variables in either of the following ways:
+    # (1) Export variables before launch (recommended for scripts or single-node runs)
+      export NNODES=2 GPUS_PER_NODE=8 NODE_RANK=0 MASTER_ADDR=host1
+      primus-cli direct -- train pretrain --config exp.yaml
+
+    # (2) Inject via CLI with --env (useful for launchers and multi-node jobs)
+      primus-cli direct --env NNODES=2 --env GPUS_PER_NODE=8 --env NODE_RANK=1 --env MASTER_ADDR=host1 -- \\
+        benchmark gemm -M 4096 -N 4096 -K 4096
+
+Examples:
+    # Pretrain with a config file (single node)
+      primus-cli direct -- train pretrain --config examples/megatron/exp_pretrain.yaml
+
+    # Benchmark GEMM (single node)
+      primus-cli direct -- benchmark gemm
+
+    # Distributed GEMM benchmark, 2 nodes, 8 GPUs per node (rank 0)
+      primus-cli direct --env NNODES=2 --env GPUS_PER_NODE=8 --env NODE_RANK=0 --env MASTER_ADDR=host1 -- \\
+        benchmark gemm -M 4096 -N 4096 -K 4096
+
+    # Launch as rank 1 (2-node distributed)
+      primus-cli direct --env NNODES=2 --env GPUS_PER_NODE=8 --env NODE_RANK=1 --env MASTER_ADDR=host1 -- \\
+        benchmark gemm -M 4096 -N 4096 -K 4096
+
+Notes:
+    - Always separate Primus arguments from launcher options using '--'.
+    - Environment variables can be mixed: 'export' takes precedence unless overridden by '--env'.
+    - Multi-node jobs require MASTER_ADDR set to the master node's hostname/IP.
+
+EOF
+}
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    print_usage
+    exit 0
+fi
+
+primus_env_kv=()
+primus_args=()
+log_file=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env)
+            if [[ "$2" == *=* ]]; then
+                export "${2%%=*}"="${2#*=}"
+                primus_env_kv+=("${2}")
+                shift 2
+            else
+                echo "[primus-entry][ERROR] --env requires KEY=VALUE"
+                exit 2
+            fi
+            ;;
+        --log_file)
+            log_file="$2"
+            shift 2
+            ;;
+        --log_file=*)
+            log_file="${1#*=}"
+            shift
+            ;;
+        --)
+            shift
+            primus_args+=("$@")
+            break
+            ;;
+        *)
+            primus_args+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${primus_args[@]}"
+
+if [[ "$*" == *"--help"* ]] || [[ "$*" == *"-h"* ]]; then
+    exec python3 -m primus.cli.main "$@"
+fi
+
+# Step 0: Setup log directory and generate log file path
+if [[ -z "$log_file" ]]; then
+    log_file="logs/log_$(date +%Y%m%d_%H%M%S).txt"
+fi
+mkdir -p "$(dirname "$log_file")"
+
+
+# Step 1: Source the environment setup script (centralizes all exports and helper functions).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/primus-env.sh"
+
+for kv in "${primus_env_kv[@]}"; do
+    export "${kv%%=*}"="${kv#*=}"
+    LOG_INFO_RANK0 "[Primus Entrypoint] Exported env: ${kv%%=*}=${kv#*=}"
+done
+
+
+pip install -qq -r requirements.txt
+
+# Step 2: Build torchrun distributed arguments.
+DISTRIBUTED_ARGS=(
+    --nproc_per_node "${GPUS_PER_NODE}"
+    --nnodes "${NNODES}"
+    --node_rank "${NODE_RANK}"
+    --master_addr "${MASTER_ADDR}"
+    --master_port "${MASTER_PORT}"
+)
+
+
+# Step 3: Build local rank filter argument.
+# Only local rank 0 on first node and last local rank on last node are filtered for special logging.
+LAST_NODE=$((NNODES - 1))
+FILTERS=()
+# Add local rank 0 on the first node
+if [ "$NODE_RANK" -eq 0 ]; then
+    FILTERS+=(0)
+fi
+
+# Add the last local rank on the last node
+if [ "$NODE_RANK" -eq "$LAST_NODE" ]; then
+    FILTERS+=($((GPUS_PER_NODE - 1)))
+fi
+
+# Build filter argument (only if FILTERS is non-empty)
+if [ "${#FILTERS[@]}" -gt 0 ]; then
+    LOCAL_FILTER=$(IFS=,; echo "${FILTERS[*]}")
+    FILTER_ARG=(--local-ranks-filter "$LOCAL_FILTER")
+else
+    FILTER_ARG=()
+fi
+
+if [[ "$1" == "train" && "$2" == "pretrain" ]]; then
+    shift 2
+
+    EXTRA_ARGS=""
+    LOG_INFO_RANK0 "[Primus Entrypoint] Detected 'train' command, running data preparation... $*"
+
+    PRIMUS_PATCH_ARGS_FILE=$(mktemp /tmp/primus_patch_args.XXXXXX.yaml)
+    trap 'rm -f "$PRIMUS_PATCH_ARGS_FILE"' EXIT
+
+    SCRIPT="examples/scripts/prepare_experiment.py"
+
+    # Run the prepare_experiment.py script with required and optional arguments
+    LOG_INFO_RANK0 "[Primus Entrypoint] Running: python3 $SCRIPT --patch_args $PRIMUS_PATCH_ARGS_FILE $*"
+    if ! python3 "$SCRIPT" --patch_args "$PRIMUS_PATCH_ARGS_FILE" "$@" ; then
+        LOG_ERROR "$SCRIPT failed, aborting."
+        exit 1
+    fi
+
+    if [[ -f "$PRIMUS_PATCH_ARGS_FILE" ]]; then
+        LOG_INFO_RANK0 "Loading patch args from $PRIMUS_PATCH_ARGS_FILE"
+        source_yaml_args() {
+            local file=$1
+            local key=$2
+            grep -E "^${key}:" "$file" | cut -d':' -f2- | xargs
+        }
+
+        EXTRA_ARGS=$(source_yaml_args "$PRIMUS_PATCH_ARGS_FILE" train_args)
+
+        if [[ -n "$EXTRA_ARGS" ]]; then
+            LOG_INFO_RANK0 "Patched TRAIN args: $EXTRA_ARGS"
+        fi
+
+    else
+        LOG_INFO_RANK0 "No patch args file found at $PRIMUS_PATCH_ARGS_FILE, skipping patch args."
+    fi
+
+    LOG_INFO_RANK0 "[Primus Entrypoint] Data preparation complete, proceeding to training..."
+    set -- train pretrain "$@" "$EXTRA_ARGS"
+fi
+
+
+# Step 4: Build the final command.
+CMD="torchrun ${DISTRIBUTED_ARGS[*]} ${FILTER_ARG[*]} ${LOCAL_RANKS} -- primus/cli/main.py $* "
+LOG_INFO "Launching distributed training with command: $CMD 2>&1 | tee $log_file"
+
+eval "$CMD" 2>&1 | tee "$log_file"
+exit_code=${PIPESTATUS[0]}
+
+# Print log based on exit code
+if [[ $exit_code -ge 128 ]]; then
+    LOG_ERROR "torchrun crashed due to signal $((exit_code - 128))"
+elif [[ $exit_code -ne 0 ]]; then
+    LOG_ERROR "torchrun exited with code $exit_code"
+else
+    LOG_INFO "torchrun finished successfully (code 0)"
+fi
+
+exit "$exit_code"

--- a/bin/primus-cli-slurm-entry.sh
+++ b/bin/primus-cli-slurm-entry.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+set -euo pipefail
+
+# Resolve script directory robustly (handles symlinks)
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+
+
+if [[ -z "${SLURM_NODELIST:-}" ]]; then
+    echo "[primus-slurm-entry][ERROR] SLURM_NODELIST not set. Are you running inside a Slurm job?"
+    exit 2
+fi
+
+# Pick master node address from SLURM_NODELIST, or fallback
+if [[ -z "${MASTER_ADDR:-}" ]]; then
+    MASTER_ADDR="$(scontrol show hostnames "$SLURM_NODELIST" | head -n1 || echo localhost)"
+fi
+MASTER_PORT="${MASTER_PORT:-1234}"
+
+# Get all node hostnames (sorted, as needed)
+readarray -t NODE_ARRAY < <(scontrol show hostnames "$SLURM_NODELIST")
+# (Optional: sort by IP if needed, e.g., for deterministic rank mapping)
+# Uncomment if you need IP sort
+# readarray -t NODE_ARRAY < <(
+#     for node in $(scontrol show hostnames "$SLURM_NODELIST"); do
+#         getent hosts "$node" | awk '{print $1, $2}'
+#     done | sort -k1,1n | awk '{print $2}'
+# )
+
+NNODES="${SLURM_NNODES:-${SLURM_JOB_NUM_NODES:-${NNODES:-1}}}"
+NODE_RANK="${SLURM_NODEID:-${SLURM_PROCID:-${NODE_RANK:-0}}}"
+GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+
+
+echo "[primus-cli-slurm-entry] MASTER_ADDR=$MASTER_ADDR"
+echo "[primus-cli-slurm-entry] MASTER_PORT=$MASTER_PORT"
+echo "[primus-cli-slurm-entry] NNODES=$NNODES"
+echo "[primus-cli-slurm-entry] NODE_RANK=$NODE_RANK"
+echo "[primus-cli-slurm-entry] GPUS_PER_NODE=$GPUS_PER_NODE"
+echo "[primus-cli-slurm-entry] NODE_LIST: ${NODE_ARRAY[*]}"
+
+# ------------- Dispatch based on mode ---------------
+
+# Default: 'container' mode, unless user overrides
+# MODE="container"
+# if [[ $# -gt 0 && "$1" =~ ^(container|direct|native|host)$ ]]; then
+#     MODE="$1"
+#     shift
+# fi
+
+PATCH_ARGS=(
+    --env MASTER_ADDR="$MASTER_ADDR"
+    --env MASTER_PORT="$MASTER_PORT"
+    --env NNODES="$NNODES"
+    --env NODE_RANK="$NODE_RANK"
+    --env GPUS_PER_NODE="$GPUS_PER_NODE"
+    --log_file "logs/log_${SLURM_JOB_ID:-nojob}_$(date +%Y%m%d_%H%M%S).txt"
+)
+
+MODE="${1:-container}"
+shift || true
+case "$MODE" in
+    container)
+        script_path="$SCRIPT_DIR/primus-cli-container.sh"
+        if [[ "$NODE_RANK" == "0" ]]; then
+            PATCH_ARGS=(--verbose "${PATCH_ARGS[@]}")
+        else
+            PATCH_ARGS=(--no-verbose "${PATCH_ARGS[@]}")
+        fi
+        ;;
+    direct/native/host)
+        script_path="$SCRIPT_DIR/primus-cli-entrypoint.sh"
+        ;;
+    *)
+        echo "[primus-cli-slurm-entry][ERROR] Unknown mode: $MODE. Use 'container' or 'direct'." >&2
+        exit 2
+        ;;
+esac
+
+if [[ ! -f "$script_path" ]]; then
+    echo "[primus-slurm-entry][ERROR] Script not found: $script_path" >&2
+    exit 2
+fi
+
+echo "[primus-slurm-entry] Executing: bash $script_path ${PATCH_ARGS[*]} $*"
+exec bash "$script_path" "${PATCH_ARGS[@]}" "$@"

--- a/bin/primus-cli-slurm.sh
+++ b/bin/primus-cli-slurm.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+set -euo pipefail
+
+print_usage() {
+cat <<'EOF'
+Primus Slurm Launcher
+
+Usage:
+    primus-cli slurm [srun|sbatch] [SLURM_FLAGS...] -- <entry> [ENTRY_ARGS...] -- [PRIMUS_ARGS...]
+
+Description:
+    Launch distributed Primus jobs via Slurm.
+    - Everything before the first '--' is passed to Slurm (srun/sbatch and flags).
+    - <entry> specifies Primus execution mode: container | direct | preflight (see below).
+    - The second '--' (if any) separates Primus entry args from Primus CLI arguments.
+
+Examples:
+    # Launch 4 nodes using srun and container mode
+    primus-cli slurm srun -N 4 -p AIG_Model -- container -- train pretrain --config exp.yaml
+
+    # # Launch with sbatch, log to file, run benchmark
+    primus-cli slurm sbatch --output=run.log -N 2 -- container -- benchmark gemm -M 4096 -N 4096 -K 4096
+
+    # Run preflight environment check across 4 nodes
+    primus-cli slurm srun -N 4 -- preflight
+
+Notes:
+    - [srun|sbatch] is optional; defaults to srun if not specified.
+    - All SLURM_FLAGS before '--' are passed directly to Slurm (supports both --flag=value and --flag value).
+    - Everything after the first '--' is passed to Primus entry (e.g. container, direct, etc.), and then to Primus CLI.
+    - For unsupported or extra Slurm options, just pass them after '--' (they'll be ignored by this wrapper).
+
+Debug:
+    - Collected SLURM flags and primus arguments will be printed before launch.
+
+EOF
+}
+
+# Show help if requested or if no args are given
+if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
+    print_usage
+    exit 0
+fi
+
+# 1. Detect srun/sbatch mode
+LAUNCH_CMD="srun"   # Default launcher
+if [[ "${1:-}" == "sbatch" || "${1:-}" == "srun" ]]; then
+    LAUNCH_CMD="$1"
+    shift
+fi
+
+# 2. Collect SLURM_FLAGS before '--'
+SLURM_FLAGS=()
+while [[ $# -gt 0 && "$1" != "--" ]]; do
+    SLURM_FLAGS+=("$1")
+    shift
+done
+
+# Skip '--'
+if [[ "$#" -gt 0 && "$1" == "--" ]]; then
+    shift
+fi
+
+# 3. Check for primus-run args
+if [[ $# -eq 0 ]]; then
+    echo "[primus-cli-slurm][ERROR] Missing Primus entry (container|direct|preflight)" >&2
+    print_usage >&2
+    exit 2
+fi
+
+# 4. Logging and launch
+SCRIPT_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+ENTRY="$SCRIPT_DIR/primus-cli-slurm-entry.sh"
+echo "[primus-cli-slurm] Executing: $LAUNCH_CMD ${SLURM_FLAGS[*]} $ENTRY $*"
+exec "$LAUNCH_CMD" "${SLURM_FLAGS[@]}" "$ENTRY" "$@"

--- a/bin/primus-env.sh
+++ b/bin/primus-env.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+# ---------------------------------------------------------------------------
+# Guard: avoid duplicate exports/logging on multiple sourcing
+# ---------------------------------------------------------------------------
+if [[ -n "${__PRIMUS_ENV_SOURCED:-}" ]]; then
+  return 0
+fi
+export __PRIMUS_ENV_SOURCED=1
+
+# Hostname is useful for logs in any script that sources this file
+HOSTNAME="$(hostname)"
+export HOSTNAME
+
+LOG_INFO() {
+    if [ "$*" = "" ]; then
+        echo ""
+    else
+        echo "[NODE-$NODE_RANK($HOSTNAME)] $*"
+    fi
+}
+
+LOG_INFO_RANK0() {
+    if [ "$NODE_RANK" -eq 0 ]; then
+        if [ "$*" = "" ]; then
+            echo ""
+        else
+            echo "[NODE-$NODE_RANK($HOSTNAME)] $*"
+        fi
+    fi
+}
+
+LOG_ERROR() {
+    echo "[NODE-$NODE_RANK($HOSTNAME)] [ERROR] $*";
+}
+
+log_exported_vars() {
+    LOG_INFO_RANK0 "========== $1 =========="
+    for var in "${@:2}"; do
+        LOG_INFO_RANK0 "    $var=${!var-}"
+    done
+}
+
+export MASTER_ADDR=${MASTER_ADDR:-localhost}
+export MASTER_PORT=${MASTER_PORT:-1234}
+export NNODES=${NNODES:-1}
+export NODE_RANK=${NODE_RANK:-0}
+export GPUS_PER_NODE=${GPUS_PER_NODE:-8}
+log_exported_vars "Training cluster info" \
+    MASTER_ADDR MASTER_PORT NNODES NODE_RANK GPUS_PER_NODE
+
+PRIMUS_PATH=$(realpath "$(dirname "$0")/..")
+export PRIMUS_PATH
+export DATA_PATH=${DATA_PATH:-"${PRIMUS_PATH}/data"}
+export HF_HOME=${HF_HOME:-"${DATA_PATH}/huggingface"}
+log_exported_vars "Training info" PRIMUS_PATH DATA_PATH HF_HOME
+
+# -------------------- NCCL and Communication Setup --------------------
+# Set visible GPUs for the current node (0 to GPUS_PER_NODE-1)
+HIP_VISIBLE_DEVICES=$(seq -s, 0 $((GPUS_PER_NODE - 1)))
+export HIP_VISIBLE_DEVICES
+
+# ----------------- NCCL and Network Settings -----------------
+# VERSION, WARN, INFO, DEBUG, TRACE
+export NCCL_DEBUG=
+
+# Disable NCCL internal checks to reduce overhead
+export NCCL_CHECKS_DISABLE=1
+
+# Set InfiniBand GID index for NCCL communication
+export NCCL_IB_GID_INDEX=3
+
+# Disable cross NIC communication for NCCL
+export NCCL_CROSS_NIC=0
+
+# Dynamically get InfiniBand Host Channel Adapter index for NCCL if not set
+if [ -z "${NCCL_IB_HCA}" ]; then
+    NCCL_IB_HCA=$(bash "${PRIMUS_PATH}/examples/scripts/get_nccl_ib_hca.sh")
+fi
+export NCCL_IB_HCA
+
+# Dynamically get network interface IP address for socket communication if not set
+if [ -z "${IP_INTERFACE}" ]; then
+    IP_INTERFACE=$(bash "${PRIMUS_PATH}/examples/scripts/get_ip_interface.sh")
+fi
+export IP_INTERFACE
+# Set network interfaces for NCCL and Gloo, fallback to detected IP_INTERFACE
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-$IP_INTERFACE}
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-$IP_INTERFACE}
+
+log_exported_vars "NCCL and Network Settings" \
+    HIP_VISIBLE_DEVICES NCCL_DEBUG NCCL_CHECKS_DISABLE NCCL_IB_GID_INDEX \
+    NCCL_IB_HCA IP_INTERFACE NCCL_SOCKET_IFNAME GLOO_SOCKET_IFNAME
+
+# ----------------- AMD-specific GPU optimizations -----------------
+# Enable system DMA engine (SDMA) on AMD GPUs for better IO throughput
+export HSA_ENABLE_SDMA=1
+
+# Prevent scratch memory from being reclaimed to stabilize large memory usage patterns (e.g., KV cache, MoE experts)
+# NOTE: Must disable scratch reclaim to avoid MoE training crash on AMD GPUs
+# Setting this to 0 prevents core dumps when using Mixture-of-Experts (MoE) models
+export HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-0}
+
+# Disable MSCCL (RCCL multi-connection feature) for better stability
+export RCCL_MSCCL_ENABLE=0
+export RCCL_MSCCLPP_ENABLE=0
+export RCCL_MSCCLPP_FORCE_ENABLE=0
+export RCCL_MSCCLPP_THRESHOLD=$((1*1024*1024*1024)) # default 1 MB
+# https://github.com/microsoft/mscclpp/blob/main/include/mscclpp/env.hpp#L82-L87
+export MSCCLPP_DISABLE_CHANNEL_CACHE=FALSE
+# pytorch need set this env to enable register comm
+export TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK=0
+
+log_exported_vars "AMD-specific GPU optimizations" \
+    HSA_ENABLE_SDMA HSA_NO_SCRATCH_RECLAIM \
+    RCCL_MSCCL_ENABLE RCCL_MSCCLPP_ENABLE RCCL_MSCCLPP_FORCE_ENABLE RCCL_MSCCLPP_THRESHOLD \
+    MSCCLPP_DISABLE_CHANNEL_CACHE TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK
+
+
+# ----------------- Performance tuning -----------------
+# Limit GPU hardware queues to 2 for performance stability
+export GPU_MAX_HW_QUEUES=2
+
+# Limit max CUDA device connections to reduce PCIe traffic
+export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
+
+# Prioritize NCCL communication for PyTorch for higher throughput
+export TORCH_NCCL_HIGH_PRIORITY=1
+
+# optimize nvte fp8 cast transpose
+export NVTE_USE_CAST_TRANSPOSE_TRITON=1
+export NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE=0
+
+# Note: Disable v3 due to accuracy issues. Will fix after TE version 2.1.
+export NVTE_CK_USES_BWD_V3=${NVTE_CK_USES_BWD_V3:-0}
+
+# nvte debug envs
+export NVTE_DEBUG=0 # 0, 1
+export NVTE_DEBUG_LEVEL=0 # 0, 1, 2
+export NVTE_FUSED_ATTN_LOG_CONFIG=0 # 0, 1
+export PATCH_TE_FLASH_ATTN=${PATCH_TE_FLASH_ATTN:-0}
+
+log_exported_vars "Performance tuning" \
+    GPU_MAX_HW_QUEUES CUDA_DEVICE_MAX_CONNECTIONS TORCH_NCCL_HIGH_PRIORITY \
+    NVTE_USE_CAST_TRANSPOSE_TRITON NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE \
+    NVTE_CK_USES_BWD_V3 NVTE_DEBUG NVTE_DEBUG_LEVEL NVTE_FUSED_ATTN_LOG_CONFIG PATCH_TE_FLASH_ATTN
+
+# -------------------- setup_pythonpath -------------------
+site_packages=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")
+export PYTHONPATH="${PRIMUS_PATH}:${site_packages}:${PYTHONPATH:-}"
+log_exported_vars "pythonpath" PYTHONPATH

--- a/examples/scripts/prepare_experiment.py
+++ b/examples/scripts/prepare_experiment.py
@@ -25,7 +25,9 @@ def log(msg, level="INFO"):
 def main():
     parser = argparse.ArgumentParser(description="Primus Backend Preparation Entry")
     parser.add_argument("--config", required=True, help="Path to experiment YAML config file")
-    parser.add_argument("--data_path", required=True, help="Root directory for datasets and tokenizer")
+    parser.add_argument(
+        "--data_path", type=str, default="./data/", help="Root directory for datasets and tokenizer"
+    )
     parser.add_argument(
         "--patch_args",
         type=str,
@@ -38,7 +40,7 @@ def main():
         default=None,
         help="Optional path to backend (e.g., Megatron), will be added to PYTHONPATH",
     )
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
 
     primus_path = Path.cwd()
     patch_args_path = Path(args.patch_args).resolve()
@@ -81,6 +83,8 @@ def main():
 
     if args.backend_path:
         cmd += ["--backend_path", args.backend_path]
+
+    cmd += unknown
     try:
         subprocess.run(
             cmd,

--- a/setup.py
+++ b/setup.py
@@ -12,23 +12,13 @@ def get_version():
 setup(
     name="primus",
     version=get_version(),
-    description="Primus: Unified Training Framework for AMD AI",
-    author="AMD AIG Team",
+    description="Primus: A Lightweight, Unified Training Framework for Large Models on AMD GPUs",
+    author="AMD AIG AI Brain-TAS Team",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    install_requires=[
-        "loguru",
-        "wandb",
-        "pre-commit",
-        "nltk",
-        "matplotlib",
-        "markdown2",
-        "weasyprint",
-        "tyro",
-        "torchao",
-        "blobfile",
-        "torchdata>=0.8.0",
-        "datasets>=3.6.0",
-    ],
+    install_requires=[],
+    extras_require={
+        "cli": [],
+    },
     package_data={
         "primus": [
             "configs/*.yaml",
@@ -40,6 +30,13 @@ setup(
             "primus=primus.cli.main:main",
         ]
     },
+    scripts=[
+        "bin/primus-cli",
+        "bin/primus-cli-slurm.sh",
+        "bin/primus-cli-slurm-entry.sh",
+        "bin/primus-cli-container.sh",
+        "bin/primus-cli-entrypoint.sh",
+    ],
     python_requires=">=3.8",
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
## 📌 Description  

This PR introduces the **unified shell entry layer** for Primus CLI.  
The new scripts standardize the way users launch Primus across different environments:  

- **bin/primus-cli** → top-level CLI entry wrapper  
- **bin/primus-cli-slurm.sh** → Slurm job launcher wrapper  
- **bin/primus-cli-slurm-entry.sh** → Slurm per-node entry point  
- **bin/primus-cli-container.sh** → container (Docker/Podman) launcher  
- **bin/primus-cli-entrypoint.sh** → host/native entry point  
- **bin/primus-env.sh** → centralized environment setup and helpers  

## ✅ Highlights  
- Unified user experience across **direct, Slurm, and container modes**  
- Centralized environment setup via `primus-env.sh`  
- Easier extension and debugging for distributed workflows  

## 🚀 Usage Examples  

### 1. Single-node pretraining

```bash
primus-cli direct -- train pretrain --config examples/megatron/configs/llama3_8B.yaml
```

### 2. Multi-node training with Slurm

```bash
primus-cli slurm sbatch -N 16 -p AIG_Model -- \
  train pretrain --config examples/megatron/configs/llama3_405B.yaml
```

### 3. Benchmark GEMM performance

```bash
primus-cli direct -- benchmark gemm --m 4096 --n 4096 --k 8192 --dtype bf16
```

### 4. Run cluster sanity check

```bash
primus-cli slurm srun -N 2 -p AIG_Model -- preflight all
```
