### PR TITLE
test(megatron): add Qwen2.5-7B and Qwen2.5-72B pretrain cases

### DIFF
--- a/primus/configs/models/megatron/language_model.yaml
+++ b/primus/configs/models/megatron/language_model.yaml
@@ -61,6 +61,8 @@ vocab_extra_ids: 0 # int
 tiktoken_pattern: null # str
 tiktoken_num_special_tokens: 1000 # int
 tiktoken_special_tokens: null # str
+legacy_tokenizer: false
+trust_remote_code: false
 
 # initialization
 init_method_std: 0.02

--- a/tests/trainer/test_megatron_trainer.py
+++ b/tests/trainer/test_megatron_trainer.py
@@ -120,6 +120,24 @@ class TestMegatronTrainer(PrimusUT):
             extra_args=["--num_layers", "4", "--train_iters", "3"],
         )
 
+    def test_qwen25_7B(self):
+        run_script(
+            self.__class__.__name__,
+            "qwen2.5_7B",
+            exp_path="examples/megatron/configs/qwen2.5_7B-pretrain.yaml",
+            env_override={},
+            extra_args=["--num_layers", "4", "--train_iters", "3"],
+        )
+
+    def test_qwen25_72B(self):
+        run_script(
+            self.__class__.__name__,
+            "qwen2.5_72B",
+            exp_path="examples/megatron/configs/qwen2.5_72B-pretrain.yaml",
+            env_override={},
+            extra_args=["--num_layers", "4", "--train_iters", "3"],
+        )
+
     def test_deepseek_v2_lite(self):
         run_script(
             self.__class__.__name__,


### PR DESCRIPTION
### Summary

This PR adds new Megatron trainer test cases for Qwen 2.5 models (7B and 72B) to improve unit test coverage and ensure stable integration of large-scale pretraining configurations in Primus.

## ✅ Changes

- `tests/trainer/test_megatron_trainer.py`
  - ➕ Added `test_qwen25_7B` test case
  - ➕ Added `test_qwen25_72B` test case
  - ⚙️  Both cases use:
    - `examples/megatron/configs/qwen2.5_7B-pretrain.yaml`
    - `examples/megatron/configs/qwen2.5_72B-pretrain.yaml`
    - With CLI args: `--num_layers=4`, `--train_iters=3`
