### PR TITLE
fix(tests): add missing expecttest dependency for distributed tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 loguru
 wandb
+expecttest
 pre-commit
 nltk
 matplotlib


### PR DESCRIPTION
This PR fixes the ModuleNotFoundError: No module named 'expecttest' issue encountered when running distributed tests such as tests/distributed/test_tp_overlap.py.
The error was caused by missing dependency expecttest, which is required by torch.testing._internal.common_distributed.