### PR TITLE
fix(config): use 1.0e-2 for moe_aux_loss_coeff to ensure correct float parsing

### DIFF
--- a/primus/configs/models/megatron/grok_base.yaml
+++ b/primus/configs/models/megatron/grok_base.yaml
@@ -12,6 +12,6 @@ num_query_groups: 8
 num_experts: 8
 moe_router_topk: 2
 moe_router_load_balancing_type: none
-moe_aux_loss_coeff: 1e-2
+moe_aux_loss_coeff: 1.0e-2
 moe_grouped_gemm: true
 moe_token_dispatcher_type: alltoall

--- a/primus/configs/models/megatron/mixtral_base.yaml
+++ b/primus/configs/models/megatron/mixtral_base.yaml
@@ -12,6 +12,6 @@ num_query_groups: 8
 num_experts: 8
 moe_router_topk: 2
 moe_router_load_balancing_type: aux_loss
-moe_aux_loss_coeff: 1e-2
+moe_aux_loss_coeff: 1.0e-2
 moe_grouped_gemm: true
 moe_token_dispatcher_type: alltoall


### PR DESCRIPTION
This PR updates the moe_aux_loss_coeff values in Megatron model configs to use explicit float notation (1.0e-2) instead of shorthand (1e-2).
Some YAML parsers interpret 1e-2 as a string, which can cause type mismatches during config loading.