### PR TITLE
feat(torchtitan): auto-install nightly torch based on ROCm version before dataset preparation

### DIFF
--- a/examples/torchtitan/prepare.py
+++ b/examples/torchtitan/prepare.py
@@ -173,14 +173,13 @@ def detect_rocm_version() -> Optional[str]:
 def install_torch_for_rocm(nightly=True):
     version = detect_rocm_version()
     if not version:
-        print("[ERROR] ROCm not detected.")
-        sys.exit(1)
+        log_error_and_exit("ROCm not detected.")
 
     tag = f"rocm{version}"
     base = "https://download.pytorch.org/whl/nightly" if nightly else "https://download.pytorch.org/whl"
     url = f"{base}/{tag}"
 
-    print(f"[INFO] Installing PyTorch for {tag} from {url}")
+    log_info(f"Installing PyTorch for {tag} from {url}")
     subprocess.run(["pip", "install", "--pre", "torch", "--index-url", url, "--force-reinstall"], check=True)
 
 


### PR DESCRIPTION
## ✨ What’s Changed

- Updated `examples/torchtitan/prepare.py` to automatically:
  - Detect the current ROCm version via `/opt/rocm/.info/version`
  - Normalize versions like `7.0.0` → `7.0`
  - Construct the appropriate PyTorch nightly index URL (e.g. `https://download.pytorch.org/whl/nightly/rocm7.0`)
  - Run `pip install` to install the correct `torch` version

- Adds helper functions:
  - `detect_rocm_version()`: returns `7.0`, `6.3`, etc.
  - `install_torch_for_rocm(nightly=True)`: installs `torch==*.dev*+rocmX.Y`

## 📌 Why

TorchTitan requires **nightly builds of PyTorch** (>= 2.9.0.dev) that match the ROCm backend version (e.g. `+rocm7.0`).  
Installing incompatible or stable versions often leads to runtime failures or missing APIs.

This PR ensures:
- A correct nightly torch build is installed before dataset preparation
- TorchTitan runs smoothly across different ROCm environments
- Users don’t need to manually manage torch wheel compatibility

## 🚧 Notes

- This auto-install behavior is **temporary** and may be removed in future Primus Docker images.  
  Once the correct nightly torch is pre-installed in container images (e.g. `rocm/primus:torchtitan-rocm7.0`),  
  this script will assume the environment is already set up and skip installation.