### PR TITLE
feat(torchtitan): add Qwen3 model configs (0.6B / 1.7B / 32B)

### DIFF
--- a/examples/torchtitan/configs/qwen3_0.6B-pretrain.yaml
+++ b/examples/torchtitan/configs/qwen3_0.6B-pretrain.yaml
@@ -1,0 +1,54 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_00.6B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_0.6b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 3.0e-4
+        eps: 1.0e-8
+
+      lr_scheduler:
+        warmup_steps: 2  # lr scheduler warm up, 20% total steps
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0    # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default"  # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/qwen3_1.7B-pretrain.yaml
+++ b/examples/torchtitan/configs/qwen3_1.7B-pretrain.yaml
@@ -1,0 +1,54 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_32B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_1.7b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 8.0e-4
+        eps: 1.0e-8
+
+      lr_scheduler:
+        warmup_steps: 20  # lr scheduler warm up, 20% total steps
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0    # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default"  # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/qwen3_32B-pretrain.yaml
+++ b/examples/torchtitan/configs/qwen3_32B-pretrain.yaml
@@ -1,0 +1,62 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_32B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_32b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 3.0e-4
+        eps: 1.0e-8
+
+      lr_scheduler:
+        warmup_steps: 2  # lr scheduler warm up, 20% total steps
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0    # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default"  # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled"  # ["disabled", "async", "async_with_pinned_mem"]
+
+      activation_checkpoint:
+        mode: "full"
+        selective_ac_option: "op"
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+
+
+
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/primus/configs/models/torchtitan/qwen3_0.6b.yaml
+++ b/primus/configs/models/torchtitan/qwen3_0.6b.yaml
@@ -1,0 +1,10 @@
+job:
+  dump_folder: "./outputs"
+  description: "Qwen 3 0.6B training"
+
+model:
+  name: "qwen3"
+  flavor: "0.6B"
+  hf_assets_path: "Qwen/Qwen3-0.6B"
+  # converters:
+  #   - "float8"

--- a/primus/configs/models/torchtitan/qwen3_1.7b.yaml
+++ b/primus/configs/models/torchtitan/qwen3_1.7b.yaml
@@ -1,0 +1,9 @@
+job:
+  dump_folder: "./outputs"
+  description: "Qwen 3 1.7B training"
+
+model:
+  name: "qwen3"
+  flavor: "1.7B"
+  hf_assets_path: "Qwen/Qwen3-1.7B"
+  # converters = ["float8"]

--- a/primus/configs/models/torchtitan/qwen3_32b.yaml
+++ b/primus/configs/models/torchtitan/qwen3_32b.yaml
@@ -1,0 +1,9 @@
+job:
+  dump_folder: "./outputs"
+  description: "Qwen 3 32B training"
+
+model:
+  name: "qwen3"
+  flavor: "32B"
+  hf_assets_path: "Qwen/Qwen3-32B"
+  # converters = ["float8"]


### PR DESCRIPTION
This PR introduces Qwen3 model configurations for the TorchTitan backend, enabling training and benchmarking across multiple model scales.