### PR TITLE
chore: update latest turbo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,8 @@ on:
   pull_request:
 
 env:
-  PRIMUS_TURBO_COMMIT: 70b76508408474f254ac048cef2005179c6cb55b # fix(deepep): fix internode_combine hang when set num_worst_token > 0 (#149)
+  PRIMUS_TURBO_COMMIT: 1fc5b8148dfd3070977fae1e9d2a46075d281ef8 # feat: jax backend support grouped_gemm (#157)
+
 jobs:
   code-lint:
     runs-on: ubuntu-latest

--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -29,7 +29,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
 from megatron.core.utils import get_tensor_model_parallel_group_if_none
 from megatron.training.global_vars import get_args
-from primus_turbo.pytorch.core.float8 import (
+from primus_turbo.pytorch.core.low_precision import (
     Float8QuantConfig,
     ScalingGranularity,
     ScalingStrategy,

--- a/primus/backends/megatron/core/fp8_utils.py
+++ b/primus/backends/megatron/core/fp8_utils.py
@@ -42,14 +42,14 @@ if HAVE_TE and HAVE_TURBO:
     from megatron.core import parallel_state
     from megatron.core.enums import Fp8Recipe
     from megatron.core.extensions.transformer_engine import TEDelayedScaling
-    from primus_turbo.pytorch.core.float8 import ScalingGranularity
+    from primus_turbo.pytorch.core.low_precision import ScalingGranularity
 
     from primus.backends.megatron.core.extensions.primus_turbo import (
         PrimusTurboFloat8QuantConfig,
     )
 
     def te_fp8_format_mapping(te_format):
-        from primus_turbo.pytorch.core.float8 import Format as TurboFormat
+        from primus_turbo.pytorch.core.low_precision import Format as TurboFormat
         from transformer_engine.common.recipe import Format as TEFormat
 
         format_mapping = {
@@ -194,7 +194,7 @@ if HAVE_TE and HAVE_TURBO:
 elif HAVE_TURBO:
     from megatron.core import parallel_state
     from megatron.core.enums import Fp8Recipe
-    from primus_turbo.pytorch.core.float8 import ScalingGranularity
+    from primus_turbo.pytorch.core.low_precision import ScalingGranularity
 
     from primus.backends.megatron.core.extensions.primus_turbo import (
         PrimusTurboFloat8QuantConfig,
@@ -235,9 +235,9 @@ elif HAVE_TURBO:
             import primus_turbo
 
             if config.fp8 == "e4m3":
-                fp8_format = primus_turbo.pytorch.core.float8.Format.E4M3
+                fp8_format = primus_turbo.pytorch.core.low_precision.Format.E4M3
             elif config.fp8 == "hybrid":
-                fp8_format = primus_turbo.pytorch.core.float8.Format.HYBRID
+                fp8_format = primus_turbo.pytorch.core.low_precision.Format.HYBRID
             else:
                 raise ValueError("E4M3 and HYBRID are the only supported FP8 formats.")
 

--- a/primus/backends/torchtitan/components/quantization/mx.py
+++ b/primus/backends/torchtitan/components/quantization/mx.py
@@ -6,7 +6,10 @@
 
 import torch
 import torch.nn as nn
-from primus_turbo.pytorch.core.float8 import Float8QuantConfig, ScalingGranularity
+from primus_turbo.pytorch.core.low_precision import (
+    Float8QuantConfig,
+    ScalingGranularity,
+)
 from primus_turbo.pytorch.modules import Float8Linear
 from torchtitan.config.job_config import JobConfig
 from torchtitan.distributed import ParallelDims


### PR DESCRIPTION

This PR updates the primus_turbo dependency to a newer version that introduces a breaking API change, where the float8 module has been renamed to low_precision. All import statements across the codebase are updated accordingly to maintain compatibility with the new version.

Updates primus_turbo commit reference from https://github.com/AMD-AGI/Primus/pull/149 to https://github.com/AMD-AGI/Primus/pull/156
Renames all imports from primus_turbo.pytorch.core.float8 to primus_turbo.pytorch.core.low_precision
Affects multiple files across both torchtitan and megatron backends


File | Description
-- | --
primus/backends/torchtitan/components/quantization/mx.py | Updates float8 imports to low_precision for torchtitan backend
primus/backends/megatron/core/fp8_utils.py | Updates multiple float8 imports to low_precision in fp8 utility functions
primus/backends/megatron/core/extensions/primus_turbo.py | Updates float8 import to low_precision in primus_turbo extension
.github/workflows/ci.yaml | Updates PRIMUS_TURBO_COMMIT reference to newer version
