### PR TITLE
fix multi node aiter build bug

### DIFF
--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -110,8 +110,8 @@ if [ "$USING_AINIC" == "1" ]; then
         -v "$RCCL_HOME_DIR":"$RCCL_HOME_DIR"
         -v "$ANP_HOME_DIR":"$ANP_HOME_DIR"
         -v /etc/libibverbs.d/:/etc/libibverbs.d
-        -v /usr/lib/x86_64-linux-gnu/:/usr/lib/x86_64-linux-gnu/
     )
+        # -v /usr/lib/x86_64-linux-gnu/:/usr/lib/x86_64-linux-gnu/
 fi
 
 export CLEAN_DOCKER_CONTAINER=${CLEAN_DOCKER_CONTAINER:-0}


### PR DESCRIPTION

This PR fixes a build failure in the 8-node aiter configuration caused by conflicting shared object files. The issue occurred when the /usr/lib/x86_64-linux-gnu/ directory was mapped into the Docker container with AINIC enabled, which prevented the linker from finding required libraries. The fix comments out this volume mount while preserving it for potential future reference.

Key Changes
- Removed the problematic volume mount that was causing shared library conflicts during the build process
- Preserved the mount configuration as a comment for documentation purposes

```
c++ @module_aiter_enum.so.rsp -shared -mcmodel=large -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,--cref -L/opt/rocm-7.0.0/lib -lamdhip64 -o module_aiter_enum.so
/usr/bin/ld: error while loading shared libraries: libbfd-2.38-system.so: cannot open shared object file: No such file or directory
collect2: error: ld returned 127 exit status
ninja: build stopped: subcommand failed.
```