### PR TITLE
backends/megatron: add env patch for CUDA_DEVICE_MAX_CONNECTIONS

### DIFF
--- a/primus/backends/megatron/patches/__init__.py
+++ b/primus/backends/megatron/patches/__init__.py
@@ -17,6 +17,7 @@ from primus.backends.megatron.patches import args_patches as _args_patches  # no
 from primus.backends.megatron.patches import (  # noqa: F401
     checkpoint_patches as _checkpoint_patches,
 )
+from primus.backends.megatron.patches import env_patches as _env_patches  # noqa: F401
 from primus.backends.megatron.patches import (  # noqa: F401
     flops_patches as _flops_patches,
 )

--- a/primus/backends/megatron/patches/env_patches.py
+++ b/primus/backends/megatron/patches/env_patches.py
@@ -1,0 +1,54 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron Environment Variable Patches
+
+Sets environment variables for optimal Megatron performance and compatibility.
+"""
+
+import os
+
+from primus.core.patches import PatchContext, register_patch
+from primus.modules.module_utils import log_rank_0
+
+# ============================================================================
+# CUDA Device Configuration
+# ============================================================================
+
+
+@register_patch(
+    "megatron.env.cuda_device_max_connections",
+    backend="megatron",
+    phase="setup",
+    description="Set CUDA_DEVICE_MAX_CONNECTIONS based on FSDP configuration",
+)
+def set_cuda_device_max_connections(ctx: PatchContext):
+    """
+    Set CUDA_DEVICE_MAX_CONNECTIONS environment variable.
+
+    This controls the number of CUDA streams for device-to-device communication.
+
+    Strategy:
+        - FSDP (Fully Sharded Data Parallel): Use 8 connections for better overlap
+        - Non-FSDP (standard DDP/TP/PP): Use 1 connection to avoid contention
+
+    The value is determined by checking the config for FSDP usage.
+    """
+    # Get config from context
+    config = ctx.extra.get("config", {})
+
+    # Determine CUDA_DEVICE_MAX_CONNECTIONS based on FSDP usage
+    use_fsdp = config.get("use_torch_fsdp2", False) or config.get("use_custom_fsdp", False)
+
+    if use_fsdp:
+        cuda_connections = "8"
+    else:
+        cuda_connections = "1"
+
+    # Set environment variable
+    os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = cuda_connections
+    log_rank_0(f"[Patch] Set CUDA_DEVICE_MAX_CONNECTIONS={cuda_connections} (FSDP={use_fsdp})")


### PR DESCRIPTION
## Summary

Add an environment patch for Megatron to set `CUDA_DEVICE_MAX_CONNECTIONS` based on FSDP usage, and register it in the Megatron patch collection.

## Changes

- **New env patch** (`primus/backends/megatron/patches/env_patches.py`)
  - Register `set_cuda_device_max_connections` as:
    - `id="megatron.env.cuda_device_max_connections"`, `backend="megatron"`, `phase="setup"`.
  - Behavior:
    - Reads `config` from `ctx.extra["config"]`.
    - If `use_torch_fsdp2` or `use_custom_fsdp` is enabled → set `CUDA_DEVICE_MAX_CONNECTIONS=8`.
    - Otherwise → set `CUDA_DEVICE_MAX_CONNECTIONS=1`.
    - Logs the chosen value and whether FSDP is enabled.

- **Patch registration** (`primus/backends/megatron/patches/__init__.py`)
  - Import `env_patches` for side-effect registration alongside other Megatron patches.

## Testing

- Manual verification:
  - Import `primus.backends.megatron.patches` and call
    `apply_megatron_patches(..., phase="setup", extra={"config": {...}})`,
    then check that `CUDA_DEVICE_MAX_CONNECTIONS` is set as expected.
- All new/modified files pass pre-commit hooks (isort, autoflake, black, end-of-file-fixer).