### PR TITLE
megatron: remove useless parameters from base configuration

### DIFF
--- a/primus/configs/modules/megatron/trainer_base.yaml
+++ b/primus/configs/modules/megatron/trainer_base.yaml
@@ -390,8 +390,6 @@ embedding_path: null
 indexer_batch_size: 128
 indexer_log_interval: 1000
 
-parallel_output: false
-
 enable_ft_package: false
 calc_ft_timeouts: false
 run_workload_inspector_server: false


### PR DESCRIPTION
Hi,

(C.C. @hisohara)

I realized that some parameters in base configuration for Megatron-LM runtime are neither referred by Primus (including Primus-Turbo) nor Megatron-LM (`core_v0.12.0..core_v0.15.0rc7`). It is preferable to delete them to prevent users from being puzzled.