### PR TITLE
fix(core): module_cfg.name AttributeError in train_runtime

### DIFF
--- a/primus/core/runtime/train_runtime.py
+++ b/primus/core/runtime/train_runtime.py
@@ -121,13 +121,13 @@ class PrimusRuntime:
 
         framework = module_cfg.framework
         if not framework:
-            raise ValueError(f"[Primus:TrainRuntime] Module '{module_cfg.name}' missing 'framework'.")
+            raise ValueError(f"[Primus:TrainRuntime] Module '{module_name}' missing 'framework'.")
 
         # Initialize TrainContext based on raw configuration (before CLI overrides).
         self.ctx = TrainContext(
             config_path=cfg_path,
             data_path=Path(getattr(self.args, "data_path", "./data")),
-            module_name=module_cfg.name,
+            module_name=module_name,
             primus_config=primus_cfg,
             module_config=module_cfg,
             framework=framework,

--- a/tests/unit_tests/core/runtime/test_train_runtime.py
+++ b/tests/unit_tests/core/runtime/test_train_runtime.py
@@ -22,8 +22,13 @@ class TestPrimusRuntime(PrimusUT):
         args = self._build_args(config="non_existent.yaml")
         runtime = PrimusRuntime(args=args)
 
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(RuntimeError) as ctx:
             runtime.run_train_module(module_name="pre_trainer", overrides=[])
+
+        # The original FileNotFoundError is wrapped in RuntimeError
+        msg = str(ctx.exception)
+        self.assertIn("Config file not found", msg)
+        self.assertIn("non_existent.yaml", msg)
 
     def test_missing_module_raises_runtime_error(self):
         # Use a real example config but request an invalid module name.
@@ -42,7 +47,7 @@ class TestPrimusRuntime(PrimusUT):
         args = self._build_args()
         runtime = PrimusRuntime(args=args)
 
-        # Fake module config with params dict.
+        # Fake module config with params dict and required attributes.
         module_cfg = SimpleNamespace(
             name="pre_trainer",
             framework="megatron",


### PR DESCRIPTION

## 🐛 Problem

Unit tests in `test_train_runtime.py` were failing with:
```python
AttributeError: 'types.SimpleNamespace' object has no attribute 'name'
```

This occurred in `PrimusRuntime._initialize_configuration()` when trying to access `module_cfg.name`.

## 🔍 Root Cause

The `get_module_config()` function returns a `SimpleNamespace` object constructed from YAML configuration like:

```yaml
modules:
  pre_trainer:
    framework: megatron
    config: pre_trainer.yaml
```

The module name (`pre_trainer`) exists as a **dictionary key**, not as an attribute on the returned object. Therefore, `module_cfg.name` does not exist.

## ✅ Solution

**Changed approach**: Use the `module_name` parameter directly instead of trying to extract it from `module_cfg`.

### Changes in `primus/core/runtime/train_runtime.py`

```python
# Before
raise ValueError(f"[Primus:TrainRuntime] Module '{module_cfg.name}' missing 'framework'.")
module_name=module_cfg.name,

# After
raise ValueError(f"[Primus:TrainRuntime] Module '{module_name}' missing 'framework'.")
module_name=module_name,
```

### Changes in `tests/unit_tests/core/runtime/test_train_runtime.py`

1. **Fixed `test_missing_config_file_raises_file_not_found`**: 
   - Changed to expect `RuntimeError` instead of `FileNotFoundError`
   - This matches actual behavior: `run_train_module()` wraps all exceptions in `RuntimeError`
   - Added assertions to verify the wrapped exception message

2. **Updated comment** in `test_apply_overrides_merges_into_module_params` for clarity

## 📊 Test Results

All 6 test cases now pass:

```bash
tests/unit_tests/core/runtime/test_train_runtime.py::TestPrimusRuntime
  ✅ test_apply_overrides_merges_into_module_params
  ✅ test_initialize_backend_wraps_adapter_errors
  ✅ test_initialize_trainer_wraps_creation_errors
  ✅ test_missing_config_file_raises_file_not_found
  ✅ test_missing_module_raises_runtime_error
  ✅ test_run_trainer_lifecycle_calls_trainer_methods_in_order

6 passed in 0.16s
```

## 🔗 Related Issues

This fixes test failures introduced in #327 (unified train runtime orchestrator).

## ✔️ Checklist

- [x] Code changes implemented
- [x] All unit tests pass
- [x] No linter errors
- [x] Commit message follows convention
- [x] Changes are minimal and focused on the bug fix

