### PR TITLE
fix(megatron): handle 2-element tensor in loss reducer

### DIFF
--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -1699,6 +1699,11 @@ class MegatronTrainer(BaseTrainer, BaseModule):
                     if isinstance(val, tuple) or isinstance(val, list):
                         numerator += val[0]
                         denominator += val[1]
+                    elif isinstance(val, torch.Tensor) and val.numel() == 2:
+                        # Handle 2-element tensor [loss, num_tokens] format
+                        # (upstream Megatron compatibility)
+                        numerator += val[0]
+                        denominator += val[1]
                     else:
                         # legacy behavior. we average over the number of microbatches,
                         # and so the denominator is 1.


### PR DESCRIPTION
Add support for 2-element tensors [loss, num_tokens] in the loss reduction logic, in addition to existing tuple/list handling. This enables compatibility with upstream Megatron's loss_func format (https://github.com/NVIDIA/Megatron-LM/blob/main/pretrain_gpt.py#L86-L119).

Tested on 8x MI325X node: 10 training iterations + 2 validation iterations completed successfully.
