### PR TITLE
fix(primus-cli): fix container image tag for v25.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Primus leverages AMD’s ROCm Docker images to provide a consistent, ready-to-ru
 1. **Pull the latest Docker image**
 
     ```bash
-    docker pull docker.io/rocm/primus:v25.10_gfx942
+    docker pull docker.io/rocm/primus:v25.10
     ```
 
 2. **Clone the repository**
@@ -61,7 +61,7 @@ Primus leverages AMD’s ROCm Docker images to provide a consistent, ready-to-ru
 
     ```bash
     # Run training in container
-    ./runner/primus-cli container --image rocm/primus:v25.10_gfx942 \
+    ./runner/primus-cli container --image rocm/primus:v25.10 \
       -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-pretrain.yaml
     ```
 

--- a/docs/cli/PRIMUS-CLI-GUIDE.md
+++ b/docs/cli/PRIMUS-CLI-GUIDE.md
@@ -207,7 +207,7 @@ slurm:
 
 # Container configuration
 container:
-  image: "rocm/primus:v25.10_gfx942"
+  image: "rocm/primus:v25.10"
   options:
     cpus: "32"
     memory: "256G"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ rocm-smi && docker --version
 
 ```bash
 # Pull Docker image
-docker pull docker.io/rocm/primus:v25.10_gfx942
+docker pull docker.io/rocm/primus:v25.10
 
 # Clone repository
 git clone --recurse-submodules https://github.com/AMD-AIG-AIMA/Primus.git
@@ -32,7 +32,7 @@ cd Primus
 
 ```bash
 # Run a quick benchmark in container
-./runner/primus-cli container --image rocm/primus:v25.10_gfx942 \
+./runner/primus-cli container --image rocm/primus:v25.10 \
   -- benchmark gemm -M 4096 -N 4096 -K 4096
 ```
 
@@ -50,7 +50,7 @@ Use the Docker image you just pulled:
 
 ```bash
 # Run training in container (recommended for getting started)
-./runner/primus-cli container --image rocm/primus:v25.10_gfx942 \
+./runner/primus-cli container --image rocm/primus:v25.10 \
   -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-pretrain.yaml
 ```
 
@@ -62,7 +62,7 @@ Use the Docker image you just pulled:
   --config examples/megatron/configs/MI300X/llama2_7B-pretrain.yaml
 
 # Slurm mode (for multi-node cluster)
-./runner/primus-cli slurm srun -N 8 -p gpu -- container --image rocm/primus:v25.10_gfx942 \
+./runner/primus-cli slurm srun -N 8 -p gpu -- container --image rocm/primus:v25.10 \
   -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-pretrain.yaml
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ We recommend using the official [rocm/megatron-lm Docker image](https://hub.dock
 
 ```bash
 # Pull the latest Docker image
-docker pull docker.io/rocm/primus:v25.10_gfx942
+docker pull docker.io/rocm/primus:v25.10
 
 ```
 
@@ -126,7 +126,7 @@ Multi-node training is launched via **SLURM**.
 Specify the number of nodes and the model config:
 
 ```bash
-export DOCKER_IMAGE="docker.io/rocm/primus:v25.10_gfx942"
+export DOCKER_IMAGE="docker.io/rocm/primus:v25.10"
 export NNODES=8
 
 # Example for megatron llama3.1_8B
@@ -285,7 +285,7 @@ When using the `create` command to start a new training workload, the following 
 | `--gpu`        | Number of GPUs                                       | 8                                        |
 | `--exp`        | Path to experiment (training config) file (required) | —                                        |
 | `--data_path`  | Path to training data                                | —                                        |
-| `--image`      | Docker image to use                                  | `docker.io/rocm/primus:v25.10_gfx942` |
+| `--image`      | Docker image to use                                  | `docker.io/rocm/primus:v25.10` |
 | `--hf_token`   | HuggingFace token                                    | Read from env var `HF_TOKEN`             |
 | `--workspace`  | Workspace name                                       | `primus-safe-pretrain`                   |
 | `--nodelist`   | Comma-separated list of node hostnames to run on     | —                                        |

--- a/examples/run_k8s_pretrain.sh
+++ b/examples/run_k8s_pretrain.sh
@@ -15,7 +15,7 @@ GPU="8"
 EXP_PATH=""
 DATA_PATH=""
 BACKEND="megatron"
-IMAGE="docker.io/rocm/primus:v25.10_gfx942"
+IMAGE="docker.io/rocm/primus:v25.10"
 HF_TOKEN="${HF_TOKEN:-}"
 WORKSPACE="primus-safe-pretrain"
 NODELIST=""
@@ -38,7 +38,7 @@ Options for create:
     --backend <name>            Training backend, e.g. megatron | torchtitan(default: megatron)
     --exp <exp_path>            Path to EXP config (optional)
     --data_path <data_path>     Data path (optional)
-    --image <docker_image>      Docker image to use (default: docker.io/rocm/primus:v25.10_gfx942)
+    --image <docker_image>      Docker image to use (default: docker.io/rocm/primus:v25.10)
     --hf_token <token>          HuggingFace token (default: from env HF_TOKEN)
     --workspace <workspace>     Workspace name (default: safe-cluster-dev)
     --nodelist <node1,node2>    Comma-separated list of node names to run on (optional)

--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -16,7 +16,7 @@ Usage: bash run_local_pretrain.sh
 This script launches a Primus pretraining task inside a Docker/Podman container.
 
 Environment Variables:
-    DOCKER_IMAGE   Docker image to use [Default: docker.io/rocm/primus:v25.10_gfx942]
+    DOCKER_IMAGE   Docker image to use [Default: docker.io/rocm/primus:v25.10]
     MASTER_ADDR    Master node IP or hostname [Default: localhost]
     MASTER_PORT    Master node port [Default: 1234]
     NNODES         Total number of nodes [Default: 1]
@@ -44,7 +44,7 @@ EXP=${EXP:-"examples/megatron/exp_pretrain.yaml"}
 if [ "${BACKEND:-}" = "MaxText" ]; then
     DOCKER_IMAGE="docker.io/rocm/jax-training:maxtext-v25.9"
 fi
-DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/primus:v25.10_gfx942"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/primus:v25.10"}
 
 # Project root
 PRIMUS_PATH=$(realpath "$(dirname "$0")/..")

--- a/runner/.primus.yaml
+++ b/runner/.primus.yaml
@@ -26,7 +26,7 @@ container:
   # All keys directly map to CLI arguments (--key value)
   options:
     # Container image
-    image: "rocm/primus:v25.10_gfx942"
+    image: "rocm/primus:v25.10"
 
     # Single-value options
     ipc: "host"

--- a/runner/primus-cli-container.sh
+++ b/runner/primus-cli-container.sh
@@ -45,7 +45,7 @@ Docker/Podman Options:
         --cap-add <CAPABILITY>       Add Linux capabilities (e.g., SYS_PTRACE)
 
     Container Configuration:
-        --image <DOCKER_IMAGE>       Docker image [default: rocm/primus:v25.10_gfx942]
+        --image <DOCKER_IMAGE>       Docker image [default: rocm/primus:v25.10]
         --name <NAME>                Container name
         --user <UID:GID>             Run as specific user (e.g., 1000:1000)
         --network <NET>              Network mode (e.g., host, bridge)

--- a/tests/runner/test_primus_cli_container.sh
+++ b/tests/runner/test_primus_cli_container.sh
@@ -106,7 +106,7 @@ test_basic_dry_run() {
     cat > "$test_config" << EOF
 container:
   options:
-    image: "rocm/primus:v25.10_gfx942"
+    image: "rocm/primus:v25.10"
     ipc: "host"
     device:
       - "/dev/null"
@@ -119,9 +119,9 @@ EOF
         -- train 2>&1)
 
     assert_contains "$output" "Launching container" "Should contain launching message"
-    assert_contains "$output" "rocm/primus:v25.10_gfx942" "Should use default image"
+    assert_contains "$output" "rocm/primus:v25.10" "Should use default image"
     assert_contains "$output" "Runtime: docker" "Should show runtime"
-    assert_contains "$output" "Image: rocm/primus:v25.10_gfx942" "Should show image"
+    assert_contains "$output" "Image: rocm/primus:v25.10" "Should show image"
 
     rm -f "$test_config"
 }
@@ -137,7 +137,7 @@ test_cli_options() {
     cat > "$test_config" << EOF
 container:
   options:
-    image: "rocm/primus:v25.10_gfx942"
+    image: "rocm/primus:v25.10"
 
     device:
       - "/dev/null"
@@ -249,7 +249,7 @@ test_volume_handling() {
     cat > "$test_config" << EOF
 container:
   options:
-    image: "rocm/primus:v25.10_gfx942"
+    image: "rocm/primus:v25.10"
 
     device:
       - "/dev/null"
@@ -283,7 +283,7 @@ test_image_specification() {
     cat > "$test_config" << EOF
 container:
   options:
-    image: "rocm/primus:v25.10_gfx942"
+    image: "rocm/primus:v25.10"
 
     device:
       - "/dev/null"
@@ -313,7 +313,7 @@ test_multiple_generic_options() {
     cat > "$test_config" << EOF
 container:
   options:
-    image: "rocm/primus:v25.10_gfx942"
+    image: "rocm/primus:v25.10"
 
     device:
       - "/dev/null"

--- a/tools/docker/start_container.sh
+++ b/tools/docker/start_container.sh
@@ -6,7 +6,7 @@
 ###############################################################################
 
 PRIMUS_PATH=$(realpath "$(dirname "$0")/../..")
-DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/primus:v25.10_gfx942"}
+DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/primus:v25.10"}
 DATA_PATH=${DATA_PATH:-"${PRIMUS_PATH}/data"}
 
 bash "${PRIMUS_PATH}"/tools/docker/docker_podman_proxy.sh run -d \

--- a/tools/preflight/run_preflight.sh
+++ b/tools/preflight/run_preflight.sh
@@ -135,7 +135,7 @@ if [ "$RUN_ENV" = "torchrun" ]; then
         2>&1 | tee $PREFLIGHT_LOG
 
 elif [ "$RUN_ENV" = "slurm" ]; then
-    export DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/primus:v25.10_gfx942"}
+    export DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/rocm/primus:v25.10"}
 
     bash "${PRIMUS_PATH}"/tools/docker/docker_podman_proxy.sh run --rm \
         --env SLURM_MASTER_ADDR=$SLURM_MASTER_ADDR \


### PR DESCRIPTION
This PR fixes an incorrect container image tag used by primus-cli in container mode.

The image tag was previously set to rocm/primus:v25.10_gfx942, which does not exist.
It is now corrected to use the valid tag: