### PR TITLE
MoE Package Blog Released

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 ## 🆕 What's New
 
+- **[2025/12/17]** MoE Training Best Practices on AMD GPUs - [MoE Package Blog](https://rocm.blogs.amd.com/software-tools-optimization/primus-moe-package/README.html)
 - **[2025/11/14]** 🎉 **Primus CLI 1.0 Released** - Unified command-line interface with comprehensive documentation
 - **[2025/08/22]** Primus introduction [blog](https://rocm.blogs.amd.com/software-tools-optimization/primus/README.html)
 - **[2025/06/18]** Added TorchTitan backend support

--- a/examples/moe_package/README.md
+++ b/examples/moe_package/README.md
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --->
 
-# MoE Training Best Practices on AMD GPUs
+# [MoE Training Best Practices on AMD GPU](https://rocm.blogs.amd.com/software-tools-optimization/primus-moe-package/README.html)
 
 This blog covers best practices for training Mixture-of-Experts (MoE) models on AMD Instinct™ MI300/MI355-series<sup>[a]</sup> GPUs with the ROCm ecosystem. Whether you're new to MoE distributed architectures or optimizing trillion-parameter models, this guide will help you identify bottlenecks and maximize efficiency on AMD hardware.
 


### PR DESCRIPTION
https://rocm.blogs.amd.com/software-tools-optimization/primus-moe-package/README.html

This PR adds a blog post announcement for MoE (Mixture-of-Experts) training best practices on AMD GPUs. The changes include adding a hyperlink to the blog post in the MoE package README title and creating a new entry in the main README's "What's New" section.

Added hyperlink to blog post in MoE package README title
Added "What's New" entry with publication date and blog link

File | Description
-- | --
examples/moe_package/README.md | Converted MoE training title to hyperlink pointing to the blog post
README.md | Added new changelog entry announcing the MoE blog post release