### PR TITLE
chore(ci): isolate UT logs per run with timestamp and commit id

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,16 +199,18 @@ jobs:
           pip install -r requirements.txt
       - name: Set UT_LOG_PATH
         run: |
+          ts="$(date +%Y%m%d-%H%M%S)"
+          commit_id="${GITHUB_SHA::7}"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/pr-${{ github.event.pull_request.number }}-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/latest" >> $GITHUB_ENV
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/main-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_NAME="${{ github.ref }}"
             TAG="${TAG_NAME#refs/tags/}"
-            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/$TAG" >> $GITHUB_ENV
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/${TAG}-${ts}-${commit_id}" >> $GITHUB_ENV
           else
-            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/others" >> $GITHUB_ENV
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/others-${ts}-${commit_id}" >> $GITHUB_ENV
           fi
       - name: Run CLI Shell Tests
         run: |
@@ -298,18 +300,18 @@ jobs:
           pip install -r requirements-jax.txt
       - name: Set UT_LOG_PATH
         run: |
+          ts="$(date +%Y%m%d-%H%M%S)"
+          commit_id="${GITHUB_SHA::7}"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/pr-${{ github.event.pull_request.number }}-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            ts="$(date +%Y%m%d-%H%M%S)"
-            commit_id="${GITHUB_SHA::7}"
             echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/main-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_NAME="${{ github.ref }}"
             TAG="${TAG_NAME#refs/tags/}"
-            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/$TAG" >> $GITHUB_ENV
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/${TAG}-${ts}-${commit_id}" >> $GITHUB_ENV
           else
-            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/others" >> $GITHUB_ENV
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/others-${ts}-${commit_id}" >> $GITHUB_ENV
           fi
       - name: Run Shell Tests
         run: |


### PR DESCRIPTION
## Background

Currently, CI sets `UT_LOG_PATH` to fixed directories in some cases (e.g. `.../ut_out/latest`).
This means different CI runs (especially consecutive pushes to `main` or multiple runners) can
reuse the same path, leading to:

- Previous run logs/results being overwritten
- Cleanup logic having trouble distinguishing runs, making debugging harder

## Changes

- **Torch CI (`run-unittest-torch`)**
  - Change `UT_LOG_PATH` from fixed paths to unique, per-run directories that include
    a **timestamp** and **short commit SHA**:
    - Pull requests: `ut_out/pr-<pr_number>-<YYYYMMDD-HHMMSS>-<commit>`
    - Push to `main`: `ut_out/main-<YYYYMMDD-HHMMSS>-<commit>`
    - Releases: `ut_out/<tag>-<YYYYMMDD-HHMMSS>-<commit>`
    - Other events: `ut_out/others-<YYYYMMDD-HHMMSS>-<commit>`

- **JAX CI (`run-unittest-jax`)**
  - Apply the same `UT_LOG_PATH` naming scheme as Torch CI, with timestamp and short commit SHA
    for PR / `main` / release / other events.

## Benefits

- Each CI run writes UT logs to a globally unique directory, avoiding cross-run interference.
- The log path encodes both time and commit, making it easy to trace logs back to a specific run.
- No change to the actual tests, only to where logs are written, so the risk is low.

## Testing

- Verified in CI logs that `UT_LOG_PATH` is set to the expected
  `<event>-<timestamp>-<commit>` pattern for both Torch and JAX jobs.
- Confirmed that the UT jobs create and use the new per-run log directories successfully.