### PR TITLE
chore(ci): update JAX unit test runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,7 +247,7 @@ jobs:
     env:
       PRIMUS_WORKDIR: /wekafs/primus-data/primus_safe_ci/jax
     needs: [code-lint]
-    runs-on: [primus-jax-l85pj]
+    runs-on: [primus-llm-cicd-jax-7b4zw]
     steps:
       - run: echo "🎉 Begin Primus-Turbo Checkout."
       - name: Set commit hash to env


### PR DESCRIPTION
Update runs-on label for run-unittest-jax job:
- Old: primus-jax-l85pj
- New: primus-llm-cicd-jax-7b4zw

This updates the CI to use the new JAX runner infrastructure for better stability and performance in JAX unit tests.