### PR TITLE
refactor(megatron): Add Primus Turbo patches module

### DIFF
--- a/primus/backends/megatron/patches/turbo/__init__.py
+++ b/primus/backends/megatron/patches/turbo/__init__.py
@@ -1,0 +1,39 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Primus Turbo Patches Module
+
+This module contains all PrimusTurbo backend related patches for Megatron.
+Each patch is organized in its own file for better maintainability.
+
+Patches included:
+  - te_spec_provider_patches: Replace TESpecProvider with PrimusTurboSpecProvider
+  - gpt_output_layer_patches: Replace GPT ColumnParallelLinear with PrimusTurbo implementation
+  - moe_dispatcher_patches: Replace MoE token dispatcher with PrimusTurbo DeepEP implementation
+  - rms_norm_patches: Replace RMSNorm with PrimusTurbo implementation
+"""
+
+# Import all patch modules to trigger registration
+# NOTE: These imports are intentionally unused; they register patches with
+# the core patch registry when this package is imported.
+from primus.backends.megatron.patches.turbo import (
+    gpt_output_layer_patches as _gpt_output_layer_patches,
+)
+from primus.backends.megatron.patches.turbo import (
+    moe_dispatcher_patches as _moe_dispatcher_patches,
+)
+from primus.backends.megatron.patches.turbo import rms_norm_patches as _rms_norm_patches
+from primus.backends.megatron.patches.turbo import (
+    te_spec_provider_patches as _te_spec_provider_patches,
+)
+
+__all__ = [
+    "_te_spec_provider_patches",
+    "_gpt_output_layer_patches",
+    "_moe_dispatcher_patches",
+    "_rms_norm_patches",
+]

--- a/primus/backends/megatron/patches/turbo/gpt_output_layer_patches.py
+++ b/primus/backends/megatron/patches/turbo/gpt_output_layer_patches.py
@@ -1,0 +1,68 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Primus Turbo GPT Output Layer Patches
+
+Patches for replacing GPT output layer with PrimusTurbo implementation.
+"""
+
+import importlib.util
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _is_turbo_parallel_linear_enabled(ctx: PatchContext) -> bool:
+    """
+    Check if PrimusTurbo parallel linear is enabled.
+
+    Requires:
+      - primus_turbo package is installed
+      - tensor_model_parallel_size == 1
+      - enable_primus_turbo == True
+      - use_turbo_parallel_linear == True
+    """
+    # Check if primus_turbo package is available
+    if importlib.util.find_spec("primus_turbo") is None:
+        return False
+
+    args = get_args(ctx)
+    tp_size = getattr(args, "tensor_model_parallel_size", 1)
+    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
+    use_turbo_parallel_linear = bool(getattr(args, "use_turbo_parallel_linear", False))
+
+    return tp_size == 1 and enable_primus_turbo and use_turbo_parallel_linear
+
+
+@register_patch(
+    "megatron.turbo.gpt_output_layer",
+    backend="megatron",
+    phase="before_train",
+    description="Replace GPT ColumnParallelLinear with PrimusTurbo implementation",
+    condition=_is_turbo_parallel_linear_enabled,
+)
+def patch_gpt_output_layer(ctx: PatchContext):
+    """
+    Patch GPT output layer to use PrimusTurbo ColumnParallelLinear.
+
+    This replaces the standard tensor_parallel.ColumnParallelLinear with
+    PrimusTurboColumnParallelLinearTorch in gpt_model.
+    """
+    from megatron.core.models.gpt import gpt_model
+
+    from primus.backends.megatron.core.extensions.primus_turbo import (
+        PrimusTurboColumnParallelLinearTorch,
+    )
+
+    log_rank_0("[Patch:megatron.turbo.gpt_output_layer] Patching GPT output layer...")
+
+    gpt_model.tensor_parallel.ColumnParallelLinear = PrimusTurboColumnParallelLinearTorch
+    log_rank_0(
+        "[Patch:megatron.turbo.gpt_output_layer]   Patched "
+        f"megatron.core.models.gpt.gpt_model.tensor_parallel.ColumnParallelLinear "
+        f"-> {PrimusTurboColumnParallelLinearTorch.__name__}"
+    )

--- a/primus/backends/megatron/patches/turbo/moe_dispatcher_patches.py
+++ b/primus/backends/megatron/patches/turbo/moe_dispatcher_patches.py
@@ -1,0 +1,84 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Primus Turbo MoE Dispatcher Patches
+
+Patches for replacing MoE token dispatcher with PrimusTurbo DeepEP implementation.
+"""
+
+import importlib.util
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _is_turbo_deepep_enabled(ctx: PatchContext) -> bool:
+    """
+    Check if PrimusTurbo DeepEP MoE dispatcher is enabled.
+
+    Requires:
+      - primus_turbo package is installed
+      - tensor_model_parallel_size == 1
+      - enable_primus_turbo == True
+      - use_turbo_deepep == True
+    """
+    # Check if primus_turbo package is available
+    if importlib.util.find_spec("primus_turbo") is None:
+        return False
+
+    args = get_args(ctx)
+    tp_size = getattr(args, "tensor_model_parallel_size", 1)
+    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
+    use_turbo_deepep = bool(getattr(args, "use_turbo_deepep", False))
+
+    return tp_size == 1 and enable_primus_turbo and use_turbo_deepep
+
+
+@register_patch(
+    "megatron.turbo.moe_dispatcher",
+    backend="megatron",
+    phase="before_train",
+    description="Replace MoE token dispatcher with PrimusTurbo DeepEP implementation",
+    condition=_is_turbo_deepep_enabled,
+)
+def patch_moe_dispatcher(ctx: PatchContext):
+    """
+    Patch MoE token dispatcher to use PrimusTurbo DeepEP implementation.
+
+    This replaces MoEFlexTokenDispatcher with PrimusTurboDeepEPTokenDispatcher
+    and automatically enables moe_enable_deepep and sets moe_token_dispatcher_type to 'flex'.
+    """
+    from megatron.core.transformer.moe import moe_layer, token_dispatcher
+
+    from primus.backends.megatron.core.extensions.primus_turbo import (
+        PrimusTurboDeepEPTokenDispatcher,
+    )
+
+    log_rank_0("[Patch:megatron.turbo.moe_dispatcher] Patching MoE token dispatcher...")
+
+    args = get_args(ctx)
+
+    # Auto-enable DeepEP and set dispatcher type
+    args.moe_enable_deepep = True
+    args.moe_token_dispatcher_type = "flex"
+    log_rank_0(
+        "[Patch:megatron.turbo.moe_dispatcher]   Set moe_enable_deepep=True, moe_token_dispatcher_type='flex'"
+    )
+
+    token_dispatcher.MoEFlexTokenDispatcher = PrimusTurboDeepEPTokenDispatcher
+    log_rank_0(
+        "[Patch:megatron.turbo.moe_dispatcher]   Patched "
+        f"megatron.core.transformer.moe.token_dispatcher.MoEFlexTokenDispatcher "
+        f"-> {PrimusTurboDeepEPTokenDispatcher.__name__}"
+    )
+
+    moe_layer.MoEFlexTokenDispatcher = PrimusTurboDeepEPTokenDispatcher
+    log_rank_0(
+        "[Patch:megatron.turbo.moe_dispatcher]   Patched "
+        f"megatron.core.transformer.moe.moe_layer.MoEFlexTokenDispatcher "
+        f"-> {PrimusTurboDeepEPTokenDispatcher.__name__}"
+    )

--- a/primus/backends/megatron/patches/turbo/rms_norm_patches.py
+++ b/primus/backends/megatron/patches/turbo/rms_norm_patches.py
@@ -1,0 +1,65 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Primus Turbo RMSNorm Patches
+
+Patches for replacing RMSNorm with PrimusTurbo implementation.
+"""
+
+import importlib.util
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _is_turbo_rms_norm_enabled(ctx: PatchContext) -> bool:
+    """
+    Check if PrimusTurbo RMSNorm is enabled.
+
+    Requires:
+      - primus_turbo package is installed
+      - tensor_model_parallel_size == 1
+      - enable_primus_turbo == True
+      - use_turbo_rms_norm == True
+    """
+    # Check if primus_turbo package is available
+    if importlib.util.find_spec("primus_turbo") is None:
+        return False
+
+    args = get_args(ctx)
+    tp_size = getattr(args, "tensor_model_parallel_size", 1)
+    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
+    use_turbo_rms_norm = bool(getattr(args, "use_turbo_rms_norm", False))
+
+    return tp_size == 1 and enable_primus_turbo and use_turbo_rms_norm
+
+
+@register_patch(
+    "megatron.turbo.rms_norm",
+    backend="megatron",
+    phase="before_train",
+    description="Replace Transformer Engine RMSNorm with PrimusTurbo implementation",
+    condition=_is_turbo_rms_norm_enabled,
+)
+def patch_rms_norm(ctx: PatchContext):
+    """
+    Patch Transformer Engine RMSNorm to use PrimusTurbo implementation.
+
+    This replaces transformer_engine.pytorch.RMSNorm with PrimusTurboRMSNorm
+    for improved performance on ROCm platforms.
+    """
+    import transformer_engine as te
+
+    from primus.backends.megatron.core.extensions.primus_turbo import PrimusTurboRMSNorm
+
+    log_rank_0("[Patch:megatron.turbo.rms_norm] Patching RMSNorm...")
+
+    te.pytorch.RMSNorm = PrimusTurboRMSNorm
+    log_rank_0(
+        "[Patch:megatron.turbo.rms_norm]   Patched "
+        f"transformer_engine.pytorch.RMSNorm -> {PrimusTurboRMSNorm.__name__}"
+    )

--- a/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
+++ b/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
@@ -1,0 +1,113 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Primus Turbo TESpecProvider Patches
+
+Patches for replacing Transformer Engine TESpecProvider with PrimusTurboSpecProvider.
+"""
+
+import importlib.util
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _is_primus_turbo_enabled(ctx: PatchContext) -> bool:
+    """
+    Check if PrimusTurbo is enabled and can be used.
+
+    Requires:
+      - primus_turbo package is installed
+      - tensor_model_parallel_size == 1
+      - enable_primus_turbo == True
+    """
+    # Check if primus_turbo package is available
+    if importlib.util.find_spec("primus_turbo") is None:
+        log_rank_0("[Patch:megatron.turbo.te_spec_provider] primus_turbo not found, use TE backend...")
+        return False
+
+    args = get_args(ctx)
+    tp_size = getattr(args, "tensor_model_parallel_size", 1)
+    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
+
+    if tp_size != 1:
+        if enable_primus_turbo:
+            log_rank_0(
+                "[Patch:megatron.turbo.te_spec_provider] "
+                "Primus Turbo does not support TP; using TE backend instead..."
+            )
+        else:
+            log_rank_0("[Patch:megatron.turbo.te_spec_provider] TP > 1; using TE backend...")
+        return False
+
+    if not enable_primus_turbo:
+        log_rank_0("[Patch:megatron.turbo.te_spec_provider] enable_primus_turbo=False; using TE backend...")
+        return False
+
+    return True
+
+
+@register_patch(
+    "megatron.turbo.te_spec_provider",
+    backend="megatron",
+    phase="before_train",
+    description="Replace TESpecProvider with PrimusTurboSpecProvider when PrimusTurbo is enabled",
+    condition=_is_primus_turbo_enabled,
+)
+def patch_te_spec_provider(ctx: PatchContext):
+    """
+    Patch Transformer Engine integration to use PrimusTurboSpecProvider.
+
+    This replaces TESpecProvider in all relevant Megatron modules with
+    PrimusTurboSpecProvider to enable PrimusTurbo backend.
+    """
+    import megatron.core.extensions as meg_ext
+    from megatron.core.extensions import (
+        transformer_engine as transformer_engine_spec_provider,
+    )
+    from megatron.core.models.gpt import gpt_layer_specs, moe_module_specs
+    from megatron.core.transformer import multi_token_prediction
+
+    from primus.backends.megatron.core.extensions.transformer_engine_spec_provider import (
+        PrimusTurboSpecProvider,
+    )
+
+    log_rank_0(
+        "[Patch:megatron.turbo.te_spec_provider] "
+        "Patch TESpecProvider to PrimusTurboSpecProvider; PrimusTurbo backend enabled"
+    )
+
+    assert (
+        meg_ext.transformer_engine.HAVE_TE
+    ), "PrimusTurboSpecProvider patch failed, can't find transformer_engine"
+
+    # Replace TESpecProvider in all relevant locations
+    transformer_engine_spec_provider.TESpecProvider = PrimusTurboSpecProvider
+    log_rank_0(
+        "[Patch:megatron.turbo.te_spec_provider]   Patched "
+        f"megatron.core.extensions.transformer_engine.TESpecProvider -> {PrimusTurboSpecProvider.__name__}"
+    )
+
+    gpt_layer_specs.TESpecProvider = PrimusTurboSpecProvider
+    log_rank_0(
+        "[Patch:megatron.turbo.te_spec_provider]   Patched "
+        f"megatron.core.models.gpt.gpt_layer_specs.TESpecProvider -> {PrimusTurboSpecProvider.__name__}"
+    )
+
+    moe_module_specs.TESpecProvider = PrimusTurboSpecProvider
+    log_rank_0(
+        "[Patch:megatron.turbo.te_spec_provider]   Patched "
+        f"megatron.core.models.gpt.moe_module_specs.TESpecProvider -> {PrimusTurboSpecProvider.__name__}"
+    )
+
+    multi_token_prediction.TESpecProvider = PrimusTurboSpecProvider
+    log_rank_0(
+        "[Patch:megatron.turbo.te_spec_provider]   Patched "
+        f"megatron.core.transformer.multi_token_prediction.TESpecProvider -> {PrimusTurboSpecProvider.__name__}"
+    )
+
+    log_rank_0("[Patch:megatron.turbo.te_spec_provider] Using PrimusTurbo backend (PT)")


### PR DESCRIPTION
Create modular Primus Turbo patches in turbo/ directory:

New patches:
- te_spec_provider_patches.py: Replace TESpecProvider with PrimusTurboSpecProvider
- gpt_output_layer_patches.py: Replace GPT ColumnParallelLinear with PrimusTurbo implementation
- moe_dispatcher_patches.py: Replace MoE token dispatcher with PrimusTurbo DeepEP
- rms_norm_patches.py: Replace RMSNorm with PrimusTurbo implementation
- __init__.py: Module entry point

Features:
- Automatic primus_turbo package detection via importlib
- Condition-based application (TP size, enable flags)
- Clear logging for backend selection (PT vs TE)
- Modular organization (one feature per file)

Conditions:
- All patches require: primus_turbo installed, TP=1, enable_primus_turbo=True
- Additional flags: use_turbo_parallel_linear, use_turbo_deepep, use_turbo_rms_norm

These replace the previous patch_pt_replace_te method from MegatronTrainer, providing better separation and clearer conditional logic.