### PR TITLE
feat(megatron): add FP8 patches for Megatron fp8 context

### DIFF
--- a/primus/backends/megatron/patches/fp8_patches.py
+++ b/primus/backends/megatron/patches/fp8_patches.py
@@ -1,0 +1,55 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron FP8 Patches
+
+This module contains patches that modify Megatron's FP8 context handling
+to use Primus-specific implementations for better ROCm compatibility.
+"""
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+@register_patch(
+    "megatron.fp8.context",
+    backend="megatron",
+    phase="before_train",
+    description="Override Megatron get_fp8_context to use Primus implementation when fp8 is enabled",
+    condition=lambda ctx: getattr(get_args(ctx), "fp8", False),
+)
+def patch_fp8_context(ctx: PatchContext):
+    """
+    Patch Megatron's get_fp8_context functions to use Primus implementation.
+
+    Behavior (moved from MegatronTrainer.patch_fp8_context):
+        - When module_config.fp8 is True, replace get_fp8_context in:
+            * megatron.core.transformer.transformer_block
+            * megatron.core.ssm.mamba_block
+            * megatron.core.transformer.multi_token_prediction
+            * megatron.core.fp8_utils
+          with Primus's ROCm-friendly get_fp8_context.
+    """
+    from megatron.core import fp8_utils
+    from megatron.core.ssm import mamba_block
+    from megatron.core.transformer import multi_token_prediction, transformer_block
+
+    from primus.backends.megatron.core.fp8_utils import get_fp8_context
+
+    log_rank_0("[Patch:megatron.fp8.context] Overriding get_fp8_context for fp8=True")
+
+    # Patch get_fp8_context in all relevant modules
+    modules_to_patch = [
+        transformer_block,
+        mamba_block,
+        multi_token_prediction,
+        fp8_utils,
+    ]
+
+    for module in modules_to_patch:
+        module.get_fp8_context = get_fp8_context
+        log_rank_0(f"[Patch:megatron.fp8.context]   Patched {module.__name__}.get_fp8_context")


### PR DESCRIPTION
## Summary

This PR introduces `fp8_patches.py` to override Megatron's FP8 context handling with a Primus-specific implementation that is more ROCm-friendly.

## Changes

- Add `primus/backends/megatron/patches/fp8_patches.py`:
  - Register patch `megatron.fp8.context` (phase: `before_train`, backend: `megatron`).
  - When `fp8=True` in module args:
    - Override `get_fp8_context` in:
      - `megatron.core.transformer.transformer_block`
      - `megatron.core.ssm.mamba_block`
      - `megatron.core.transformer.multi_token_prediction`
      - `megatron.core.fp8_utils`
    - Use `primus.backends.megatron.core.fp8_utils.get_fp8_context` instead of the default implementation.
  - Add rank-0 logging for easier debugging/traceability.

## How to Enable

- In the Primus module / training config, set:
  - `fp8 = True`
- The patch is guarded by this condition and will no-op when FP8 is disabled.

## Testing

- [ ] FP8 training runs end-to-end with Megatron backend on ROCm.
- [ ] Verified `get_fp8_context` is consistently coming from `primus.backends.megatron.core.fp8_utils`.
- [ ] Checked that loss curves and numerical behavior are reasonable vs. non-FP8 runs.

## Notes / Risks

- This PR replaces multiple `get_fp8_context` symbols at import time; any code relying on Megatron's original FP8 context behavior should be validated.
- Please pay special attention to:
  - Interaction with SSM (`mamba_block`) under FP8.
  - Multi-token prediction path using the patched FP8 context.