### PR TITLE
feature(megatron): Add Torch FSDP2 patch to Megatron patch system

### DIFF
--- a/primus/backends/megatron/patches/__init__.py
+++ b/primus/backends/megatron/patches/__init__.py
@@ -25,6 +25,9 @@ from primus.backends.megatron.patches import (  # noqa: F401
     recompute_layer_patches as _recompute_layer_patches,
 )
 from primus.backends.megatron.patches import (  # noqa: F401
+    torch_fsdp2_patches as _torch_fsdp2_patches,
+)
+from primus.backends.megatron.patches import (  # noqa: F401
     training_log_patches as _training_log_patches,
 )
 from primus.core.patches import run_patches

--- a/primus/backends/megatron/patches/torch_fsdp2_patches.py
+++ b/primus/backends/megatron/patches/torch_fsdp2_patches.py
@@ -1,0 +1,61 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron FSDP Patches
+
+This module contains patches that modify Megatron's FSDP integration to use
+Primus-specific implementations when requested via module_config.
+"""
+
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+@register_patch(
+    "megatron.fsdp.torch_fsdp2",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Replace Megatron's TorchFullyShardedDataParallel with Primus implementation "
+        "when use_torch_fsdp2 is enabled."
+    ),
+    condition=lambda ctx: getattr(get_args(ctx), "use_torch_fsdp2", False),
+)
+def patch_torch_fsdp(ctx: PatchContext):
+    """
+    Patch Megatron to use Primus's TorchFullyShardedDataParallel wrapper.
+
+    Behavior (moved from MegatronTrainer.patch_torch_fsdp):
+        - If backend_args.use_torch_fsdp2 is True:
+            * Patch megatron.core.distributed.torch_fully_sharded_data_parallel.
+            * Patch megatron.training.training.torch_FSDP reference.
+    """
+
+    # Import custom FSDP wrapper
+    # Patch Megatron's internal reference to FSDP2 class
+    import megatron.core.distributed.torch_fully_sharded_data_parallel as torch_fsdp_module
+
+    from primus.backends.megatron.core.distributed.torch_fully_sharded_data_parallel import (
+        PrimusTorchFullyShardedDataParallel,
+    )
+
+    torch_fsdp_module.TorchTorchFullyShardedDataParallel = PrimusTorchFullyShardedDataParallel
+    log_rank_0(
+        "[Patch:megatron.fsdp.torch_fsdp2]   Patched "
+        "megatron.core.distributed.torch_fully_sharded_data_parallel.TorchTorchFullyShardedDataParallel "
+        f"-> {PrimusTorchFullyShardedDataParallel.__name__}"
+    )
+
+    # Patch training code reference
+    from megatron.training import training
+
+    training.torch_FSDP = PrimusTorchFullyShardedDataParallel
+    log_rank_0(
+        f"[Patch:megatron.fsdp.torch_fsdp2]   Patched megatron.training.training.torch_FSDP "
+        f"-> {PrimusTorchFullyShardedDataParallel.__name__}"
+    )


### PR DESCRIPTION
## Summary

- Move the existing Torch FSDP2 integration into the Primus Megatron patch system.
- No new behavior is intended; this only refactors how the FSDP2 override is wired.

## Changes

- **New patch module**
  - File: `primus/backends/megatron/patches/torch_fsdp2_patches.py`
  - Patch ID: `megatron.fsdp.torch_fsdp2`
  - Condition: enabled when `use_torch_fsdp2=True`.
  - Behavior:
    - Patch `megatron.core.distributed.torch_fully_sharded_data_parallel.TorchTorchFullyShardedDataParallel`
      to `PrimusTorchFullyShardedDataParallel`.
    - Patch `megatron.training.training.torch_FSDP` to `PrimusTorchFullyShardedDataParallel`.

- **Patch system wiring**
  - File: `primus/backends/megatron/patches/__init__.py`
  - Import `torch_fsdp2_patches` for side-effect registration:
    - `from primus.backends.megatron.patches import torch_fsdp2_patches as _torch_fsdp2_patches  # noqa: F401`

## Testing

- [ ] Run a training job with `use_torch_fsdp2=True` and confirm it still uses the Primus FSDP2 wrapper.
- [ ] Check logs for `megatron.fsdp.torch_fsdp2` patch application.
- [ ] Sanity-check loss and performance vs previous implementation.