### PR TITLE
NCCL_IB_GID_INDEX on base_env.sh

### DIFF
--- a/runner/helpers/envs/base_env.sh
+++ b/runner/helpers/envs/base_env.sh
@@ -125,7 +125,7 @@ export NCCL_DEBUG=${NCCL_DEBUG:-}
 export NCCL_CHECKS_DISABLE=1
 
 # Set InfiniBand GID index for NCCL communication
-export NCCL_IB_GID_INDEX=3
+export NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX:-3}
 
 # Disable cross NIC communication for NCCL
 export NCCL_CROSS_NIC=0


### PR DESCRIPTION
Hard-coding NCCL_IB_GID_INDEX=3 in this file prevents users from overriding the value via external environment variables.
This change applies a default value of NCCL_IB_GID_INDEX=3 only when the variable is not already set, allowing user-provided environment flags to take precedence.