### PR TITLE
fix(torchtitan): adjust DeepSeek V3 16B batch size to 8

### DIFF
--- a/examples/torchtitan/configs/MI300X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -39,7 +39,7 @@ modules:
 
       training:
         debug_moe_force_load_balance: true
-        local_batch_size: 12
+        local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15


### PR DESCRIPTION
- Reduce local_batch_size from 12 to 8 for better memory efficiency