### PR TITLE
Add MaxText Support to primus-cli

### DIFF
--- a/runner/helpers/hooks/train/pretrain/maxtext/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/maxtext/prepare.py
@@ -214,6 +214,56 @@ def main():
     log_info(f"Exposing resolved backend path via extra.backend_path={maxtext_path}")
     print(f"extra.backend_path={maxtext_path}")
 
+    # Expose JAX coordinator environment variables for distributed training
+    # These will be exported by execute_hooks.sh
+    import os
+
+    master_addr = os.getenv("MASTER_ADDR", "localhost")
+    master_port = os.getenv("MASTER_PORT", "1234")
+
+    log_info(
+        f"Exposing JAX coordinator: JAX_COORDINATOR_IP={master_addr}, JAX_COORDINATOR_PORT={master_port}"
+    )
+    print(f"env.JAX_COORDINATOR_IP={master_addr}")
+    print(f"env.JAX_COORDINATOR_PORT={master_port}")
+
+    # Expose MaxText/JAX performance tuning environment variables
+    # These mirror the settings from examples/run_pretrain.sh
+    log_info("Exposing MaxText performance tuning environment variables")
+
+    # XLA/JAX settings
+    dump_hlo_dir = os.getenv("DUMP_HLO_DIR", f"{primus_path}/output/xla_dump_hlo")
+    dump_hlo = os.getenv("DUMP_HLO", "0")
+    print(f"env.DUMP_HLO_DIR={dump_hlo_dir}")
+    print(f"env.DUMP_HLO={dump_hlo}")
+    print("env.NVTE_ALLOW_NONDETERMINISTIC_ALGO=1")
+    print("env.XLA_PYTHON_CLIENT_MEM_FRACTION=.97")
+    print("env.NVTE_USE_HIPBLASLT=1")
+
+    xla_flags = "--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_graph_level=0 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE"
+    if dump_hlo == "1":
+        xla_flags += f" --xla_dump_to={dump_hlo_dir}"
+        log_info(f"XLA HLO dumping enabled, output directory: {dump_hlo_dir}")
+    print(f"env.XLA_FLAGS={xla_flags}")
+
+    # AMD GPU optimizations
+    print("env.HIP_FORCE_DEV_KERNARG=1")
+    print("env.HSA_FORCE_FINE_GRAIN_PCIE=1")
+
+    # Transformer Engine settings for MaxText
+    print("env.NVTE_FUSED_ATTN=1")
+    print("env.NVTE_CK_USES_BWD_V3=1")
+    print("env.NVTE_CK_USES_FWD_V3=1")
+    print("env.NVTE_CK_IS_V3_ATOMIC_FP32=0")
+    print("env.NVTE_CK_HOW_V3_BF16_CVT=2")
+    print("env.NVTE_FUSED_ATTN_CK=1")
+    print("env.NVTE_FUSED_ATTN_AOTRITON=0")
+
+    # Expose run mode: MaxText uses single mode (plain python instead of torchrun)
+    # This will be exported as RUN_MODE env var by execute_hooks.sh
+    log_info("Exposing run mode via env.RUN_MODE=single")
+    print("env.RUN_MODE=single")
+
 
 if __name__ == "__main__":
     log_info("========== Prepare MaxText Env (pre-train hook) ==========")


### PR DESCRIPTION
## Background

MaxText (JAX) requires plain `python3` launcher, while Megatron/TorchTitan (PyTorch) require `torchrun`. Previously, MaxText only worked through legacy `run_pretrain.sh` with hardcoded backend checks.

## Solution

**Dynamic launcher selection via `RUN_MODE` env var:**
- `torchrun` (default) → PyTorch backends  
- `single` → JAX backend (plain python)

**MaxText hook auto-configures:**
- Sets `RUN_MODE=single` to disable torchrun
- Exports JAX coordinator vars (`JAX_COORDINATOR_IP/PORT`)
- Exports performance tuning vars (`XLA_FLAGS`, `NVTE_*`, etc.)
- Installs JAX dependencies

**Refactored command building:**
```bash
CMD="python3 ${script}"           # Base
CMD="${NUMA_PREFIX} ${CMD}"       # Add NUMA if needed  
CMD="torchrun ${ARGS} ${CMD}"     # Add launcher if RUN_MODE=torchrun
```

## Result

All backends now use unified interface:
```bash
primus-cli direct -- train pretrain --config <config.yaml>
```

Backend-specific logic moved to hooks, no more hardcoded `if BACKEND == ...` checks.

**Files changed:**
- `runner/primus-cli-direct.sh`: RUN_MODE support + command building refactor
- `runner/helpers/hooks/train/pretrain/maxtext/prepare.py`: Auto-config env vars