### PR TITLE
Pass `RCCL_*` and `IONIC_*` environment variables

### DIFF
--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -73,7 +73,7 @@ if [ "$NODE_RANK" = "0" ]; then
     echo ""
 fi
 
-# Pass all PRIMUS_ and NCCL_ environment variables into the container
+# Pass all PRIMUS_, NCCL_, RCCL_, and IONIC_ environment variables into the container
 ENV_ARGS=()
 
 while IFS='=' read -r name _; do
@@ -82,6 +82,12 @@ done < <(env | grep "^PRIMUS_")
 while IFS='=' read -r name _; do
     ENV_ARGS+=("--env" "$name")
 done < <(env | grep "^NCCL_")
+while IFS='=' read -r name _; do
+    ENV_ARGS+=("--env" "$name")
+done < <(env | grep "^RCCL_")
+while IFS='=' read -r name _; do
+    ENV_ARGS+=("--env" "$name")
+done < <(env | grep "^IONIC_")
 while IFS='=' read -r name _; do
     ENV_ARGS+=("--env" "$name")
 done < <(env | grep "^PRIMUS_TURBO_")


### PR DESCRIPTION
Extends the `run_local_pretrain.sh` script to automatically pass `RCCL_*` and `IONIC_*` environment variables into the Docker/Podman container.

- Added environment variable capture for `RCCL_*` prefix (e.g., `RCCL_LL128_FORCE_ENABLE`, `RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING`)
- Added environment variable capture for `IONIC_*` prefix (e.g., `IONIC_RCQ_SIGN_BIT`, `IONIC_RCQ_NUM_PATHS`)