### PR TITLE
megatron(turbo): rely on patch system for missing imports in spec provider

### DIFF
--- a/primus/backends/megatron/core/extensions/transformer_engine_spec_provider.py
+++ b/primus/backends/megatron/core/extensions/transformer_engine_spec_provider.py
@@ -29,33 +29,21 @@ from megatron.core.transformer.moe.experts import (
 )
 from megatron.core.utils import get_te_version, is_te_min_version
 
+from primus.backends.megatron.core.extensions.primus_turbo import (
+    PrimusTurboAttention,
+    PrimusTurboColumnParallelLinear,
+    PrimusTurboGroupedMLP,
+    PrimusTurboLayerNormColumnParallelLinear,
+    PrimusTurboLinear,
+    PrimusTurboRowParallelLinear,
+)
 from primus.backends.megatron.training.global_vars import get_primus_args
-
-try:
-    from primus.backends.megatron.core.extensions.primus_turbo import (
-        PrimusTurboAttention,
-        PrimusTurboColumnParallelLinear,
-        PrimusTurboGroupedMLP,
-        PrimusTurboLayerNormColumnParallelLinear,
-        PrimusTurboLinear,
-        PrimusTurboRowParallelLinear,
-    )
-
-    HAVE_PRIMUS_TURBO = True
-except ImportError:
-
-    HAVE_PRIMUS_TURBO = False
 
 
 class PrimusTurboSpecProvider(BackendSpecProvider):
     """A protocol for providing the submodules used in Spec building."""
 
     def __init__(self):
-        if not HAVE_PRIMUS_TURBO:
-            raise ImportError(
-                "PrimusTurbo extension requires the primus_Turbo package. " "Please install it."
-            )
-
         self.cfg = get_primus_args()
 
     def linear(self) -> type:


### PR DESCRIPTION
### Summary
This PR removes local “optional import / runtime guard” logic from PrimusTurboSpecProvider so that import failures surface immediately and the patch system can uniformly decide to skip/not apply the turbo patch (instead of deferring failures to runtime).

----

### Changes
Updated primus/backends/megatron/core/extensions/transformer_engine_spec_provider.py
Removed HAVE_PRIMUS_TURBO and the try/except ImportError fallback.
Removed the __init__ guard that raised ImportError at runtime.
Keep a direct import of PrimusTurbo extension symbols.

### Why
Avoid “half-enabled” turbo behavior where the failure only appears later at runtime.
Centralize error handling in the patch system: if turbo import fails, the patch won’t be applied.