### PR TITLE
[Fix] fix quant config arg name

### DIFF
--- a/primus/backends/megatron/core/fp8_utils.py
+++ b/primus/backends/megatron/core/fp8_utils.py
@@ -209,7 +209,7 @@ if HAVE_TE and HAVE_TURBO:
                     fp8_recipe=fp8_recipe,
                     fp8_group=fp8_group,
                     enabled_turbo=True if fp8_quant_config is not None else False,
-                    turbo_fp8_quant_config=fp8_quant_config,
+                    turbo_quant_config=fp8_quant_config,
                 )
             else:
                 import inspect


### PR DESCRIPTION
RE: https://github.com/AMD-AGI/Primus/pull/470/changes#diff-7b5426c2b7c70c5fb3904971a75a26c2fbdf5e3cb575f5514688186ecd65f673R168

This `turbo_fp8_quant_config` was renamed `turbo_quant_config`, but the caller still uses the old arg name. This PR fixes the caller to use the new arg name.