### PR TITLE
Enable turbo classic attention

### DIFF
--- a/examples/torchtitan/configs/MI355X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         enable_attention_float8: false
         use_turbo_grouped_mm: true
         use_moe_fp8: false
-        use_classic_attention: false
+        use_classic_attention: true
 
       # quantize:
       #   linear:


### PR DESCRIPTION
Enabling classic turbo improves TGS from 21672 to 28257 on MI355X with v26.1 RC