### PR TITLE
Pass missed HIPBLASLT env to docker

### DIFF
--- a/examples/run_local_pretrain.sh
+++ b/examples/run_local_pretrain.sh
@@ -73,9 +73,12 @@ if [ "$NODE_RANK" = "0" ]; then
     echo ""
 fi
 
-# Pass all PRIMUS_, NCCL_, RCCL_, and IONIC_ environment variables into the container
+# Pass all PRIMUS_, NCCL_, RCCL_, HIPBLASLT_, and IONIC_ environment variables into the container
 ENV_ARGS=()
 
+while IFS='=' read -r name _; do
+    ENV_ARGS+=("--env" "$name")
+done < <(env | grep "^HIPBLASLT_")
 while IFS='=' read -r name _; do
     ENV_ARGS+=("--env" "$name")
 done < <(env | grep "^PRIMUS_")


### PR DESCRIPTION
Lorri:
We need to add this capture flag to let the hipblaslt profile/tune work.
I met this issue when working on DLC cluster (slurm based)