### PR TITLE
feat(megatron-bridge): enable DEBUG logging for MI355X configs

### DIFF
--- a/examples/megatron_bridge/configs/MI355X/llama31_70b_lora_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/llama31_70b_lora_posttrain.yaml
@@ -12,6 +12,8 @@ modules:
     model: llama31_70b.yaml
 
     overrides:
+      stderr_sink_level: DEBUG
+
       # Parallelism configuration
       tensor_model_parallel_size: 8
       pipeline_model_parallel_size: 1

--- a/examples/megatron_bridge/configs/MI355X/llama31_70b_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/llama31_70b_sft_posttrain.yaml
@@ -12,6 +12,8 @@ modules:
     model: llama31_70b.yaml
 
     overrides:
+      stderr_sink_level: DEBUG
+
       # Parallelism configuration (adjusted for 8 GPUs)
       tensor_model_parallel_size: 8
       pipeline_model_parallel_size: 1

--- a/examples/megatron_bridge/configs/MI355X/qwen3_32b_lora_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/qwen3_32b_lora_posttrain.yaml
@@ -12,6 +12,8 @@ modules:
     model: qwen3_32b.yaml
 
     overrides:
+      stderr_sink_level: DEBUG
+
       # Parallelism configuration
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1

--- a/examples/megatron_bridge/configs/MI355X/qwen3_32b_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/qwen3_32b_sft_posttrain.yaml
@@ -12,6 +12,8 @@ modules:
     model: qwen3_32b.yaml
 
     overrides:
+      stderr_sink_level: DEBUG
+
       # Parallelism configuration
       tensor_model_parallel_size: 4
       pipeline_model_parallel_size: 1

--- a/examples/megatron_bridge/configs/MI355X/qwen3_8b_lora_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/qwen3_8b_lora_posttrain.yaml
@@ -12,6 +12,8 @@ modules:
     model: qwen3_8b.yaml
 
     overrides:
+      stderr_sink_level: DEBUG
+
       # Parallelism configuration
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1

--- a/examples/megatron_bridge/configs/MI355X/qwen3_8b_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/qwen3_8b_sft_posttrain.yaml
@@ -12,6 +12,8 @@ modules:
     model: qwen3_8b.yaml
 
     overrides:
+      stderr_sink_level: DEBUG
+
       # Parallelism configuration
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1


### PR DESCRIPTION
Enable DEBUG level logging for all MI355X Megatron-Bridge post-training configurations to improve debugging capabilities and provide more detailed runtime information.
