### PR TITLE
fix(megatron): add TEGroupedMLP compatibility check for PrimusTurbo

### DIFF
--- a/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
+++ b/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
@@ -12,6 +12,7 @@ Patches for replacing Transformer Engine TESpecProvider with PrimusTurboSpecProv
 
 import importlib.util
 
+from primus.backends.megatron.patches.te_patches.utils import is_te_min_version
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
 
@@ -24,6 +25,8 @@ def _is_primus_turbo_enabled(ctx: PatchContext) -> bool:
       - primus_turbo package is installed
       - tensor_model_parallel_size == 1
       - enable_primus_turbo == True
+      - If use_turbo_grouped_mlp is enabled with moe_grouped_gemm,
+        must use legacy grouped gemm (moe_use_legacy_grouped_gemm=True)
     """
     # Check if primus_turbo package is available
     if importlib.util.find_spec("primus_turbo") is None:
@@ -46,6 +49,17 @@ def _is_primus_turbo_enabled(ctx: PatchContext) -> bool:
 
     if not enable_primus_turbo:
         log_rank_0("[Patch:megatron.turbo.te_spec_provider] enable_primus_turbo=False; using TE backend...")
+        return False
+
+    if (
+        getattr(args, "use_turbo_grouped_mlp", False)
+        and getattr(args, "moe_grouped_gemm", False)
+        and not getattr(args, "moe_use_legacy_grouped_gemm", True)
+        and is_te_min_version("1.9.0")
+    ):
+        log_rank_0(
+            "[Patch:megatron.turbo.te_spec_provider] PrimusTurbo not support TEGroupedMLP (TE>=1.9.0); using TE backend..."
+        )
         return False
 
     return True


### PR DESCRIPTION
Adds a condition check to disable PrimusTurbo when using TEGroupedMLP with non-legacy grouped gemm (TE>=1.9.0), preventing the AssertionError: 'PrimusTurbo not support RowParallelGroupedLinear'.