### PR TITLE
fix(docker): use PEP 517 for aiter editable install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,7 +231,7 @@ jobs:
           git submodule update --init --recursive
           start_time=$(date +%s)
           echo "✅ [Build aiter] started at: $(date)"
-          PREBUILD_KERNELS=3 python3 setup.py develop
+          PREBUILD_KERNELS=3 pip install --no-cache-dir --use-pep517 .
           end_time=$(date +%s)
           elapsed=$((end_time - start_time))
           echo "✅ [Build aiter] ended at: $(date)"

--- a/.github/workflows/docker/Dockerfile
+++ b/.github/workflows/docker/Dockerfile
@@ -57,7 +57,7 @@ RUN pip3 uninstall aiter amd-aiter -y || true && \
     cd aiter && \
     git checkout ${PRIMUS_TURBO_AITER_COMMIT} && \
     git submodule update --init --recursive && \
-    PREBUILD_KERNELS=3 python3 setup.py develop
+    PREBUILD_KERNELS=3 pip install --no-cache-dir --use-pep517 .
 
 RUN cd /opt && \
     git clone https://github.com/AMD-AGI/Primus-Turbo.git && \


### PR DESCRIPTION
The aiter reinstall flow introduced with the Primus-Turbo docker update still relies on `python setup.py develop`, which now fails in Docker with `ModuleNotFoundError: vcs_versioning`. Switch to `pip install --use-pep517 -e .` so aiter resolves build dependencies through its `pyproject.toml`.