### PR TITLE
feat: add NVIDIA GPU support for Megatron-LM, TorchTitan, and MaxText backends

### DIFF
--- a/docker/Dockerfile.nvidia
+++ b/docker/Dockerfile.nvidia
@@ -1,0 +1,28 @@
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:26.01-py3
+FROM ${BASE_IMAGE}
+
+# Install Megatron-LM from source (not available on PyPI)
+COPY third_party/Megatron-LM /opt/Megatron-LM
+RUN pip install --no-build-isolation /opt/Megatron-LM && rm -rf /opt/Megatron-LM
+
+# Install TorchTitan dependencies
+COPY third_party/torchtitan /opt/torchtitan
+RUN pip install --no-build-isolation /opt/torchtitan && rm -rf /opt/torchtitan
+
+# Install Primus dependencies (skip AMD-only packages: pyrsmi, torchao ROCm build)
+RUN pip install \
+    loguru \
+    wandb \
+    expecttest \
+    nltk \
+    matplotlib \
+    markdown2 \
+    tyro \
+    blobfile \
+    transformers \
+    "torchdata>=0.8.0" \
+    "datasets>=3.6.0" \
+    "mlflow==3.4.0" \
+    plotext
+
+WORKDIR /opt

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Guides for common workflows and features:
 
 In-depth technical documentation:
 
+- **[NVIDIA GPU Support](./nvidia-gpu-support.md)** - Running Primus on NVIDIA GPUs (Megatron-LM, TorchTitan)
 - **[Post-Training Guide](./posttraining.md)** - Fine-tuning with SFT and LoRA using Primus CLI
 - **[Performance Projection](./projection.md)** - Project training performance to multi-node configurations
 - **[Preflight](./preflight.md)** - Cluster diagnostics (host/GPU/network info + perf tests)

--- a/docs/nvidia-gpu-support.md
+++ b/docs/nvidia-gpu-support.md
@@ -1,0 +1,196 @@
+# NVIDIA GPU support
+
+Primus is primarily designed for AMD/ROCm, but the Megatron-LM and TorchTitan backends work on NVIDIA GPUs too. This document covers setup and the `target_gpu` field that controls which GPU-specific code runs.
+
+> **Note:** MaxText/JAX on NVIDIA requires a separate JAX+CUDA container image, not covered by `docker/Dockerfile.nvidia`. See [MaxText on NVIDIA](#maxtext-on-nvidia).
+
+---
+
+## Prerequisites
+
+- NVIDIA GPU with CUDA compute capability ≥ 8.0 (Ampere or newer)
+- Docker with [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+- NVIDIA driver ≥ 525
+
+```bash
+# Verify prerequisites
+nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi
+```
+
+---
+
+## Quick start (Megatron-LM)
+
+### 1. Build the Docker image
+
+```bash
+docker build -t primus-nvidia:latest -f docker/Dockerfile.nvidia .
+```
+
+### 2. Run training
+
+```bash
+GPUS_PER_NODE=2 ./primus-cli --config runner/nvidia.yaml container \
+  -- train pretrain --config examples/megatron/configs/nvidia/llama3.2_1B-BF16-pretrain.yaml
+```
+
+---
+
+## The `target_gpu` field
+
+All Primus YAML experiment configs accept a top-level `target_gpu` field:
+
+```yaml
+target_gpu: auto   # auto | amd | nvidia  (default: auto)
+```
+
+| Value | Behavior |
+|-------|----------|
+| `auto` | Detects GPU at runtime: AMD if `torch.version.hip` is set, NVIDIA otherwise |
+| `amd` | Forces AMD/ROCm — enables ROCm validation and Primus-Turbo patches |
+| `nvidia` | Forces NVIDIA/CUDA — skips ROCm validation and Primus-Turbo patches |
+
+| `target_gpu` | `torch.version.hip` | Effective target | ROCm validation | Primus-Turbo |
+|---|---|---|---|---|
+| `auto` | set (ROCm) | `amd` | called | applied if installed |
+| `auto` | unset (CUDA) | `nvidia` | skipped | skipped |
+| `amd` | any | `amd` | called | applied if installed |
+| `nvidia` | any | `nvidia` | skipped | skipped |
+
+---
+
+## Provided example configs
+
+| Backend | Config file |
+|---------|-------------|
+| Megatron-LM | `examples/megatron/configs/nvidia/llama3.2_1B-BF16-pretrain.yaml` |
+| TorchTitan | `examples/torchtitan/configs/nvidia/llama3.1_8B-BF16-pretrain.yaml` |
+| MaxText | `examples/maxtext/configs/nvidia/llama2_7B-pretrain.yaml` |
+
+All NVIDIA configs set `target_gpu: nvidia` and disable Primus-Turbo:
+
+```yaml
+target_gpu: nvidia
+
+# Turbo (AMD-only; disabled for NVIDIA)
+enable_primus_turbo: false
+use_turbo_attention: false
+use_turbo_grouped_mlp: false
+```
+
+---
+
+## Runner configuration (`runner/nvidia.yaml`)
+
+`runner/nvidia.yaml` holds NVIDIA defaults for both `container` and `direct` modes:
+
+```yaml
+container:
+  options:
+    image: "primus-nvidia:latest"
+    gpus: "all"          # NVIDIA GPU access (replaces ROCm --device flags)
+    device: []           # no /dev/kfd or /dev/dri needed
+    ...
+
+direct:
+  gpus_per_node: 2
+  run_mode: "torchrun"
+  numa: "false"
+  env:
+    - "GPUS_PER_NODE=2"
+```
+
+Pass it with `--config runner/nvidia.yaml` to override the default `runner/.primus.yaml`.
+
+---
+
+## Docker image (`docker/Dockerfile.nvidia`)
+
+The NVIDIA Dockerfile starts from `nvcr.io/nvidia/pytorch:26.01-py3` and installs:
+
+- Megatron-LM from `third_party/Megatron-LM/` (not on PyPI)
+- TorchTitan from `third_party/torchtitan/`
+- Primus Python dependencies, excluding AMD-only packages like `pyrsmi`
+
+```bash
+docker build -t primus-nvidia:latest -f docker/Dockerfile.nvidia .
+
+# Use a different base image
+docker build -t primus-nvidia:latest -f docker/Dockerfile.nvidia \
+  --build-arg BASE_IMAGE=nvcr.io/nvidia/pytorch:24.12-py3 .
+```
+
+---
+
+## Environment variables
+
+When `nvidia-smi` is detected (and `rocm-smi` is absent), `runner/helpers/envs/NVIDIA.sh` is sourced automatically. It:
+
+- Sets `CUDA_VISIBLE_DEVICES` from `GPUS_PER_NODE`
+- Unsets AMD-specific variables (`HIP_VISIBLE_DEVICES`, `HSA_ENABLE_SDMA`, `NVTE_ROCM_ENABLE_MXFP8`, ROCm CK kernel flags, etc.)
+- Sets `CUDA_DEVICE_MAX_CONNECTIONS=1`
+
+---
+
+## Per-backend notes
+
+### Megatron-LM
+
+- ROCm-specific argument validation (`validate_args_on_rocm`) is skipped when `target_gpu` resolves to `nvidia`.
+- Primus-Turbo patches check `importlib.util.find_spec("primus_turbo")` before activating — they are no-ops when the package is absent.
+- Set `gradient_accumulation_fusion: false` (default in the NVIDIA config) to avoid a CUDA kernel incompatibility.
+
+### TorchTitan
+
+- All Primus-Turbo patch conditions include a `find_spec("primus_turbo")` guard, so patches are silently skipped when `primus_turbo` is not installed.
+- **Known limitation:** `primus/backends/torchtitan/models/moe/moe.py` and `components/quantization/mx.py` have unconditional top-level `import primus_turbo` statements. These files are only imported for MoE and MX-precision models — LLaMA BF16 is not affected. NVIDIA support for those model types requires wrapping those imports in `try/except ImportError`.
+
+### MaxText on NVIDIA
+
+MaxText uses JAX, not PyTorch. Running it on NVIDIA requires a JAX+CUDA container image (e.g. `nvcr.io/nvidia/jax:24.04-py3` or the Google JAX stable-stack wheel), which `docker/Dockerfile.nvidia` does not provide.
+
+When `target_gpu: nvidia` is set in a MaxText config, the prepare hook (`runner/helpers/hooks/train/pretrain/maxtext/prepare.py`) emits only NVIDIA-compatible environment variables and skips all AMD/ROCm-specific ones (`HIP_FORCE_DEV_KERNARG`, `HSA_FORCE_FINE_GRAIN_PCIE`, `NVTE_CK_*`, etc.).
+
+---
+
+## Usage examples
+
+```bash
+# Megatron-LM: LLaMA 3.2 1B on 2× RTX 3090
+docker build -t primus-nvidia:latest -f docker/Dockerfile.nvidia .
+GPUS_PER_NODE=2 ./primus-cli --config runner/nvidia.yaml container \
+  -- train pretrain --config examples/megatron/configs/nvidia/llama3.2_1B-BF16-pretrain.yaml
+
+# TorchTitan: LLaMA 3.1 8B on 2× RTX 3090
+GPUS_PER_NODE=2 ./primus-cli --config runner/nvidia.yaml container \
+  -- train pretrain --config examples/torchtitan/configs/nvidia/llama3.1_8B-BF16-pretrain.yaml
+
+# Direct mode (inside container or bare-metal CUDA environment)
+GPUS_PER_NODE=2 ./primus-cli --config runner/nvidia.yaml direct \
+  -- train pretrain --config examples/megatron/configs/nvidia/llama3.2_1B-BF16-pretrain.yaml
+
+# AMD (unchanged)
+./primus-cli container \
+  -- train pretrain --config examples/megatron/configs/MI300X/llama3.2_1B-BF16-pretrain.yaml
+```
+
+---
+
+## Troubleshooting
+
+**Container exits with "No GPU devices configured" or `/dev/kfd` errors**
+
+Make sure you are using `runner/nvidia.yaml`. It sets `gpus: all` and `device: []`, which skips the ROCm device path validation.
+
+**`ImportError: No module named 'primus_turbo'`**
+
+Set all Turbo flags to `false` in your config and add `target_gpu: nvidia`. Primus-Turbo is AMD-only and is not in the NVIDIA Docker image.
+
+**NCCL errors on multi-GPU**
+
+Set `NCCL_SOCKET_IFNAME` and `MASTER_ADDR` to the correct network interface/IP. Add them to the `env:` list in `runner/nvidia.yaml` if needed.
+
+**`torchrun` only starts 1 process instead of 2**
+
+Check that `GPUS_PER_NODE` is exported before calling `primus-cli`, or set it under `direct.env` in `runner/nvidia.yaml`.

--- a/examples/maxtext/configs/nvidia/llama2_7B-pretrain.yaml
+++ b/examples/maxtext/configs/nvidia/llama2_7B-pretrain.yaml
@@ -1,0 +1,38 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_7B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_7B.yaml
+    overrides:
+      run_name: "llama2_7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 2
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 2048
+      per_device_batch_size: 4

--- a/examples/megatron/configs/nvidia/deepseek_v2-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/deepseek_v2-BF16-pretrain.yaml
@@ -1,0 +1,103 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:deepseek_v2}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 1
+      global_batch_size: 256
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 14 # int
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:4}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      moe_use_legacy_grouped_gemm: true
+      # MLA
+      multi_latent_attention: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+
+      # remove once super flag is functional again
+      moe_use_fused_router_with_aux_score: true
+      moe_permute_fusion: true
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/deepseek_v2-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/deepseek_v2-FP8-pretrain.yaml
@@ -1,0 +1,102 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:deepseek_v2}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 1
+      global_batch_size: 256
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 14 # int
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:4}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # MLA
+      multi_latent_attention: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/deepseek_v2_lite-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/deepseek_v2_lite-BF16-pretrain.yaml
@@ -1,0 +1,98 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2_lite-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:deepseek_v2_lite}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 12
+      global_batch_size: 768
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      moe_use_legacy_grouped_gemm: true
+      # MLA
+      multi_latent_attention: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+
+      # remove once super flag is functional again
+      moe_use_fused_router_with_aux_score: true
+      moe_permute_fusion: true
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/deepseek_v2_lite-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/deepseek_v2_lite-FP8-pretrain.yaml
@@ -1,0 +1,98 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2_lite-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:deepseek_v2_lite}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 14
+      global_batch_size: 896
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # MLA
+      multi_latent_attention: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 2
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: e4m3
+      fp8_recipe: tensorwise
+      moe_use_legacy_grouped_gemm: true

--- a/examples/megatron/configs/nvidia/deepseek_v3-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/deepseek_v3-BF16-pretrain.yaml
@@ -1,0 +1,97 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v3-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:deepseek_v3}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 4
+      global_batch_size: 256
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      moe_use_legacy_grouped_gemm: true
+      # MLA
+      multi_latent_attention: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+
+      # remove once super flag is functional again
+      moe_use_fused_router_with_aux_score: true
+      moe_permute_fusion: true
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/deepseek_v3-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/deepseek_v3-FP8-pretrain.yaml
@@ -1,0 +1,92 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v3-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:deepseek_v3}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 4
+      global_batch_size: 256
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # MLA
+      multi_latent_attention: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/gpt_oss_120B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/gpt_oss_120B-BF16-pretrain.yaml
@@ -1,0 +1,123 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:tas}
+user_name: ${PRIMUS_USER:qyy}
+exp_name: ${PRIMUS_EXP_NAME:gpt_oss_120B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:gpt_oss_120B}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_GPT_OSS_120B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # mla false
+      # multi_latent_attention: false
+      # # attn uses "bshd" layout, enabling AMD optimized kernel.
+      # apply_rope_fusion: true
+
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: false
+
+      # Sink attention (PR 208) - GPT-OSS style learned sinks
+      # Reference: gpt-oss/gpt_oss/triton/attention.py
+      use_sink_attention: true
+      # Note: sliding window not yet supported by aiter Triton backend
+      # Set to 0 to disable, or wait for backend support
+      sink_sliding_window: 0 # gpt-oss default is 128, but disabled for now
+      sink_window_even_layers_only: true # apply sliding window only to even layers
+
+      apply_rope_fusion: true
+
+      # profile
+      profile: true
+      use_pytorch_profiler: true
+      profile_step_end: 7
+      profile_step_start: 6
+
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 8
+      global_batch_size: 2048
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:2}
+      virtual_pipeline_model_parallel_size: ${PRIMUS_VP:2}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      # train_data_path: data
+      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # fusion
+      # 20250321: need latest megatron docker image
+      moe_permute_fusion: false
+      # fused wgrad gemm and accumulation
+      gradient_accumulation_fusion: false
+      # recommend set `false` in fp8
+      moe_use_legacy_grouped_gemm: false
+      # fused topk router with aux score
+      moe_use_fused_router_with_aux_score: false
+      # pad 192/128 for deepseek attention
+      # fused_padded_mla_attention: false
+
+      multi_latent_attention: false
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      cross_entropy_loss_fusion: true
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 4 # int
+      # Turbo
+      # fp8: hybrid
+      # enable_primus_turbo: true
+      # use_turbo_attention: true
+      # use_turbo_grouped_mlp: false
+      # enable_primus_turbo: false
+      # enable_turbo_attention_float8 : false
+      # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/nvidia/gpt_oss_120B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/gpt_oss_120B-FP8-pretrain.yaml
@@ -1,0 +1,123 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:tas}
+user_name: ${PRIMUS_USER:qyy}
+exp_name: ${PRIMUS_EXP_NAME:gpt_oss_120B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:gpt_oss_120B}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_GPT_OSS_120B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # mla false
+      # multi_latent_attention: false
+      # # attn uses "bshd" layout, enabling AMD optimized kernel.
+      # apply_rope_fusion: true
+
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: false
+
+      # Sink attention (PR 208) - GPT-OSS style learned sinks
+      # Reference: gpt-oss/gpt_oss/triton/attention.py
+      use_sink_attention: true
+      # Note: sliding window not yet supported by aiter Triton backend
+      # Set to 0 to disable, or wait for backend support
+      sink_sliding_window: 0 # gpt-oss default is 128, but disabled for now
+      sink_window_even_layers_only: true # apply sliding window only to even layers
+
+      apply_rope_fusion: true
+
+      # profile
+      profile: true
+      use_pytorch_profiler: true
+      profile_step_end: 7
+      profile_step_start: 6
+
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 8
+      global_batch_size: 2048
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:2}
+      virtual_pipeline_model_parallel_size: ${PRIMUS_VP:2}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      # train_data_path: data
+      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # fusion
+      # 20250321: need latest megatron docker image
+      moe_permute_fusion: false
+      # fused wgrad gemm and accumulation
+      gradient_accumulation_fusion: false
+      # recommend set `false` in fp8
+      moe_use_legacy_grouped_gemm: false
+      # fused topk router with aux score
+      moe_use_fused_router_with_aux_score: false
+      # pad 192/128 for deepseek attention
+      # fused_padded_mla_attention: false
+
+      multi_latent_attention: false
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      cross_entropy_loss_fusion: true
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 4 # int
+
+      fp8: hybrid
+      # enable_primus_turbo: true
+      # use_turbo_attention: true
+      # use_turbo_grouped_mlp: false
+      # enable_primus_turbo: false
+      # enable_turbo_attention_float8 : false
+      # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/nvidia/gpt_oss_20B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/gpt_oss_20B-BF16-pretrain.yaml
@@ -1,0 +1,116 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:tas}
+user_name: ${PRIMUS_USER:qyy}
+exp_name: ${PRIMUS_EXP_NAME:gpt_oss_20B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:gpt_oss_20B}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_GPT_OSS_20B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # mla false
+      # multi_latent_attention: false
+      # # attn uses "bshd" layout, enabling AMD optimized kernel.
+      # apply_rope_fusion: true
+
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: false
+
+      # Sink attention (PR 208) - GPT-OSS style learned sinks
+      # Reference: gpt-oss/gpt_oss/triton/attention.py
+      use_sink_attention: true
+      # Note: sliding window not yet supported by aiter Triton backend
+      # Set to 0 to disable, or wait for backend support
+      sink_sliding_window: 0 # gpt-oss default is 128, but disabled for now
+      sink_window_even_layers_only: true # apply sliding window only to even layers
+
+      apply_rope_fusion: true
+
+      # profile
+      profile: true
+      use_pytorch_profiler: true
+      profile_step_end: 7
+      profile_step_start: 6
+
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 8
+      global_batch_size: 512
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      # train_data_path: data
+      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # fusion
+      # 20250321: need latest megatron docker image
+      moe_permute_fusion: false
+      # fused wgrad gemm and accumulation
+      gradient_accumulation_fusion: false
+      # recommend set `false` in fp8
+      moe_use_legacy_grouped_gemm: false
+      # fused topk router with aux score
+      moe_use_fused_router_with_aux_score: false
+      # pad 192/128 for deepseek attention
+      # fused_padded_mla_attention: false
+
+      multi_latent_attention: false
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      cross_entropy_loss_fusion: true
+      # fp8: hybrid
+      # enable_primus_turbo: true
+      # use_turbo_attention: true
+      # use_turbo_grouped_mlp: false
+      # enable_primus_turbo: false
+      # enable_turbo_attention_float8 : false
+      # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/nvidia/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/gpt_oss_20B-FP8-pretrain.yaml
@@ -1,0 +1,117 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:tas}
+user_name: ${PRIMUS_USER:qyy}
+exp_name: ${PRIMUS_EXP_NAME:gpt_oss_20B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:gpt_oss_20B}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_GPT_OSS_20B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # mla false
+      # multi_latent_attention: false
+      # # attn uses "bshd" layout, enabling AMD optimized kernel.
+      # apply_rope_fusion: true
+
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: false
+
+      # Sink attention (PR 208) - GPT-OSS style learned sinks
+      # Reference: gpt-oss/gpt_oss/triton/attention.py
+      use_sink_attention: true
+      # Note: sliding window not yet supported by aiter Triton backend
+      # Set to 0 to disable, or wait for backend support
+      sink_sliding_window: 0 # gpt-oss default is 128, but disabled for now
+      sink_window_even_layers_only: true # apply sliding window only to even layers
+
+      apply_rope_fusion: true
+
+      # profile
+      profile: true
+      use_pytorch_profiler: true
+      profile_step_end: 7
+      profile_step_start: 6
+
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 8
+      global_batch_size: 512
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      # train_data_path: data
+      train_data_path: ${TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # fusion
+      # 20250321: need latest megatron docker image
+      moe_permute_fusion: false
+      # fused wgrad gemm and accumulation
+      gradient_accumulation_fusion: false
+      # recommend set `false` in fp8
+      moe_use_legacy_grouped_gemm: false
+      # fused topk router with aux score
+      moe_use_fused_router_with_aux_score: false
+      # pad 192/128 for deepseek attention
+      # fused_padded_mla_attention: false
+
+      multi_latent_attention: false
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      cross_entropy_loss_fusion: true
+
+      fp8: hybrid
+      # enable_primus_turbo: true
+      # use_turbo_attention: true
+      # use_turbo_grouped_mlp: false
+      # enable_primus_turbo: false
+      # enable_turbo_attention_float8 : false
+      # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/nvidia/grok1-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/grok1-BF16-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:grok1-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: grok1.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Grok1_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
-      train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 2
+      global_batch_size: 512
       seq_length: 8192
       max_position_embeddings: 8192
-
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -41,19 +39,29 @@ modules:
       init_method_std: 0.008
       norm_epsilon: 1e-6
 
-      # parallel
+      # parallel (for 8 nodes)
       tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      num_virtual_stages_per_pipeline_rank: 4
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 8 # int
 
       # data
       mock_data: true
       train_data_path: null
       valid_data_path: null
       test_data_path: null
+
+      moe_use_legacy_grouped_gemm: true
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true
 
       # ckpt
       finetune: false
@@ -67,17 +75,3 @@ modules:
       no_save_rng: null
       disable_last_saving: true
       ckpt_format: torch
-
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/grok1-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/grok1-FP8-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:grok1-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: grok1.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Grok1_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
-      train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 2
+      global_batch_size: 512
       seq_length: 8192
       max_position_embeddings: 8192
-
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -41,19 +39,28 @@ modules:
       init_method_std: 0.008
       norm_epsilon: 1e-6
 
-      # parallel
+      # parallel (for 8 nodes)
       tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      num_virtual_stages_per_pipeline_rank: 4
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 8 # int
 
       # data
       mock_data: true
       train_data_path: null
       valid_data_path: null
       test_data_path: null
+
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true
 
       # ckpt
       finetune: false
@@ -68,16 +75,6 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/grok2-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/grok2-BF16-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:grok2-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: grok2.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Grok2_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
-      train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 2
+      global_batch_size: 128
       seq_length: 8192
       max_position_embeddings: 8192
-
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -41,19 +39,29 @@ modules:
       init_method_std: 0.008
       norm_epsilon: 1e-6
 
-      # parallel
+      # parallel (for 8 nodes)
       tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      num_virtual_stages_per_pipeline_rank: 4
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 8 # int
 
       # data
       mock_data: true
       train_data_path: null
       valid_data_path: null
       test_data_path: null
+
+      moe_use_legacy_grouped_gemm: true
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true
 
       # ckpt
       finetune: false
@@ -67,17 +75,3 @@ modules:
       no_save_rng: null
       disable_last_saving: true
       ckpt_format: torch
-
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/grok2-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/grok2-FP8-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:grok2-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: grok2.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Grok2_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
-      train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 2
+      global_batch_size: 128
       seq_length: 8192
       max_position_embeddings: 8192
-
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -41,19 +39,28 @@ modules:
       init_method_std: 0.008
       norm_epsilon: 1e-6
 
-      # parallel
+      # parallel (for 8 nodes)
       tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      num_virtual_stages_per_pipeline_rank: 4
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 8 # int
 
       # data
       mock_data: true
       train_data_path: null
       valid_data_path: null
       test_data_path: null
+
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true
 
       # ckpt
       finetune: false
@@ -68,16 +75,6 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama2_13B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama2_13B-BF16-pretrain.yaml
@@ -1,33 +1,34 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama2_13B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama2_13B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
+
+      eval_iters: 0
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
       micro_batch_size: 4
-      global_batch_size: 32
+      global_batch_size: 64
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: 4096
+      max_position_embeddings: 4096
 
       lr: 1e-5
       min_lr: 0.0
@@ -68,16 +69,22 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 40 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
+
+      # use_torch_fsdp2: true
+      # use_distributed_optimizer: false
+      # overlap_param_gather: false
+      # ckpt_format: torch
+      # sequence_parallel: 1
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama2_13B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama2_13B-FP8-pretrain.yaml
@@ -1,33 +1,34 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama2_13B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama2_13B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
+
+      eval_iters: 0
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
       micro_batch_size: 4
-      global_batch_size: 32
+      global_batch_size: 64
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: 4096
+      max_position_embeddings: 4096
 
       lr: 1e-5
       min_lr: 0.0
@@ -68,16 +69,27 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 40 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
+
+      # use_torch_fsdp2: true
+      # use_distributed_optimizer: false
+      # overlap_param_gather: false
+      # ckpt_format: torch
+      # sequence_parallel: 1
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/llama2_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama2_70B-BF16-pretrain.yaml
@@ -1,33 +1,28 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama2_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama2_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 17
+      global_batch_size: 272
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: 4096
+      max_position_embeddings: 4096
 
       lr: 1e-5
       min_lr: 0.0
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,26 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # TransformerEngine
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama2_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama2_70B-FP8-pretrain.yaml
@@ -1,33 +1,28 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama2_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama2_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 7
+      global_batch_size: 56
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: 4096
+      max_position_embeddings: 4096
 
       lr: 1e-5
       min_lr: 0.0
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,31 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # TransformerEngine
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/llama2_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama2_7B-BF16-pretrain.yaml
@@ -1,33 +1,34 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama2_7B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama2_7B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
+
+      eval_iters: 0
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 10
+      global_batch_size: 640
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: 4096
+      max_position_embeddings: 4096
 
       lr: 1e-5
       min_lr: 0.0
@@ -68,16 +69,17 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # use_torch_fsdp2: true
+      # use_distributed_optimizer: false
+      # overlap_param_gather: false
+      # ckpt_format: torch
+      # sequence_parallel: 1
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama2_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama2_7B-FP8-pretrain.yaml
@@ -1,33 +1,34 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama2_7B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama2_7B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
+
+      eval_iters: 0
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 13
+      global_batch_size: 416
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: 4096
+      max_position_embeddings: 4096
 
       lr: 1e-5
       min_lr: 0.0
@@ -47,7 +48,7 @@ modules:
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
       overlap_param_gather: true
-      gradient_accumulation_fusion: false
+      gradient_accumulation_fusion: true
 
       # data
       mock_data: true
@@ -68,16 +69,21 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # use_torch_fsdp2: true
+      # use_distributed_optimizer: false
+      # overlap_param_gather: false
+      # ckpt_format: torch
+      # sequence_parallel: 1
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama3.1_405B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.1_405B-BF16-pretrain.yaml
@@ -1,30 +1,25 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: exp-llama3_405B-pretrain
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.1_405B.yaml
     overrides:
       # log
       wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 1
+      global_batch_size: 256
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -42,12 +37,9 @@ modules:
       norm_epsilon: 1e-6
 
       # parallel
-      tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
+      tensor_model_parallel_size: 8
+      pipeline_model_parallel_size: 8
       expert_model_parallel_size: 1
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +58,8 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      use_distributed_optimizer: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: true
+      overlap_grad_reduce: true

--- a/examples/megatron/configs/nvidia/llama3.1_405B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.1_405B-FP8-pretrain.yaml
@@ -1,30 +1,25 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: exp-llama3_405B-pretrain
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.1_405B.yaml
     overrides:
       # log
       wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 1
+      global_batch_size: 256
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -42,12 +37,9 @@ modules:
       norm_epsilon: 1e-6
 
       # parallel
-      tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
+      tensor_model_parallel_size: 8
+      pipeline_model_parallel_size: 8
       expert_model_parallel_size: 1
-      overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +58,12 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_distributed_optimizer: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: true
+      overlap_grad_reduce: true
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama3.1_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.1_70B-BF16-pretrain.yaml
@@ -1,30 +1,25 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.1_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 1
+      global_batch_size: 128
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,19 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 30 # int
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama3.1_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.1_70B-FP8-pretrain.yaml
@@ -1,22 +1,17 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.1_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,24 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/llama3.1_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.1_8B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.1_8B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -24,7 +23,7 @@ modules:
 
       train_iters: 50
       micro_batch_size: 4
-      global_batch_size: 32
+      global_batch_size: 256
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -68,16 +67,11 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
+      # Turbo
       enable_primus_turbo: false
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama3.1_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.1_8B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.1_8B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,8 +22,8 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 6
+      global_batch_size: 384
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -47,7 +46,7 @@ modules:
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
       overlap_param_gather: true
-      gradient_accumulation_fusion: false
+      gradient_accumulation_fusion: true
 
       # data
       mock_data: true
@@ -68,16 +67,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
+      # Turbo
       enable_primus_turbo: false
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama3.2_1B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.2_1B-BF16-pretrain.yaml
@@ -1,0 +1,94 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    # data_path: ./data
+
+    # model to run
+    model: llama3.2_1B.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Pretrain"
+      # disable_wandb: false
+      # disable_tensorboard: false
+      stderr_sink_level: DEBUG
+
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      train_iters: 50
+      micro_batch_size: 1
+      global_batch_size: 8
+
+      seq_length: 2048
+      max_position_embeddings: 2048
+
+      lr: 1.0e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+
+      # parallel
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # tokenizer: use NullTokenizer for mock data (avoids HuggingFace download)
+      tokenizer_type: NullTokenizer
+      vocab_size: 128256
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+
+      # disable wandb for NVIDIA (no AMD-specific project needed)
+      disable_wandb: true
+
+      # Turbo (AMD-only; disabled for NVIDIA)
+      enable_primus_turbo: false
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
+      # but not in bare Python environments. Use local transformer impl for direct mode
+      # compatibility; switch to transformer_engine in container for best performance.
+      # Activation recomputation compensates for higher memory use without flash attention.
+      apply_rope_fusion: false
+      transformer_impl: local
+      no_persist_layer_norm: true
+      recompute_activations: true
+
+      # Cross entropy flags
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama3.2_1B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.2_1B-FP8-pretrain.yaml
@@ -68,16 +68,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"
       # cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama3.2_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.2_3B-BF16-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3.2_3B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,7 +11,7 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.2_3B.yaml
     overrides:
       # log
       wandb_project: "Primus_Pretrain"
@@ -68,16 +68,10 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"
       # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama3.2_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.2_3B-FP8-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3.2_3B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,7 +11,7 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.2_3B.yaml
     overrides:
       # log
       wandb_project: "Primus_Pretrain"
@@ -68,16 +68,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"
       # cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama3.3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.3_70B-BF16-pretrain.yaml
@@ -1,30 +1,25 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.3_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 6
+      global_batch_size: 48
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,24 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama3.3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3.3_70B-FP8-pretrain.yaml
@@ -1,30 +1,25 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3.3_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 3
+      global_batch_size: 24
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,29 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/llama3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3_70B-BF16-pretrain.yaml
@@ -1,30 +1,25 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 3
+      global_batch_size: 24
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,24 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3_70B-FP8-pretrain.yaml
@@ -1,30 +1,25 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    model: llama3_70B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 3
+      global_batch_size: 24
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -46,8 +41,6 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
-      gradient_accumulation_fusion: false
 
       # data
       mock_data: true
@@ -66,18 +59,28 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      ckpt_format: torch_dist
+      sequence_parallel: 1
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama3_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3_8B-BF16-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_8B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,10 +11,10 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama3_8B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,8 +23,8 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 2
+      global_batch_size: 16
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -68,16 +68,11 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/llama3_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama3_8B-FP8-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_8B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,10 +11,10 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: llama3_8B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,8 +23,8 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 2
+      global_batch_size: 16
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -68,16 +68,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama4_17B128E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama4_17B128E-BF16-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17B128E-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: ${PRIMUS_MODEL:llama4_17B128E}.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
+      # debug
+      moe_router_force_load_balancing: true
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
-      seq_length: 8192
-      max_position_embeddings: 8192
-
+      micro_batch_size: 1
+      global_batch_size: 8
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -42,18 +40,20 @@ modules:
       norm_epsilon: 1e-6
 
       # parallel
-      tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
 
       # data
       mock_data: true
-      train_data_path: null
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
       valid_data_path: null
       test_data_path: null
+
+      moe_use_legacy_grouped_gemm: false
 
       # ckpt
       finetune: false
@@ -67,17 +67,14 @@ modules:
       no_save_rng: null
       disable_last_saving: true
       ckpt_format: torch
+      eval_iters: 0
 
-      # Turbo (AMD-only; disabled for NVIDIA)
       enable_primus_turbo: false
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      use_turbo_parallel_linear: false
+      enable_turbo_attention_float8: false
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 48 # int

--- a/examples/megatron/configs/nvidia/llama4_17B128E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama4_17B128E-FP8-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17B128E-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: ${PRIMUS_MODEL:llama4_17B128E}.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
+      # debug
+      moe_router_force_load_balancing: true
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
-      seq_length: 8192
-      max_position_embeddings: 8192
-
+      micro_batch_size: 1
+      global_batch_size: 8
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -42,16 +40,16 @@ modules:
       norm_epsilon: 1e-6
 
       # parallel
-      tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
 
       # data
       mock_data: true
-      train_data_path: null
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
       valid_data_path: null
       test_data_path: null
 
@@ -67,17 +65,19 @@ modules:
       no_save_rng: null
       disable_last_saving: true
       ckpt_format: torch
+      eval_iters: 0
 
-      # Turbo (AMD-only; disabled for NVIDIA)
       enable_primus_turbo: false
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
+      use_turbo_parallel_linear: false
+      enable_turbo_attention_float8: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 48 # int
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/llama4_17B16E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama4_17B16E-BF16-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17B16E-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: ${PRIMUS_MODEL:llama4_17B16E}.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
+      # debug
+      moe_router_force_load_balancing: true
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
-      seq_length: 8192
-      max_position_embeddings: 8192
-
+      micro_batch_size: 1
+      global_batch_size: 8
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -42,18 +40,20 @@ modules:
       norm_epsilon: 1e-6
 
       # parallel
-      tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
 
       # data
       mock_data: true
-      train_data_path: null
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
       valid_data_path: null
       test_data_path: null
+
+      moe_use_legacy_grouped_gemm: false
 
       # ckpt
       finetune: false
@@ -67,17 +67,18 @@ modules:
       no_save_rng: null
       disable_last_saving: true
       ckpt_format: torch
+      eval_iters: 0
 
-      # Turbo (AMD-only; disabled for NVIDIA)
       enable_primus_turbo: false
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
+      use_turbo_parallel_linear: false
+      enable_turbo_attention_float8: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
+      # TransformerEngine
       apply_rope_fusion: true
       transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 48 # int

--- a/examples/megatron/configs/nvidia/llama4_17B16E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/llama4_17B16E-FP8-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17B16E-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: ${PRIMUS_MODEL:llama4_17B16E}.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_DeepSeek_Pretrain"
       stderr_sink_level: DEBUG
 
+      # debug
+      moe_router_force_load_balancing: true
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
-      seq_length: 8192
-      max_position_embeddings: 8192
-
+      micro_batch_size: 1
+      global_batch_size: 8
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -42,16 +40,16 @@ modules:
       norm_epsilon: 1e-6
 
       # parallel
-      tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
 
       # data
       mock_data: true
-      train_data_path: null
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
       valid_data_path: null
       test_data_path: null
 
@@ -67,17 +65,23 @@ modules:
       no_save_rng: null
       disable_last_saving: true
       ckpt_format: torch
+      eval_iters: 0
 
-      # Turbo (AMD-only; disabled for NVIDIA)
       enable_primus_turbo: false
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
+      use_turbo_parallel_linear: false
+      enable_turbo_attention_float8: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
+      # TransformerEngine
       apply_rope_fusion: true
       transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 48 # int
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/mixtral_8x22B_v0.1-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/mixtral_8x22B_v0.1-BF16-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x22B_v0.1-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: mixtral_8x22B_v0.1.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
+      micro_batch_size: 2
+      global_batch_size: 128
       seq_length: 8192
       max_position_embeddings: 8192
-
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -43,17 +41,24 @@ modules:
 
       # parallel
       tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 0 # int
 
       # data
       mock_data: true
       train_data_path: null
       valid_data_path: null
       test_data_path: null
+
+      moe_use_legacy_grouped_gemm: false
 
       # ckpt
       finetune: false
@@ -68,16 +73,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
+      # TransformerEngine
       apply_rope_fusion: true
       transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/mixtral_8x22B_v0.1-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/mixtral_8x22B_v0.1-FP8-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x22B_v0.1-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: mixtral_8x22B_v0.1.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
-
+      micro_batch_size: 2
+      global_batch_size: 128
       seq_length: 8192
       max_position_embeddings: 8192
-
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -43,11 +41,16 @@ modules:
 
       # parallel
       tensor_model_parallel_size: 1
-      pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 0 # int
 
       # data
       mock_data: true
@@ -68,16 +71,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/mixtral_8x7B_v0.1-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/mixtral_8x7B_v0.1-BF16-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x22B_v0.1-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: mixtral_8x7B_v0.1.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
       micro_batch_size: 4
-      global_batch_size: 32
-
-      seq_length: 8192
-      max_position_embeddings: 8192
-
+      global_batch_size: 256
+      seq_length: 4096
+      max_position_embeddings: 4096
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -44,7 +42,7 @@ modules:
       # parallel
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
@@ -54,6 +52,8 @@ modules:
       train_data_path: null
       valid_data_path: null
       test_data_path: null
+
+      moe_use_legacy_grouped_gemm: false
 
       # ckpt
       finetune: false
@@ -68,16 +68,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
+      # TransformerEngine
       apply_rope_fusion: true
       transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/mixtral_8x7B_v0.1-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/mixtral_8x7B_v0.1-FP8-pretrain.yaml
@@ -1,34 +1,32 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x22B_v0.1-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
-    framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
-
-    # model to run
-    model: llama3.2_1B.yaml
+    framework: megatron
+    model: mixtral_8x7B_v0.1.yaml
     overrides:
-      # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_DeepSeek_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
 
+      # moe
+      moe_router_force_load_balancing: true
+      moe_router_dtype: null
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
+      # hyper parameters
       train_iters: 50
-      micro_batch_size: 4
+      micro_batch_size: 2
       global_batch_size: 32
-
-      seq_length: 8192
-      max_position_embeddings: 8192
-
+      seq_length: 4096
+      max_position_embeddings: 4096
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
@@ -44,7 +42,7 @@ modules:
       # parallel
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
-      expert_model_parallel_size: 1
+      expert_model_parallel_size: 8
       overlap_grad_reduce: true
       overlap_param_gather: true
       gradient_accumulation_fusion: false
@@ -68,16 +66,19 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
+      # TransformerEngine
       apply_rope_fusion: true
       transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/qwen2.5_14B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_14B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_14B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_14B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_14B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -26,28 +25,33 @@ modules:
       micro_batch_size: 4
       global_batch_size: 32
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
-      lr: 1e-5
-      min_lr: 0.0
+      lr: 1e-4
+      min_lr: 1e-5
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
-      weight_decay: 0.1
+      weight_decay: 1e-1
       adam_beta1: 0.9
       adam_beta2: 0.95
       eod_mask_loss: true
       init_method_std: 0.008
-      norm_epsilon: 1e-6
+      norm_epsilon: 1e-5
 
       # parallel
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
+      sequence_parallel: 1
       overlap_grad_reduce: true
+
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+      ckpt_format: torch
 
       # data
       mock_data: true
@@ -66,18 +70,17 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 48 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen2.5_14B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_14B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_14B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_14B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_14B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -26,28 +25,33 @@ modules:
       micro_batch_size: 4
       global_batch_size: 32
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
-      lr: 1e-5
-      min_lr: 0.0
+      lr: 1e-4
+      min_lr: 1e-5
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
-      weight_decay: 0.1
+      weight_decay: 1e-1
       adam_beta1: 0.9
       adam_beta2: 0.95
       eod_mask_loss: true
       init_method_std: 0.008
-      norm_epsilon: 1e-6
+      norm_epsilon: 1e-5
 
       # parallel
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
+      sequence_parallel: 1
       overlap_grad_reduce: true
+
       overlap_param_gather: true
       gradient_accumulation_fusion: false
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+      ckpt_format: torch
 
       # data
       mock_data: true
@@ -66,18 +70,22 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 48 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/qwen2.5_32B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_32B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_32B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_32B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_32B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,31 +22,36 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 16
+      global_batch_size: 128
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
-      lr: 1e-5
-      min_lr: 0.0
+      lr: 1e-4
+      min_lr: 1e-5
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
-      weight_decay: 0.1
+      weight_decay: 1e-1
       adam_beta1: 0.9
       adam_beta2: 0.95
       eod_mask_loss: true
       init_method_std: 0.008
-      norm_epsilon: 1e-6
+      norm_epsilon: 1e-5
 
       # parallel
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
+      sequence_parallel: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
+
+      overlap_param_gather: false
       gradient_accumulation_fusion: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      ckpt_format: torch_dist
 
       # data
       mock_data: true
@@ -66,18 +70,17 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 64 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen2.5_32B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_32B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_32B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_32B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_32B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,31 +22,36 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 16
+      global_batch_size: 128
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
-      lr: 1e-5
-      min_lr: 0.0
+      lr: 1e-4
+      min_lr: 1e-5
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
-      weight_decay: 0.1
+      weight_decay: 1e-1
       adam_beta1: 0.9
       adam_beta2: 0.95
       eod_mask_loss: true
       init_method_std: 0.008
-      norm_epsilon: 1e-6
+      norm_epsilon: 1e-5
 
       # parallel
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
+      sequence_parallel: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
+
+      overlap_param_gather: false
       gradient_accumulation_fusion: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      ckpt_format: torch_dist
 
       # data
       mock_data: true
@@ -66,18 +70,22 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 64 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
+
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/qwen2.5_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_3B-BF16-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_3B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,10 +11,10 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_3B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_3B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,16 +23,16 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 10
+      global_batch_size: 640
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:32768}
 
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
       weight_decay: 0.1
       adam_beta1: 0.9
@@ -57,7 +57,7 @@ modules:
 
       # ckpt
       finetune: false
-      auto_continue_train: false
+      auto_continue_train: ${CONTI_PARAMS:0}
       load: null
       no_load_optim: null
       no_load_rng: null
@@ -68,16 +68,11 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen2.5_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_3B-FP8-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_3B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,10 +11,10 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_3B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_3B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,16 +23,16 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 10
+      global_batch_size: 640
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:32768}
 
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
       weight_decay: 0.1
       adam_beta1: 0.9
@@ -57,7 +57,7 @@ modules:
 
       # ckpt
       finetune: false
-      auto_continue_train: false
+      auto_continue_train: ${CONTI_PARAMS:0}
       load: null
       no_load_optim: null
       no_load_rng: null
@@ -68,16 +68,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/qwen2.5_72B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_72B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_72B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_72B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_72B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,18 +22,18 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 16
+      global_batch_size: 256
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
-      lr: 1e-5
-      min_lr: 0.0
+      lr: 1e-4
+      min_lr: 1e-5
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
-      weight_decay: 0.1
+      weight_decay: 1e-1
       adam_beta1: 0.9
       adam_beta2: 0.95
       eod_mask_loss: true
@@ -45,9 +44,14 @@ modules:
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
+      sequence_parallel: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
+
+      overlap_param_gather: false
       gradient_accumulation_fusion: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      ckpt_format: torch_dist
 
       # data
       mock_data: true
@@ -66,18 +70,17 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen2.5_72B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_72B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_72B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_72B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_72B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -26,15 +25,15 @@ modules:
       micro_batch_size: 4
       global_batch_size: 32
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
-      lr: 1e-5
-      min_lr: 0.0
+      lr: 1e-4
+      min_lr: 1e-5
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
-      weight_decay: 0.1
+      weight_decay: 1e-1
       adam_beta1: 0.9
       adam_beta2: 0.95
       eod_mask_loss: true
@@ -45,9 +44,14 @@ modules:
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
+      sequence_parallel: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
+
+      overlap_param_gather: false
       gradient_accumulation_fusion: false
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
+      ckpt_format: torch_dist
 
       # data
       mock_data: true
@@ -66,18 +70,22 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 80 # int
+
+      # Turbo
+      enable_primus_turbo: true
       use_turbo_attention: false
       use_turbo_grouped_mlp: false
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/qwen2.5_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_7B-BF16-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_7B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,10 +11,10 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_7B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_7B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,16 +23,16 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 16
+      global_batch_size: 768
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
       weight_decay: 0.1
       adam_beta1: 0.9
@@ -57,7 +57,7 @@ modules:
 
       # ckpt
       finetune: false
-      auto_continue_train: false
+      auto_continue_train: ${CONTI_PARAMS:0}
       load: null
       no_load_optim: null
       no_load_rng: null
@@ -68,16 +68,11 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen2.5_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen2.5_7B-FP8-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_7B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -11,10 +11,10 @@ modules:
     # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen2.5_7B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen2.5_7B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,16 +23,16 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 20
+      global_batch_size: 800
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
 
       lr: 1e-5
       min_lr: 0.0
       lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr_decay_iters: 320000
       lr_decay_style: cosine
       weight_decay: 0.1
       adam_beta1: 0.9
@@ -47,7 +47,7 @@ modules:
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
       overlap_param_gather: true
-      gradient_accumulation_fusion: false
+      gradient_accumulation_fusion: true
 
       # data
       mock_data: true
@@ -57,7 +57,7 @@ modules:
 
       # ckpt
       finetune: false
-      auto_continue_train: false
+      auto_continue_train: ${CONTI_PARAMS:0}
       load: null
       no_load_optim: null
       no_load_rng: null
@@ -68,16 +68,15 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_grouped_mlp: true
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/qwen3_14B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_14B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_14B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_14B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen3_14B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -26,8 +25,8 @@ modules:
       micro_batch_size: 4
       global_batch_size: 32
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:40960}
 
       lr: 1e-5
       min_lr: 0.0
@@ -49,6 +48,9 @@ modules:
       overlap_param_gather: true
       gradient_accumulation_fusion: false
 
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+
       # data
       mock_data: true
       train_data_path: null
@@ -68,16 +70,11 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 40 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen3_14B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_14B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_14B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_14B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen3_14B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -26,8 +25,8 @@ modules:
       micro_batch_size: 4
       global_batch_size: 32
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:40960}
 
       lr: 1e-5
       min_lr: 0.0
@@ -45,9 +44,12 @@ modules:
       tensor_model_parallel_size: 1
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
-      overlap_grad_reduce: true
       overlap_param_gather: true
+      overlap_grad_reduce: true
       gradient_accumulation_fusion: false
+
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
 
       # data
       mock_data: true
@@ -66,18 +68,18 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
+      ckpt_format: torch_dist
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      # recompute_granularity: full # full, selective
+      # recompute_method: block # uniform, block
+      # recompute_num_layers: 40 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/qwen3_235B_A22B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_235B_A22B-BF16-pretrain.yaml
@@ -1,0 +1,103 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_235B_A22B-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_235B_A22B.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Qwen3_235B_A22B_Pretrain"
+      # disable_wandb: false
+      # disable_tensorboard: false
+      stderr_sink_level: DEBUG
+
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+      moe_router_force_load_balancing: true
+
+      train_iters: 50
+      micro_batch_size: 4
+      global_batch_size: 8192 # 32nodes
+
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+
+      lr: 1e-4
+      min_lr: 1e-5
+      lr_warmup_iters: 2
+      lr_decay_iters: 320000
+      lr_decay_style: cosine
+      weight_decay: 1e-1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      # Qwen3-235B has 94 decoder layers. For PP4+VPP4 (16 chunks): 6*14 + 5*2 = 94
+      pipeline_model_parallel_layout: "Et*5|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*5,L"
+      expert_model_parallel_size: 8
+      sequence_parallel: 1
+      overlap_grad_reduce: true
+
+      overlap_param_gather: true
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+      gradient_accumulation_fusion: true
+      ckpt_format: torch
+
+      # data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 3 # int
+
+      moe_use_legacy_grouped_gemm: true
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+      # Cross entropy flags
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen3_235B_A22B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_235B_A22B-FP8-pretrain.yaml
@@ -1,0 +1,106 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_235B_A22B-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_235B_A22B.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Qwen3_235B_A22B_Pretrain"
+      # disable_wandb: false
+      # disable_tensorboard: false
+      stderr_sink_level: DEBUG
+
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+      moe_router_force_load_balancing: true
+
+      train_iters: 50
+      micro_batch_size: 4
+      global_batch_size: 8192 # 32nodes
+
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+
+      lr: 1e-4
+      min_lr: 1e-5
+      lr_warmup_iters: 2
+      lr_decay_iters: 320000
+      lr_decay_style: cosine
+      weight_decay: 1e-1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # parallel
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 4
+      # Qwen3-235B has 94 decoder layers. For PP4+VPP4 (16 chunks): 6*14 + 5*2 = 94
+      pipeline_model_parallel_layout: "Et*5|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*6|t*5,L"
+      expert_model_parallel_size: 8
+      sequence_parallel: 1
+      overlap_grad_reduce: true
+
+      overlap_param_gather: true
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+      gradient_accumulation_fusion: true
+      ckpt_format: torch
+
+      # data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 3 # int
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+
+      # Cross entropy flags
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/qwen3_30B_A3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_30B_A3B-BF16-pretrain.yaml
@@ -1,0 +1,96 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_30B_A3B-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:qwen3_30B_A3B}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Qwen3_30B_A3B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 8
+      global_batch_size: 512
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 5 # int
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      gradient_accumulation_fusion: true
+      moe_use_legacy_grouped_gemm: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+      # Cross entropy flags
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen3_30B_A3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_30B_A3B-FP8-pretrain.yaml
@@ -1,0 +1,100 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_30B_A3B-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:qwen3_30B_A3B}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Qwen3_30B_A3B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 10
+      micro_batch_size: 8
+      global_batch_size: 512
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1e-6
+
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 5 # int
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      gradient_accumulation_fusion: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_mlp: false
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 1-2, 0 means not use sync-free moe
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 1
+
+      # Cross entropy flags
+      # cross_entropy_fusion_impl: "te"
+      # cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/qwen3_32B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_32B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_32B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_32B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen3_32B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,11 +22,11 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 16
+      global_batch_size: 128
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:40960}
 
       lr: 1e-5
       min_lr: 0.0
@@ -46,8 +45,10 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
 
       # data
       mock_data: true
@@ -66,18 +67,13 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
+      ckpt_format: torch_dist
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 64 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen3_32B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_32B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_32B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_32B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen3_32B_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,11 +22,11 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 16
+      global_batch_size: 128
 
-      seq_length: 8192
-      max_position_embeddings: 8192
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:40960}
 
       lr: 1e-5
       min_lr: 0.0
@@ -46,8 +45,10 @@ modules:
       pipeline_model_parallel_size: 1
       expert_model_parallel_size: 1
       overlap_grad_reduce: true
-      overlap_param_gather: true
       gradient_accumulation_fusion: false
+
+      use_torch_fsdp2: true
+      use_distributed_optimizer: false
 
       # data
       mock_data: true
@@ -66,18 +67,18 @@ modules:
       no_save_optim: null
       no_save_rng: null
       disable_last_saving: true
-      ckpt_format: torch
+      ckpt_format: torch_dist
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      # recompute
+      recompute_granularity: full # full, selective
+      recompute_method: block # uniform, block
+      recompute_num_layers: 64 # int
 
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false
+      no_fp8_weight_transpose_cache: true

--- a/examples/megatron/configs/nvidia/qwen3_4B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_4B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_4B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_4B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,8 +22,8 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 2
+      global_batch_size: 128
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -68,16 +67,6 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen3_4B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_4B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_4B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_4B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,8 +22,8 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 2
+      global_batch_size: 128
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -68,16 +67,10 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/qwen3_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_8B-BF16-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_8B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_8B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,8 +22,8 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 2
+      global_batch_size: 128
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -67,17 +66,6 @@ modules:
       no_save_rng: null
       disable_last_saving: true
       ckpt_format: torch
-
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"
       # cross_entropy_loss_fusion: true

--- a/examples/megatron/configs/nvidia/qwen3_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/qwen3_8B-FP8-pretrain.yaml
@@ -1,20 +1,19 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_8B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: qwen3_8B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
+      wandb_project: "Primus_Qwen_Pretrain"
       # disable_wandb: false
       # disable_tensorboard: false
       stderr_sink_level: DEBUG
@@ -23,8 +22,8 @@ modules:
       log_avg_reset_interval: 50
 
       train_iters: 50
-      micro_batch_size: 4
-      global_batch_size: 32
+      micro_batch_size: 2
+      global_batch_size: 128
 
       seq_length: 8192
       max_position_embeddings: 8192
@@ -68,16 +67,10 @@ modules:
       disable_last_saving: true
       ckpt_format: torch
 
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"
       # cross_entropy_loss_fusion: true
+
+      # enable fp8 training
+      fp8: hybrid
+      moe_use_legacy_grouped_gemm: false

--- a/examples/megatron/configs/nvidia/zebra_llama_1B-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/zebra_llama_1B-pretrain.yaml
@@ -1,0 +1,71 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:zebra_llama_1B-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: zebra_llama_1B.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Zebra_Llama_1B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      eval_iters: 0
+
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      train_iters: 100
+      micro_batch_size: 12
+      global_batch_size: 96
+
+      seq_length: 8192
+      max_position_embeddings: 8192
+      original_max_position_embeddings: 8192
+
+      lr: 2e-4
+      min_lr: 2e-5
+      lr_warmup_iters: 200
+      lr_decay_iters: 10000
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+
+      # Mamba-specific: must provide spec
+      # Use custom hybrid Mamba+MLA spec
+      spec: [ 'primus.backends.megatron.core.models.hybrid.hybrid_mamba_mla_layer_specs', 'hybrid_stack_spec' ]
+
+      # Tokenizer
+      tokenizer_type: HuggingFaceTokenizer
+      tokenizer_model: meta-llama/Llama-3.2-1B
+
+      # parallel
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      save: null
+      save_interval: 10000
+      disable_last_saving: true
+      ckpt_format: torch

--- a/examples/megatron/configs/nvidia/zebra_llama_3B-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/zebra_llama_3B-pretrain.yaml
@@ -1,0 +1,71 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:zebra_llama_3B-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: zebra_llama_3B.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Zebra_Llama_3B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      eval_iters: 0
+
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      train_iters: 100
+      micro_batch_size: 7
+      global_batch_size: 56
+
+      seq_length: 8192
+      max_position_embeddings: 8192
+      original_max_position_embeddings: 8192
+
+      lr: 2e-4
+      min_lr: 2e-5
+      lr_warmup_iters: 200
+      lr_decay_iters: 10000
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+
+      # Mamba-specific: must provide spec
+      # Use custom hybrid Mamba+MLA spec
+      spec: [ 'primus.backends.megatron.core.models.hybrid.hybrid_mamba_mla_layer_specs', 'hybrid_stack_spec' ]
+
+      # Tokenizer
+      tokenizer_type: HuggingFaceTokenizer
+      tokenizer_model: meta-llama/Llama-3.2-3B
+
+      # parallel
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: false
+
+      # data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      save: null
+      save_interval: 10000
+      disable_last_saving: true
+      ckpt_format: torch

--- a/examples/megatron/configs/nvidia/zebra_llama_8B-pretrain.yaml
+++ b/examples/megatron/configs/nvidia/zebra_llama_8B-pretrain.yaml
@@ -1,45 +1,51 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.2_1B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:zebra_llama_8B-pretrain}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
   pre_trainer:
     framework: megatron
     config: pre_trainer.yaml
-    # data_path: ./data
 
     # model to run
-    model: llama3.2_1B.yaml
+    model: zebra_llama_8B.yaml
     overrides:
       # log
-      wandb_project: "Primus_Pretrain"
-      # disable_wandb: false
-      # disable_tensorboard: false
+      wandb_project: "Primus_Zebra_Llama_8B_Pretrain"
       stderr_sink_level: DEBUG
+
+      eval_iters: 0
 
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
-      train_iters: 50
+      train_iters: 100
       micro_batch_size: 4
       global_batch_size: 32
 
       seq_length: 8192
       max_position_embeddings: 8192
+      original_max_position_embeddings: 8192
 
-      lr: 1e-5
-      min_lr: 0.0
-      lr_warmup_iters: 2
-      lr_decay_iters: null
+      lr: 2e-4
+      min_lr: 2e-5
+      lr_warmup_iters: 200
+      lr_decay_iters: 10000
       lr_decay_style: cosine
       weight_decay: 0.1
       adam_beta1: 0.9
       adam_beta2: 0.95
       eod_mask_loss: true
-      init_method_std: 0.008
-      norm_epsilon: 1e-6
+
+      # Mamba-specific: must provide spec
+      # Use custom hybrid Mamba+MLA spec
+      spec: [ 'primus.backends.megatron.core.models.hybrid.hybrid_mamba_mla_layer_specs', 'hybrid_stack_spec' ]
+
+      # Tokenizer
+      tokenizer_type: HuggingFaceTokenizer
+      tokenizer_model: meta-llama/Llama-3.1-8B
 
       # parallel
       tensor_model_parallel_size: 1
@@ -59,25 +65,7 @@ modules:
       finetune: false
       auto_continue_train: false
       load: null
-      no_load_optim: null
-      no_load_rng: null
       save: null
-      save_interval: 20000
-      no_save_optim: null
-      no_save_rng: null
+      save_interval: 10000
       disable_last_saving: true
       ckpt_format: torch
-
-      # Turbo (AMD-only; disabled for NVIDIA)
-      enable_primus_turbo: false
-      use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-
-      # TransformerEngine / Apex: available in container (nvcr.io/nvidia/pytorch:26.01-py3)
-      # but not in bare Python environments. Use local transformer impl for direct mode
-      # compatibility; switch to transformer_engine in container for best performance.
-      apply_rope_fusion: true
-      transformer_impl: transformer_engine
-      # Cross entropy flags
-      # cross_entropy_fusion_impl: "te"
-      # cross_entropy_loss_fusion: true

--- a/examples/torchtitan/configs/nvidia/deepseek_v3_16b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/deepseek_v3_16b-FP8-pretrain.yaml
@@ -1,0 +1,91 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v3_16b-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v3_16b-fp8.yaml
+    overrides:
+      profiling:
+        enable_profiling: false
+        save_traces_folder: "profile_trace"
+        profile_freq: 10
+        enable_memory_snapshot: false
+        save_memory_snapshot_folder: "memory_snapshot"
+
+      metrics:
+        log_freq: 1
+        disable_color_printing: false
+        enable_tensorboard: false
+        save_tb_folder: "tb"
+        enable_wandb: false
+
+      optimizer:
+        name: "AdamW"
+        lr: 2.2e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 200 # lr scheduler warm up, normally 20% of the train steps
+        decay_ratio: 0.8 # lr scheduler decay ratio, 80% of the train steps
+        decay_type: "cosine"
+        min_lr_factor: 0.1
+
+      training:
+        debug_moe_force_load_balance: true
+        local_batch_size: 14
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 15
+        dataset: "c4_test" # supported datasets: c4_test (2K), c4 (177M)
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        enable_async_tensor_parallel: false
+        pipeline_parallel_degree: 1
+        pipeline_parallel_schedule: "Interleaved1F1B"
+        expert_parallel_degree: 8
+        expert_tensor_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 10
+        last_save_model_only: true
+        export_dtype: "float32"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      activation_checkpoint:
+        mode: "none" # ["none", "selective", "full"]
+        selective_ac_option: "op" # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+      compile:
+        enable: true
+        components: [ "model", "loss" ] # ["model", "loss"]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        use_turbo_mx_linear: false
+        use_turbo_float8_linear: true
+        enable_attention_float8: false
+        use_turbo_grouped_mm: true
+        use_moe_fp8: true
+        use_classic_attention: false
+      # quantize:
+      #   linear:
+      #     float8:
+      #     enable_fsdp_float8_all_gather: false
+      #     precompute_float8_dynamic_scale_for_fsdp: false
+      #     filter_fqns: ["output", "router.gate"]
+      #   grouped_mm:
+      #     float8:
+      #     fqns: ["experts"]

--- a/examples/torchtitan/configs/nvidia/deepseek_v3_236b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/deepseek_v3_236b-BF16-pretrain.yaml
@@ -1,0 +1,91 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v3_236b-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v3_236b.yaml
+    overrides:
+      profiling:
+        enable_profiling: false
+        save_traces_folder: "profile_trace"
+        profile_freq: 10
+        enable_memory_snapshot: false
+        save_memory_snapshot_folder: "memory_snapshot"
+
+      metrics:
+        log_freq: 1
+        disable_color_printing: false
+        enable_tensorboard: false
+        save_tb_folder: "tb"
+        enable_wandb: false
+
+      optimizer:
+        name: "AdamW"
+        lr: 2.2e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 200 # lr scheduler warm up, normally 20% of the train steps
+        decay_ratio: 0.8 # lr scheduler decay ratio, 80% of the train steps
+        decay_type: "cosine"
+        min_lr_factor: 0.1
+
+      training:
+        debug_moe_force_load_balance: true
+        local_batch_size: 8
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 15
+        dataset: "c4_test" # supported datasets: c4_test (2K), c4 (177M)
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        enable_async_tensor_parallel: false
+        pipeline_parallel_degree: 1
+        pipeline_parallel_schedule: "Interleaved1F1B"
+        expert_parallel_degree: 8
+        expert_tensor_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 10
+        last_save_model_only: true
+        export_dtype: "float32"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      activation_checkpoint:
+        mode: "none" # ["none", "selective", "full"]
+        selective_ac_option: "op" # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+      compile:
+        enable: true
+        components: [ "model", "loss" ] # ["model", "loss"]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        use_turbo_mx_linear: false
+        use_turbo_float8_linear: false
+        enable_attention_float8: false
+        use_turbo_grouped_mm: true
+        use_moe_fp8: false
+        use_classic_attention: true
+      # quantize:
+      #   linear:
+      #     float8:
+      #     enable_fsdp_float8_all_gather: false
+      #     precompute_float8_dynamic_scale_for_fsdp: false
+      #     filter_fqns: ["output", "router.gate"]
+      #   grouped_mm:
+      #     float8:
+      #     fqns: ["experts"]

--- a/examples/torchtitan/configs/nvidia/deepseek_v3_236b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/deepseek_v3_236b-FP8-pretrain.yaml
@@ -1,0 +1,91 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v3_236b-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v3_236b-fp8.yaml
+    overrides:
+      profiling:
+        enable_profiling: false
+        save_traces_folder: "profile_trace"
+        profile_freq: 10
+        enable_memory_snapshot: false
+        save_memory_snapshot_folder: "memory_snapshot"
+
+      metrics:
+        log_freq: 1
+        disable_color_printing: false
+        enable_tensorboard: false
+        save_tb_folder: "tb"
+        enable_wandb: false
+
+      optimizer:
+        name: "AdamW"
+        lr: 2.2e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 200 # lr scheduler warm up, normally 20% of the train steps
+        decay_ratio: 0.8 # lr scheduler decay ratio, 80% of the train steps
+        decay_type: "cosine"
+        min_lr_factor: 0.1
+
+      training:
+        debug_moe_force_load_balance: true
+        local_batch_size: 8
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 15
+        dataset: "c4_test" # supported datasets: c4_test (2K), c4 (177M)
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        enable_async_tensor_parallel: false
+        pipeline_parallel_degree: 1
+        pipeline_parallel_schedule: "Interleaved1F1B"
+        expert_parallel_degree: 8
+        expert_tensor_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 10
+        last_save_model_only: true
+        export_dtype: "float32"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      activation_checkpoint:
+        mode: "none" # ["none", "selective", "full"]
+        selective_ac_option: "op" # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+      compile:
+        enable: true
+        components: [ "model", "loss" ] # ["model", "loss"]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        use_turbo_mx_linear: false
+        use_turbo_float8_linear: true
+        enable_attention_float8: false
+        use_turbo_grouped_mm: true
+        use_moe_fp8: true
+        use_classic_attention: false
+      # quantize:
+      #   linear:
+      #     float8:
+      #     enable_fsdp_float8_all_gather: false
+      #     precompute_float8_dynamic_scale_for_fsdp: false
+      #     filter_fqns: ["output", "router.gate"]
+      #   grouped_mm:
+      #     float8:
+      #     fqns: ["experts"]

--- a/examples/torchtitan/configs/nvidia/deepseek_v3_671b-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/deepseek_v3_671b-pretrain.yaml
@@ -1,0 +1,91 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v3_671b-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v3_671b.yaml
+    overrides:
+      profiling:
+        enable_profiling: false
+        save_traces_folder: "profile_trace"
+        profile_freq: 10
+        enable_memory_snapshot: false
+        save_memory_snapshot_folder: "memory_snapshot"
+
+      metrics:
+        log_freq: 1
+        disable_color_printing: false
+        enable_tensorboard: false
+        save_tb_folder: "tb"
+        enable_wandb: false
+
+      optimizer:
+        name: "AdamW"
+        lr: 2.2e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 200 # lr scheduler warm up, normally 20% of the train steps
+        decay_ratio: 0.8 # lr scheduler decay ratio, 80% of the train steps
+        decay_type: "cosine"
+        min_lr_factor: 0.1
+
+      training:
+        debug_moe_force_load_balance: true
+        local_batch_size: 16
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 15
+        dataset: "c4_test" # supported datasets: c4_test (2K), c4 (177M)
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        enable_async_tensor_parallel: false
+        pipeline_parallel_degree: 1
+        pipeline_parallel_schedule: "Interleaved1F1B"
+        expert_parallel_degree: 8
+        expert_tensor_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 10
+        last_save_model_only: true
+        export_dtype: "float32"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      activation_checkpoint:
+        mode: "full" # ["none", "selective", "full"]
+        selective_ac_option: "op" # 'int' = ac every positive int layer or 'op', ac based on ops policy
+
+      compile:
+        enable: true
+        components: [ "model", "loss" ] # ["model", "loss"]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        use_turbo_mx_linear: false
+        use_turbo_float8_linear: true
+        enable_attention_float8: false
+        use_classic_attention: true
+        use_turbo_grouped_mm: true
+        use_moe_fp8: false
+      # quantize:
+      #   linear:
+      #     float8:
+      #     enable_fsdp_float8_all_gather: false
+      #     precompute_float8_dynamic_scale_for_fsdp: false
+      #     filter_fqns: ["output", "router.gate"]
+      #   grouped_mm:
+      #     float8:
+      #     fqns: ["experts"]

--- a/examples/torchtitan/configs/nvidia/llama3.1_405B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama3.1_405B-BF16-pretrain.yaml
@@ -1,0 +1,33 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_405B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3.1_405B.yaml
+    overrides:
+      sink_level: null
+      file_sink_level: DEBUG
+      stderr_sink_level: INFO
+
+      training:
+        local_batch_size: 2
+
+      optimizer:
+        lr: 8e-5
+
+      parallelism:
+        tensor_parallel_degree: 1
+
+      activation_checkpoint:
+        mode: full
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/llama3.1_405B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama3.1_405B-FP8-pretrain.yaml
@@ -1,0 +1,52 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_405B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3.1_405B-fp8.yaml
+    overrides:
+      sink_level: null
+      file_sink_level: DEBUG
+      stderr_sink_level: INFO
+
+      training:
+        local_batch_size: 2
+        steps: 10
+
+      # profiling:
+      #   enable_profiling: false
+      #   save_traces_folder: "profile_trace_405B_fp8"
+      #   profile_freq: 6
+
+      metrics:
+        log_freq: 1
+
+      # model:
+      #   n_layers: 20
+
+      optimizer:
+        lr: 8e-5
+
+      parallelism:
+        tensor_parallel_degree: 1
+
+      activation_checkpoint:
+        mode: full
+
+      quantize:
+        linear:
+          float8:
+            enable_fsdp_float8_all_gather: true
+            precompute_float8_dynamic_scale_for_fsdp: true
+            filter_fqns: [ "output" ]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/llama3.1_70B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama3.1_70B-BF16-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
 workspace: ./output
 
 modules:
@@ -10,27 +10,37 @@ modules:
     config: pre_trainer.yaml
 
     # model to run
-    model: llama3.1_8B.yaml
+    model: llama3.1_70B.yaml
     overrides:
       sink_level: null
       file_sink_level: DEBUG
       stderr_sink_level: INFO
 
-      metrics:
-        log_freq: 1
-        enable_wandb: false
-
       lr_scheduler:
         # lr scheduler warm up
         warmup_steps: 10
 
+      metrics:
+        log_freq: 1
+
       training:
-        local_batch_size: 6
+        local_batch_size: 3
         seq_len: 8192
         mock_data: false
         steps: 50
         gc_freq: 100
 
+      profiling:
+        enable_profiling: false
+        save_traces_folder: "profile_trace_70B_bf16"
+        profile_freq: 6
+
+      optimizer:
+        lr: 1.5e-4
+
       activation_checkpoint:
-        mode: "none" # ["none", "selective", "full"]
-        selective_ac_option: "op" # "int" = ac every positive int layer or 'op', ac based on ops policy
+        mode: full
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/llama3.1_70B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama3.1_70B-FP8-pretrain.yaml
@@ -1,0 +1,54 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3.1_70B-fp8.yaml
+    overrides:
+      sink_level: null
+      file_sink_level: DEBUG
+      stderr_sink_level: INFO
+
+      lr_scheduler:
+        # lr scheduler warm up
+        warmup_steps: 10
+
+      profiling:
+        enable_profiling: false
+        save_traces_folder: "profile_trace"
+        profile_freq: 6
+
+      metrics:
+        log_freq: 1
+
+      training:
+        local_batch_size: 3
+        global_batch_size: 96
+        seq_len: 8192
+        mock_data: false
+        steps: 50
+        gc_freq: 100
+
+      optimizer:
+        lr: 1.5e-4
+
+      activation_checkpoint:
+        mode: full
+
+      quantize:
+        linear:
+          float8:
+            enable_fsdp_float8_all_gather: true
+            precompute_float8_dynamic_scale_for_fsdp: true
+            filter_fqns: [ "output" ]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/llama3.1_8B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama3.1_8B-BF16-pretrain.yaml
@@ -1,0 +1,45 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3.1_8B.yaml
+    overrides:
+      sink_level: null
+      file_sink_level: DEBUG
+      stderr_sink_level: INFO
+
+      metrics:
+        log_freq: 1
+        enable_wandb: false
+
+      lr_scheduler:
+        warmup_steps: 10
+
+      training:
+        local_batch_size: 2
+        seq_len: 4096
+        mock_data: true
+        steps: 50
+        gc_freq: 100
+
+      activation_checkpoint:
+        mode: "selective"
+        selective_ac_option: "op"
+
+      # Primus-Turbo is AMD-only; all flags disabled for NVIDIA
+      primus_turbo:
+        enable_primus_turbo: false
+        use_turbo_attention: false
+        use_turbo_async_tp: false
+        use_turbo_mx_linear: false
+        use_turbo_float8_linear: false
+        use_turbo_grouped_mm: false
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/llama3.1_8B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama3.1_8B-FP8-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama3_8B-pretrain}
 workspace: ./output
 
 modules:
@@ -10,22 +10,21 @@ modules:
     config: pre_trainer.yaml
 
     # model to run
-    model: llama3.1_8B.yaml
+    model: llama3.1_8B-fp8.yaml
     overrides:
       sink_level: null
       file_sink_level: DEBUG
       stderr_sink_level: INFO
 
-      metrics:
-        log_freq: 1
-        enable_wandb: false
-
       lr_scheduler:
         # lr scheduler warm up
         warmup_steps: 10
 
+      metrics:
+        log_freq: 1
+
       training:
-        local_batch_size: 6
+        local_batch_size: 8
         seq_len: 8192
         mock_data: false
         steps: 50
@@ -34,3 +33,14 @@ modules:
       activation_checkpoint:
         mode: "none" # ["none", "selective", "full"]
         selective_ac_option: "op" # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+      quantize:
+        linear:
+          float8:
+            enable_fsdp_float8_all_gather: true
+            precompute_float8_dynamic_scale_for_fsdp: true
+            filter_fqns: [ "output" ]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/llama4_17Bx128E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama4_17Bx128E-BF16-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17Bx128E-pretrain}
 workspace: ./output
 
 modules:
@@ -10,7 +10,7 @@ modules:
     config: pre_trainer.yaml
 
     # model to run
-    model: llama3.1_8B.yaml
+    model: llama4_17Bx128E.yaml
     overrides:
       sink_level: null
       file_sink_level: DEBUG
@@ -25,12 +25,16 @@ modules:
         warmup_steps: 10
 
       training:
-        local_batch_size: 6
+        local_batch_size: 4
         seq_len: 8192
         mock_data: false
         steps: 50
-        gc_freq: 100
 
       activation_checkpoint:
-        mode: "none" # ["none", "selective", "full"]
+        mode: "full" # ["none", "selective", "full"]
         selective_ac_option: "op" # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false
+        use_turbo_grouped_mm: true

--- a/examples/torchtitan/configs/nvidia/llama4_17Bx128E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama4_17Bx128E-FP8-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17Bx128E-pretrain}
 workspace: ./output
 
 modules:
@@ -10,7 +10,7 @@ modules:
     config: pre_trainer.yaml
 
     # model to run
-    model: llama3.1_8B.yaml
+    model: llama4_17Bx128E-fp8.yaml
     overrides:
       sink_level: null
       file_sink_level: DEBUG
@@ -25,12 +25,24 @@ modules:
         warmup_steps: 10
 
       training:
-        local_batch_size: 6
+        local_batch_size: 8
         seq_len: 8192
         mock_data: false
         steps: 50
-        gc_freq: 100
 
       activation_checkpoint:
-        mode: "none" # ["none", "selective", "full"]
+        mode: "full" # ["none", "selective", "full"]
         selective_ac_option: "op" # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+      quantize:
+        linear:
+          float8:
+            enable_fsdp_float8_all_gather: true
+            precompute_float8_dynamic_scale_for_fsdp: true
+            filter_fqns: [ "output" ]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        use_turbo_float8_linear: true
+        enable_attention_float8: false
+        use_turbo_grouped_mm: true

--- a/examples/torchtitan/configs/nvidia/llama4_17Bx16E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama4_17Bx16E-BF16-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17Bx16E-pretrain}
 workspace: ./output
 
 modules:
@@ -10,7 +10,7 @@ modules:
     config: pre_trainer.yaml
 
     # model to run
-    model: llama3.1_8B.yaml
+    model: llama4_17Bx16E.yaml
     overrides:
       sink_level: null
       file_sink_level: DEBUG
@@ -25,12 +25,16 @@ modules:
         warmup_steps: 10
 
       training:
-        local_batch_size: 6
+        local_batch_size: 4
         seq_len: 8192
         mock_data: false
         steps: 50
-        gc_freq: 100
 
       activation_checkpoint:
-        mode: "none" # ["none", "selective", "full"]
+        mode: "full" # ["none", "selective", "full"]
         selective_ac_option: "op" # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false
+        use_turbo_grouped_mm: true

--- a/examples/torchtitan/configs/nvidia/llama4_17Bx16E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/llama4_17Bx16E-FP8-pretrain.yaml
@@ -1,7 +1,7 @@
 target_gpu: nvidia
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain}
+exp_name: ${PRIMUS_EXP_NAME:llama4_17Bx16E-pretrain}
 workspace: ./output
 
 modules:
@@ -10,7 +10,7 @@ modules:
     config: pre_trainer.yaml
 
     # model to run
-    model: llama3.1_8B.yaml
+    model: llama4_17Bx16E-fp8.yaml
     overrides:
       sink_level: null
       file_sink_level: DEBUG
@@ -25,12 +25,24 @@ modules:
         warmup_steps: 10
 
       training:
-        local_batch_size: 6
+        local_batch_size: 8
         seq_len: 8192
         mock_data: false
         steps: 50
-        gc_freq: 100
 
       activation_checkpoint:
-        mode: "none" # ["none", "selective", "full"]
+        mode: "full" # ["none", "selective", "full"]
         selective_ac_option: "op" # "int" = ac every positive int layer or 'op', ac based on ops policy
+
+      quantize:
+        linear:
+          float8:
+            enable_fsdp_float8_all_gather: true
+            precompute_float8_dynamic_scale_for_fsdp: true
+            filter_fqns: [ "output" ]
+
+      primus_turbo:
+        enable_primus_turbo: true
+        use_turbo_float8_linear: true
+        enable_attention_float8: false
+        use_turbo_grouped_mm: true

--- a/examples/torchtitan/configs/nvidia/qwen3_0.6B-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/qwen3_0.6B-pretrain.yaml
@@ -1,0 +1,55 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_0.6B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_0.6b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 3e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 2 # lr scheduler warm up, 20% total steps
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/qwen3_1.7B-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/qwen3_1.7B-pretrain.yaml
@@ -1,0 +1,55 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_1.7B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_1.7b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 8e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 20 # lr scheduler warm up, 20% total steps
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/qwen3_14B-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/qwen3_14B-pretrain.yaml
@@ -1,0 +1,58 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_14B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_14b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 8e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 10 # lr scheduler warm up, 20% total steps
+
+      metrics:
+        log_freq: 1
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/qwen3_32B-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/qwen3_32B-pretrain.yaml
@@ -1,0 +1,59 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_32B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_32b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 3e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 2 # lr scheduler warm up, 20% total steps
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      activation_checkpoint:
+        mode: "full"
+        selective_ac_option: "op"
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/qwen3_4B-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/qwen3_4B-pretrain.yaml
@@ -1,0 +1,58 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_4B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_4b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 8e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 10 # lr scheduler warm up, 20% total steps
+
+      metrics:
+        log_freq: 1
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/examples/torchtitan/configs/nvidia/qwen3_8B-pretrain.yaml
+++ b/examples/torchtitan/configs/nvidia/qwen3_8B-pretrain.yaml
@@ -1,0 +1,58 @@
+target_gpu: nvidia
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_8B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: torchtitan
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_8b.yaml
+    overrides:
+
+      optimizer:
+        name: "AdamW"
+        lr: 8e-4
+        eps: 1e-8
+
+      lr_scheduler:
+        warmup_steps: 10 # lr scheduler warm up, 20% total steps
+
+      metrics:
+        log_freq: 1
+
+      training:
+        local_batch_size: 4
+        seq_len: 4096
+        max_norm: 1.0 # grad norm clipping
+        steps: 50
+
+      parallelism:
+        data_parallel_replicate_degree: 1
+        data_parallel_shard_degree: -1
+        fsdp_reshard_after_forward: "default" # default / never / always
+        tensor_parallel_degree: 1
+        context_parallel_degree: 1
+
+      checkpoint:
+        enable: false
+        folder: "checkpoint"
+        interval: 500
+        last_save_model_only: false
+        export_dtype: "float16"
+        async_mode: "disabled" # ["disabled", "async", "async_with_pinned_mem"]
+
+      # quantize:
+      #   linear:
+      #     float8:
+      #       enable_fsdp_float8_all_gather: false
+      #       precompute_float8_dynamic_scale_for_fsdp: false
+      #       filter_fqns:
+      #         - "output"
+
+      primus_turbo:
+        enable_primus_turbo: true
+        enable_attention_float8: false

--- a/primus/backends/megatron/argument_builder.py
+++ b/primus/backends/megatron/argument_builder.py
@@ -108,6 +108,11 @@ class MegatronArgBuilder:
             if key in megatron_keys:
                 self.overrides[key] = value
 
+        # Force primus_turbo settings to False when target_gpu is nvidia
+        # (Primus-Turbo is AMD-only; NVIDIA GPUs don't support these features)
+        if self.overrides.get("target_gpu") == "nvidia":
+            self._disable_primus_turbo_for_nvidia()
+
         return self
 
     # ------------------------------------------------------------------
@@ -145,3 +150,16 @@ class MegatronArgBuilder:
     # Alias for usage style:
     # builder.finalize()
     finalize = to_namespace
+
+    # ------------------------------------------------------------------
+    # GPU-specific configuration handling
+    # ------------------------------------------------------------------
+    def _disable_primus_turbo_for_nvidia(self) -> None:
+        """
+        Disable Primus-Turbo when running on NVIDIA GPUs.
+
+        Primus-Turbo optimizations are AMD-specific and not compatible with NVIDIA.
+        This method ensures enable_primus_turbo is forced to False when target_gpu
+        is 'nvidia', overriding any user configuration.
+        """
+        self.overrides["enable_primus_turbo"] = False

--- a/primus/backends/megatron/megatron_base_trainer.py
+++ b/primus/backends/megatron/megatron_base_trainer.py
@@ -33,6 +33,54 @@ class MegatronBaseTrainer(BaseTrainer):
             log_rank_0("parse_args() called; returning Primus arguments") or self.backend_args
         )
 
+        original_validate_args = megatron_args.validate_args
+
+        def _run_modified_validate(ori_code, new_code, *args, **kwargs):
+            before_patch_validate = megatron_args.validate_args
+            before_init_validate = megatron_init.validate_args
+            try:
+                megatron_args.validate_args = original_validate_args
+                megatron_init.validate_args = original_validate_args
+                validated_args = validate_args_modified(*args, **kwargs, ori_code=ori_code, new_code=new_code)
+                if validated_args is None:
+                    validated_args = args[0] if args else kwargs.get("args", None)
+                return validated_args
+            finally:
+                # Always restore wrapper references to avoid leaking global monkey patches.
+                megatron_args.validate_args = before_patch_validate
+                megatron_init.validate_args = before_init_validate
+
+        def patched_validate_args(*args, **kwargs):
+            parsed_args = args[0] if args else kwargs.get("args", None)
+            if parsed_args is None:
+                return original_validate_args(*args, **kwargs)
+
+            if getattr(parsed_args, "decoder_pipeline_manual_split_list", None) is not None:
+                ori_code = "if args.decoder_first_pipeline_num_layers is None and args.decoder_last_pipeline_num_layers is None:"
+                new_code = (
+                    "if args.decoder_pipeline_manual_split_list is None and " + ori_code.split("if ")[-1]
+                )
+                validated_args = _run_modified_validate(ori_code, new_code, *args, **kwargs)
+            elif getattr(parsed_args, "fp4", None) is not None:
+                ori_code = """raise ValueError("--fp4-format requires Transformer Engine >= 2.7.0.dev0 for NVFP4BlockScaling support.")"""
+                new_code = """pass"""
+                validated_args = _run_modified_validate(ori_code, new_code, *args, **kwargs)
+            else:
+                validated_args = original_validate_args(*args, **kwargs)
+
+            import torch
+
+            _target = getattr(self.backend_args, "target_gpu", "auto")
+            if _target == "auto":
+                _target = "amd" if getattr(torch.version, "hip", None) else "nvidia"
+
+            if _target == "amd":
+                log_rank_0("validate_args() called; validating on ROCm")
+                validate_args_on_rocm(validated_args)
+            else:
+                log_rank_0("validate_args() called; non-ROCm target, skipping ROCm-specific validation")
+            return validated_args
+
         megatron_args.parse_args = patched_parse_args
         megatron_init.parse_args = patched_parse_args
 

--- a/primus/backends/megatron/patches/runtime_hooks_patches.py
+++ b/primus/backends/megatron/patches/runtime_hooks_patches.py
@@ -11,8 +11,17 @@ These patches are applied early (priority=0) to ensure Megatron runtime
 behaves correctly on ROCm / AMD GPUs.
 """
 
-from primus.core.patches import PatchContext, register_patch
+from primus.core.patches import PatchContext, get_param, register_patch
 from primus.modules.module_utils import log_rank_0
+
+
+def _is_amd_target(ctx: PatchContext) -> bool:
+    import torch
+
+    target = get_param(ctx, "target_gpu", "auto")
+    if target == "auto":
+        return getattr(torch.version, "hip", None) is not None
+    return target == "amd"
 
 
 @register_patch(
@@ -21,6 +30,7 @@ from primus.modules.module_utils import log_rank_0
     phase="before_train",
     priority=0,
     description="Skip Megatron CUDA fused kernel compilation (ROCm compatibility)",
+    condition=_is_amd_target,
 )
 def patch_skip_compile_dependencies(ctx: PatchContext) -> None:
     """

--- a/primus/backends/torchtitan/argument_builder.py
+++ b/primus/backends/torchtitan/argument_builder.py
@@ -100,6 +100,12 @@ class TorchTitanJobConfigBuilder:
 
         # Directly merge into the working configuration
         self.config = deep_merge(self.config, values_dict)
+
+        # Force all Primus-Turbo flags to False when target_gpu is nvidia
+        # (Primus-Turbo is AMD-only; NVIDIA GPUs don't support these features)
+        if self.config.get("target_gpu") == "nvidia":
+            self._disable_primus_turbo_for_nvidia()
+
         return self
 
     # ------------------------------------------------------------------
@@ -141,3 +147,28 @@ class TorchTitanJobConfigBuilder:
     # Alias for usage style consistency with MegatronArgBuilder:
     # builder.finalize()
     finalize = to_namespace
+
+    # ------------------------------------------------------------------
+    # GPU-specific configuration handling
+    # ------------------------------------------------------------------
+    def _disable_primus_turbo_for_nvidia(self) -> None:
+        """
+        Disable all Primus-Turbo features when running on NVIDIA GPUs.
+
+        Primus-Turbo optimizations are AMD-specific and not compatible with NVIDIA.
+        This method ensures all turbo-related flags are forced to False regardless
+        of user configuration, preventing misconfiguration and runtime errors.
+        """
+        if "primus_turbo" not in self.config:
+            return
+
+        primus_turbo_config = self.config["primus_turbo"]
+
+        # Force all turbo-related flags to False
+        primus_turbo_config["enable_primus_turbo"] = False
+        primus_turbo_config["use_turbo_attention"] = False
+        primus_turbo_config["use_turbo_async_tp"] = False
+        primus_turbo_config["use_turbo_mx_linear"] = False
+        primus_turbo_config["use_turbo_float8_linear"] = False
+        primus_turbo_config["use_turbo_grouped_mm"] = False
+        primus_turbo_config["enable_attention_float8"] = False

--- a/primus/backends/torchtitan/patches/turbo/async_tp_patches.py
+++ b/primus/backends/torchtitan/patches/turbo/async_tp_patches.py
@@ -15,6 +15,7 @@ It is now also expressed as a backend patch so it can be managed via the
 Primus patch system.
 """
 
+import importlib.util
 from typing import Any, Optional
 
 from primus.core.patches import PatchContext, get_param, register_patch
@@ -27,7 +28,8 @@ from primus.modules.module_utils import log_rank_0
     phase="setup",
     description="Use Primus-Turbo async tensor-parallel collectives",
     condition=lambda ctx: (
-        get_param(ctx, "primus_turbo.enable_primus_turbo", False)
+        importlib.util.find_spec("primus_turbo") is not None
+        and get_param(ctx, "primus_turbo.enable_primus_turbo", False)
         and get_param(ctx, "primus_turbo.use_turbo_async_tp", False)
         and get_param(ctx, "parallelism.enable_async_tensor_parallel", False)
     ),

--- a/primus/backends/torchtitan/patches/turbo/attention_patches.py
+++ b/primus/backends/torchtitan/patches/turbo/attention_patches.py
@@ -15,6 +15,8 @@ The original logic lives inside ``TorchTitanPretrainTrainer``. It is now also
 expressed as a backend patch so it can be managed via the Primus patch system.
 """
 
+import importlib.util
+
 from primus.core.patches import PatchContext, get_param, register_patch
 from primus.modules.module_utils import log_rank_0
 
@@ -25,7 +27,8 @@ from primus.modules.module_utils import log_rank_0
     phase="setup",
     description="Use Primus-Turbo Attention kernels for supported models",
     condition=lambda ctx: (
-        get_param(ctx, "primus_turbo.enable_primus_turbo", False)
+        importlib.util.find_spec("primus_turbo") is not None
+        and get_param(ctx, "primus_turbo.enable_primus_turbo", False)
         and get_param(ctx, "primus_turbo.use_turbo_attention", False)
     ),
 )

--- a/primus/backends/torchtitan/patches/turbo/deepseek_v3_classic_attention_patches.py
+++ b/primus/backends/torchtitan/patches/turbo/deepseek_v3_classic_attention_patches.py
@@ -16,6 +16,8 @@ It is now expressed as a backend patch so it can be managed via the Primus
 patch system.
 """
 
+import importlib.util
+
 from primus.core.patches import PatchContext, get_param, register_patch
 from primus.modules.module_utils import log_rank_0
 
@@ -26,7 +28,8 @@ from primus.modules.module_utils import log_rank_0
     phase="setup",
     description="Use classic DeepSeek-V3 attention and args when requested",
     condition=lambda ctx: (
-        get_param(ctx, "primus_turbo.enable_primus_turbo", False)
+        importlib.util.find_spec("primus_turbo") is not None
+        and get_param(ctx, "primus_turbo.enable_primus_turbo", False)
         and get_param(ctx, "primus_turbo.use_classic_attention", False)
     ),
 )

--- a/primus/backends/torchtitan/patches/turbo/fp8_linear_patches.py
+++ b/primus/backends/torchtitan/patches/turbo/fp8_linear_patches.py
@@ -15,6 +15,8 @@ The original logic lives inside ``TorchTitanPretrainTrainer``. It is now also
 expressed as a backend patch so it can be managed via the Primus patch system.
 """
 
+import importlib.util
+
 from primus.core.patches import PatchContext, get_param, register_patch
 from primus.modules.module_utils import log_rank_0
 
@@ -25,7 +27,8 @@ from primus.modules.module_utils import log_rank_0
     phase="setup",
     description="Use Primus-Turbo FP8Linear and model converter",
     condition=lambda ctx: (
-        get_param(ctx, "primus_turbo.enable_primus_turbo", False)
+        importlib.util.find_spec("primus_turbo") is not None
+        and get_param(ctx, "primus_turbo.enable_primus_turbo", False)
         and get_param(ctx, "primus_turbo.use_turbo_float8_linear", False)
     ),
 )

--- a/primus/backends/torchtitan/patches/turbo/moe_grouped_mm_patches.py
+++ b/primus/backends/torchtitan/patches/turbo/moe_grouped_mm_patches.py
@@ -20,6 +20,7 @@ Behavior:
 """
 
 import functools
+import importlib.util
 
 from primus.core.patches import PatchContext, get_param, register_patch
 from primus.modules.module_utils import log_rank_0
@@ -31,7 +32,8 @@ from primus.modules.module_utils import log_rank_0
     phase="setup",
     description="Use Primus-Turbo grouped_mm for TorchTitan MoE experts",
     condition=lambda ctx: (
-        get_param(ctx, "primus_turbo.enable_primus_turbo", False)
+        importlib.util.find_spec("primus_turbo") is not None
+        and get_param(ctx, "primus_turbo.enable_primus_turbo", False)
         and get_param(ctx, "primus_turbo.use_turbo_grouped_mm", False)
     ),
 )

--- a/primus/backends/torchtitan/patches/turbo/mx_linear_patches.py
+++ b/primus/backends/torchtitan/patches/turbo/mx_linear_patches.py
@@ -15,6 +15,8 @@ The original logic lives inside ``TorchTitanPretrainTrainer``. It is now also
 expressed as a backend patch so it can be managed via the Primus patch system.
 """
 
+import importlib.util
+
 from primus.core.patches import PatchContext, get_param, register_patch
 from primus.modules.module_utils import log_rank_0
 
@@ -25,7 +27,8 @@ from primus.modules.module_utils import log_rank_0
     phase="setup",
     description="Use Primus-Turbo MXLinear and model converter",
     condition=lambda ctx: (
-        get_param(ctx, "primus_turbo.enable_primus_turbo", False)
+        importlib.util.find_spec("primus_turbo") is not None
+        and get_param(ctx, "primus_turbo.enable_primus_turbo", False)
         and get_param(ctx, "primus_turbo.use_turbo_mx_linear", False)
     ),
 )

--- a/primus/core/runtime/train_runtime.py
+++ b/primus/core/runtime/train_runtime.py
@@ -294,6 +294,11 @@ class PrimusRuntime:
         merge_namespace(backend_args, module_config.params, allow_override=False, excepts=[])
         module_config.params = backend_args
 
+        # Propagate top-level target_gpu into backend_args for use by trainers
+        target_gpu = getattr(self.ctx.primus_config, "target_gpu", "auto")
+        if not getattr(backend_args, "target_gpu", None):
+            backend_args.target_gpu = target_gpu
+
         # Load trainer class and instantiate
         stage = getattr(module_config.params, "stage", "pretrain") or "pretrain"
         TrainerClass = adapter.load_trainer_class(stage=stage)

--- a/runner/helpers/envs/NVIDIA.sh
+++ b/runner/helpers/envs/NVIDIA.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+# =============================================================================
+# NVIDIA GPU-specific environment overrides
+# Loaded by primus-env.sh when nvidia-smi is detected (no rocm-smi present).
+# Overrides AMD/ROCm env vars set in base_env.sh.
+# =============================================================================
+
+# Use CUDA device numbering; clear AMD counterpart
+export CUDA_VISIBLE_DEVICES=$(seq -s, 0 $((GPUS_PER_NODE - 1)))
+unset HIP_VISIBLE_DEVICES
+
+# Unset AMD/ROCm-specific variables that are not applicable on NVIDIA
+unset HSA_ENABLE_SDMA
+unset HSA_NO_SCRATCH_RECLAIM
+unset GPU_MAX_HW_QUEUES
+unset NVTE_ROCM_ENABLE_MXFP8
+unset PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32
+unset NVTE_CK_USES_BWD_V3
+unset NVTE_CK_USES_FWD_V3
+unset NVTE_CK_IS_V3_ATOMIC_FP32
+unset NVTE_CK_HOW_V3_BF16_CVT
+unset NVTE_FUSED_ATTN_CK
+unset NVTE_FUSED_ATTN_AOTRITON
+unset HIP_FORCE_DEV_KERNARG
+unset HSA_FORCE_FINE_GRAIN_PCIE
+
+# NVIDIA performance settings
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+# NCCL: use loopback for single-node bootstrap (override if multi-node)
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-lo}
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-lo}
+
+LOG_INFO_RANK0 "NVIDIA GPU environment configured (CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES})"

--- a/runner/helpers/envs/primus-env.sh
+++ b/runner/helpers/envs/primus-env.sh
@@ -40,9 +40,12 @@ detect_gpu_model() {
     local gpu_model
     gpu_model="unknown"
 
-    # Check if rocm-smi is available
+    # Check if rocm-smi is available; fall back to nvidia-smi for NVIDIA GPUs
     if ! command -v rocm-smi &> /dev/null; then
-        echo "Error: rocm-smi not found. Is ROCm installed?" >&2
+        if command -v nvidia-smi &> /dev/null; then
+            echo "NVIDIA"
+            return 0
+        fi
         echo "unknown"
         return 1
     fi

--- a/runner/helpers/hooks/train/pretrain/maxtext/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/maxtext/prepare.py
@@ -201,20 +201,24 @@ def main():
     print(f"env.JAX_COORDINATOR_PORT={master_port}")
 
     # Expose MaxText/JAX performance tuning environment variables
-    # These mirror the settings from examples/run_pretrain.sh
     log_info("Exposing MaxText performance tuning environment variables")
 
-    # XLA/JAX settings
+    # Determine target GPU (AMD vs NVIDIA)
+    target_gpu = getattr(primus_config, "target_gpu", "auto")
+    if target_gpu == "auto":
+        import torch
+
+        target_gpu = "amd" if getattr(torch.version, "hip", None) else "nvidia"
+    log_info(f"Target GPU: {target_gpu}")
+
+    # XLA/JAX settings (common to both AMD and NVIDIA)
     dump_hlo_dir = os.getenv("DUMP_HLO_DIR", f"{primus_path}/output/xla_dump_hlo")
     dump_hlo = os.getenv("DUMP_HLO", "0")
     print(f"env.DUMP_HLO_DIR={dump_hlo_dir}")
     print(f"env.DUMP_HLO={dump_hlo}")
     print("env.NVTE_ALLOW_NONDETERMINISTIC_ALGO=1")
-    # set XLA_PYTHON_CLIENT_MEM_FRACTION to 0.93
-    # to avoid HSA_STATUS_ERROR_OUT_OF_RESOURCES error during multi-node training
     xla_python_client_mem_fraction = os.getenv("XLA_PYTHON_CLIENT_MEM_FRACTION", ".97")
     print(f"env.XLA_PYTHON_CLIENT_MEM_FRACTION={xla_python_client_mem_fraction}")
-    print("env.NVTE_USE_HIPBLASLT=1")
 
     xla_flags = "--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=false --xla_gpu_enable_cublaslt=true --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=false"
     if dump_hlo == "1":
@@ -222,20 +226,24 @@ def main():
         log_info(f"XLA HLO dumping enabled, output directory: {dump_hlo_dir}")
     print(f"env.XLA_FLAGS={xla_flags}")
     # set TF_CPP_MIN_LOG_LEVEL=2 to suppress the error messages at the end of JAX/MaxText training
-    print(f"env.TF_CPP_MIN_LOG_LEVEL=2")
+    print("env.TF_CPP_MIN_LOG_LEVEL=2")
 
-    # AMD GPU optimizations
-    print("env.HIP_FORCE_DEV_KERNARG=1")
-    print("env.HSA_FORCE_FINE_GRAIN_PCIE=1")
-
-    # Transformer Engine settings for MaxText
+    # GPU-specific Transformer Engine and hardware settings
     print("env.NVTE_FUSED_ATTN=1")
-    print("env.NVTE_CK_USES_BWD_V3=1")
-    print("env.NVTE_CK_USES_FWD_V3=1")
-    print("env.NVTE_CK_IS_V3_ATOMIC_FP32=0")
-    print("env.NVTE_CK_HOW_V3_BF16_CVT=2")
-    print("env.NVTE_FUSED_ATTN_CK=1")
-    print("env.NVTE_FUSED_ATTN_AOTRITON=0")
+    if target_gpu == "amd":
+        log_info("Exposing AMD/ROCm-specific environment variables")
+        print("env.NVTE_USE_HIPBLASLT=1")
+        print("env.HIP_FORCE_DEV_KERNARG=1")
+        print("env.HSA_FORCE_FINE_GRAIN_PCIE=1")
+        print("env.NVTE_CK_USES_BWD_V3=1")
+        print("env.NVTE_CK_USES_FWD_V3=1")
+        print("env.NVTE_CK_IS_V3_ATOMIC_FP32=0")
+        print("env.NVTE_CK_HOW_V3_BF16_CVT=2")
+        print("env.NVTE_FUSED_ATTN_CK=1")
+        print("env.NVTE_FUSED_ATTN_AOTRITON=0")
+    else:
+        log_info("Exposing NVIDIA/CUDA-specific environment variables")
+        print("env.NVTE_FUSED_ATTN_AOTRITON=0")
 
     # Expose run mode: MaxText uses single mode (plain python instead of torchrun)
     # This will be exported as RUN_MODE env var by execute_hooks.sh

--- a/runner/nvidia.yaml
+++ b/runner/nvidia.yaml
@@ -1,0 +1,51 @@
+# Primus CLI NVIDIA GPU Configuration
+# Use this config for running Primus on NVIDIA GPUs (e.g., 2x RTX 3090).
+#
+# Usage:
+#   docker build -t primus-nvidia:latest -f docker/Dockerfile.nvidia .
+#   GPUS_PER_NODE=2 ./primus-cli --config runner/nvidia.yaml container \
+#     -- train pretrain --config examples/megatron/configs/nvidia/llama3.2_1B-BF16-pretrain.yaml
+#
+# Note: MaxText/JAX requires a separate JAX+CUDA container image (not covered here).
+
+container:
+  options:
+    image: "primus-nvidia:latest"
+
+    ipc: "host"
+    network: "host"
+    name: "primus-training-nvidia"
+
+    # NVIDIA GPU access via --gpus (replaces ROCm --device flags)
+    gpus: "all"
+    device: []
+
+    cap-add:
+      - "SYS_PTRACE"
+
+    env:
+      - "MASTER_ADDR"
+      - "MASTER_PORT"
+      - "NNODES"
+      - "NODE_RANK"
+      - "GPUS_PER_NODE"
+      - "WANDB_API_KEY"
+      - "HF_TOKEN"
+      - "NCCL_IB_HCA"
+      - "NCCL_SOCKET_IFNAME"
+      - "GLOO_SOCKET_IFNAME"
+
+direct:
+  gpus_per_node: 2
+  master_port: 1234
+  nnodes: 1
+  master_addr: "localhost"
+  run_mode: "torchrun"
+  script: "primus/cli/main.py"
+  numa: "false"
+  env:
+    - "GPUS_PER_NODE=2"
+    - "MASTER_ADDR=localhost"
+    - "NCCL_SOCKET_IFNAME=lo"
+    - "GLOO_SOCKET_IFNAME=lo"
+    - "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"

--- a/runner/primus-cli-container.sh
+++ b/runner/primus-cli-container.sh
@@ -289,17 +289,21 @@ validate_positional_args \
     POSITIONAL_ARGS \
     "[container] Missing Primus commands after '--'. Usage: primus-cli container [options] -- <primus-commands>"
 
-validate_device_paths \
-    "${container_config[options.device]:-}" \
-    "[container]" \
-    "[container] No GPU devices configured. Specify via CLI (--device /dev/kfd --device /dev/dri) or config file:
+if [[ -n "${container_config[options.gpus]:-}" ]]; then
+    LOG_INFO_RANK0 "[container] NVIDIA GPU mode (--gpus) — skipping ROCm device validation"
+else
+    validate_device_paths \
+        "${container_config[options.device]:-}" \
+        "[container]" \
+        "[container] No GPU devices configured. Specify via CLI (--device /dev/kfd --device /dev/dri) or config file:
   container:
     options:
       device:
         - \"/dev/kfd\"
         - \"/dev/dri\"
         - \"/dev/infiniband\"" \
-    "[container] Device validation failed. Ensure ROCm drivers are installed on host. Check: ls -la /dev/kfd /dev/dri /dev/infiniband"
+        "[container] Device validation failed. Ensure ROCm drivers are installed on host. Check: ls -la /dev/kfd /dev/dri /dev/infiniband"
+fi
 
 # Validate parameter formats (if specified)
 validate_memory_format \

--- a/runner/primus-cli-direct.sh
+++ b/runner/primus-cli-direct.sh
@@ -472,7 +472,7 @@ elif [[ "$RUN_MODE" == "torchrun" ]]; then
     fi
 
     # Add the last local rank on the last node
-    if [ "${NODE_RANK:-0}" -eq "$LAST_NODE" ] && [ "${NNODES:-1}" -ne 1 ]; then
+    if [ "${NODE_RANK:-0}" -eq "$LAST_NODE" ]; then
         FILTERS+=($((${GPUS_PER_NODE:-8} - 1)))
     fi
 


### PR DESCRIPTION
## Summary

Add NVIDIA GPU support across all three training backends (Megatron-LM, TorchTitan, MaxText), enabling Primus to run on both AMD and NVIDIA hardware.

### Core changes
- Add `target_gpu` detection in `PrimusRuntime` (auto-detect AMD/NVIDIA via `torch.version.hip`)
- Add `validate_args` patching in Megatron base trainer for NVIDIA-specific argument handling
- Skip Primus-Turbo optimizations (AMD-only) when running on NVIDIA GPUs
- Add NVIDIA environment config (`runner/helpers/envs/NVIDIA.sh`, `runner/nvidia.yaml`)
- Add `Dockerfile.nvidia` for NVIDIA container builds
- Fix torchrun `--local-ranks-filter` to show last rank log in single-node runs

### Example configs
- 60+ Megatron-LM configs for NVIDIA (Llama 2/3/4, Qwen 2.5/3, DeepSeek v2/v3, Grok, Mixtral, GPT-OSS, Zebra)
- 15+ TorchTitan configs for NVIDIA (Llama 3.1/4, Qwen 3, DeepSeek v3)
- 1 MaxText config for NVIDIA (Llama 2 7B)
- All configs include `target_gpu: nvidia` field

### Backend changes
- `primus/backends/megatron/argument_builder.py` -- disable primus_turbo for nvidia
- `primus/backends/megatron/megatron_base_trainer.py` -- validate_args with target_gpu awareness
- `primus/backends/torchtitan/argument_builder.py` -- target_gpu passthrough
- 6 torchtitan turbo patches -- skip when not on AMD

## Test plan
- [ ] Verify Megatron-LM pretrain on NVIDIA GPU (e.g., `llama3.2_1B-BF16-pretrain.yaml`)
- [ ] Verify TorchTitan pretrain on NVIDIA GPU
- [ ] Verify AMD GPU training still works (no regression)