### PR TITLE
feat(megatron): add PRIMUS_EXIT_FAST to exit training much faster

### DIFF
--- a/primus/backends/megatron/megatron_base_trainer.py
+++ b/primus/backends/megatron/megatron_base_trainer.py
@@ -4,6 +4,8 @@
 # See LICENSE for license information.
 ###############################################################################
 
+import os
+
 from primus.backends.megatron.training.global_vars import set_primus_global_variables
 from primus.core.trainer.base_trainer import BaseTrainer
 from primus.modules.module_utils import log_rank_0
@@ -21,6 +23,33 @@ class MegatronBaseTrainer(BaseTrainer):
         """Initialize Megatron training components."""
         log_rank_0("Initializing Megatron training...")
         # log_dict_aligned("Backend arguments", self.backend_args)
+
+    def cleanup(self, on_error: bool = False):
+        """Megatron cleanup: optional fast exit.
+
+        * ``PRIMUS_EXIT_FAST=1`` — after ``super().cleanup()``, skip Python
+          shutdown and call ``os._exit(0)`` directly. Saves ~20 s of Python
+          interpreter shutdown / torchrun reaper lag at the cost of any
+          ``atexit`` handlers below us. OFF by default.
+
+        When both are off this method just delegates to ``super().cleanup()``,
+        identical to the previous behavior.
+        """
+        super().cleanup(on_error=on_error)
+
+        exit_fast = os.environ.get("PRIMUS_EXIT_FAST", "0") == "1"
+
+        if exit_fast and not on_error:
+            log_rank_0("[MegatronBaseTrainer] PRIMUS_EXIT_FAST=1 -> os._exit(0)")
+            # Flush stdout/stderr so the final log lines are not lost.
+            try:
+                import sys
+
+                sys.stdout.flush()
+                sys.stderr.flush()
+            except Exception:  # pragma: no cover
+                pass
+            os._exit(0)
 
     def _patch_parse_args(self):
         """Patch Megatron's parse_args to return pre-configured Primus arguments."""

--- a/tests/unit_tests/backends/megatron/test_pp_warmup_patches.py
+++ b/tests/unit_tests/backends/megatron/test_pp_warmup_patches.py
@@ -221,6 +221,11 @@ def _build_training_cmd(
             "TRAIN_LOG": str(log_file),
         }
     )
+    # Mirror tests/utils.py::run_training_script — save ~20s/run by skipping
+    # Python / torchrun teardown on success. Loss parity and iter-time
+    # parsing both rely on in-training log lines, which are flushed well
+    # before os._exit(0). Override with PRIMUS_EXIT_FAST=0 to opt out.
+    env.setdefault("PRIMUS_EXIT_FAST", "1")
     return cmd, env
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,6 +71,13 @@ def run_training_script(
     Raises:
         AssertionError: If training did not complete successfully.
     """
+    # Short-circuit Python / torchrun teardown on successful runs to save
+    # ~20s per end-to-end test. The marker we rely on ("Training completed.")
+    # is emitted well before cleanup(), so this does not affect assertions.
+    # Developers can opt out locally via PRIMUS_EXIT_FAST=0.
+    if env is not None:
+        env.setdefault("PRIMUS_EXIT_FAST", "1")
+
     try:
         logger.info(f"[{tag}] Begin run...")
         start = time.time()


### PR DESCRIPTION
## Summary

Introduces **`PRIMUS_EXIT_FAST`** (experimental): after a successful Megatron trainer `cleanup()`, optionally skip normal Python shutdown and call `os._exit(0)` to avoid ~20s+ of interpreter / torchrun teardown lag per process.

## Motivation

Distributed pretrain jobs often spend noticeable wall time **after** the last training log line on process teardown. For **local debugging**, **CI**, and **short UT / perf smoke runs**, that tail latency adds up with little benefit. Real production runs typically want full shutdown semantics (atexit, logging flush, NCCL teardown order).

## Behavior

- **Env:** `PRIMUS_EXIT_FAST=1` 
- **Scope:** Megatron path (`MegatronBaseTrainer.cleanup`): runs `super().cleanup()` first, then fast-exits **only** when `on_error=False`.
- **Trade-off:** Skips normal Python shutdown (e.g. `atexit` handlers below this stack). **Not recommended for long-running production training** until you accept that trade-off.

## Experimental & usage guidance

| Context | Recommendation |
|---------|------------------|
| CI / UT / short smoke / perf harness | Reasonable to enable to shave job tail time |
| Production / long runs / anything relying on graceful teardown | **Prefer off** (default) until explicitly validated |

## Measured impact

| Scenario | `PRIMUS_EXIT_FAST` | Wall time |
|----------|--------------------|-----------|
| MI355X, DSV3 4-layer EP8 (post-train exit tail) | Off | **23 s** |
| Same | On | **1 s** |
| MI300X, Primus Model Tests (Megatron LM), full E2E UT suite | Off | **26 m 6 s** |
| Same | On | **23 m 54 s** |

*E2E UT numbers are aggregate suite time on the measured runner; savings depend on case count and hardware.*

## Testing

- [ ] Megatron UT / CI path exercised with `PRIMUS_EXIT_FAST=1` where intended.
- [ ] Confirm logs still contain the success marker used by tests (e.g. `Training completed.`) before fast exit.