### PR TITLE
Lazy-import matplotlib/markdown2/weasyprint in preflight

### DIFF
--- a/docs/run-preflight-without-container.md
+++ b/docs/run-preflight-without-container.md
@@ -26,20 +26,23 @@ There is a list of package in the project's top-level `requirements.txt`.
 
 ### Create virtual environment and install packages
 
-The environment is shared between all nodes in the cluster. So we need to create a virtual environment and install packages on a shared file system. Python venv or uv is recommended to create a virtual environment and install packages. Here is an example of creating a virtual environment and installing packages using uv: 
+The environment is shared between all nodes in the cluster. So we need to create a virtual environment and install packages on a shared file system. Python venv or uv is recommended to create a virtual environment and install packages. Here is an example of creating a virtual environment and installing packages using uv:
+
+#### Basic installation
 
 ```bash
-# Use a shared file system accessible from all nodes (e.g. NFS home, /shared)
 mkdir -p ~/envs/preflight
 cd ~/envs/preflight
 
 uv venv --python 3.12
 source .venv/bin/activate
 
-# install torch for rocm
 uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.1
+```
 
-# install other packages
+#### Full installation (for plotting and PDF reports)
+
+```bash
 cd /path/to/Primus
 uv pip install -r requirements.txt
 ```

--- a/primus/core/config/yaml_loader.py
+++ b/primus/core/config/yaml_loader.py
@@ -7,8 +7,6 @@
 import os
 import re
 
-import yaml
-
 from primus.core.config.merge_utils import deep_merge
 
 ENV_PATTERN = re.compile(r"\${([^:{}]+)(?::([^}]*))?}")
@@ -30,6 +28,8 @@ def parse_yaml(path: str) -> dict:
 # 1. Load YAML
 # ================================================================
 def _load_yaml(path: str):
+    import yaml
+
     with open(path, "r") as f:
         return yaml.load(f, Loader=yaml.SafeLoader)
 

--- a/primus/core/utils/yaml_utils.py
+++ b/primus/core/utils/yaml_utils.py
@@ -8,8 +8,6 @@ import json
 from types import SimpleNamespace
 from typing import Any, Mapping
 
-import yaml
-
 from primus.core.config.merge_utils import deep_merge
 from primus.core.config.yaml_loader import parse_yaml as _parse_yaml_core
 
@@ -140,6 +138,7 @@ def dump_namespace_to_yaml(ns: SimpleNamespace, file_path: str):
         >>> ns = SimpleNamespace(a=1, b=SimpleNamespace(c=2))
         >>> dump_namespace_to_yaml(ns, "config.yaml")
     """
+    import yaml
 
     def ns_to_dict(obj):
         if isinstance(obj, SimpleNamespace):

--- a/primus/tools/preflight/inter_node_comm.py
+++ b/primus/tools/preflight/inter_node_comm.py
@@ -6,7 +6,6 @@
 
 import time
 
-import matplotlib.pyplot as plt
 import torch
 import torch.distributed as dist
 
@@ -162,6 +161,8 @@ def run_inter_node_comm(args):
 
                 if not args.plot:
                     continue
+
+                import matplotlib.pyplot as plt
 
                 log(f"=======Plot IntraNode {case_name} Bandwidth=======")
                 with open(args.markdown_file, "a", encoding="utf-8") as f:

--- a/primus/tools/preflight/inter_node_comm_p2p.py
+++ b/primus/tools/preflight/inter_node_comm_p2p.py
@@ -6,7 +6,6 @@
 
 import time
 
-import matplotlib.pyplot as plt
 import torch
 import torch.distributed as dist
 
@@ -162,6 +161,8 @@ def run_inter_node_comm_p2p(args):
 
         if not args.plot:
             return
+
+        import matplotlib.pyplot as plt
 
         log(f"=======Plot InterNode {case_name} Bandwidth=======")
         with open(args.markdown_file, "a", encoding="utf-8") as f:

--- a/primus/tools/preflight/intra_node_comm.py
+++ b/primus/tools/preflight/intra_node_comm.py
@@ -6,7 +6,6 @@
 
 import time
 
-import matplotlib.pyplot as plt
 import torch
 import torch.distributed as dist
 
@@ -147,6 +146,8 @@ def run_intra_node_comm(args):
 
                     if not args.plot:
                         continue
+
+                import matplotlib.pyplot as plt
 
                 log(f"=======Plot IntraNode {case_name} Bandwidth=======")
                 with open(args.markdown_file, "a", encoding="utf-8") as f:

--- a/primus/tools/preflight/square_gemm.py
+++ b/primus/tools/preflight/square_gemm.py
@@ -6,7 +6,6 @@
 
 import time
 
-import matplotlib.pyplot as plt
 import torch
 import torch.distributed as dist
 
@@ -86,6 +85,8 @@ def run_square_gemm(args):
 
         if not args.plot:
             return
+
+        import matplotlib.pyplot as plt
 
         log("=======Plot Square GEMM TFLOPS=======")
         with open(args.markdown_file, "a", encoding="utf-8") as f:

--- a/primus/tools/preflight/utility.py
+++ b/primus/tools/preflight/utility.py
@@ -8,10 +8,8 @@ import os
 import socket
 from pathlib import Path
 
-import markdown2
 import torch
 import torch.distributed as dist
-from weasyprint import HTML
 
 from primus.tools.preflight.global_vars import RANK, WORLD_SIZE
 
@@ -70,6 +68,9 @@ def extract_first_middle_last(lst):
 
 
 def md_to_pdf(md_path, pdf_path):
+    import markdown2
+    from weasyprint import HTML
+
     with open(md_path, "r", encoding="utf-8") as f:
         markdown_text = f.read()
 


### PR DESCRIPTION
Move optional dependencies to lazy imports so preflight can run with only torch installed. matplotlib is now imported only when --plot is used; markdown2 and weasyprint are imported only inside md_to_pdf() (skipped when --disable-pdf is passed).