### PR TITLE
feat(backend-gap): add dashboard publishing toolchain and torchtitan baseline report

### DIFF
--- a/.cursor/skills/backend-gap-report/SKILL.md
+++ b/.cursor/skills/backend-gap-report/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: backend-gap-report
+description: Compare a Primus backend against an upstream repository or reference, verify git state, dependencies, directory changes, and integration coupling, then generate comparison reports, dashboard metadata, and a deployable dashboard index. Use when comparing TorchTitan, Megatron, or other Primus backends with upstream branches, tags, or releases.
+---
+
+# Backend Gap Report
+
+Use this skill when the user asks to compare a Primus backend with upstream code and wants stable deliverables instead of ad hoc notes.
+
+## Default Outputs
+
+Unless the user explicitly asks otherwise, produce:
+
+- detailed report: `docs/backend-gap/reports/<backend>/<target>/report.md`
+- one-page summary: `docs/backend-gap/reports/<backend>/<target>/summary.md`
+- publish-time PDF copies of both reports with the same basename
+- Dashboard metadata: `docs/backend-gap/dashboard-data/reports/<backend>-<target>.json`
+- Refreshed dashboard index: `docs/backend-gap/dashboard-data/index.json`
+
+If legacy report files already exist, update them in place instead of renaming them. For new report series, keep the default artifact names unsuffixed. Only add a language suffix when a non-default variant coexists or when a legacy file pattern already established one.
+
+## Required Inputs
+
+Resolve these inputs before writing:
+
+1. `backend`
+2. Local source path or submodule path
+3. Upstream repository and comparison ref (`main`, tag, release commit, etc.)
+4. Authoritative dependency evidence files
+5. Primus integration directories for that backend
+
+If any of these are ambiguous, ask the user before proceeding.
+
+## Workflow
+
+### 1. Establish the Comparison Baseline
+
+Verify:
+
+- local version or pinned commit
+- upstream target commit
+- commit dates
+- commit gap
+- merge-base relation
+- diff size
+
+Use git facts from the actual local checkout. If the upstream ref might be stale, fetch it first.
+
+### 2. Verify Dependency Facts
+
+Prefer authoritative sources in this order:
+
+1. package metadata such as `pyproject.toml`
+2. runtime or CI requirements files
+3. workflow install commands
+4. release notes or release docs
+5. README install examples
+
+Do not treat README examples as stronger evidence than workflow or package metadata.
+
+### 3. Verify Directory and Capability Changes
+
+Check the actual tree or diffs for areas such as:
+
+- model directories
+- distributed runtime
+- experiments
+- components
+- docs
+- workflows
+- tests
+
+Only write facts you can confirm from the repository state.
+
+### 4. Verify Primus Coupling
+
+Identify direct Primus dependencies on upstream internal paths, such as:
+
+- imports from backend internals
+- monkey patches
+- trainer or adapter coupling
+- config object dependencies
+
+If the report discusses upgrade cost or blast radius, ground it in these concrete coupling points.
+
+### 5. Write the Reports
+
+Default report set:
+
+- detailed comparison report
+- one-page summary
+
+When continuing an existing report series, preserve the established naming pattern and structure. Keep summary and detailed versions factually consistent.
+
+### 6. Export PDFs
+
+Use the shared stylesheet at `tools/backend_gap_report/templates/pdf-report.css`.
+
+Preferred command pattern:
+
+```bash
+pandoc "docs/backend-gap/reports/<backend>/<target>/<report>.md" --from gfm --standalone \
+  --css "tools/backend_gap_report/templates/pdf-report.css" \
+  --metadata pagetitle="<title>" \
+  --pdf-engine=weasyprint \
+  -o "/tmp/backend-gap-pdf/<backend>/<target>/<report>.pdf"
+```
+
+Use `pagetitle`, not `title`, to avoid duplicate visible titles in the PDF.
+
+Note:
+
+- Markdown reports are the tracked source artifacts in the repository.
+- PDF files are generated for publishing and are not tracked in the repository.
+
+### 7. Emit Dashboard Metadata
+
+Create a metadata JSON file under `docs/backend-gap/dashboard-data/reports/`.
+
+The metadata must:
+
+- be relative to the `docs/` root
+- reference publish artifact paths that can be generated
+- map to markdown source files that exist in the repo
+- include backend identity, refs, stats, highlights, and artifact links
+
+Use the schema and examples in [reference.md](reference.md) and [examples.md](examples.md).
+
+### 8. Refresh the Dashboard Index
+
+Run:
+
+```bash
+python3 tools/backend_gap_report/build_dashboard_index.py
+```
+
+This validates metadata files and rewrites `docs/backend-gap/dashboard-data/index.json`.
+
+### 8.5 Build the Standalone Site Bundle
+
+For publishing or local preview, build the standalone dashboard bundle from the site templates plus generated artifacts:
+
+```bash
+python3 tools/backend_gap_report/build_site_bundle.py --output-dir /tmp/backend-gap-site
+```
+
+This assembles a publishable site root from:
+
+- `tools/backend_gap_report/site/`
+- `docs/backend-gap/dashboard-data/`
+- `docs/backend-gap/reports/`
+
+This command rebuilds dashboard index, generates PDF files from markdown report sources, builds the standalone bundle, and validates bundle integrity in one run.
+
+### 9. Final Verification
+
+Before finishing:
+
+- verify the Markdown files exist
+- verify the metadata JSON exists
+- run the site bundle build successfully
+- check lints for edited files when applicable
+
+## Update Semantics
+
+- For the same `backend` + `target`, update the existing files in place.
+- Re-running the same report series should overwrite or refresh:
+  - `report.md`
+  - `summary.md`
+  - `docs/backend-gap/dashboard-data/reports/<backend>-<target>.json`
+  - `docs/backend-gap/dashboard-data/index.json`
+- PDF artifacts are regenerated during standalone site bundle build.
+- Create new sibling paths only when the backend or target changes.
+- Running the skill does not trigger background automation by itself; updates happen only when the agent is explicitly asked to run the workflow in a task.
+
+## Output Rules
+
+- Keep the default report set as the primary artifact set.
+- Do not over-emphasize the default language in filenames, labels, or dashboard copy.
+- Add language suffixes or labels only when needed to distinguish a non-default variant or preserve a legacy series.
+- Keep facts synchronized across detailed and summary reports.
+- Prefer concise factual wording over long explanations.
+- Do not invent missing versions or release claims.
+- If a file contains comments only, do not call it "empty".
+
+## Dashboard Rules
+
+- Dashboard source templates live under `tools/backend_gap_report/site/`.
+- `docs/backend-gap/` stores generated data and report artifacts, not the site templates.
+- The deployed site root is a generated standalone bundle.
+- Dashboard source data lives under `docs/backend-gap/dashboard-data/reports/`.
+- `docs/backend-gap/dashboard-data/index.json` is generated, not hand-maintained.
+- Artifact paths in metadata are relative to the standalone published site root.
+
+## Additional Resources
+
+- Schema, metadata fields, and path conventions: [reference.md](reference.md)
+- Concrete report and metadata examples: [examples.md](examples.md)

--- a/.cursor/skills/backend-gap-report/examples.md
+++ b/.cursor/skills/backend-gap-report/examples.md
@@ -1,0 +1,82 @@
+# Backend Gap Report Examples
+
+## Example 1: TorchTitan vs Upstream Main
+
+User request:
+
+```text
+Compare the current Primus TorchTitan with upstream pytorch/torchtitan main, generate the report and PDF, and refresh the dashboard.
+```
+
+Expected outputs:
+
+```text
+docs/backend-gap/reports/torchtitan/upstream-main/report.md
+docs/backend-gap/reports/torchtitan/upstream-main/summary.md
+docs/backend-gap/dashboard-data/reports/torchtitan-upstream-main-YYYY-MM-DD.json
+docs/backend-gap/dashboard-data/index.json
+```
+
+Publish bundle output (generated, not tracked in repo) includes:
+
+```text
+<bundle-root>/reports/torchtitan/upstream-main/report.pdf
+<bundle-root>/reports/torchtitan/upstream-main/summary.pdf
+```
+
+Standalone publish bundle for preview or deployment:
+
+```bash
+python3 tools/backend_gap_report/build_site_bundle.py --output-dir /tmp/backend-gap-site
+```
+
+## Example 2: Megatron Backend Comparison
+
+User request:
+
+```text
+Compare Primus Megatron backend with upstream Megatron-LM main, keep the report factual, export PDFs, and publish it to the dashboard.
+```
+
+Suggested evidence sources:
+
+- `third_party/Megatron-LM/README.md`
+- `third_party/Megatron-LM/requirements*`
+- `third_party/Megatron-LM/.github/workflows/*`
+- `primus/backends/megatron/*`
+- `primus/modules/trainer/megatron/*`
+- `docs/backends/megatron/patch-notes.md`
+
+Expected outputs:
+
+```text
+docs/backend-gap/reports/megatron/upstream-main/report.md
+docs/backend-gap/reports/megatron/upstream-main/summary.md
+docs/backend-gap/dashboard-data/reports/megatron-upstream-main-YYYY-MM-DD.json
+docs/backend-gap/dashboard-data/index.json
+```
+
+## Example Metadata Artifact Set
+
+Preferred artifact list inside a metadata JSON file:
+
+```json
+[
+  {
+    "label": "Detailed Report (PDF)",
+    "path": "./reports/torchtitan/upstream-main/report.pdf",
+    "format": "pdf",
+    "language": "en",
+    "kind": "detail",
+    "primary": true
+  },
+  {
+    "label": "One-Page Summary (PDF)",
+    "path": "./reports/torchtitan/upstream-main/summary.pdf",
+    "format": "pdf",
+    "language": "en",
+    "kind": "summary",
+    "primary": false
+  }
+]
+```

--- a/.cursor/skills/backend-gap-report/reference.md
+++ b/.cursor/skills/backend-gap-report/reference.md
@@ -1,0 +1,217 @@
+# Backend Gap Report Reference
+
+## Preferred Artifact Layout
+
+For new report series, prefer:
+
+```text
+docs/
+  backend-gap/
+    dashboard-data/
+      reports/
+        <backend>-<target>.json
+      index.json
+    reports/
+      <backend>/
+        <target>/
+          report.md
+          summary.md
+```
+
+For example:
+
+```text
+docs/
+  backend-gap/
+    reports/
+      torchtitan/
+        upstream-main/
+          report.md
+          summary.md
+    dashboard-data/
+      reports/
+        torchtitan-upstream-main-2026-04-21.json
+      index.json
+```
+
+PDF files are generated at publish time and are not tracked in the repository.
+
+Use unsuffixed names for the default report set. Only add language suffixes when a non-default variant coexists or a legacy series already established them.
+
+If the repository already has a legacy file pattern for the same comparison, update those files in place and register them in metadata instead of forcing a rename.
+
+Shared generation templates belong under:
+
+```text
+tools/backend_gap_report/
+  README.md
+  build_dashboard_index.py
+  build_site_bundle.py
+  site/
+    index.html
+    assets/
+      dashboard.css
+      dashboard.js
+  templates/
+    pdf-report.css
+```
+
+## Metadata JSON Shape
+
+Each file under `docs/backend-gap/dashboard-data/reports/` should follow this structure:
+
+```json
+{
+  "id": "torchtitan-upstream-main-2026-04-21",
+  "title": "Primus TorchTitan vs upstream main",
+  "backend": {
+    "key": "torchtitan",
+    "label": "TorchTitan"
+  },
+  "generated_at": "2026-04-21",
+  "status": "verified",
+  "scope": "Current TorchTitan bundled in Primus vs upstream pytorch/torchtitan origin/main",
+  "local": {
+    "source_path": "third_party/torchtitan",
+    "version": "0.1.0",
+    "commit": "5fb7cc2e",
+    "commit_date": "2025-10-15"
+  },
+  "upstream": {
+    "repo": "https://github.com/pytorch/torchtitan",
+    "ref": "origin/main",
+    "version": "0.2.2",
+    "commit": "fc54b897",
+    "commit_date": "2026-04-20"
+  },
+  "stats": {
+    "commit_gap": 493,
+    "diff_files": 447,
+    "insertions": 56071,
+    "deletions": 17716
+  },
+  "integration": {
+    "backend_files": 90,
+    "tracked_files": 147,
+    "integration_model": "third_party/torchtitan + Primus outer adapter / trainer / patches"
+  },
+  "highlights": [
+    "Primus bundles TorchTitan 0.1.0 while upstream main is at 0.2.2.",
+    "Upstream main tracks the latest nightly on CUDA cu130 / ROCm 7.1, while the current Primus baseline is centered on cu126.",
+    "Primus has a non-trivial outer integration layer that directly depends on upstream internal paths."
+  ],
+  "artifacts": [
+    {
+      "label": "Detailed Report (PDF)",
+      "path": "./reports/torchtitan/upstream-main/report.pdf",
+      "format": "pdf",
+      "language": "en",
+      "kind": "detail",
+      "primary": true
+    }
+  ]
+}
+```
+
+## Required Metadata Fields
+
+Top level:
+
+- `id`
+- `title`
+- `backend.key`
+- `backend.label`
+- `generated_at`
+- `status`
+- `scope`
+- `local.source_path`
+- `local.commit`
+- `upstream.repo`
+- `upstream.ref`
+- `upstream.commit`
+- `stats.commit_gap`
+- `highlights`
+- `artifacts`
+
+Each artifact requires:
+
+- `label`
+- `path`
+- `format`
+- `language`
+- `kind`
+
+## Metadata Conventions
+
+- `generated_at` should use `YYYY-MM-DD`.
+- `status` should normally be `verified`, `draft`, or `superseded`.
+- Artifact `path` values are relative to `docs/backend-gap/`.
+- Artifact `format` should be `pdf` (site bundle only includes PDFs).
+- Each artifact `path` should map to an existing markdown source path with the same basename.
+- Keep default artifact labels plain. Add language suffixes only for non-default variants when needed.
+- Prefer marking the most user-facing PDF as `primary: true`.
+
+## Recommended Report Sections
+
+Detailed report:
+
+1. High-level comparison
+2. Dependency comparison
+3. Directory and capability differences
+4. Primus integration or coupling
+5. Evidence sources
+
+One-page summary:
+
+1. High-level comparison
+2. Key dependency differences
+3. Representative upstream changes
+4. Primus integration layer
+
+## Evidence Priority
+
+When two sources disagree, prefer:
+
+1. actual repository files under the compared refs
+2. workflow installation logic
+3. release documentation
+4. README examples
+
+## Dashboard Refresh
+
+After writing or updating metadata:
+
+```bash
+python3 tools/backend_gap_report/build_dashboard_index.py
+```
+
+This script validates required fields and checks that each PDF artifact has a corresponding markdown source under `docs/backend-gap/`.
+
+One-click build and validation:
+
+```bash
+python3 tools/backend_gap_report/build_site_bundle.py --output-dir /tmp/backend-gap-site
+```
+
+## Overwrite Behavior
+
+For the same `backend` + `target`:
+
+- rewrite `report.md` and `summary.md`
+- update the matching metadata JSON in place
+- rewrite `docs/backend-gap/dashboard-data/index.json`
+- regenerate PDFs when building the standalone site bundle
+
+Create a new report subtree only when the backend key or target key changes.
+
+## GitHub Pages Deployment Model
+
+The dashboard is published from a generated standalone bundle:
+
+- site templates come from `tools/backend_gap_report/site/`
+- generated metadata and reports come from `docs/backend-gap/`
+- `build_site_bundle.py` assembles the publishable site root
+- `build_site_bundle.py` also verifies bundle integrity as a hard acceptance gate
+- `index.html` is the dashboard entrypoint at the published site root
+- `dashboard-data/index.json` is the runtime data source
+- report PDFs are generated into the standalone bundle and directly linkable from the dashboard

--- a/.github/workflows/deploy-backend-gap-dashboard.yml
+++ b/.github/workflows/deploy-backend-gap-dashboard.yml
@@ -1,0 +1,59 @@
+name: Deploy Backend Gap Dashboard
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/backend-gap/**"
+      - "tools/backend_gap_report/**"
+      - ".github/workflows/deploy-backend-gap-dashboard.yml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: backend-gap-dashboard-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PDF toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc weasyprint fonts-noto-cjk
+
+      - name: Build and validate standalone dashboard bundle
+        run: python3 tools/backend_gap_report/build_site_bundle.py --output-dir "${{ runner.temp }}/backend-gap-site"
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ runner.temp }}/backend-gap-site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/backend-gap/dashboard-data/index.json
+++ b/docs/backend-gap/dashboard-data/index.json
@@ -1,0 +1,76 @@
+{
+  "generated_at": "2026-04-23T05:53:16Z",
+  "summary": {
+    "total_reports": 1,
+    "verified_reports": 1,
+    "total_backends": 1,
+    "latest_report_date": "2026-04-21"
+  },
+  "backends": [
+    {
+      "key": "torchtitan",
+      "label": "TorchTitan",
+      "count": 1
+    }
+  ],
+  "reports": [
+    {
+      "id": "torchtitan-upstream-main-2026-04-21",
+      "title": "Primus TorchTitan vs upstream main",
+      "backend": {
+        "key": "torchtitan",
+        "label": "TorchTitan"
+      },
+      "generated_at": "2026-04-21",
+      "status": "verified",
+      "scope": "Current TorchTitan bundled in Primus vs upstream pytorch/torchtitan origin/main.",
+      "local": {
+        "source_path": "third_party/torchtitan",
+        "version": "0.1.0",
+        "commit": "5fb7cc2e",
+        "commit_date": "2025-10-15"
+      },
+      "upstream": {
+        "repo": "https://github.com/pytorch/torchtitan",
+        "ref": "origin/main",
+        "version": "0.2.2",
+        "commit": "fc54b897",
+        "commit_date": "2026-04-20"
+      },
+      "stats": {
+        "commit_gap": 493,
+        "diff_files": 447,
+        "insertions": 56071,
+        "deletions": 17716
+      },
+      "integration": {
+        "backend_files": 90,
+        "tracked_files": 147,
+        "integration_model": "third_party/torchtitan + Primus outer adapter / trainer / patches"
+      },
+      "highlights": [
+        "Primus bundles TorchTitan 0.1.0 while upstream main is at 0.2.2.",
+        "Upstream main tracks the latest nightly on CUDA cu130 and ROCm 7.1, while the current Primus baseline is centered on cu126.",
+        "Primus has a non-trivial outer integration layer with direct dependencies on upstream internal paths."
+      ],
+      "artifacts": [
+        {
+          "label": "Detailed Report (PDF)",
+          "path": "./reports/torchtitan/upstream-main/report.pdf",
+          "format": "pdf",
+          "language": "en",
+          "kind": "detail",
+          "primary": true
+        },
+        {
+          "label": "One-Page Summary (PDF)",
+          "path": "./reports/torchtitan/upstream-main/summary.pdf",
+          "format": "pdf",
+          "language": "en",
+          "kind": "summary",
+          "primary": false
+        }
+      ]
+    }
+  ]
+}

--- a/docs/backend-gap/dashboard-data/reports/torchtitan-upstream-main-2026-04-21.json
+++ b/docs/backend-gap/dashboard-data/reports/torchtitan-upstream-main-2026-04-21.json
@@ -1,0 +1,58 @@
+{
+  "id": "torchtitan-upstream-main-2026-04-21",
+  "title": "Primus TorchTitan vs upstream main",
+  "backend": {
+    "key": "torchtitan",
+    "label": "TorchTitan"
+  },
+  "generated_at": "2026-04-21",
+  "status": "verified",
+  "scope": "Current TorchTitan bundled in Primus vs upstream pytorch/torchtitan origin/main.",
+  "local": {
+    "source_path": "third_party/torchtitan",
+    "version": "0.1.0",
+    "commit": "5fb7cc2e",
+    "commit_date": "2025-10-15"
+  },
+  "upstream": {
+    "repo": "https://github.com/pytorch/torchtitan",
+    "ref": "origin/main",
+    "version": "0.2.2",
+    "commit": "fc54b897",
+    "commit_date": "2026-04-20"
+  },
+  "stats": {
+    "commit_gap": 493,
+    "diff_files": 447,
+    "insertions": 56071,
+    "deletions": 17716
+  },
+  "integration": {
+    "backend_files": 90,
+    "tracked_files": 147,
+    "integration_model": "third_party/torchtitan + Primus outer adapter / trainer / patches"
+  },
+  "highlights": [
+    "Primus bundles TorchTitan 0.1.0 while upstream main is at 0.2.2.",
+    "Upstream main tracks the latest nightly on CUDA cu130 and ROCm 7.1, while the current Primus baseline is centered on cu126.",
+    "Primus has a non-trivial outer integration layer with direct dependencies on upstream internal paths."
+  ],
+  "artifacts": [
+    {
+      "label": "Detailed Report (PDF)",
+      "path": "./reports/torchtitan/upstream-main/report.pdf",
+      "format": "pdf",
+      "language": "en",
+      "kind": "detail",
+      "primary": true
+    },
+    {
+      "label": "One-Page Summary (PDF)",
+      "path": "./reports/torchtitan/upstream-main/summary.pdf",
+      "format": "pdf",
+      "language": "en",
+      "kind": "summary",
+      "primary": false
+    }
+  ]
+}

--- a/docs/backend-gap/reports/torchtitan/upstream-main/report.md
+++ b/docs/backend-gap/reports/torchtitan/upstream-main/report.md
@@ -1,0 +1,147 @@
+# Primus TorchTitan vs Upstream `main` Comparison Report
+
+> Date: 2026-04-21
+> Scope: Current TorchTitan bundled in `Primus` vs upstream `pytorch/torchtitan` `origin/main`
+
+## High-Level Comparison
+
+| Item | Current TorchTitan in Primus | Upstream `pytorch/torchtitan` `main` |
+| --- | --- | --- |
+| Submodule version | `0.1.0` | `0.2.2` |
+| Pinned commit | `5fb7cc2e` | `fc54b897` |
+| Commit date | 2025-10-15 | 2026-04-20 |
+| Commit gap | Behind by `493` commits | - |
+| Git relation | `merge-base(HEAD, origin/main) = HEAD` | - |
+| Diff size | `447 files changed, 56071 insertions, 17716 deletions` | - |
+| Integration model | `third_party/torchtitan` + Primus outer layer (`adapter / trainer / patches`) | Upstream mainline |
+| Integration footprint | `primus/backends/torchtitan/` has about `90` files; total across report-covered directories is about `147` files | No Primus integration layer |
+| Private submodule commits | None | - |
+| Extra private requirements | `requirements-torchtitan.txt` has comments only, with no effective dependency entries | - |
+
+## Torch / TorchAO / Dependency Comparison
+
+### Install Channels and Version Semantics
+
+| Item | Current TorchTitan in Primus | Upstream `main` |
+| --- | --- | --- |
+| README nightly channel | `nightly/cu126` | `nightly/cu130` |
+| Workflow install channel | `nightly/cu126` | `nightly/cu130`; ROCm uses `nightly/rocm7.1` |
+| Workflow `torch-version` parameter | No explicit fixed version | Empty string in `set-matrix.yaml` |
+| `v0.1.0` release anchor | `torch-2.8.0.dev20250617+cu126` / `torchao-0.12.0.dev20250617+cu126` | - |
+| `v0.2.2` release anchor | - | `torch-2.12.0.dev20260220+cu126` / `torchao-0.17.0.dev20260220+cu126` |
+
+### Python Dependency Differences
+
+| Dependency | Current TorchTitan in Primus | Upstream `main` |
+| --- | --- | --- |
+| `torchdata` | `>=0.8.0` | Explicitly installed as `0.12.0.dev20260327` in workflow |
+| `datasets` | `>=2.21.0` | `>=3.6.0`, constrained to `<4.8.0` in CI |
+| `tokenizers` | No fixed lower bound | `>=0.15.0` |
+| `safetensors` | Not present | Added |
+| `wandb` | Dev-only dependency | Moved into runtime dependencies |
+| `einops` | Not present | Added |
+| `pillow` | Not present | Added |
+| `av` | Not present | Added for VLM-related dependencies |
+| `torchvision` | Not present | Added in VLM / CPU tests |
+| `expecttest` | Pinned at `0.1.6` | `>=0.2.0` |
+| `pyrefly` | Not present | `==0.45.1` |
+| `numpy` | Not present | Added to dev / CI dependencies |
+| `tyro` | No fixed lower bound | Raised to `>=1.0.5` in CI dependencies |
+| `tomli` | Present in runtime dependencies | Removed from runtime dependencies |
+
+## Directory and Capability Differences
+
+### Model Directories
+
+The current TorchTitan in Primus still follows an earlier model layout. Upstream `main` has added new model families and shared abstractions:
+
+- Added `torchtitan/models/common/` with shared modules: `attention / decoder / embedding / feed_forward / linear / moe / param_init / rmsnorm / rope / token_dispatcher`
+- Added `torchtitan/models/gpt_oss/`
+- Added `torchtitan/models/qwen3_vl/`
+- Added `torchtitan/models/flux/`; `flux` was moved from `experiments/flux`
+- `llama3 / llama4 / qwen3 / deepseek_v3` were reorganized into a more unified shape around `config_registry.py`, `parallelize.py`, and `state_dict_adapter.py`
+
+### `experiments/` Directory
+
+The current TorchTitan in Primus keeps an earlier experiments layout. Upstream `main` added or moved the following:
+
+- Added `torchtitan/experiments/autoparallel/`
+- Added `torchtitan/experiments/graph_trainer/`
+- Added `torchtitan/experiments/rl/`
+- Added `torchtitan/experiments/transformers_modeling_backend/`
+- Added `torchtitan/experiments/ft/`; content from `components/ft` moved here
+- Main content from `torchtitan/experiments/flux/` moved into `torchtitan/models/flux/`
+- Multiple files in `torchtitan/experiments/simple_fsdp/` were removed or moved
+- Multiple files in `torchtitan/experiments/torchcomms/` were removed
+
+### `distributed/` and `components/`
+
+The current TorchTitan in Primus keeps older distributed/components layouts. Upstream `main` added or continuously evolved these paths:
+
+- Added `torchtitan/distributed/compile.py`
+- Added `torchtitan/distributed/context_parallel.py`
+- Added `torchtitan/distributed/deepep/`
+- Added `torchtitan/distributed/fsdp.py`
+- `torchtitan/distributed/tensor_parallel.py` continuously updated
+- `torchtitan/distributed/pipeline_parallel.py` continuously updated
+- `torchtitan/distributed/expert_parallel.py` continuously updated
+- Added `torchtitan/components/quantization/module_utils.py`
+- `torchtitan/components/quantization/float8.py` continuously updated
+- `torchtitan/components/quantization/mx.py` continuously updated
+- `torchtitan/components/metrics.py` continuously updated
+- `torchtitan/components/optimizer.py` continuously updated
+- `torchtitan/components/tokenizer.py` continuously updated
+
+## Change Hotspots
+
+| Area | Representative changes |
+| --- | --- |
+| `tests/unit_tests/` | Broader unit-test coverage |
+| `.github/workflows/` | Added `integration_test_4gpu_rl.yaml`, `integration_test_8gpu_autoparallel.yaml`, `integration_test_8gpu_graph_trainer.yaml`, `integration_test_8gpu_rl_h100.yaml`, `integration_test_8gpu_transformers_modeling_backend.yaml`, `set-matrix.yaml` |
+| `torchtitan/experiments/graph_trainer/` | Added `compile.py / cudagraph.py / precompile.py / passes.py / storage.py`; covers `llama3 / deepseek_v3 / qwen3`; includes `tests/test_profiler.py` |
+| `torchtitan/models/common/` | Added `attention / decoder / embedding / feed_forward / linear / moe / param_init / rmsnorm / rope / token_dispatcher` |
+| `docs/` | Added `docs/mxfp8.md`, `docs/bf16_optimizer_states.md`, and updated docs such as `release / debugging / metrics / datasets / checkpoint` |
+| `torchtitan/models/flux/` | `flux` moved from `experiments/flux` into `models/flux` |
+| `torchtitan/distributed/` | Added `compile.py`, `context_parallel.py`, `deepep/deepep.py`, `deepep/hybridep.py`, `fsdp.py` |
+| `torchtitan/experiments/rl/` | Added `actors/`, `models/vllm_wrapper.py`, `simple_grpo_sum_digits.py` |
+| `torchtitan/components/` | Added `module_utils`; continuous updates in `float8 / mx / metrics / optimizer / tokenizer / validate` |
+| `torchtitan/models/gpt_oss/` | Added `gpt_oss` |
+| `torchtitan/models/qwen3_vl/` | Added `qwen3_vl` |
+| `torchtitan/experiments/autoparallel/` | Added `llama3`, `deepseek_v3`, `local_map_deepseek_v3` |
+| `torchtitan/experiments/transformers_modeling_backend/` | Added transformers-based modeling backend experiments |
+
+## Primus Outer Integration Layer
+
+### Related Directories
+
+The Primus outer integration layer is mainly distributed across:
+
+- `primus/backends/torchtitan/`
+- `primus/modules/trainer/torchtitan/`
+- `primus/configs/modules/torchtitan/`
+- `examples/torchtitan/`
+- `runner/helpers/hooks/train/pretrain/torchtitan/`
+- `tests/unit_tests/backends/torchtitan/`
+- `tests/trainer/test_torchtitan_trainer.py`
+
+### Directly Referenced Upstream Paths
+
+| Primus code location | Direct upstream dependency path |
+| --- | --- |
+| `primus/modules/trainer/torchtitan/pre_trainer.py` | `torchtitan.config.job_config.JobConfig`, `torchtitan.train.Trainer` |
+| `primus/backends/torchtitan/patches/turbo/attention_patches.py` | `torchtitan.models.llama3.model.model`, `torchtitan.models.llama4.model.model`, `torchtitan.models.deepseek_v3.model.model` |
+| `primus/backends/torchtitan/patches/turbo/fp8_linear_patches.py` | `torchtitan.components.quantization.float8` |
+| `primus/backends/torchtitan/patches/turbo/mx_linear_patches.py` | `torchtitan.components.quantization.mx` |
+| `primus/backends/torchtitan/patches/turbo/moe_grouped_mm_patches.py` | `torchtitan.models.moe.moe` |
+
+## Evidence Sources
+
+- `third_party/torchtitan/pyproject.toml`
+- `third_party/torchtitan/README.md`
+- `third_party/torchtitan/docs/release.md`
+- `third_party/torchtitan/.github/workflows/*`
+- [pytorch/torchtitan](https://github.com/pytorch/torchtitan)
+- [pytorch/torchtitan/docs/release.md](https://github.com/pytorch/torchtitan/blob/main/docs/release.md)
+- `primus/backends/torchtitan/*`
+- `primus/modules/trainer/torchtitan/*`
+- `docs/backends/torchtitan/patch-notes.md`

--- a/docs/backend-gap/reports/torchtitan/upstream-main/summary.md
+++ b/docs/backend-gap/reports/torchtitan/upstream-main/summary.md
@@ -1,0 +1,82 @@
+# Primus TorchTitan Upstream Gap One-Page Summary
+
+> Date: 2026-04-21
+
+## High-Level Comparison
+
+| Item | Current TorchTitan in Primus | Upstream `pytorch/torchtitan` `main` | Impact |
+| --- | --- | --- | --- |
+| Submodule version | `0.1.0` | `0.2.2` | Spans multiple upstream release iterations |
+| Pinned commit | `5fb7cc2e` | `fc54b897` | Current submodule is significantly behind |
+| Commit gap | Behind by `493` commits | - | Not a small patch-level gap anymore |
+| Integration model | `third_party/torchtitan` + Primus outer layer (`adapter / trainer / patches`) | Upstream mainline | Upgrade is more than a submodule bump |
+| Integration footprint | `primus/backends/torchtitan/` has about `90` files; total across summary-covered directories is about `147` files | No Primus integration layer | Upgrade blast radius is large |
+| Private submodule commits | None | - | Git history remains traceable and clean |
+| Extra private requirements | `requirements-torchtitan.txt` has comments only, with no effective dependency entries | - | Primus mainly reuses upstream dependencies |
+| Torch / TorchAO version semantics | `nightly/cu126`; `v0.1.0` anchors `torch-2.8.0.dev20250617+cu126` / `torchao-0.12.0.dev20250617+cu126` | GitHub current `main` tracks the latest nightly at the time (`CUDA cu130`, `ROCm rocm7.1`) | The key comparison is `cu126` generation vs `cu130/rocm7.1` generation |
+| `torchdata` | `>=0.8.0` | `0.12.0.dev20260327` (workflow) | Data stack baseline increased |
+| `datasets` | `>=2.21.0` | `>=3.6.0, <4.8.0` | Compatibility and streaming behavior changed |
+| `tokenizers` | No fixed lower bound | `>=0.15.0` | Tokenizer baseline increased |
+| Runtime added deps | No runtime `safetensors / wandb / einops / pillow` | Added | Runtime environment is heavier |
+| Multimodal added deps | No `av / torchvision` | Added | Multimodal environment requirements increased |
+| New upstream capabilities | Existing training main path | `graph_trainer / autoparallel / rl / qwen3_vl / gpt_oss` | Upstream capability surface is much broader |
+
+## Torch / TorchAO / Dependencies
+
+| Item | Current TorchTitan in Primus | Upstream `main` |
+| --- | --- | --- |
+| README nightly channel | `nightly/cu126` | `nightly/cu130` |
+| Workflow install channel | `nightly/cu126` | `nightly/cu130`; ROCm uses `nightly/rocm7.1` |
+| Workflow `torch-version` parameter | No explicit fixed version | Empty string in `set-matrix.yaml` |
+| `v0.1.0` release anchor | `torch-2.8.0.dev20250617+cu126` / `torchao-0.12.0.dev20250617+cu126` | - |
+| `torchdata` | `>=0.8.0` | Explicitly installed as `0.12.0.dev20260327` in workflow |
+| `datasets` | `>=2.21.0` | `>=3.6.0, <4.8.0` |
+| `tokenizers` | No fixed lower bound | `>=0.15.0` |
+| `safetensors` | No | Added |
+| `wandb` | Dev-only dependency | Moved into runtime dependencies |
+| `einops` | No | Added |
+| `pillow` | No | Added |
+| `av` | No | Added |
+| `torchvision` | No | Added |
+
+## Representative Upstream Changes
+
+| Area | Representative changes |
+| --- | --- |
+| `models/` | Added `gpt_oss`, `qwen3_vl`; moved `flux` into `models/flux`; added shared `models/common` layer |
+| `distributed/` | Added `compile.py`, `context_parallel.py`, `deepep/`, `fsdp.py` |
+| `experiments/` | Added `autoparallel`, `graph_trainer`, `rl`, `transformers_modeling_backend`, `ft` |
+| `components/` | Added `module_utils`; continuous updates in `float8 / mx / metrics / optimizer / tokenizer / validate` |
+| `.github/workflows/` | Added `integration_test_4gpu_rl.yaml`, `integration_test_8gpu_autoparallel.yaml`, `integration_test_8gpu_graph_trainer.yaml`, `integration_test_8gpu_transformers_modeling_backend.yaml`, `set-matrix.yaml` |
+| `docs/` | Added `docs/mxfp8.md`, `docs/bf16_optimizer_states.md`, and updated docs such as `release / debugging / metrics / datasets / checkpoint` |
+
+## Primus Outer Integration Layer
+
+The Primus outer integration layer is mainly distributed across:
+
+- `primus/backends/torchtitan/`
+- `primus/modules/trainer/torchtitan/`
+- `primus/configs/modules/torchtitan/`
+- `examples/torchtitan/`
+- `runner/helpers/hooks/train/pretrain/torchtitan/`
+- `tests/unit_tests/backends/torchtitan/`
+- `tests/trainer/test_torchtitan_trainer.py`
+
+Directly referenced upstream paths include:
+
+- `torchtitan.config.job_config.JobConfig`
+- `torchtitan.train.Trainer`
+- `torchtitan.models.llama3.model.model`
+- `torchtitan.models.llama4.model.model`
+- `torchtitan.models.deepseek_v3.model.model`
+- `torchtitan.components.quantization.float8`
+- `torchtitan.components.quantization.mx`
+- `torchtitan.models.moe.moe`
+
+## Evidence Sources
+
+- `third_party/torchtitan/README.md`
+- `third_party/torchtitan/docs/release.md`
+- `third_party/torchtitan/.github/workflows/*`
+- [pytorch/torchtitan](https://github.com/pytorch/torchtitan)
+- [pytorch/torchtitan/docs/release.md](https://github.com/pytorch/torchtitan/blob/main/docs/release.md)

--- a/tools/backend_gap_report/README.md
+++ b/tools/backend_gap_report/README.md
@@ -1,0 +1,41 @@
+# Backend Gap Tooling
+
+This directory contains the generation and publishing toolchain for backend-to-upstream comparison reports.
+
+## Responsibilities
+
+- `build_dashboard_index.py`: validate report metadata and rewrite `docs/backend-gap/dashboard-data/index.json`
+- `build_site_bundle.py`: rebuild dashboard index, assemble the standalone publishable bundle, generate PDF artifacts, and run structural validation
+- `templates/pdf-report.css`: shared PDF export stylesheet
+- `site/`: dashboard site source templates
+
+## Current Model
+
+- markdown report artifacts and metadata remain in the Primus repository under `docs/backend-gap/`
+- PDF artifacts are generated during site bundle build and are not tracked in the repository
+- dashboard source templates live under `tools/backend_gap_report/site/`
+- GitHub Pages publishes a generated site bundle rather than the repository source directory directly
+
+## Typical Flow
+
+1. Generate or update:
+   - `docs/backend-gap/reports/<backend>/<target>/report.md`
+   - `docs/backend-gap/reports/<backend>/<target>/summary.md`
+2. Update `docs/backend-gap/dashboard-data/reports/<backend>-<target>.json` with PDF artifact paths
+3. One-click build + validation:
+
+```bash
+python3 tools/backend_gap_report/build_site_bundle.py --output-dir /tmp/backend-gap-site
+```
+
+If you only want to refresh source index without building the site bundle:
+
+```bash
+python3 tools/backend_gap_report/build_dashboard_index.py
+```
+
+`build_site_bundle.py` includes structural acceptance checks:
+
+- bundle entrypoint and dashboard data files exist
+- `dashboard-data/index.json` and `dashboard-data/reports/*.json` are valid and consistent by report id
+- every artifact path declared in dashboard data resolves to an existing file in the built bundle

--- a/tools/backend_gap_report/build_dashboard_index.py
+++ b/tools/backend_gap_report/build_dashboard_index.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = REPO_ROOT / "docs"
+BACKEND_GAP_ROOT = DOCS_ROOT / "backend-gap"
+DASHBOARD_DATA_ROOT = BACKEND_GAP_ROOT / "dashboard-data"
+REPORTS_DIR = DASHBOARD_DATA_ROOT / "reports"
+OUTPUT_PATH = DASHBOARD_DATA_ROOT / "index.json"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def get_required(data: dict, path: str):
+    current = data
+    parts = path.split(".")
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            fail(f"missing required field '{path}'")
+        current = current[part]
+    return current
+
+
+def validate_date(value: str, field_name: str) -> None:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        fail(f"field '{field_name}' must use YYYY-MM-DD, got {value!r}: {exc}")
+
+
+def ensure_relative_to_backend_gap(path_value: str, report_id: str) -> None:
+    rel_path = Path(path_value)
+    if rel_path.is_absolute():
+        fail(
+            f"artifact path must be relative to docs/backend-gap/: " f"report={report_id}, path={path_value}"
+        )
+
+    candidate = (BACKEND_GAP_ROOT / rel_path).resolve()
+    backend_gap_root = BACKEND_GAP_ROOT.resolve()
+
+    try:
+        candidate.relative_to(backend_gap_root)
+    except ValueError as exc:
+        fail(
+            f"artifact path escapes docs/backend-gap/: " f"report={report_id}, path={path_value}, error={exc}"
+        )
+
+
+def load_report(report_path: Path) -> dict:
+    try:
+        data = json.loads(report_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {report_path}: {exc}")
+
+    report_id = get_required(data, "id")
+    if not isinstance(report_id, str) or not report_id.strip():
+        fail(f"field 'id' must be a non-empty string in {report_path}")
+
+    required_fields = [
+        "title",
+        "backend.key",
+        "backend.label",
+        "generated_at",
+        "status",
+        "scope",
+        "local.source_path",
+        "local.commit",
+        "upstream.repo",
+        "upstream.ref",
+        "upstream.commit",
+        "stats.commit_gap",
+        "highlights",
+        "artifacts",
+    ]
+    for field_name in required_fields:
+        get_required(data, field_name)
+
+    validate_date(data["generated_at"], "generated_at")
+
+    highlights = data["highlights"]
+    if not isinstance(highlights, list) or not highlights:
+        fail(f"report '{report_id}' must have a non-empty 'highlights' list")
+    if not all(isinstance(item, str) and item.strip() for item in highlights):
+        fail(f"report '{report_id}' has an invalid highlight entry")
+
+    artifacts = data["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        fail(f"report '{report_id}' must have a non-empty 'artifacts' list")
+
+    has_pdf = False
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            fail(f"report '{report_id}' has a non-object artifact entry")
+        for key in ("label", "path", "format", "language", "kind"):
+            value = artifact.get(key)
+            if not isinstance(value, str) or not value.strip():
+                fail(f"report '{report_id}' artifact missing valid '{key}'")
+        ensure_relative_to_backend_gap(artifact["path"], report_id)
+        if artifact["format"] != "pdf":
+            fail(
+                f"report '{report_id}' has unsupported artifact format "
+                f"'{artifact['format']}', only 'pdf' is allowed for publish artifacts"
+            )
+
+        has_pdf = True
+
+        pdf_rel = Path(artifact["path"])
+        source_md = (BACKEND_GAP_ROOT / pdf_rel).with_suffix(".md").resolve()
+        backend_gap_root = BACKEND_GAP_ROOT.resolve()
+        try:
+            source_md.relative_to(backend_gap_root)
+        except ValueError as exc:
+            fail(
+                f"report '{report_id}' source markdown path escapes docs/backend-gap/: "
+                f"path={source_md}, error={exc}"
+            )
+
+        if not source_md.exists():
+            fail(
+                f"report '{report_id}' source markdown missing for artifact "
+                f"{artifact['path']}: expected {source_md.relative_to(REPO_ROOT)}"
+            )
+
+    if not has_pdf:
+        fail(f"report '{report_id}' must include at least one PDF artifact")
+
+    return data
+
+
+def build_index(reports: list[dict]) -> dict:
+    backend_counts: dict[str, dict] = {}
+    verified_reports = 0
+
+    for report in reports:
+        backend_key = report["backend"]["key"]
+        backend_label = report["backend"]["label"]
+        backend_entry = backend_counts.setdefault(
+            backend_key,
+            {"key": backend_key, "label": backend_label, "count": 0},
+        )
+        backend_entry["count"] += 1
+        if report["status"] == "verified":
+            verified_reports += 1
+
+    latest_report_date = reports[0]["generated_at"] if reports else None
+
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "summary": {
+            "total_reports": len(reports),
+            "verified_reports": verified_reports,
+            "total_backends": len(backend_counts),
+            "latest_report_date": latest_report_date,
+        },
+        "backends": sorted(
+            backend_counts.values(),
+            key=lambda item: (item["label"].lower(), item["key"]),
+        ),
+        "reports": reports,
+    }
+
+
+def main() -> int:
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    report_files = sorted(REPORTS_DIR.glob("*.json"))
+    reports = [load_report(report_path) for report_path in report_files]
+
+    seen_ids: set[str] = set()
+    for report in reports:
+        if report["id"] in seen_ids:
+            fail(f"duplicate report id: {report['id']}")
+        seen_ids.add(report["id"])
+
+    reports.sort(
+        key=lambda item: (
+            item["generated_at"],
+            item["backend"]["label"].lower(),
+            item["id"],
+        ),
+        reverse=True,
+    )
+
+    output = build_index(reports)
+    OUTPUT_PATH.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Wrote dashboard index with {len(reports)} report(s) to " f"{OUTPUT_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/backend_gap_report/build_site_bundle.py
+++ b/tools/backend_gap_report/build_site_bundle.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_GAP_DOCS_ROOT = REPO_ROOT / "docs" / "backend-gap"
+SITE_SOURCE_ROOT = REPO_ROOT / "tools" / "backend_gap_report" / "site"
+SOURCE_DASHBOARD_DATA_DIR = BACKEND_GAP_DOCS_ROOT / "dashboard-data"
+METADATA_REPORTS_DIR = SOURCE_DASHBOARD_DATA_DIR / "reports"
+PDF_TEMPLATE = REPO_ROOT / "tools" / "backend_gap_report" / "templates" / "pdf-report.css"
+BUILD_INDEX_SCRIPT = Path(__file__).resolve().with_name("build_dashboard_index.py")
+REQUIRED_REPORT_FIELDS = (
+    "id",
+    "title",
+    "backend",
+    "generated_at",
+    "status",
+    "scope",
+    "highlights",
+    "artifacts",
+)
+REQUIRED_ARTIFACT_FIELDS = ("label", "path", "format", "language", "kind")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def load_json(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing required file: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+
+    if not isinstance(payload, dict):
+        fail(f"JSON payload in {path} must be an object")
+    return payload
+
+
+def copy_tree(src: Path, dst: Path) -> None:
+    if not src.exists():
+        fail(f"missing source path: {src}")
+    shutil.copytree(src, dst, dirs_exist_ok=True)
+
+
+def ensure_within(root: Path, candidate: Path, context: str) -> Path:
+    root_resolved = root.resolve()
+    candidate_resolved = candidate.resolve()
+    try:
+        candidate_resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        fail(f"{context} escapes {root_resolved}: {candidate_resolved} ({exc})")
+    return candidate_resolved
+
+
+def extract_markdown_title(markdown_path: Path) -> str:
+    for line in markdown_path.read_text(encoding="utf-8").splitlines():
+        text = line.strip()
+        if text.startswith("# "):
+            return text[2:].strip()
+    return markdown_path.stem
+
+
+def run_build_index() -> None:
+    print("[backend-gap] Rebuild dashboard index", flush=True)
+    try:
+        subprocess.run(["python3", str(BUILD_INDEX_SCRIPT)], check=True)
+    except subprocess.CalledProcessError as exc:
+        fail(f"failed to rebuild dashboard index (exit={exc.returncode})")
+
+
+def load_report_metadata() -> list[dict]:
+    metadata_files = sorted(METADATA_REPORTS_DIR.glob("*.json"))
+    reports: list[dict] = []
+    for metadata_file in metadata_files:
+        reports.append(load_json(metadata_file))
+    return reports
+
+
+def render_pdf(markdown_path: Path, output_pdf_path: Path) -> None:
+    output_pdf_path.parent.mkdir(parents=True, exist_ok=True)
+    title = extract_markdown_title(markdown_path)
+    command = [
+        "pandoc",
+        str(markdown_path),
+        "--from",
+        "gfm",
+        "--standalone",
+        "--css",
+        str(PDF_TEMPLATE),
+        "--metadata",
+        f"pagetitle={title}",
+        "--pdf-engine=weasyprint",
+        "-o",
+        str(output_pdf_path),
+    ]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        fail(f"pandoc is required to build PDF artifacts: {exc}")
+    except subprocess.CalledProcessError as exc:
+        fail(f"failed to render PDF from {markdown_path}: " f"stdout={exc.stdout}\nstderr={exc.stderr}")
+
+
+def build_pdf_artifacts(output_dir: Path) -> None:
+    reports = load_report_metadata()
+    for report in reports:
+        report_id = report.get("id", "<unknown>")
+        artifacts = report.get("artifacts", [])
+        if not isinstance(artifacts, list):
+            fail(f"report '{report_id}' has invalid 'artifacts' field")
+
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                fail(f"report '{report_id}' contains a non-object artifact")
+            if artifact.get("format") != "pdf":
+                continue
+
+            artifact_rel_path = Path(str(artifact.get("path", "")))
+            if artifact_rel_path.is_absolute():
+                fail(f"report '{report_id}' artifact path must be relative: " f"{artifact_rel_path}")
+
+            source_markdown = (BACKEND_GAP_DOCS_ROOT / artifact_rel_path).with_suffix(".md")
+            ensure_within(BACKEND_GAP_DOCS_ROOT, source_markdown, "source markdown")
+            if not source_markdown.exists():
+                fail(
+                    f"report '{report_id}' source markdown missing for artifact "
+                    f"{artifact_rel_path}: expected {source_markdown.relative_to(REPO_ROOT)}"
+                )
+
+            output_pdf = output_dir / artifact_rel_path
+            ensure_within(output_dir, output_pdf, "output pdf")
+            render_pdf(source_markdown, output_pdf)
+
+
+def validate_report_entry(report: dict, bundle_dir: Path) -> str:
+    for field in REQUIRED_REPORT_FIELDS:
+        if field not in report:
+            fail(f"report entry missing required field: {field}")
+
+    report_id = report["id"]
+    if not isinstance(report_id, str) or not report_id.strip():
+        fail("report field 'id' must be a non-empty string")
+
+    artifacts = report["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        fail(f"report '{report_id}' must contain a non-empty artifacts list")
+
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            fail(f"report '{report_id}' has a non-object artifact at index {index}")
+
+        for field in REQUIRED_ARTIFACT_FIELDS:
+            value = artifact.get(field)
+            if not isinstance(value, str) or not value.strip():
+                fail(f"report '{report_id}' artifact[{index}] missing valid field '{field}'")
+
+        artifact_file = ensure_within(
+            bundle_dir,
+            bundle_dir / artifact["path"],
+            f"report '{report_id}' artifact[{index}]",
+        )
+        if not artifact_file.exists():
+            fail(f"report '{report_id}' artifact[{index}] path not found in bundle: " f"{artifact['path']}")
+
+    return report_id
+
+
+def validate_bundle(bundle_dir: Path) -> None:
+    index_html = bundle_dir / "index.html"
+    if not index_html.exists():
+        fail(f"bundle missing entrypoint: {index_html}")
+
+    payload = load_json(bundle_dir / "dashboard-data" / "index.json")
+    for key in ("summary", "backends", "reports"):
+        if key not in payload:
+            fail(f"dashboard-data index missing required key: {key}")
+
+    reports = payload["reports"]
+    if not isinstance(reports, list):
+        fail("dashboard-data index field 'reports' must be a list")
+
+    index_report_ids: set[str] = set()
+    for report in reports:
+        if not isinstance(report, dict):
+            fail("dashboard-data index contains a non-object report entry")
+        report_id = validate_report_entry(report, bundle_dir)
+        if report_id in index_report_ids:
+            fail(f"duplicate report id in index: {report_id}")
+        index_report_ids.add(report_id)
+
+    metadata_dir = bundle_dir / "dashboard-data" / "reports"
+    if not metadata_dir.exists():
+        fail(f"bundle missing report metadata directory: {metadata_dir}")
+
+    metadata_ids: set[str] = set()
+    for metadata_file in sorted(metadata_dir.glob("*.json")):
+        metadata = load_json(metadata_file)
+        metadata_id = metadata.get("id")
+        if not isinstance(metadata_id, str) or not metadata_id.strip():
+            fail(f"metadata file missing valid 'id': {metadata_file}")
+        if metadata_id in metadata_ids:
+            fail(f"duplicate metadata id in dashboard-data/reports: {metadata_id}")
+        metadata_ids.add(metadata_id)
+
+    if index_report_ids != metadata_ids:
+        fail(
+            "report ids in dashboard-data/index.json and "
+            "dashboard-data/reports/*.json are inconsistent: "
+            f"index={sorted(index_report_ids)}, metadata={sorted(metadata_ids)}"
+        )
+
+
+def build_site(output_dir: Path) -> None:
+    run_build_index()
+    if not PDF_TEMPLATE.exists():
+        fail(f"missing PDF template: {PDF_TEMPLATE}")
+    if not SOURCE_DASHBOARD_DATA_DIR.exists():
+        fail(f"missing dashboard data directory: {SOURCE_DASHBOARD_DATA_DIR}")
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print("[backend-gap] Build standalone dashboard bundle", flush=True)
+    copy_tree(SITE_SOURCE_ROOT, output_dir)
+    copy_tree(SOURCE_DASHBOARD_DATA_DIR, output_dir / "dashboard-data")
+    build_pdf_artifacts(output_dir)
+    print("[backend-gap] Validate standalone dashboard bundle", flush=True)
+    validate_bundle(output_dir)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build a standalone backend-gap dashboard publish bundle.")
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Output directory for the standalone site bundle.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    build_site(output_dir)
+    print(f"[backend-gap] Done: {output_dir}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/backend_gap_report/site/assets/dashboard.css
+++ b/tools/backend_gap_report/site/assets/dashboard.css
@@ -1,0 +1,333 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --panel-border: #d9e1f2;
+  --text: #172033;
+  --muted: #5a6782;
+  --accent: #2157d5;
+  --accent-soft: #e8efff;
+  --success: #1f7a4d;
+  --success-soft: #e8f6ee;
+  --warning: #9b6a00;
+  --warning-soft: #fff3d6;
+  --danger: #ad2434;
+  --danger-soft: #fde9eb;
+  --shadow: 0 10px 30px rgba(23, 32, 51, 0.08);
+  --radius: 18px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+
+a {
+  color: var(--accent);
+}
+
+.hero {
+  background: linear-gradient(135deg, #12254e 0%, #2157d5 100%);
+  color: #ffffff;
+  padding: 3rem clamp(1.25rem, 3vw, 3rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero__content {
+  max-width: 60rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  opacity: 0.78;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.25rem);
+}
+
+.hero__summary {
+  margin: 1rem 0 0;
+  max-width: 48rem;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  opacity: 0.92;
+}
+
+.hero__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 1rem;
+}
+
+.stat-card {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  backdrop-filter: blur(8px);
+}
+
+.stat-card__label {
+  display: block;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.78;
+  margin-bottom: 0.5rem;
+}
+
+.stat-card strong {
+  font-size: 1.45rem;
+  font-weight: 700;
+}
+
+.layout {
+  padding: 1.5rem clamp(1rem, 3vw, 3rem) 3rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.filters {
+  padding: 1.25rem;
+}
+
+.filter-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.field span {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.field select,
+.field input {
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  font: inherit;
+  color: var(--text);
+  background: #ffffff;
+}
+
+.field--search {
+  grid-column: span 2;
+}
+
+.filter-summary {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+#reports-panel {
+  padding: 1.25rem;
+}
+
+.state {
+  padding: 2.5rem 1rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.state--error {
+  color: var(--danger);
+}
+
+.report-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.report-card {
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  padding: 1.1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.report-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.report-card__title-group h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.report-card__scope {
+  margin: 0.45rem 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.badges {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.34rem 0.72rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.badge--backend {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.badge--verified {
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.badge--draft {
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.badge--superseded {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.75rem;
+}
+
+.metric {
+  background: #f8faff;
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  padding: 0.85rem 0.95rem;
+}
+
+.metric__label {
+  display: block;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  margin-bottom: 0.35rem;
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 1rem;
+}
+
+.detail-block h3 {
+  margin: 0 0 0.55rem;
+  font-size: 0.95rem;
+}
+
+.detail-block dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.45rem 0.75rem;
+}
+
+.detail-block dt {
+  color: var(--muted);
+}
+
+.detail-block dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.highlights {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.artifacts {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.artifact-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 0.95rem;
+  border-radius: 12px;
+  border: 1px solid var(--panel-border);
+  background: #ffffff;
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.artifact-link--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+
+.artifact-link:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 720px) {
+  .field--search {
+    grid-column: span 1;
+  }
+}

--- a/tools/backend_gap_report/site/assets/dashboard.js
+++ b/tools/backend_gap_report/site/assets/dashboard.js
@@ -1,0 +1,267 @@
+const DATA_URL = "./dashboard-data/index.json";
+
+const state = {
+  reports: [],
+  filteredReports: [],
+};
+
+const elements = {
+  totalReports: document.getElementById("total-reports"),
+  totalBackends: document.getElementById("total-backends"),
+  verifiedReports: document.getElementById("verified-reports"),
+  latestReportDate: document.getElementById("latest-report-date"),
+  backendFilter: document.getElementById("backend-filter"),
+  statusFilter: document.getElementById("status-filter"),
+  searchFilter: document.getElementById("search-filter"),
+  resultCount: document.getElementById("result-count"),
+  loadingState: document.getElementById("loading-state"),
+  errorState: document.getElementById("error-state"),
+  emptyState: document.getElementById("empty-state"),
+  reportList: document.getElementById("report-list"),
+};
+
+
+function formatNumber(value) {
+  if (value === undefined || value === null || value === "") {
+    return "-";
+  }
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+
+function setSummary(summary) {
+  elements.totalReports.textContent = formatNumber(summary.total_reports);
+  elements.totalBackends.textContent = formatNumber(summary.total_backends);
+  elements.verifiedReports.textContent = formatNumber(summary.verified_reports);
+  elements.latestReportDate.textContent = summary.latest_report_date || "-";
+}
+
+
+function buildBadge(label, className) {
+  const span = document.createElement("span");
+  span.className = `badge ${className}`;
+  span.textContent = label;
+  return span;
+}
+
+
+function buildMetric(label, value) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "metric";
+
+  const labelNode = document.createElement("span");
+  labelNode.className = "metric__label";
+  labelNode.textContent = label;
+
+  const valueNode = document.createElement("strong");
+  valueNode.textContent = value;
+
+  wrapper.append(labelNode, valueNode);
+  return wrapper;
+}
+
+
+function createDetailBlock(title, rows) {
+  const block = document.createElement("section");
+  block.className = "detail-block";
+
+  const heading = document.createElement("h3");
+  heading.textContent = title;
+
+  const list = document.createElement("dl");
+  rows.forEach(([label, value]) => {
+    const dt = document.createElement("dt");
+    dt.textContent = label;
+    const dd = document.createElement("dd");
+    dd.textContent = value || "-";
+    list.append(dt, dd);
+  });
+
+  block.append(heading, list);
+  return block;
+}
+
+
+function createArtifactLink(artifact) {
+  const link = document.createElement("a");
+  link.className = `artifact-link${artifact.primary ? " artifact-link--primary" : ""}`;
+  link.href = artifact.path;
+  link.textContent = artifact.label;
+  if (artifact.format === "pdf") {
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+  }
+  return link;
+}
+
+
+function renderReports(reports) {
+  elements.reportList.innerHTML = "";
+  elements.resultCount.textContent = `${reports.length} report${reports.length === 1 ? "" : "s"}`;
+
+  if (!reports.length) {
+    elements.reportList.hidden = true;
+    elements.emptyState.hidden = false;
+    return;
+  }
+
+  elements.emptyState.hidden = true;
+  elements.reportList.hidden = false;
+
+  reports.forEach((report) => {
+    const card = document.createElement("article");
+    card.className = "report-card";
+
+    const header = document.createElement("div");
+    header.className = "report-card__header";
+
+    const titleGroup = document.createElement("div");
+    titleGroup.className = "report-card__title-group";
+
+    const title = document.createElement("h2");
+    title.textContent = report.title;
+
+    const scope = document.createElement("p");
+    scope.className = "report-card__scope";
+    scope.textContent = report.scope;
+
+    titleGroup.append(title, scope);
+
+    const badges = document.createElement("div");
+    badges.className = "badges";
+    badges.append(
+      buildBadge(report.backend.label, "badge--backend"),
+      buildBadge(report.status, `badge--${report.status}`)
+    );
+
+    header.append(titleGroup, badges);
+
+    const metrics = document.createElement("div");
+    metrics.className = "metrics";
+    metrics.append(
+      buildMetric("Generated", report.generated_at),
+      buildMetric("Commit Gap", formatNumber(report.stats.commit_gap)),
+      buildMetric("Diff Files", formatNumber(report.stats.diff_files)),
+      buildMetric(
+        "Diff Size",
+        `+${formatNumber(report.stats.insertions)} / -${formatNumber(report.stats.deletions)}`
+      )
+    );
+
+    const detailGrid = document.createElement("div");
+    detailGrid.className = "detail-grid";
+    detailGrid.append(
+      createDetailBlock("Local", [
+        ["Source", report.local.source_path],
+        ["Version", report.local.version],
+        ["Commit", report.local.commit],
+        ["Date", report.local.commit_date],
+      ]),
+      createDetailBlock("Upstream", [
+        ["Repository", report.upstream.repo],
+        ["Ref", report.upstream.ref],
+        ["Version", report.upstream.version],
+        ["Commit", report.upstream.commit],
+      ]),
+      createDetailBlock("Integration", [
+        ["Model", report.integration?.integration_model || "-"],
+        ["Backend Files", formatNumber(report.integration?.backend_files)],
+        ["Tracked Files", formatNumber(report.integration?.tracked_files)],
+        ["Status", report.status],
+      ])
+    );
+
+    const highlightList = document.createElement("ul");
+    highlightList.className = "highlights";
+    report.highlights.forEach((highlight) => {
+      const item = document.createElement("li");
+      item.textContent = highlight;
+      highlightList.append(item);
+    });
+
+    const artifactBar = document.createElement("div");
+    artifactBar.className = "artifacts";
+    report.artifacts.forEach((artifact) => {
+      artifactBar.append(createArtifactLink(artifact));
+    });
+
+    card.append(header, metrics, detailGrid, highlightList, artifactBar);
+    elements.reportList.append(card);
+  });
+}
+
+
+function applyFilters() {
+  const backendValue = elements.backendFilter.value;
+  const statusValue = elements.statusFilter.value;
+  const searchValue = elements.searchFilter.value.trim().toLowerCase();
+
+  state.filteredReports = state.reports.filter((report) => {
+    const backendMatch =
+      backendValue === "all" || report.backend.key === backendValue;
+    const statusMatch =
+      statusValue === "all" || report.status === statusValue;
+
+    const haystack = [
+      report.title,
+      report.scope,
+      report.backend.label,
+      report.backend.key,
+      ...(report.highlights || []),
+    ]
+      .join(" ")
+      .toLowerCase();
+
+    const searchMatch = !searchValue || haystack.includes(searchValue);
+    return backendMatch && statusMatch && searchMatch;
+  });
+
+  renderReports(state.filteredReports);
+}
+
+
+function populateBackendFilter(backends) {
+  backends.forEach((backend) => {
+    const option = document.createElement("option");
+    option.value = backend.key;
+    option.textContent = `${backend.label} (${backend.count})`;
+    elements.backendFilter.append(option);
+  });
+}
+
+
+function attachFilters() {
+  elements.backendFilter.addEventListener("change", applyFilters);
+  elements.statusFilter.addEventListener("change", applyFilters);
+  elements.searchFilter.addEventListener("input", applyFilters);
+}
+
+
+async function loadDashboard() {
+  try {
+    const response = await fetch(DATA_URL, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Failed to load ${DATA_URL}: ${response.status}`);
+    }
+
+    const payload = await response.json();
+    state.reports = payload.reports || [];
+
+    setSummary(payload.summary || {});
+    populateBackendFilter(payload.backends || []);
+    attachFilters();
+    applyFilters();
+
+    elements.loadingState.hidden = true;
+    elements.errorState.hidden = true;
+  } catch (error) {
+    elements.loadingState.hidden = true;
+    elements.reportList.hidden = true;
+    elements.emptyState.hidden = true;
+    elements.errorState.hidden = false;
+    elements.errorState.textContent = `Unable to load dashboard data. ${error.message}`;
+  }
+}
+
+
+loadDashboard();

--- a/tools/backend_gap_report/site/index.html
+++ b/tools/backend_gap_report/site/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Primus Backend Gap Dashboard</title>
+    <link rel="stylesheet" href="./assets/dashboard.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <p class="eyebrow">Primus Backend Gap</p>
+        <h1>Backend Gap Dashboard</h1>
+        <p class="hero__summary">
+          Browse backend-to-upstream comparison reports, generated artifacts,
+          and the latest verified metadata published from this repository.
+        </p>
+      </div>
+      <div class="hero__meta">
+        <div class="stat-card">
+          <span class="stat-card__label">Total Reports</span>
+          <strong id="total-reports">-</strong>
+        </div>
+        <div class="stat-card">
+          <span class="stat-card__label">Backends</span>
+          <strong id="total-backends">-</strong>
+        </div>
+        <div class="stat-card">
+          <span class="stat-card__label">Verified</span>
+          <strong id="verified-reports">-</strong>
+        </div>
+        <div class="stat-card">
+          <span class="stat-card__label">Latest Report</span>
+          <strong id="latest-report-date">-</strong>
+        </div>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="panel filters">
+        <div class="filter-row">
+          <label class="field">
+            <span>Backend</span>
+            <select id="backend-filter">
+              <option value="all">All backends</option>
+            </select>
+          </label>
+
+          <label class="field">
+            <span>Status</span>
+            <select id="status-filter">
+              <option value="all">All statuses</option>
+              <option value="verified">Verified</option>
+              <option value="draft">Draft</option>
+              <option value="superseded">Superseded</option>
+            </select>
+          </label>
+
+          <label class="field field--search">
+            <span>Search</span>
+            <input
+              id="search-filter"
+              type="search"
+              placeholder="Search backend, title, scope, highlight..."
+            />
+          </label>
+        </div>
+
+        <div class="filter-summary">
+          <span id="result-count">0 reports</span>
+        </div>
+      </section>
+
+      <section class="panel" id="reports-panel">
+        <div id="loading-state" class="state">Loading dashboard data...</div>
+        <div id="error-state" class="state state--error" hidden></div>
+        <div id="empty-state" class="state" hidden>No reports match the current filters.</div>
+        <div id="report-list" class="report-list" hidden></div>
+      </section>
+    </main>
+
+    <script src="./assets/dashboard.js"></script>
+  </body>
+</html>

--- a/tools/backend_gap_report/templates/pdf-report.css
+++ b/tools/backend_gap_report/templates/pdf-report.css
@@ -1,0 +1,86 @@
+@page {
+  size: A4;
+  margin: 18mm 16mm 18mm 16mm;
+}
+
+html {
+  color: #111827;
+  font-family: "DejaVu Sans", "Noto Sans CJK SC", "Noto Sans SC", sans-serif;
+  font-size: 11pt;
+  line-height: 1.45;
+}
+
+body {
+  max-width: none;
+}
+
+h1, h2, h3 {
+  color: #111827;
+  margin-top: 1.2em;
+  margin-bottom: 0.4em;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: 20pt;
+  border-bottom: 2px solid #d1d5db;
+  padding-bottom: 6px;
+}
+
+h2 {
+  font-size: 14pt;
+  border-bottom: 1px solid #e5e7eb;
+  padding-bottom: 4px;
+}
+
+h3 {
+  font-size: 12pt;
+}
+
+p, li, blockquote {
+  orphans: 3;
+  widows: 3;
+}
+
+blockquote {
+  margin: 0.8em 0;
+  padding: 0.6em 0.9em;
+  border-left: 4px solid #9ca3af;
+  background: #f9fafb;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.8em 0 1em;
+  table-layout: fixed;
+}
+
+th, td {
+  border: 1px solid #d1d5db;
+  padding: 6px 8px;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+th {
+  background: #f3f4f6;
+  text-align: left;
+}
+
+code {
+  font-family: "DejaVu Sans Mono", "Noto Sans Mono", monospace;
+  font-size: 0.92em;
+}
+
+pre {
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+ul, ol {
+  padding-left: 1.3em;
+}


### PR DESCRIPTION
Add a reusable backend-gap reporting workflow with project-level skill docs, dashboard site assets, and build scripts that generate a standalone Pages bundle from markdown sources. Keep report sources and dashboard metadata in-repo under dashboard-data, generate PDFs only at build time, and publish the initial TorchTitan upstream-main report set through the new workflow.