### PR TITLE
Non-powers of 2 support for Primus preflight

### DIFF
--- a/docs/run-preflight-without-container.md
+++ b/docs/run-preflight-without-container.md
@@ -1,0 +1,137 @@
+# Run Primus preflight without docker container
+
+## clone the Primus repository
+
+```bash
+git clone --recurse-submodules https://github.com/AMD-AIG-AIMA/Primus.git
+cd Primus
+git checkout dev/fuyuajin/preflight-without-container
+git submodule update --init --recursive
+```
+
+## Create python environment on a shared file system
+
+### Required Python Packages
+
+Based on the imports across all files in primus/tools/preflight/, here are the third-party (non-stdlib) packages needed:
+
+| Package    | Used in                                                        | Purpose                                           |
+|------------|----------------------------------------------------------------|---------------------------------------------------|
+| torch      | Most files (square_gemm.py, intra_node_comm.py, inter_node_comm.py, etc.) | GPU compute, distributed communication (torch.distributed), profiler |
+| matplotlib | square_gemm.py, intra_node_comm.py, inter_node_comm.py, inter_node_comm_p2p.py | Plotting benchmark results (charts)               |
+| markdown2  | utility.py                                                     | Converting the Markdown report to HTML            |
+| weasyprint | utility.py                                                     | Converting HTML to PDF for the final report       |
+
+There is a list of package in the project's top-level `requirements.txt`.
+
+### Create virtual environment and install packages
+
+The environment is shared between all nodes in the cluster. So we need to create a virtual environment and install packages on a shared file system. Python venv or uv is recommended to create a virtual environment and install packages. Here is an example of creating a virtual environment and installing packages using uv: 
+
+```bash
+# Use a shared file system accessible from all nodes (e.g. NFS home, /shared)
+mkdir -p ~/envs/preflight
+cd ~/envs/preflight
+
+uv venv --python 3.12
+source .venv/bin/activate
+
+# install torch for rocm
+uv pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm7.1
+
+# install other packages
+cd /path/to/Primus
+uv pip install -r requirements.txt
+```
+
+### System level package dependencies
+
+Preflight will run performance tests for the intra-node and inter-node communication. The packages for networking and communication are required. These should be already installed on the cluster.
+
+
+## Run preflight on the cluster
+### With cluster that does not use Pensando Pollara (AINIC) for RDMA
+If you're using Broadcom NICs, you can use a command like this
+```bash
+# set the environment variable VENV_PATH to the path of the virtual environment activate script
+export VENV_PATH=~/envs/preflight/.venv/bin/activate
+
+# run preflight with slurm
+# it will collect basic information and performance tests on the cluster.
+srun -t 00:45:00 -N 4 -c 128 --gpus-per-node=8 --nodelist <nodes> \
+  runner/primus-cli-direct-preflight.sh \
+  --env NCCL_CROSS_NIC=1 --env NCCL_PXN_DISABLE=0 \
+  -- preflight --perf-test --report-file-name preflight-report-4N
+```
+
+### With cluster that does use Pensando Pollara (AINIC) for RDMA
+```bash
+# set the environment variable VENV_PATH to the path of the virtual environment activate script
+export VENV_PATH=~/envs/preflight/.venv/bin/activate
+
+# run preflight with slurm
+# it will collect basic information and performance tests on the cluster.
+# note that these are setting cluster-specific environment variables for a cluster that uses AINIC.
+srun -t 00:45:00 -N 4 -c 128 --gpus-per-node=8 --nodelist <nodes> \
+  runner/primus-cli-direct-preflight.sh \
+  --env USING_AINIC=1 --env NCCL_IB_GID_INDEX=1 --env NCCL_PXN_DISABLE=0 \
+  -- preflight --report-file-name preflight-report-4N
+```
+
+### Key srun flags explained
+
+| Flag | Why it is necessary |
+|------|-----|
+| `-c 128` | Allocates all CPU cores per task — without this, Slurm may default to 1 core, starving RCCL network proxy threads and causing 35x slowdown |
+| `--gpus-per-node=8` | Grants GPU device access (`/dev/kfd`, `/dev/dri`) — required for non-container mode |
+| `--env NCCL_CROSS_NIC=1` | Enables cross-NIC traffic for multi-rail IB fabrics — the runner default (`=0`) restricts to single-NIC paths |
+| `--env NCCL_PXN_DISABLE=0` | Enables PXN (peer exchange over NIC) for multi-hop NIC sharing |
+
+> **Note:** Set `-c` to the number of CPU cores per node on your cluster (e.g. `-c 128` for 128-core nodes). You can check with: `srun -N 1 --gpus-per-node=8 bash -c 'nproc'`
+
+## Troubleshooting
+### Using other virtual environment tools
+Currently, our script uses this pattern `source <env_name>/bin/activate` to activate the virtual environment across all nodes. Specifically it picks up the `VENV_PATH` to run `source "$VENV_PATH"`.
+
+However, if you use `conda`, the command is `conda activate <env_name>`. As a result, you may need to replace this [line](https://github.com/AMD-AGI/Primus/blob/dev/fuyuajin/preflight-without-container/runner/primus-cli-direct-preflight.sh#L375) to have something like this
+```
+source "$HOME/miniconda3/etc/profile.d/conda.sh"
+conda activate py_3.11
+```
+instead of 
+```
+source "$VENV_PATH"
+```
+NOTE: you may still need to export `VENV_PATH` (by running `export VENV_PATH=conda`) so the script can enter the `if` statement in the conditional to be able to run `conda activate py_3.11`.
+
+### Can't detect GPUs
+You may see
+```bash
+[Primus:Preflight] FAIL: No GPUs detected (torch.cuda.is_available/device_count)
+```
+Run
+```bash
+srun --nodes=1 --nodelist=<nodes> bash -c '
+echo "=== PATH ==="
+echo $PATH
+echo "=== LD_LIBRARY_PATH ==="
+echo $LD_LIBRARY_PATH
+echo "=== rocm-smi ==="
+rocm-smi --showid 2>&1
+echo "=== Python torch check ==="
+source ~/envs/preflight/.venv/bin/activate
+python3 -c "import torch; print(\"hip:\", torch.version.hip); print(\"available:\", torch.cuda.is_available()); print(\"count:\", torch.cuda.device_count())"
+'
+```
+If `LD_LIBRARY_PATH` is empty, try setting it explicitly.
+```bash
+# Most common ROCm install location:
+export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
+```
+If you still have issue, try
+```bash
+srun -t 00:30:00 -N 4 -c 128 --gpus-per-node=8 --nodelist <nodes> \
+  runner/primus-cli-direct-preflight.sh \
+  -- preflight --report-file-name preflight-report-4N \
+  2>&1 | tee preflight-report-4N.log
+```

--- a/primus/tools/preflight/inter_node_comm.py
+++ b/primus/tools/preflight/inter_node_comm.py
@@ -62,20 +62,36 @@ def run_inter_node_comm(args):
             latency_results = {}
             bandwidth_results = {}
 
-            num_procs = adjacent_nodes * LOCAL_WORLD_SIZE
-            num_adjacent_groups = num_nodes // adjacent_nodes
+            num_full_groups = num_nodes // adjacent_nodes
+            remainder_nodes = num_nodes % adjacent_nodes
             adjacent_group = None
-            for i_group in range(num_adjacent_groups):
+            group_leaders = []
+
+            for i_group in range(num_full_groups):
+                group_start = i_group * adjacent_nodes * LOCAL_WORLD_SIZE
                 group_ranks = [
-                    i_group * adjacent_nodes * LOCAL_WORLD_SIZE + r
+                    group_start + r
                     for r in range(adjacent_nodes * LOCAL_WORLD_SIZE)
                 ]
                 tmp_group = dist.new_group(ranks=group_ranks)
                 if RANK in group_ranks:
                     assert adjacent_group is None
                     adjacent_group = tmp_group
-            if RANK < num_adjacent_groups * adjacent_nodes * LOCAL_WORLD_SIZE:
-                assert adjacent_group is not None
+                group_leaders.append(group_start)
+
+            if remainder_nodes >= 2:
+                group_start = num_full_groups * adjacent_nodes * LOCAL_WORLD_SIZE
+                group_ranks = [
+                    group_start + r
+                    for r in range(remainder_nodes * LOCAL_WORLD_SIZE)
+                ]
+                tmp_group = dist.new_group(ranks=group_ranks)
+                if RANK in group_ranks:
+                    assert adjacent_group is None
+                    adjacent_group = tmp_group
+                group_leaders.append(group_start)
+
+            num_procs = dist.get_world_size(adjacent_group) if adjacent_group is not None else 0
 
             for size in sizes:
                 if adjacent_group is None:
@@ -133,7 +149,7 @@ def run_inter_node_comm(args):
                     log(f"{'Hostname':<{max_len}} {'Node':<5} {'Rank':<5} {' '.join(formatted_keys)}")
                     for rank, r in enumerate(all_latency_results):
                         hostname = get_hostnames()[rank]
-                        if rank % num_procs != 0:
+                        if rank not in group_leaders:
                             continue
                         node_id = rank // LOCAL_WORLD_SIZE
 
@@ -151,7 +167,7 @@ def run_inter_node_comm(args):
                     log(f"{'Hostname':<{max_len}} {'Node':<5} {'Rank':<5} {' '.join(formatted_keys)}")
                     for rank, r in enumerate(all_bandwidth_results):
                         hostname = get_hostnames()[rank]
-                        if rank % num_procs != 0:
+                        if rank not in group_leaders:
                             continue
                         node_id = rank // LOCAL_WORLD_SIZE
 
@@ -171,17 +187,17 @@ def run_inter_node_comm(args):
                 create_dir(dump_path)
                 print_keys = extract_first_middle_last(keys)
                 first_rank_bandwidth_results = [
-                    all_bandwidth_results[i] for i in range(len(all_bandwidth_results)) if i % num_procs == 0
+                    all_bandwidth_results[i] for i in group_leaders
                 ]
                 num_print_ranks = len(first_rank_bandwidth_results)
                 for size_key in print_keys:
                     values = [r[size_key] for r in first_rank_bandwidth_results]
                     plt.figure(figsize=(10, 4))
                     bars = plt.bar(range(num_print_ranks), values)
-                    plt.xlabel(f"RankPair ({num_procs} ranks)")
+                    plt.xlabel(f"Group (starting rank)")
                     plt.ylabel("Bandwidth")
                     plt.title(f"Inter Node {case_name} Bandwidth for {size_key}")
-                    xtick_labels = [f"{i*num_procs}" for i in range(num_print_ranks)]
+                    xtick_labels = [f"{r}" for r in group_leaders]
                     plt.xticks(range(num_print_ranks), xtick_labels)
                     plt.grid(True, axis="y")
 

--- a/primus/tools/preflight/inter_node_comm.py
+++ b/primus/tools/preflight/inter_node_comm.py
@@ -66,6 +66,7 @@ def run_inter_node_comm(args):
             remainder_nodes = num_nodes % adjacent_nodes
             adjacent_group = None
             group_leaders = []
+            group_node_counts = []
 
             for i_group in range(num_full_groups):
                 group_start = i_group * adjacent_nodes * LOCAL_WORLD_SIZE
@@ -78,6 +79,7 @@ def run_inter_node_comm(args):
                     assert adjacent_group is None
                     adjacent_group = tmp_group
                 group_leaders.append(group_start)
+                group_node_counts.append(adjacent_nodes)
 
             if remainder_nodes >= 2:
                 group_start = num_full_groups * adjacent_nodes * LOCAL_WORLD_SIZE
@@ -90,8 +92,15 @@ def run_inter_node_comm(args):
                     assert adjacent_group is None
                     adjacent_group = tmp_group
                 group_leaders.append(group_start)
+                group_node_counts.append(remainder_nodes)
 
             num_procs = dist.get_world_size(adjacent_group) if adjacent_group is not None else 0
+
+            total_grouped_ranks = num_full_groups * adjacent_nodes * LOCAL_WORLD_SIZE
+            if remainder_nodes >= 2:
+                total_grouped_ranks += remainder_nodes * LOCAL_WORLD_SIZE
+            if RANK < total_grouped_ranks:
+                assert adjacent_group is not None
 
             for size in sizes:
                 if adjacent_group is None:
@@ -197,7 +206,10 @@ def run_inter_node_comm(args):
                     plt.xlabel(f"Group (starting rank)")
                     plt.ylabel("Bandwidth")
                     plt.title(f"Inter Node {case_name} Bandwidth for {size_key}")
-                    xtick_labels = [f"{r}" for r in group_leaders]
+                    xtick_labels = [
+                        f"{group_leaders[i]} ({group_node_counts[i]}N)"
+                        for i in range(num_print_ranks)
+                    ]
                     plt.xticks(range(num_print_ranks), xtick_labels)
                     plt.grid(True, axis="y")
 

--- a/primus/tools/preflight/inter_node_comm_p2p.py
+++ b/primus/tools/preflight/inter_node_comm_p2p.py
@@ -49,10 +49,13 @@ def run_inter_node_comm_p2p(args):
     bandwidth_results = {}
 
     num_adjacent_groups = num_nodes // adjacent_nodes
+    num_paired_ranks = num_adjacent_groups * adjacent_nodes * LOCAL_WORLD_SIZE
     p2p_group = None
     is_src_rank = ((RANK // LOCAL_WORLD_SIZE) % 2) == 0
-    peer_rank = RANK + LOCAL_WORLD_SIZE if is_src_rank else RANK - LOCAL_WORLD_SIZE
-    assert peer_rank >= 0 and peer_rank < WORLD_SIZE
+    if RANK < num_paired_ranks:
+        peer_rank = RANK + LOCAL_WORLD_SIZE if is_src_rank else RANK - LOCAL_WORLD_SIZE
+    else:
+        peer_rank = -1
     for i_group in range(num_adjacent_groups):
         for i_r in range(LOCAL_WORLD_SIZE):
             group_ranks = [
@@ -114,9 +117,10 @@ def run_inter_node_comm_p2p(args):
         src_rank_latency_results = []
         src_rank_bandwidth_results = []
         for rank, r in enumerate(all_bandwidth_results):
+            if rank >= num_paired_ranks:
+                continue
             is_src_rank = ((rank // LOCAL_WORLD_SIZE) % 2) == 0
             peer_rank = rank + LOCAL_WORLD_SIZE if is_src_rank else rank - LOCAL_WORLD_SIZE
-            assert peer_rank >= 0 and peer_rank < WORLD_SIZE
             if not is_src_rank:
                 continue
             src_ranks.append(rank)

--- a/primus/tools/preflight/inter_node_comm_p2p.py
+++ b/primus/tools/preflight/inter_node_comm_p2p.py
@@ -54,6 +54,7 @@ def run_inter_node_comm_p2p(args):
     is_src_rank = ((RANK // LOCAL_WORLD_SIZE) % 2) == 0
     if RANK < num_paired_ranks:
         peer_rank = RANK + LOCAL_WORLD_SIZE if is_src_rank else RANK - LOCAL_WORLD_SIZE
+        assert peer_rank >= 0 and peer_rank < WORLD_SIZE
     else:
         peer_rank = -1
     for i_group in range(num_adjacent_groups):
@@ -121,6 +122,7 @@ def run_inter_node_comm_p2p(args):
                 continue
             is_src_rank = ((rank // LOCAL_WORLD_SIZE) % 2) == 0
             peer_rank = rank + LOCAL_WORLD_SIZE if is_src_rank else rank - LOCAL_WORLD_SIZE
+            assert peer_rank >= 0 and peer_rank < WORLD_SIZE
             if not is_src_rank:
                 continue
             src_ranks.append(rank)

--- a/runner/primus-cli-direct-preflight.sh
+++ b/runner/primus-cli-direct-preflight.sh
@@ -1,0 +1,614 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+set -euo pipefail
+
+print_usage() {
+cat << EOF
+Primus Direct Launcher
+
+Usage:
+    primus-cli direct [--env KEY=VALUE ...] [--single] [--script <file.py>] [--patch <file>] [-- primus-args]
+
+Description:
+    Launch Primus training, benchmarking, or preflight directly on the host (or inside a container).
+    Distributed settings can be controlled by either exporting environment variables in advance,
+    or by specifying them inline using --env KEY=VALUE.
+
+    This script automatically detects your GPU model (e.g., MI300X, MI250X) and loads GPU-specific
+    environment variable optimizations from runner/helpers/envs/<GPU_MODEL>.sh for best performance.
+
+Options:
+    --config <file>      Specify configuration file (default: .primus.yaml or system default)
+    --debug              Enable debug mode with verbose logging
+    --dry-run            Show configuration and command without executing
+    --single             Run with python3 instead of torchrun (single process only)
+    --script <file.py>   Python script to execute (default: primus/cli/main.py)
+    --env KEY=VALUE      Set environment variable before execution
+    --patch <file>       Apply a patch script before execution (can specify multiple times)
+    --log_file PATH      Save log to a specific file (default: logs/log_TIMESTAMP.txt)
+    --numa               Force enable NUMA binding for processes
+    --no-numa            Force disable NUMA binding for processes
+
+Distributed Environment Variables:
+    NNODES        Number of nodes participating in distributed run        [default: 1]
+    NODE_RANK     Rank of the current node (unique integer per node)      [default: 0]
+    GPUS_PER_NODE Number of GPUs to use per node                          [default: 8]
+    MASTER_ADDR   Hostname or IP of master node                           [default: localhost]
+    MASTER_PORT   Port of master node                                     [default: 1234]
+
+You can set these variables in either of the following ways:
+    # (1) Export variables before launch (recommended for scripts or single-node runs)
+      export NNODES=2 GPUS_PER_NODE=8 NODE_RANK=0 MASTER_ADDR=host1
+      primus-cli direct -- train pretrain --config exp.yaml
+
+    # (2) Inject via CLI with --env (useful for launchers and multi-node jobs)
+      primus-cli direct --env NNODES=2 --env GPUS_PER_NODE=8 --env NODE_RANK=1 --env MASTER_ADDR=host1 -- \\
+        benchmark gemm -M 4096 -N 4096 -K 4096
+
+Examples:
+    # Pretrain with a config file (single node)
+      primus-cli direct -- train pretrain --config examples/megatron/exp_pretrain.yaml
+
+    # Benchmark GEMM (single node)
+      primus-cli direct -- benchmark gemm
+
+    # Distributed GEMM benchmark, 2 nodes, 8 GPUs per node (rank 0)
+      primus-cli direct --env NNODES=2 --env GPUS_PER_NODE=8 --env NODE_RANK=0 --env MASTER_ADDR=host1 -- \\
+        benchmark gemm -M 4096 -N 4096 -K 4096
+
+    # Launch as rank 1 (2-node distributed)
+      primus-cli direct --env NNODES=2 --env GPUS_PER_NODE=8 --env NODE_RANK=1 --env MASTER_ADDR=host1 -- \\
+        benchmark gemm -M 4096 -N 4096 -K 4096
+
+    # Run a custom script directly (no torchrun)
+      primus-cli direct --single --script examples/debug_run.py -- --arg1 val1
+
+    # Run a custom script with torchrun
+      primus-cli direct --script examples/run_distributed.py -- --config conf.yaml
+
+    # Apply patch scripts before execution
+      primus-cli direct --patch patches/fix_env.sh --patch patches/setup.py -- train pretrain --config exp.yaml
+
+    # Force enable NUMA binding for better performance
+      primus-cli direct --numa -- benchmark gemm -M 8192 -N 8192 -K 8192
+
+Notes:
+    - If --single is specified, Primus skips torchrun and uses python3 directly.
+    - If --script is not specified, defaults to primus/cli/main.py.
+    - Always separate Primus arguments from launcher options using '--'.
+    - Environment variables can be mixed: 'export' takes precedence unless overridden by '--env'.
+    - Multi-node jobs require MASTER_ADDR set to the master node's hostname/IP.
+    - Patch scripts are executed in order before running the main script (useful for env setup, hot fixes, etc.).
+    - NUMA binding is auto-disabled by default; use --numa to enable for better memory locality.
+    - GPU-specific optimizations: The script automatically sources primus-env.sh, which detects your
+      GPU model and loads optimized environment variables from runner/helpers/envs/<GPU_MODEL>.sh
+      (e.g., MI300X.sh, MI250X.sh). If no GPU-specific config is found, it uses base_env.sh only.
+
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    print_usage
+    exit 0
+fi
+
+# Resolve runner directory
+# Use RUNNER_DIR instead of SCRIPT_DIR to avoid conflicts with sourced scripts
+RUNNER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load common library (required)
+# shellcheck disable=SC1091
+source "$RUNNER_DIR/lib/common.sh" || {
+    echo "[ERROR] Failed to load common library: $RUNNER_DIR/lib/common.sh" >&2
+    exit 1
+}
+
+# Load config library (required)
+# shellcheck disable=SC1091
+source "$RUNNER_DIR/lib/config.sh" || {
+    LOG_ERROR "[direct] Failed to load config library: $RUNNER_DIR/lib/config.sh"
+    exit 1
+}
+
+LOG_INFO_RANK0 "-----------------------------------------------"
+LOG_INFO_RANK0 "primus-cli-direct.sh"
+LOG_INFO_RANK0 "-----------------------------------------------"
+
+
+
+###############################################################################
+# STEP 1: Pre-parse global options (--config, --debug, --dry-run, --help)
+###############################################################################
+CONFIG_FILE=""
+DEBUG_MODE=0
+DRY_RUN_MODE=0
+PRE_PARSE_ARGS=()
+PRIMUS_ARGS=()
+
+# If the first argument is the subcommand "direct", skip it
+if [[ "${1:-}" == "direct" ]]; then
+    shift
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --config)
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        --debug)
+            DEBUG_MODE=1
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN_MODE=1
+            shift
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        --env)
+            if [[ "${2:-}" == *=* ]]; then
+                # Inline KEY=VALUE form: export immediately and keep for later so that
+                # direct.env / --env can be re-applied with highest priority.
+                _env_val="${2:-}"
+                export "${_env_val%%=*}"="${_env_val#*=}"
+                PRE_PARSE_ARGS+=("$1" "${2:-}")
+                shift 2
+            else
+                # Non KEY=VALUE form: treat as env file path and defer sourcing until
+                # after hooks and patches (STEP 9). Use a synthetic --env_file option
+                # so that it is tracked via direct_config[env_file].
+                PRE_PARSE_ARGS+=("--env_file" "${2:-}")
+                LOG_INFO_RANK0 "[direct] CLI: --env_file ${2:-}"
+                shift 2
+            fi
+            ;;
+        --script|--log_file|--patch)
+            # Runner options that take a value
+            PRE_PARSE_ARGS+=("$1" "${2:-}")
+            shift 2
+            ;;
+        --numa|--no-numa|--single)
+            # Runner boolean flags (no value)
+            PRE_PARSE_ARGS+=("$1")
+            shift
+            ;;
+        --)
+            # Explicit separator: remaining args are for primus Python module
+            shift  # skip the '--'
+            PRIMUS_ARGS+=("$@")
+            break
+            ;;
+        *)
+            # First unrecognized argument (typically a subcommand like 'train'):
+            # Stop parsing runner options, pass everything from here to primus Python module.
+            # This prevents runner from intercepting options meant for Python (e.g., --config).
+            PRIMUS_ARGS+=("$@")
+            break
+            ;;
+    esac
+done
+# Restore arguments for second pass. Use `set --` so that options parsing stops
+# and all following tokens (including those starting with '-') become positional
+# parameters for the next parsing stage.
+set -- "${PRE_PARSE_ARGS[@]}" -- "${PRIMUS_ARGS[@]}"
+LOG_INFO_RANK0 "[direct] PRE_PARSE_ARGS (runner options): ${PRE_PARSE_ARGS[*]}"
+LOG_INFO_RANK0 "[direct] PRIMUS_ARGS (python module args): ${PRIMUS_ARGS[*]}"
+LOG_INFO_RANK0 "[direct] Combined args for second pass: $*"
+
+# Enable debug mode early if set via CLI
+if [[ "$DEBUG_MODE" == "1" ]]; then
+    export PRIMUS_LOG_LEVEL="DEBUG"
+    LOG_INFO_RANK0 "[direct] Debug mode enabled via CLI (PRIMUS_LOG_LEVEL=DEBUG)"
+fi
+
+###############################################################################
+# STEP 2: Load configuration files
+###############################################################################
+load_config_auto "$CONFIG_FILE" "direct" || {
+    LOG_ERROR "[direct] Configuration loading failed"
+    exit 1
+}
+
+###############################################################################
+# STEP 3: Extract direct.* config and apply defaults
+###############################################################################
+declare -A direct_config
+extract_config_section "direct" direct_config || true
+
+# Check debug/dry-run from config (CLI takes precedence, already set in STEP 1)
+if [[ "$DEBUG_MODE" == "0" ]]; then
+    debug_value="${direct_config[debug]:-false}"
+    if [[ "$debug_value" == "true" || "$debug_value" == "1" ]]; then
+        DEBUG_MODE=1
+        export PRIMUS_LOG_LEVEL="DEBUG"
+        LOG_INFO_RANK0 "[direct] Debug mode enabled via config (PRIMUS_LOG_LEVEL=DEBUG)"
+    fi
+fi
+
+if [[ "$DRY_RUN_MODE" == "0" ]]; then
+    dry_run_value="${direct_config[dry_run]:-false}"
+    if [[ "$dry_run_value" == "true" || "$dry_run_value" == "1" ]]; then
+        DRY_RUN_MODE=1
+        LOG_INFO_RANK0 "[direct] Dry-run mode enabled via config"
+    fi
+fi
+
+# Set default values for parameters not in config
+direct_config[run_mode]="${direct_config[run_mode]:-torchrun}"
+direct_config[script]="${direct_config[script]:-primus/cli/main.py}"
+direct_config[numa]="${direct_config[numa]:-auto}"
+direct_config[log_file]="${direct_config[log_file]:-}"
+
+# Clean up empty array markers ("[]")
+for key in "${!direct_config[@]}"; do
+    if [[ "${direct_config[$key]}" == "[]" ]]; then
+        unset "direct_config[$key]"
+    fi
+done
+
+LOG_DEBUG_RANK0 "[direct] Configuration loaded, ready for CLI argument override"
+
+###############################################################################
+# STEP 4: Parse CLI arguments (all stored as newline-separated strings)
+# Priority: CLI args > Config file > Defaults
+###############################################################################
+primus_args=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --)
+            shift
+            primus_args+=("$@")
+            break
+            ;;
+        --single)
+            # Special case: --single maps to run_mode=single
+            direct_config[run_mode]="single"
+            LOG_DEBUG_RANK0 "[direct] CLI: run_mode=single"
+            shift
+            ;;
+        --no-numa)
+            # Special case: --no-numa maps to numa=false
+            direct_config[numa]="false"
+            LOG_DEBUG_RANK0 "[direct] CLI: numa=false"
+            shift
+            ;;
+        --*)
+            # Generic option handler
+            opt_name="${1#--}"
+            opt_value="${2:-}"
+
+            # Check if next argument is a value or another flag
+            if [[ -z "$opt_value" ]] || [[ "$opt_value" == --* ]]; then
+                # Boolean flag (no value or next is a flag)
+                direct_config[$opt_name]="true"
+                LOG_INFO_RANK0 "[direct] CLI: $opt_name=true"
+                shift
+            else
+                # Key-value option: append with newline
+                if [[ -z "${direct_config[$opt_name]:-}" ]]; then
+                    direct_config[$opt_name]="$opt_value"
+                else
+                    direct_config[$opt_name]+=$'\n'"$opt_value"
+                fi
+                LOG_INFO_RANK0 "[direct] CLI: $opt_name += $opt_value"
+                shift 2
+            fi
+            ;;
+        *)
+            primus_args+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${primus_args[@]}"
+
+###############################################################################
+# STEP 4.5: Process non-cumulative parameters (use last value only)
+###############################################################################
+
+# For non-cumulative parameters with multiple values (config + CLI), use only the last value
+for param in "script" "log_file"; do
+    if [[ -n "${direct_config[$param]:-}" && "${direct_config[$param]}" == *$'\n'* ]]; then
+        # Has newlines, take last value (CLI overrides config)
+        last_value=$(echo "${direct_config[$param]}" | tail -1)
+        direct_config[$param]="$last_value"
+        LOG_DEBUG_RANK0 "[direct] Using last value for $param: $last_value"
+    fi
+done
+
+###############################################################################
+# STEP 4.6: Setup log file path
+###############################################################################
+if [[ -z "${direct_config[log_file]:-}" ]]; then
+    direct_config[log_file]="logs/log_$(date +%Y%m%d_%H%M%S).txt"
+fi
+mkdir -p "$(dirname "${direct_config[log_file]:-}")"
+
+
+###############################################################################
+# STEP 5: Install dependencies
+###############################################################################
+# Detect the backend framework from the experiment YAML (--config in PRIMUS_ARGS)
+# so we can install the correct requirements file:
+#   maxtext -> requirements-jax.txt
+#   others  -> requirements.txt
+_detect_framework() {
+    local cfg_path=""
+    local args=("${primus_args[@]}")
+    for ((i=0; i<${#args[@]}; i++)); do
+        if [[ "${args[$i]}" == "--config" && -n "${args[$((i+1))]:-}" ]]; then
+            cfg_path="${args[$((i+1))]}"
+            break
+        fi
+    done
+    if [[ -z "$cfg_path" || ! -f "$cfg_path" ]]; then
+        echo ""
+        return
+    fi
+    python3 -c "
+import yaml, sys
+try:
+    cfg = yaml.safe_load(open('$cfg_path'))
+    print(cfg.get('modules',{}).get('pre_trainer',{}).get('framework',''))
+except Exception:
+    print('')
+" 2>/dev/null
+}
+
+DETECTED_FRAMEWORK="$(_detect_framework)"
+LOG_INFO_RANK0 "[direct] Detected framework: ${DETECTED_FRAMEWORK:-unknown}"
+
+# Skip pip install in dry-run mode
+if [[ "$DRY_RUN_MODE" != "1" ]]; then
+    # $VENV_PATH is set in the environment variables
+    if [[ -n "$VENV_PATH" ]]; then
+        LOG_INFO_RANK0 "[direct] activate python environment"
+        source "$VENV_PATH"
+    else
+        LOG_ERROR "[direct] VENV_PATH is not set"
+        exit 1
+    fi
+fi
+
+###############################################################################
+# STEP 6: Source GPU environment and helper modules
+###############################################################################
+
+# Source primus-env.sh (it will set its own SCRIPT_DIR, which is fine)
+# shellcheck disable=SC1091
+source "${RUNNER_DIR}/helpers/envs/primus-env.sh"
+
+###############################################################################
+# STEP 7: Execute hooks and capture extra arguments / env
+###############################################################################
+# Hooks can return:
+#   - Extra Primus CLI arguments by printing lines:  extra.<name>=<value>
+#   - Environment variables by printing lines:       env.VAR_NAME=VALUE
+# The detailed parsing logic lives in execute_hooks.sh, which fills the
+# global HOOK_EXTRA_PRIMUS_ARGS array and exports env.* entries.
+# shellcheck disable=SC1091
+source "${RUNNER_DIR}/helpers/execute_hooks.sh"
+HOOK_EXTRA_PRIMUS_ARGS=()
+if ! execute_hooks "${1:-}" "${2:-}" "$@"; then
+    LOG_ERROR "[direct] Hooks execution failed"
+    exit 1
+fi
+
+# Prepend collected extra args to the current Primus arguments ($@) so that
+# they are automatically picked up when building the final CMD below.
+if [[ ${#HOOK_EXTRA_PRIMUS_ARGS[@]} -gt 0 ]]; then
+    set -- "$@" "${HOOK_EXTRA_PRIMUS_ARGS[@]}"
+fi
+
+###############################################################################
+# STEP 8: Execute patch scripts
+###############################################################################
+# Execute patch scripts from config + CLI.
+# Note: direct_config[patch] is stored as a newline-separated list.
+# Initialize so it is defined when no patches run (set -u safe).
+PATCH_EXTRA_PRIMUS_ARGS=()
+if [[ -n "${direct_config[patch]:-}" ]]; then
+    # shellcheck disable=SC1091
+    source "${RUNNER_DIR}/helpers/execute_patches.sh"
+    # Reset collected extra args from patches for this run
+    PATCH_EXTRA_PRIMUS_ARGS=()
+    if ! execute_patches "${direct_config[patch]}"; then
+        LOG_ERROR "[direct] Patch execution failed"
+        exit 1
+    fi
+fi
+
+###############################################################################
+# STEP 8.5: Apply extra Primus args from patches (extra.* protocol)
+###############################################################################
+if [[ ${#PATCH_EXTRA_PRIMUS_ARGS[@]} -gt 0 ]]; then
+    set -- "$@" "${PATCH_EXTRA_PRIMUS_ARGS[@]}"
+    LOG_INFO_RANK0 "[direct] Applied extra args from patches: ${PATCH_EXTRA_PRIMUS_ARGS[*]}"
+fi
+
+###############################################################################
+# STEP 9: Build and export environment variables (highest priority)
+###############################################################################
+
+# First, source any env files specified via --env <file> (tracked as env_file).
+if [[ -n "${direct_config[env_file]:-}" ]]; then
+    while IFS= read -r env_file; do
+        [[ -n "$env_file" ]] || continue
+        if [[ ! -f "$env_file" || ! -r "$env_file" ]]; then
+            LOG_ERROR "[direct] Env file not found or not readable: $env_file"
+            exit 1
+        fi
+        # shellcheck disable=SC1090
+        source "$env_file"
+        LOG_INFO_RANK0 "[direct] Sourced env file (final): $env_file"
+    done <<< "${direct_config[env_file]:-}"
+fi
+
+# Then, build primus_env_kv array and export inline KEY=VALUE envs. This happens
+# after hooks, patches, and env files so that CLI/config-provided envs
+# (direct.env / --env KEY=VALUE) take final precedence for the actual Primus run.
+primus_env_kv=()
+if [[ -n "${direct_config[env]:-}" ]]; then
+    while IFS= read -r env_entry; do
+        [[ -n "$env_entry" ]] || continue
+        # Validate env format (KEY=VALUE)
+        if ! [[ "$env_entry" == *=* ]]; then
+            LOG_ERROR "[direct] Invalid env format: $env_entry"
+            LOG_ERROR "  Expected format: KEY=VALUE (e.g., NCCL_DEBUG=INFO)"
+            exit 1
+        fi
+        primus_env_kv+=("$env_entry")
+        export "${env_entry%%=*}"="${env_entry#*=}"
+        LOG_INFO_RANK0 "[direct] Exported env (final): ${env_entry%%=*}=${env_entry#*=}"
+    done <<< "${direct_config[env]:-}"
+fi
+
+###############################################################################
+# STEP 9.5: Auto-detect Slurm distributed settings (if running under Slurm)
+###############################################################################
+if [[ -n "${SLURM_JOB_ID:-}" ]]; then
+    export NNODES="${SLURM_NNODES:-${NNODES:-1}}"
+    export NODE_RANK="${SLURM_NODEID:-${NODE_RANK:-0}}"
+    if [[ -z "${MASTER_ADDR:-}" || "${MASTER_ADDR}" == "localhost" ]]; then
+        MASTER_ADDR="$(scontrol show hostnames "$SLURM_NODELIST" | head -n1)"
+        export MASTER_ADDR
+    fi
+    export MASTER_PORT="${MASTER_PORT:-1234}"
+    LOG_INFO_RANK0 "[direct] Slurm detected: NNODES=$NNODES NODE_RANK=$NODE_RANK MASTER_ADDR=$MASTER_ADDR"
+fi
+
+###############################################################################
+# STEP 10: Build launch command
+###############################################################################
+
+# Allow RUN_MODE to be overridden by environment variable
+RUN_MODE="${RUN_MODE:-${direct_config[run_mode]:-torchrun}}"
+
+CMD="${direct_config[script]:-} $* 2>&1 | tee ${direct_config[log_file]:-}"
+if [[ "$RUN_MODE" == "single" ]]; then
+    CMD="python3 ${CMD}"
+    LOG_INFO_RANK0 "[direct] Using python launcher (single mode)"
+elif [[ "$RUN_MODE" == "torchrun" ]]; then
+    # Step 2: Add NUMA binding prefix if enabled
+    if [[ "${direct_config[numa]:-}" == "true" ]]; then
+        CMD="--no-python ${RUNNER_DIR}/helpers/numa_bind.sh ${CMD}"
+        LOG_INFO_RANK0 "[direct] NUMA binding: ENABLED (forced by CLI)"
+    else
+        LOG_INFO_RANK0 "[direct] NUMA binding: AUTO (default OFF)"
+    fi
+
+    DISTRIBUTED_ARGS=(
+        --nproc_per_node "${GPUS_PER_NODE:-8}"
+        --nnodes "${NNODES:-1}"
+        --node_rank "${NODE_RANK:-0}"
+        --master_addr "${MASTER_ADDR:-localhost}"
+        --master_port "${MASTER_PORT:-1234}"
+    )
+
+    LAST_NODE=$((${NNODES:-1} - 1))
+    FILTERS=()
+    # Add local rank 0 on the first node
+    if [ "${NODE_RANK:-0}" -eq 0 ]; then
+        FILTERS+=(0)
+    fi
+
+    # Add the last local rank on the last node
+    if [ "${NODE_RANK:-0}" -eq "$LAST_NODE" ]; then
+        FILTERS+=($((${GPUS_PER_NODE:-8} - 1)))
+    fi
+
+    # Build filter argument (only if FILTERS is non-empty)
+    if [ "${#FILTERS[@]}" -gt 0 ]; then
+        LOCAL_FILTER=$(IFS=,; echo "${FILTERS[*]}")
+        FILTER_ARG=(--local-ranks-filter "$LOCAL_FILTER")
+    else
+        FILTER_ARG=()
+    fi
+
+    CMD="torchrun ${DISTRIBUTED_ARGS[*]} ${FILTER_ARG[*]} ${LOCAL_RANKS:-} ${CMD}"
+fi
+
+###############################################################################
+# STEP 11: Display configuration (always)
+###############################################################################
+if [[ "$DRY_RUN_MODE" == "1" ]]; then
+    print_section "[DRY RUN] Direct Launch Configuration"
+else
+    print_section "Primus Direct Launch Configuration"
+fi
+
+PRINT_INFO_RANK0 "  Run Mode        : ${direct_config[run_mode]:-}"
+PRINT_INFO_RANK0 "  Script Path     : ${direct_config[script]:-}"
+PRINT_INFO_RANK0 "  Config File     : ${CONFIG_FILE:-<none>}"
+PRINT_INFO_RANK0 "  Log File        : ${direct_config[log_file]:-}"
+PRINT_INFO_RANK0 "  NUMA Binding    : ${direct_config[numa]:-}"
+if [[ -n "${direct_config[patch]:-}" ]]; then
+    PRINT_INFO_RANK0 "  Patch Scripts   : $(echo "${direct_config[patch]:-}" | tr '\n' ' ')"
+else
+    PRINT_INFO_RANK0 "  Patch Scripts   : <none>"
+fi
+PRINT_INFO_RANK0 "  Primus Args     : $*"
+PRINT_INFO_RANK0 ""
+
+if [[ ${#primus_env_kv[@]} -gt 0 ]]; then
+    PRINT_INFO_RANK0 "  Environment Variables:"
+    for kv in "${primus_env_kv[@]}"; do
+        PRINT_INFO_RANK0 "    $kv"
+    done
+    PRINT_INFO_RANK0 ""
+fi
+
+if [[ "${direct_config[run_mode]:-}" == "torchrun" ]]; then
+    PRINT_INFO_RANK0 "  Distributed Settings:"
+    PRINT_INFO_RANK0 "    NNODES          : ${NNODES:-1}"
+    PRINT_INFO_RANK0 "    NODE_RANK       : ${NODE_RANK:-0}"
+    PRINT_INFO_RANK0 "    GPUS_PER_NODE   : ${GPUS_PER_NODE:-8}"
+    PRINT_INFO_RANK0 "    MASTER_ADDR     : ${MASTER_ADDR:-localhost}"
+    PRINT_INFO_RANK0 "    MASTER_PORT     : ${MASTER_PORT:-1234}"
+    PRINT_INFO_RANK0 ""
+fi
+
+print_system_info
+
+PRINT_INFO_RANK0 "  Full Command:"
+if [[ "$DRY_RUN_MODE" == "1" ]]; then
+    PRINT_INFO_RANK0 "    Would Execute: $CMD"
+else
+    PRINT_INFO_RANK0 "    Executing: $CMD"
+fi
+
+# In dry-run mode, exit after displaying the command
+if [[ "$DRY_RUN_MODE" == "1" ]]; then
+    print_section "End of Dry Run"
+    LOG_INFO_RANK0 "[direct] Dry-run mode: command not executed"
+    exit 0
+fi
+
+print_section ""
+
+###############################################################################
+# STEP 12: Execute command
+###############################################################################
+# Temporarily allow pipeline to fail so we can capture PIPESTATUS and log it
+eval "$CMD"
+exit_code=$?
+
+# Print result based on exit code
+if [[ $exit_code -ge 128 ]]; then
+    LOG_ERROR "[direct] torchrun crashed due to signal $((exit_code - 128))"
+elif [[ $exit_code -ne 0 ]]; then
+    LOG_ERROR "[direct] torchrun exited with code $exit_code"
+else
+    LOG_INFO "[direct] torchrun finished successfully (code 0)"
+fi
+
+exit "$exit_code"


### PR DESCRIPTION

### Summary

Preflight inter-node benchmarks assumed power-of-2 node counts, causing two bugs:

1. **Silent exclusion** -- remainder nodes never benchmarked for 2-node/4-node adjacency tests (e.g., on 6 nodes with 4-node adjacency, nodes 4-5 were silently dropped -- 33% of nodes never tested)
2. **P2P crash** -- odd node counts triggered `AssertionError: peer_rank >= WORLD_SIZE` because the unpaired trailing node tried to compute a peer beyond world size

This PR fixes both so preflight runs correctly on **any** node count.

### What changed

| File | Change |
|---|---|
| `inter_node_comm.py` | Create remainder group when `num_nodes % adjacent_nodes >= 2`. Use `dist.get_world_size()` for actual group size. Report via explicit `group_leaders` list instead of modular arithmetic. |
| `inter_node_comm_p2p.py` | Guard `peer_rank` with `RANK < num_paired_ranks`. Unpaired ranks get `peer_rank = -1` and skip gracefully. Same guard in reporting loop. |

### How it works

```
remainder = num_nodes % adjacent_nodes

remainder = 0  -> all nodes in equal groups (unchanged)
remainder = 1  -> excluded (correct -- can't do inter-node comm with 1 node)
remainder >= 2 -> OLD: silently excluded. NEW: remainder group created & benchmarked
```

Example -- 6 nodes, `allreduce-4nodes`:
- **Old:** only nodes 0-3 benchmarked (1 group of 32 ranks). Nodes 4-5 silently excluded.
- **New:** nodes 0-3 form the main group (32 ranks), nodes 4-5 form a remainder group (16 ranks). Both reported.

### Test plan

Ran preflight on **1-9 nodes** with `NCCL_DEBUG=INFO` enabled. All passed cleanly.

| Nodes | Verification |
|---|---|
| 2, 4, 8 | POW2 regression -- identical to main |
| 3, 5, 9 | Odd counts -- P2P no crash, unpaired node skipped gracefully |
| 6 | `allreduce-4nodes` reports 2 group leaders: rank 0 (4-node main) + rank 32 (2-node remainder) |
| 7 | `allreduce-4nodes` reports 2 group leaders: rank 0 (4-node main) + rank 32 (3-node remainder) |
| 1 | All inter-node tests skip cleanly |

#### NCCL-level verification (6N example)

Confirmed via `ncclCommSplit_impl` logs that two separate sub-communicators are created:
```
splitCount 87: g52+g53 (nodes 4-5) -> nranks=16, color 1721561492  (remainder group)
splitCount 88: g2+g14+g50+g51 (nodes 0-3) -> nranks=32, color 2008404567  (main group)
```
Different colors = separate sub-communicators. Remainder nodes do NOT appear in the main group's split.

#### Caveat

When `remainder = 1` (e.g., 5N with 4-node adjacency), the single leftover node is excluded from that sub-group test -- inter-node communication requires >= 2 nodes. It's still covered by the full N-node allreduce/alltoall and ring P2P.

### Test results

All jobs ran on partition `amd-tw` with `NCCL_DEBUG=INFO`. Node g57 excluded due to faulty RDMA NIC.

| Nodes | Ranks | Slurm Job | Nodes Used | Exit |
|---|---|---|---|---|
| 1 | 8 | 477 | g59 | 0 |
| 2 | 16 | 478 | g2, g14 | 0 |
| 3 | 24 | 479 | g25, g26, g27 | 0 |
| 4 | 32 | 480 | g50, g51, g52, g53 | 0 |
| 5 | 40 | 481 | g15, g29, g54, g55, g59 | 0 |
| 6 | 48 | 482 | g2, g14, g50, g51, g52, g53 | 0 |
| 7 | 56 | 483 | g15, g25, g26, g27, g29, g54, g55 | 0 |
| 8 | 64 | 484 | g2, g14, g15, g25, g26, g27, g29, g50 | 0 |
| 9 | 72 | 485 | g2, g14, g15, g50, g51, g52, g53, g54, g55 | 0 |

#### Remainder group output (6N, `slurm-482.out` line 54476)

```
=======InterNodeComm - allreduce-4nodes (GB/s)=======
Hostname      Node  Rank  2MB    4MB    8MB    16MB   32MB   64MB   128MB  256MB  512MB  1024MB
tus1-p3-g2    0     0     3.73   5.31   5.03   5.84   10.96  7.55   7.41   8.01   15.01  29.27
tus1-p3-g52   4     32    32.46  53.65  77.70  96.48  135.12 175.10 215.54 324.20 336.77 344.32
```

Two group leaders reported: rank 0 (main 4-node group, nodes 0-3) and rank 32 (remainder 2-node group, nodes 4-5).

#### Remainder group output (7N, `slurm-483.out` line 68237)

```
=======InterNodeComm - allreduce-4nodes (GB/s)=======
Hostname      Node  Rank  2MB    4MB    8MB    16MB   32MB   64MB   128MB  256MB  512MB  1024MB
tus1-p3-g15   0     0     4.28   5.64   5.49   6.03   11.37  7.55   7.40   8.11   18.00  30.02
tus1-p3-g29   4     32    9.94   14.09  14.52  15.25  30.92  20.28  19.93  20.25  40.16  77.46
```

Two group leaders: rank 0 (main 4-node group, nodes 0-3) and rank 32 (remainder 3-node group, nodes 4-6).

#### P2P on odd counts (no crash)

```
=======InterNodeComm - p2p-2nodes (GB/s)=======  [3N, slurm-479.out]
Hostname      Node  Rank  2MB    ...    1024MB
tus1-p3-g25   0     0     12.25  ...    20.40    <- paired (node 0 <-> node 1)
                                                    node 2 absent (unpaired, skipped)

=======InterNodeComm - p2p-2nodes (GB/s)=======  [5N, slurm-481.out]
Hostname      Node  Rank  2MB    ...    1024MB
tus1-p3-g15   0     0     10.83  ...    10.12    <- pair 1 (node 0 <-> node 1)
tus1-p3-g15   0     1     11.00  ...    9.98
...
                                                    node 4 absent (unpaired, skipped)
```

#### Ring P2P includes all nodes (odd counts)

```
=======InterNodeRingP2P bidirectional bandwidth - ringsize=5 - (GB/s)=======
ring 10MB   20MB   40MB   80MB   160MB
0    49.79  52.22  53.95  54.93  54.87
1    49.57  53.02  53.80  54.93  55.19
2    49.71  52.39  53.84  54.78  54.98
3    49.37  52.21  53.94  54.69  55.21
4    48.15  53.20  53.84  54.94  55.24
5    47.59  52.54  53.73  54.70  55.07
```

All 5 nodes participate in the ring (including node 4 which was excluded from P2P pairing).

#### NCCL warnings

All NCCL WARN messages across all jobs are benign IB port-state notifications:
```
NCCL WARN NET/IB : rdmaN:1 Got async error event: port active
```
No `NCCL ERROR`, `ncclSystemError`, or `SIGTERM` in any completed job.

### Out of scope

This PR addresses preflight benchmark correctness only. Early-stopping / RCCL hang diagnosis is in progress in #689.
