### PR TITLE
feat(preflight): add --no-split-nodes-subgroup to skip subgroup inter-node tests

### DIFF
--- a/primus/tools/preflight/inter_node_comm.py
+++ b/primus/tools/preflight/inter_node_comm.py
@@ -41,9 +41,11 @@ def run_inter_node_comm(args):
     # N-node allreduce & alltoall (adjacent pairs)
     # 2-node allreduce, pair nodes: [0, 1], [2, 3], ...
     # 4-node allreduce, pair nodes: [0, 1, 2, 3], [4, 5, 6, 7]...
+    node_counts = [2, 4, num_nodes] if args.split_nodes_subgroup else [num_nodes]
+    node_counts = sorted(set(node_counts))
     cases = {
-        "allreduce": list(set([2, 4] + [num_nodes])),
-        "alltoall": list(set([2, 4] + [num_nodes])),
+        "allreduce": node_counts,
+        "alltoall": node_counts,
     }
 
     if RANK == 0:

--- a/primus/tools/preflight/preflight_args.py
+++ b/primus/tools/preflight/preflight_args.py
@@ -59,6 +59,13 @@ def add_preflight_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
 
     # Performance test specific options (only used with --perf-test)
     parser.add_argument("--plot", action="store_true", help="Generate plots (only with --perf-test)")
+    parser.add_argument(
+        "--no-split-nodes-subgroup",
+        dest="split_nodes_subgroup",
+        action="store_false",
+        help="Skip inter-node comm tests on node subgroups (2-node, 4-node). "
+        "Only run the all-node test.",
+    )
 
     # Distributed init timeout (prevents hangs when network/rendezvous is misconfigured)
     parser.add_argument(

--- a/primus/tools/preflight/preflight_perf_test.py
+++ b/primus/tools/preflight/preflight_perf_test.py
@@ -315,7 +315,9 @@ def run_preflight(args):
         run_square_gemm(args)
         run_intra_node_comm(args)
         run_inter_node_comm(args)
-        run_inter_node_comm_p2p(args)
+        if args.split_nodes_subgroup:
+            # p2p test only exercises 2-node pairs; skip when subgroups disabled
+            run_inter_node_comm_p2p(args)
         run_inter_node_ring_p2p(args)
 
         if RANK == 0 and args.save_pdf:


### PR DESCRIPTION
…-node tests

Allows skipping 2-node and 4-node subgroup inter-node comm tests, running only the all-node allreduce/alltoall and ring p2p.