### PR TITLE
feat(dashboard): refine Primus dashboard homepage and backend summaries

### DIFF
--- a/.cursor/skills/backend-gap-report/SKILL.md
+++ b/.cursor/skills/backend-gap-report/SKILL.md
@@ -123,6 +123,7 @@ The metadata must:
 - reference publish artifact paths that can be generated
 - map to markdown source files that exist in the repo
 - include backend identity, refs, stats, highlights, and artifact links
+- include `dashboard_summary` with concise homepage-ready facts when the report has enough evidence
 
 Use the schema and examples in [reference.md](reference.md) and [examples.md](examples.md).
 
@@ -191,6 +192,20 @@ Before finishing:
 - Dashboard source data lives under `docs/backend-gap/dashboard-data/reports/`.
 - `docs/backend-gap/dashboard-data/index.json` is generated, not hand-maintained.
 - Artifact paths in metadata are relative to the standalone published site root.
+- Backend deep-dive cards should render structured `dashboard_summary` fields when present. Do not make the frontend infer important conclusions from Markdown prose.
+
+### Backend Dashboard Summary
+
+When generating backend metadata, add a `dashboard_summary` object whenever the comparison has confirmed facts worth surfacing on the homepage:
+
+- `headline`: one sentence explaining why this backend comparison matters
+- `recommendation`: concise action label such as `monitor`, `plan sync`, or `urgent sync`
+- `why_it_matters`: 3-5 concise facts or risks
+- `feature_deltas`: notable upstream capabilities added since the Primus pin
+- `dependency_deltas`: dependency, runtime, CUDA, ROCm, or package-channel differences
+- `integration_risks`: Primus-specific coupling points or upgrade risks
+
+All `dashboard_summary` content must be derived from the same evidence used in the detailed report. Do not invent features, versions, or risks to make the dashboard look richer.
 
 ## Weekly Engineering Report Integration
 
@@ -239,15 +254,19 @@ combined bundle:
 python3 tools/backend_gap_report/build_site_bundle.py --output-dir /tmp/primus-dashboard-site
 ```
 
-### Presentation rules for weekly reports
+### Presentation rules for the shared dashboard
 
-- The dashboard must keep backend-gap content first-class and add weekly
-  reports as a peer section, not as a decorative widget.
-- Home/hero should surface the latest weekly report id, generation time, and
-  a featured summary (merged PR count, category breakdown, recommendations,
-  key findings, link to the Markdown report).
-- A history list/cards below the featured block shows older weekly reports,
-  newest first.
+- The homepage should lead with the latest weekly engineering snapshot because
+  the weekly report is the broad Primus status view.
+- Backend gap reports should appear as backend deep-dive cards, not as a
+  separate top-level dashboard module or tab.
+- Backend deep-dive cards should be generated from backend metadata records and
+  should automatically expand when new backend reports are added.
+- The backend card should prioritize `dashboard_summary` content: why it
+  matters, new upstream capabilities, dependency shifts, integration risks, and
+  PDF links.
+- Weekly archive/list sections should stay simple. Avoid unnecessary filters or
+  history affordances when there is only one report.
 - Visual style must remain calm, editorial, presentation-ready. No emoji,
   no animations, no decorative gradients beyond the existing header treatment.
 

--- a/.cursor/skills/backend-gap-report/reference.md
+++ b/.cursor/skills/backend-gap-report/reference.md
@@ -100,6 +100,29 @@ Each file under `docs/backend-gap/dashboard-data/reports/` should follow this st
     "Upstream main tracks the latest nightly on CUDA cu130 / ROCm 7.1, while the current Primus baseline is centered on cu126.",
     "Primus has a non-trivial outer integration layer that directly depends on upstream internal paths."
   ],
+  "dashboard_summary": {
+    "headline": "TorchTitan is 493 commits behind upstream main, with dependency-channel and Primus integration impact.",
+    "recommendation": "urgent sync",
+    "why_it_matters": [
+      "Primus bundles TorchTitan 0.1.0 while upstream main is at 0.2.2.",
+      "Upstream main moved to nightly cu130 and ROCm 7.1 while the Primus baseline remains centered on cu126.",
+      "The gap includes 447 changed files, so this is not a narrow dependency bump.",
+      "Primus trainer, adapter, and patch layers directly depend on upstream internal paths."
+    ],
+    "feature_deltas": [
+      "GraphTrainer precompile and cudagraph paths",
+      "MoE token dispatcher and DeepEP / HybridEP distributed runtime updates",
+      "Fused QKV GQAttention and FlexAttention context-parallel work"
+    ],
+    "dependency_deltas": [
+      "README nightly channel moved from nightly/cu126 to nightly/cu130.",
+      "ROCm workflow coverage now targets nightly/rocm7.1."
+    ],
+    "integration_risks": [
+      "Primus trainer imports torchtitan.config.job_config.JobConfig and torchtitan.train.Trainer.",
+      "Turbo patches reference upstream model, quantization, and MoE internals."
+    ]
+  },
   "artifacts": [
     {
       "label": "Detailed Report (PDF)",
@@ -133,6 +156,15 @@ Top level:
 - `highlights`
 - `artifacts`
 
+Recommended for dashboard presentation:
+
+- `dashboard_summary.headline`
+- `dashboard_summary.recommendation`
+- `dashboard_summary.why_it_matters`
+- `dashboard_summary.feature_deltas`
+- `dashboard_summary.dependency_deltas`
+- `dashboard_summary.integration_risks`
+
 Each artifact requires:
 
 - `label`
@@ -150,6 +182,8 @@ Each artifact requires:
 - Each artifact `path` should map to an existing markdown source path with the same basename.
 - Keep default artifact labels plain. Add language suffixes only for non-default variants when needed.
 - Prefer marking the most user-facing PDF as `primary: true`.
+- `dashboard_summary` should be short, factual, and derived from the detailed report evidence.
+- Prefer structured `dashboard_summary` fields over making the frontend infer conclusions from Markdown prose.
 
 ## Recommended Report Sections
 

--- a/docs/backend-gap/dashboard-data/index.json
+++ b/docs/backend-gap/dashboard-data/index.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-24T09:10:26Z",
+  "generated_at": "2026-04-30T05:53:54Z",
   "summary": {
     "total_reports": 1,
     "verified_reports": 1,
@@ -53,6 +53,36 @@
         "Upstream main tracks the latest nightly on CUDA cu130 and ROCm 7.1, while the current Primus baseline is centered on cu126.",
         "Primus has a non-trivial outer integration layer with direct dependencies on upstream internal paths."
       ],
+      "dashboard_summary": {
+        "headline": "TorchTitan is 493 commits behind upstream main, with dependency-channel and Primus integration impact.",
+        "recommendation": "urgent sync",
+        "why_it_matters": [
+          "Primus bundles TorchTitan 0.1.0 while upstream main is at 0.2.2.",
+          "Upstream main moved to nightly cu130 and ROCm 7.1 while the Primus baseline remains centered on cu126.",
+          "The gap includes 447 changed files, so this is not a narrow dependency bump.",
+          "Primus trainer, adapter, and patch layers directly depend on upstream internal paths."
+        ],
+        "feature_deltas": [
+          "GraphTrainer precompile and cudagraph paths",
+          "MoE token dispatcher and DeepEP / HybridEP distributed runtime updates",
+          "Fused QKV GQAttention and FlexAttention context-parallel work",
+          "FSDP2 fully_shard and broader distributed runtime updates",
+          "New model families and reorganized shared model abstractions"
+        ],
+        "dependency_deltas": [
+          "README nightly channel moved from nightly/cu126 to nightly/cu130.",
+          "ROCm workflow coverage now targets nightly/rocm7.1.",
+          "torchdata is explicitly installed as 0.12.0.dev20260327 in workflow.",
+          "datasets lower bound moved from >=2.21.0 to >=3.6.0 with CI constraints.",
+          "safetensors, einops, pillow, av, torchvision, numpy, and pyrefly were added or expanded."
+        ],
+        "integration_risks": [
+          "Primus trainer imports torchtitan.config.job_config.JobConfig and torchtitan.train.Trainer.",
+          "Turbo attention patches reference upstream llama3, llama4, and deepseek_v3 internals.",
+          "FP8 and MX patches depend on torchtitan.components.quantization.float8 and mx.",
+          "MoE grouped-mm patch depends on torchtitan.models.moe.moe."
+        ]
+      },
       "artifacts": [
         {
           "label": "Detailed Report (PDF)",

--- a/docs/backend-gap/dashboard-data/index.json
+++ b/docs/backend-gap/dashboard-data/index.json
@@ -1,12 +1,17 @@
 {
-  "generated_at": "2026-04-30T05:53:54Z",
+  "generated_at": "2026-05-06T07:15:17Z",
   "summary": {
-    "total_reports": 1,
-    "verified_reports": 1,
-    "total_backends": 1,
-    "latest_report_date": "2026-04-21"
+    "total_reports": 2,
+    "verified_reports": 2,
+    "total_backends": 2,
+    "latest_report_date": "2026-04-30"
   },
   "backends": [
+    {
+      "key": "megatron",
+      "label": "Megatron",
+      "count": 1
+    },
     {
       "key": "torchtitan",
       "label": "TorchTitan",
@@ -14,6 +19,93 @@
     }
   ],
   "reports": [
+    {
+      "id": "megatron-upstream-main-2026-04-30",
+      "title": "Primus Megatron vs upstream main",
+      "backend": {
+        "key": "megatron",
+        "label": "Megatron"
+      },
+      "generated_at": "2026-04-30",
+      "status": "verified",
+      "scope": "Current Megatron-LM bundled in Primus vs upstream NVIDIA/Megatron-LM origin/main.",
+      "local": {
+        "source_path": "third_party/Megatron-LM",
+        "version": "0.16.0rc0",
+        "commit": "d3528a21",
+        "commit_date": "2026-03-06"
+      },
+      "upstream": {
+        "repo": "https://github.com/NVIDIA/Megatron-LM",
+        "ref": "origin/main",
+        "version": "0.18.0",
+        "commit": "0d98cb83",
+        "commit_date": "2026-04-29"
+      },
+      "stats": {
+        "commit_gap": 403,
+        "diff_files": 1300,
+        "insertions": 615916,
+        "deletions": 326835
+      },
+      "integration": {
+        "backend_files": 136,
+        "tracked_files": 365,
+        "integration_model": "third_party/Megatron-LM + Primus outer trainer / adapter / patches"
+      },
+      "highlights": [
+        "Primus pins Megatron Core source version 0.16.0rc0 while upstream main declares 0.18.0.",
+        "Upstream main is 403 commits ahead with broad FSDP, MoE, Hybrid/Mamba, inference, RL, MiMo, and resharding changes.",
+        "Primus has a large Megatron integration layer with direct dependencies on upstream training, distributed, optimizer, MoE, and pipeline internals."
+      ],
+      "dashboard_summary": {
+        "headline": "Megatron is 403 commits behind upstream main, with broad API and capability drift across training, MoE, FSDP, inference, and Hybrid paths.",
+        "recommendation": "plan sync",
+        "why_it_matters": [
+          "Primus pins Megatron Core source version 0.16.0rc0 while upstream main declares 0.18.0.",
+          "The gap spans 1300 changed files, so this is a broad upstream movement.",
+          "Package dependency metadata is mostly unchanged; the main risk is API and capability drift.",
+          "Primus trainer, adapter, optimizer, MoE, and patch layers depend on upstream internals."
+        ],
+        "feature_deltas": [
+          "Megatron-FSDP fixes for mixed precision, MXFP8, uneven DTensor, frozen parameters, and async save",
+          "MoE shared expert overlap, FlexDispatcher support, router score function, and A2A combine backprop overlap",
+          "Hybrid/Mamba model path expansion and Mamba-to-Hybrid naming movement",
+          "Inference CUDA graphs, prefix caching, per-block MoE routing storage, and text generation controller updates",
+          "MiMo, RL, resharding, and broader test coverage updates"
+        ],
+        "dependency_deltas": [
+          "pyproject.toml project dependencies are unchanged in the compared range.",
+          "megatron/core/requirements.txt remains torch and packaging.",
+          "Source-declared Megatron Core version moved from 0.16.0rc0 to 0.18.0.",
+          "Selected workflow and documentation paths changed, but the primary drift is upstream API/capability movement."
+        ],
+        "integration_risks": [
+          "Primus MegatronTrainer imports and wraps megatron.training, checkpointing, initialization, distributed, optimizer, and dataset internals.",
+          "Primus patches Megatron argument parsing, training flow, scheduler, recompute, Muon optimizer, and runtime hooks.",
+          "Primus Turbo paths depend on transformer engine spec provider, MoE token dispatcher, transformer config, and tensor-parallel internals.",
+          "FSDP, MoE/router, inference, and Hybrid/Mamba upstream movement overlap with existing Primus patch surfaces."
+        ]
+      },
+      "artifacts": [
+        {
+          "label": "Detailed Report (PDF)",
+          "path": "./reports/megatron/upstream-main/report.pdf",
+          "format": "pdf",
+          "language": "en",
+          "kind": "detail",
+          "primary": true
+        },
+        {
+          "label": "One-Page Summary (PDF)",
+          "path": "./reports/megatron/upstream-main/summary.pdf",
+          "format": "pdf",
+          "language": "en",
+          "kind": "summary",
+          "primary": false
+        }
+      ]
+    },
     {
       "id": "torchtitan-upstream-main-2026-04-21",
       "title": "Primus TorchTitan vs upstream main",

--- a/docs/backend-gap/dashboard-data/reports/megatron-upstream-main-2026-04-30.json
+++ b/docs/backend-gap/dashboard-data/reports/megatron-upstream-main-2026-04-30.json
@@ -1,0 +1,87 @@
+{
+  "id": "megatron-upstream-main-2026-04-30",
+  "title": "Primus Megatron vs upstream main",
+  "backend": {
+    "key": "megatron",
+    "label": "Megatron"
+  },
+  "generated_at": "2026-04-30",
+  "status": "verified",
+  "scope": "Current Megatron-LM bundled in Primus vs upstream NVIDIA/Megatron-LM origin/main.",
+  "local": {
+    "source_path": "third_party/Megatron-LM",
+    "version": "0.16.0rc0",
+    "commit": "d3528a21",
+    "commit_date": "2026-03-06"
+  },
+  "upstream": {
+    "repo": "https://github.com/NVIDIA/Megatron-LM",
+    "ref": "origin/main",
+    "version": "0.18.0",
+    "commit": "0d98cb83",
+    "commit_date": "2026-04-29"
+  },
+  "stats": {
+    "commit_gap": 403,
+    "diff_files": 1300,
+    "insertions": 615916,
+    "deletions": 326835
+  },
+  "integration": {
+    "backend_files": 136,
+    "tracked_files": 365,
+    "integration_model": "third_party/Megatron-LM + Primus outer trainer / adapter / patches"
+  },
+  "highlights": [
+    "Primus pins Megatron Core source version 0.16.0rc0 while upstream main declares 0.18.0.",
+    "Upstream main is 403 commits ahead with broad FSDP, MoE, Hybrid/Mamba, inference, RL, MiMo, and resharding changes.",
+    "Primus has a large Megatron integration layer with direct dependencies on upstream training, distributed, optimizer, MoE, and pipeline internals."
+  ],
+  "dashboard_summary": {
+    "headline": "Megatron is 403 commits behind upstream main, with broad API and capability drift across training, MoE, FSDP, inference, and Hybrid paths.",
+    "recommendation": "plan sync",
+    "why_it_matters": [
+      "Primus pins Megatron Core source version 0.16.0rc0 while upstream main declares 0.18.0.",
+      "The gap spans 1300 changed files, so this is a broad upstream movement.",
+      "Package dependency metadata is mostly unchanged; the main risk is API and capability drift.",
+      "Primus trainer, adapter, optimizer, MoE, and patch layers depend on upstream internals."
+    ],
+    "feature_deltas": [
+      "Megatron-FSDP fixes for mixed precision, MXFP8, uneven DTensor, frozen parameters, and async save",
+      "MoE shared expert overlap, FlexDispatcher support, router score function, and A2A combine backprop overlap",
+      "Hybrid/Mamba model path expansion and Mamba-to-Hybrid naming movement",
+      "Inference CUDA graphs, prefix caching, per-block MoE routing storage, and text generation controller updates",
+      "MiMo, RL, resharding, and broader test coverage updates"
+    ],
+    "dependency_deltas": [
+      "pyproject.toml project dependencies are unchanged in the compared range.",
+      "megatron/core/requirements.txt remains torch and packaging.",
+      "Source-declared Megatron Core version moved from 0.16.0rc0 to 0.18.0.",
+      "Selected workflow and documentation paths changed, but the primary drift is upstream API/capability movement."
+    ],
+    "integration_risks": [
+      "Primus MegatronTrainer imports and wraps megatron.training, checkpointing, initialization, distributed, optimizer, and dataset internals.",
+      "Primus patches Megatron argument parsing, training flow, scheduler, recompute, Muon optimizer, and runtime hooks.",
+      "Primus Turbo paths depend on transformer engine spec provider, MoE token dispatcher, transformer config, and tensor-parallel internals.",
+      "FSDP, MoE/router, inference, and Hybrid/Mamba upstream movement overlap with existing Primus patch surfaces."
+    ]
+  },
+  "artifacts": [
+    {
+      "label": "Detailed Report (PDF)",
+      "path": "./reports/megatron/upstream-main/report.pdf",
+      "format": "pdf",
+      "language": "en",
+      "kind": "detail",
+      "primary": true
+    },
+    {
+      "label": "One-Page Summary (PDF)",
+      "path": "./reports/megatron/upstream-main/summary.pdf",
+      "format": "pdf",
+      "language": "en",
+      "kind": "summary",
+      "primary": false
+    }
+  ]
+}

--- a/docs/backend-gap/dashboard-data/reports/torchtitan-upstream-main-2026-04-21.json
+++ b/docs/backend-gap/dashboard-data/reports/torchtitan-upstream-main-2026-04-21.json
@@ -37,6 +37,36 @@
     "Upstream main tracks the latest nightly on CUDA cu130 and ROCm 7.1, while the current Primus baseline is centered on cu126.",
     "Primus has a non-trivial outer integration layer with direct dependencies on upstream internal paths."
   ],
+  "dashboard_summary": {
+    "headline": "TorchTitan is 493 commits behind upstream main, with dependency-channel and Primus integration impact.",
+    "recommendation": "urgent sync",
+    "why_it_matters": [
+      "Primus bundles TorchTitan 0.1.0 while upstream main is at 0.2.2.",
+      "Upstream main moved to nightly cu130 and ROCm 7.1 while the Primus baseline remains centered on cu126.",
+      "The gap includes 447 changed files, so this is not a narrow dependency bump.",
+      "Primus trainer, adapter, and patch layers directly depend on upstream internal paths."
+    ],
+    "feature_deltas": [
+      "GraphTrainer precompile and cudagraph paths",
+      "MoE token dispatcher and DeepEP / HybridEP distributed runtime updates",
+      "Fused QKV GQAttention and FlexAttention context-parallel work",
+      "FSDP2 fully_shard and broader distributed runtime updates",
+      "New model families and reorganized shared model abstractions"
+    ],
+    "dependency_deltas": [
+      "README nightly channel moved from nightly/cu126 to nightly/cu130.",
+      "ROCm workflow coverage now targets nightly/rocm7.1.",
+      "torchdata is explicitly installed as 0.12.0.dev20260327 in workflow.",
+      "datasets lower bound moved from >=2.21.0 to >=3.6.0 with CI constraints.",
+      "safetensors, einops, pillow, av, torchvision, numpy, and pyrefly were added or expanded."
+    ],
+    "integration_risks": [
+      "Primus trainer imports torchtitan.config.job_config.JobConfig and torchtitan.train.Trainer.",
+      "Turbo attention patches reference upstream llama3, llama4, and deepseek_v3 internals.",
+      "FP8 and MX patches depend on torchtitan.components.quantization.float8 and mx.",
+      "MoE grouped-mm patch depends on torchtitan.models.moe.moe."
+    ]
+  },
   "artifacts": [
     {
       "label": "Detailed Report (PDF)",

--- a/docs/backend-gap/reports/megatron/upstream-main/report.md
+++ b/docs/backend-gap/reports/megatron/upstream-main/report.md
@@ -1,0 +1,122 @@
+# Primus Megatron vs Upstream `main` Comparison Report
+
+> Date: 2026-04-30
+> Scope: Current Megatron-LM bundled in `Primus` vs upstream `NVIDIA/Megatron-LM` `origin/main`
+
+## High-Level Comparison
+
+| Item | Current Megatron-LM in Primus | Upstream `NVIDIA/Megatron-LM` `main` |
+| --- | --- | --- |
+| Source-declared Megatron Core version | `0.16.0rc0` from `megatron/core/package_info.py` | `0.18.0` from `origin/main:megatron/core/package_info.py` |
+| Pinned commit | `d3528a21` | `0d98cb83` |
+| Commit date | 2026-03-06 | 2026-04-29 |
+| Commit gap | Behind by `403` commits | - |
+| Git relation | `merge-base(HEAD, origin/main) = HEAD` | - |
+| Diff size | `1300 files changed, 615916 insertions, 326835 deletions` | - |
+| Integration model | `third_party/Megatron-LM` + Primus outer trainer / adapter / patches | Upstream mainline |
+| Integration footprint | `primus/backends/megatron/` has about `136` files; report-covered Primus Megatron directories have about `365` files | No Primus integration layer |
+| Private submodule commits | None | - |
+
+## Dependency and Package Metadata Comparison
+
+| Item | Current Megatron-LM in Primus | Upstream `main` |
+| --- | --- | --- |
+| `pyproject.toml` project dependencies | `torch>=2.6.0`, `numpy`, `packaging>=24.2` | No diff in the compared range |
+| `megatron/core/requirements.txt` | `torch`, `packaging` | No diff in the compared range |
+| Source-declared version source | `megatron/core/package_info.py`: `0.16.0rc0` | `0.18.0` with git SHA suffix logic |
+| Dev dependency groups | Present in `pyproject.toml` | No direct diff in the compared range |
+| Workflow / docs surface | Existing CI and docs | About `42` changed entries across selected workflow/docs paths |
+
+## Directory and Capability Differences
+
+### Megatron-FSDP and Distributed Runtime
+
+Upstream `main` has continued Megatron-FSDP and distributed-runtime work:
+
+- Unified and refactored Megatron-FSDP documentation.
+- Fixed FusedAdam `use_decoupled_grad` handling in Megatron-FSDP.
+- Added and fixed mixed-precision / MXFP8 / uneven DTensor / frozen parameter paths.
+- Added support around DCP and FSDP async save.
+- Refined parameter layout, all-gather / reduce-scatter overlap, and precision-aware optimizer behavior.
+
+### MoE, Router, and Expert Parallelism
+
+The upstream gap includes active MoE and expert-parallel changes:
+
+- Improved shared expert overlap and FlexDispatcher support.
+- Added a new router score function.
+- Added NVFP4 native weights for DDP.
+- Fixed non-quantized MoE dispatch padding.
+- Added overlap for A2A combine backprop with wgrad GEMM.
+- Added broader MoE inference and prefix-cache related updates.
+
+### Hybrid / Mamba and Inference
+
+Upstream `main` has expanded the Hybrid/Mamba and inference surface:
+
+- Added `megatron/core/models/hybrid/`.
+- Renamed Mamba model / stack concepts toward Hybrid naming.
+- Added YARN support and DeepSeek Sparse Attention paths for Hybrid/Mamba work.
+- Added CUDA graph support for MTP inference and prefix caching.
+- Added per-block MoE routing storage for prefix caching.
+- Reorganized order of operations in inference context and text generation controller.
+
+### MiMo, RL, and Resharding
+
+Upstream has broader non-core-training surface area:
+
+- Updated `examples/mimo/` and `megatron/core/models/mimo/`.
+- Added `ColocatedBridgeCommunicator` and `MimoOptimizer` related paths.
+- Updated RL agents, token throughput / packing metrics, and RL inference flows.
+- Added and evolved `megatron/core/resharding/` APIs and copy services.
+
+## Change Hotspots
+
+| Area | Representative changes |
+| --- | --- |
+| `megatron/core/distributed/fsdp/` | Megatron-FSDP fixes, docs, DTensor conversion, mixed precision, MXFP8, async save |
+| `megatron/core/transformer/moe/` | Shared expert overlap, router score function, MoE dispatch fixes |
+| `megatron/core/inference/` | CUDA graph / prefix caching / hybrid inference / text generation controller updates |
+| `megatron/core/models/hybrid/` | Added Hybrid model/block/layer allocation/spec files |
+| `megatron/core/models/mimo/` | MiMo communication, config, optimizer, and submodule updates |
+| `megatron/core/resharding/` | Added / evolved resharding planner, execution, transforms, and copy services |
+| `examples/rl/` and `megatron/rl/` | RL agents, inference API, packing metrics, and reward fixes |
+| `tests/` | Broad functional and unit-test churn across MoE, inference, FSDP, SSM, resharding, and training |
+
+## Primus Outer Integration Layer
+
+### Related Directories
+
+The Primus outer integration layer is mainly distributed across:
+
+- `primus/backends/megatron/`
+- `primus/modules/trainer/megatron/`
+- `primus/configs/models/megatron/`
+- `examples/megatron/`
+- `tests/unit_tests/backends/megatron/`
+
+### Directly Referenced Upstream Paths
+
+| Primus code location | Direct upstream dependency path |
+| --- | --- |
+| `primus/modules/trainer/megatron/trainer.py` | `megatron.core.distributed`, `megatron.core.optimizer`, `megatron.training.*`, dataset builders, checkpointing, initialization, parallel state |
+| `primus/modules/trainer/megatron/utils.py` | `megatron.core.parallel_state`, `megatron.training.global_vars`, pipeline-parallel schedules, transformer block/layer helpers |
+| `primus/backends/megatron/megatron_base_trainer.py` | `megatron.training.arguments`, `megatron.training.initialize` |
+| `primus/backends/megatron/core/extensions/transformer_engine_spec_provider.py` | `megatron.core.extensions.transformer_engine`, `megatron.core.transformer.moe.experts`, `megatron.core.models.backends` |
+| `primus/backends/megatron/core/extensions/primus_turbo.py` | `megatron.core.tensor_parallel`, `megatron.core.transformer.moe.token_dispatcher`, `megatron.core.transformer.transformer_config`, `megatron.training.global_vars` |
+| `primus/backends/megatron/patches/turbo/te_spec_provider_patches.py` | `megatron.core.extensions`, `megatron.core.models.gpt.gpt_layer_specs`, `megatron.core.models.gpt.moe_module_specs`, `megatron.core.transformer.multi_token_prediction` |
+| `primus/backends/megatron/patches/muon_optimizer_patches.py` | `megatron.training.training.get_megatron_optimizer` namespace |
+
+## Evidence Sources
+
+- `third_party/Megatron-LM/megatron/core/package_info.py`
+- `third_party/Megatron-LM/pyproject.toml`
+- `third_party/Megatron-LM/megatron/core/requirements.txt`
+- `third_party/Megatron-LM/README.md`
+- `third_party/Megatron-LM/.github/workflows/*`
+- [NVIDIA/Megatron-LM](https://github.com/NVIDIA/Megatron-LM)
+- `primus/backends/megatron/*`
+- `primus/modules/trainer/megatron/*`
+- `primus/configs/models/megatron/*`
+- `examples/megatron/*`
+- `tests/unit_tests/backends/megatron/*`

--- a/docs/backend-gap/reports/megatron/upstream-main/summary.md
+++ b/docs/backend-gap/reports/megatron/upstream-main/summary.md
@@ -1,0 +1,69 @@
+# Primus Megatron Upstream Gap One-Page Summary
+
+> Date: 2026-04-30
+
+## High-Level Comparison
+
+| Item | Current Megatron-LM in Primus | Upstream `NVIDIA/Megatron-LM` `main` | Impact |
+| --- | --- | --- | --- |
+| Source-declared Megatron Core version | `0.16.0rc0` from `megatron/core/package_info.py` | `0.18.0` | Spans multiple upstream version steps |
+| Pinned commit | `d3528a21` | `0d98cb83` | Current submodule is materially behind |
+| Commit gap | Behind by `403` commits | - | Not a small patch-level gap |
+| Diff size | `1300 files changed, 615916 insertions, 326835 deletions` | - | Very broad upstream churn |
+| Integration model | `third_party/Megatron-LM` + Primus trainer / adapter / patches | Upstream mainline | Upgrade is more than a submodule bump |
+| Integration footprint | `primus/backends/megatron/` has about `136` files; report-covered Primus Megatron directories have about `365` files | No Primus integration layer | Upgrade blast radius is large |
+| Dependency metadata | `pyproject.toml` and `megatron/core/requirements.txt` unchanged in compared range | Same dependency metadata | Main concern is API / capability drift, not dependency metadata drift |
+
+## Dependency / Package Facts
+
+| Item | Current Megatron-LM in Primus | Upstream `main` |
+| --- | --- | --- |
+| `pyproject.toml` project dependencies | `torch>=2.6.0`, `numpy`, `packaging>=24.2` | No direct diff |
+| `megatron/core/requirements.txt` | `torch`, `packaging` | No direct diff |
+| Source-declared version source | `megatron/core/package_info.py`: `0.16.0rc0` | `0.18.0` with git SHA suffix logic |
+
+## Representative Upstream Changes
+
+| Area | Representative changes |
+| --- | --- |
+| Megatron-FSDP | Documentation refactor; mixed precision, MXFP8, uneven DTensor, frozen parameter, async save, and optimizer fixes |
+| MoE / Router | Shared expert overlap, FlexDispatcher support, new router score function, non-quantized dispatch padding fix, A2A combine backprop overlap |
+| Hybrid / Mamba | Added `megatron/core/models/hybrid`; renamed Mamba concepts toward Hybrid; added YARN and DeepSeek Sparse Attention paths |
+| Inference | CUDA graph support for MTP inference, prefix caching, per-block MoE routing storage, text generation controller reordering |
+| MiMo / RL | MiMo communication and optimizer updates; RL agents, inference flows, token throughput and packing metrics |
+| Resharding | Updated planner, execution, transforms, and copy services |
+| Tests | Broad functional and unit-test changes across MoE, inference, FSDP, SSM, resharding, and training |
+
+## Primus Outer Integration Layer
+
+The Primus Megatron integration layer is broad and directly coupled to upstream internals:
+
+- `primus/backends/megatron/`
+- `primus/modules/trainer/megatron/`
+- `primus/configs/models/megatron/`
+- `examples/megatron/`
+- `tests/unit_tests/backends/megatron/`
+
+Direct upstream dependency paths include:
+
+- `megatron.training.*`
+- `megatron.core.distributed.*`
+- `megatron.core.optimizer.*`
+- `megatron.core.transformer.moe.*`
+- `megatron.core.extensions.transformer_engine`
+- `megatron.core.models.gpt.*`
+- `megatron.core.pipeline_parallel.*`
+
+## Recommendation
+
+Treat this as a planned sync, not a trivial dependency bump. The largest risks are API compatibility in trainer initialization, distributed/FSDP paths, MoE/router behavior, inference/Hybrid changes, and Primus patch compatibility.
+
+## Evidence Sources
+
+- `third_party/Megatron-LM/megatron/core/package_info.py`
+- `third_party/Megatron-LM/pyproject.toml`
+- `third_party/Megatron-LM/megatron/core/requirements.txt`
+- [NVIDIA/Megatron-LM](https://github.com/NVIDIA/Megatron-LM)
+- `primus/backends/megatron/*`
+- `primus/modules/trainer/megatron/*`
+- `tests/unit_tests/backends/megatron/*`

--- a/tools/backend_gap_report/site/assets/dashboard.css
+++ b/tools/backend_gap_report/site/assets/dashboard.css
@@ -80,7 +80,7 @@ code {
 .hero h1 {
   margin: 0;
   max-width: 52rem;
-  font-size: clamp(1.9rem, 3.2vw, 2.8rem);
+  font-size: clamp(2.2rem, 4vw, 3.5rem);
   line-height: 1.15;
   font-weight: 700;
   letter-spacing: -0.01em;
@@ -181,8 +181,52 @@ code {
   gap: 1.5rem;
 }
 
+.section--lead {
+  margin-top: -0.25rem;
+}
+
 .section[hidden] {
   display: none;
+}
+
+.section-heading {
+  display: grid;
+  gap: 0.4rem;
+  max-width: 56rem;
+}
+
+.section-heading--split {
+  max-width: none;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 1rem;
+}
+
+.section-heading__eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: clamp(1.55rem, 2.4vw, 2.1rem);
+  letter-spacing: -0.02em;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.section-heading__meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+  white-space: nowrap;
 }
 
 .panel {
@@ -193,6 +237,10 @@ code {
   padding: 1.4rem 1.5rem;
   display: grid;
   gap: 1rem;
+}
+
+.panel--quiet {
+  box-shadow: none;
 }
 
 .panel__header h2 {
@@ -339,6 +387,56 @@ code {
 
 .featured-panel__card--wide {
   grid-column: 1 / -1;
+}
+
+.compact-facts {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.compact-fact {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #ffffff;
+}
+
+.compact-fact__label {
+  color: var(--muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.compact-fact__value {
+  color: var(--text);
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.compact-fact--success .compact-fact__value {
+  color: var(--success);
+}
+
+.compact-fact--warning .compact-fact__value {
+  color: var(--warning);
+}
+
+.compact-fact--danger .compact-fact__value {
+  color: var(--danger);
+}
+
+.artifact-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.artifact-list .artifact-link {
+  justify-content: space-between;
+  width: 100%;
 }
 
 .featured-panel__card h3 {
@@ -566,7 +664,166 @@ code {
   flex-wrap: wrap;
 }
 
-/* ---------- Backend gap report cards (reuse & modernize) ---------- */
+/* ---------- Backend deep dives ---------- */
+.backend-deep-dive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(23rem, 1fr));
+  gap: 1rem;
+}
+
+.backend-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  padding: 1.35rem;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.backend-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.backend-card__title-group {
+  min-width: 0;
+}
+
+.backend-card__eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.backend-card__title-group h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+}
+
+.backend-card__scope {
+  margin: 0.45rem 0 0;
+  color: var(--muted);
+  font-size: 0.93rem;
+  line-height: 1.5;
+}
+
+.commit-gap-badge {
+  flex: 0 0 auto;
+  min-width: 6.2rem;
+  border-radius: 14px;
+  padding: 0.65rem 0.75rem;
+  display: grid;
+  gap: 0.1rem;
+  text-align: right;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+}
+
+.commit-gap-badge strong {
+  font-size: 1.35rem;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+
+.commit-gap-badge span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+
+.commit-gap-badge--success strong {
+  color: var(--success);
+}
+
+.commit-gap-badge--warning strong {
+  color: var(--warning);
+}
+
+.commit-gap-badge--danger strong {
+  color: var(--danger);
+}
+
+.backend-card__facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.backend-card__focus {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.backend-card__focus h4 {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.backend-card__insights {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.backend-card__insight {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-muted);
+  padding: 0.85rem 0.95rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.backend-card__insight h4 {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.compact-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.compact-list li::marker {
+  color: var(--accent);
+}
+
+.backend-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--border);
+  padding-top: 0.9rem;
+}
+
+.backend-card__meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+/* ---------- Legacy backend report cards (kept for generated record compatibility) ---------- */
 #reports-panel {
   padding: 1.4rem 1.5rem;
 }
@@ -769,7 +1026,15 @@ code {
 
 /* ---------- Responsive ---------- */
 @media (max-width: 900px) {
+  .section-heading--split {
+    grid-template-columns: 1fr;
+  }
+
   .featured-panel__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .backend-card__insights {
     grid-template-columns: 1fr;
   }
 
@@ -779,6 +1044,20 @@ code {
 }
 
 @media (max-width: 640px) {
+  .backend-deep-dive-grid,
+  .backend-card__facts {
+    grid-template-columns: 1fr;
+  }
+
+  .backend-card__header {
+    display: grid;
+  }
+
+  .commit-gap-badge {
+    text-align: left;
+    width: 100%;
+  }
+
   .field--search {
     grid-column: span 1;
   }

--- a/tools/backend_gap_report/site/assets/dashboard.js
+++ b/tools/backend_gap_report/site/assets/dashboard.js
@@ -18,21 +18,17 @@ const el = (id) => document.getElementById(id);
 
 const elements = {
   heroChips: el("hero-chips"),
-  tabs: document.querySelectorAll(".section-tab"),
-  tabWeeklySub: el("tab-weekly-sub"),
-  tabGapSub: el("tab-gap-sub"),
-  sectionPanels: document.querySelectorAll("[data-section-panel]"),
 
   weekly: {
     statRow: el("weekly-stat-row"),
     featured: el("weekly-featured"),
     featuredTitle: el("weekly-featured-title"),
     featuredWindow: el("weekly-featured-window"),
-    featuredLink: el("weekly-featured-link"),
     featuredPrs: el("weekly-featured-prs"),
     featuredCategories: el("weekly-featured-categories"),
     featuredRecommendations: el("weekly-featured-recommendations"),
     featuredFindings: el("weekly-featured-findings"),
+    filterRow: el("weekly-filter-row"),
     recommendationFilter: el("weekly-recommendation-filter"),
     searchFilter: el("weekly-search-filter"),
     resultCount: el("weekly-result-count"),
@@ -44,11 +40,12 @@ const elements = {
 
   backendGap: {
     statRow: el("gap-stat-row"),
+    filterRow: el("gap-filter-row"),
     totalReports: null,
     backendFilter: el("backend-filter"),
     statusFilter: el("status-filter"),
     searchFilter: el("search-filter"),
-    resultCount: el("result-count"),
+    resultCount: el("gap-result-count"),
     loadingState: el("loading-state"),
     errorState: el("error-state"),
     emptyState: el("empty-state"),
@@ -130,28 +127,13 @@ function heroChip(label, value) {
   return chip;
 }
 
-// ---------- Section switching ----------
-
-function activateSection(sectionKey) {
-  elements.tabs.forEach((tab) => {
-    const isActive = tab.dataset.section === sectionKey;
-    tab.classList.toggle("is-active", isActive);
-    tab.setAttribute("aria-selected", isActive ? "true" : "false");
-  });
-  elements.sectionPanels.forEach((panel) => {
-    const hidden = panel.dataset.sectionPanel !== sectionKey;
-    if (hidden) {
-      panel.setAttribute("hidden", "");
-    } else {
-      panel.removeAttribute("hidden");
-    }
-  });
-}
-
-function attachSectionTabs() {
-  elements.tabs.forEach((tab) => {
-    tab.addEventListener("click", () => activateSection(tab.dataset.section));
-  });
+function recommendationCounts(summary) {
+  const counts = summary && summary.recommendation_counts ? summary.recommendation_counts : {};
+  return {
+    urgent: counts["urgent sync"] || 0,
+    plan: counts["plan sync"] || 0,
+    monitor: counts.monitor || 0,
+  };
 }
 
 // ---------- Weekly Reports ----------
@@ -160,6 +142,7 @@ function renderHeroChips(weeklyPayload, gapPayload) {
   elements.heroChips.innerHTML = "";
   const weeklySummary = weeklyPayload && weeklyPayload.summary ? weeklyPayload.summary : {};
   const gapSummary = gapPayload && gapPayload.summary ? gapPayload.summary : {};
+  const recCounts = recommendationCounts(weeklySummary);
 
   if (weeklySummary.latest_report_id) {
     elements.heroChips.append(heroChip("Latest week", weeklySummary.latest_report_id));
@@ -171,19 +154,24 @@ function renderHeroChips(weeklyPayload, gapPayload) {
   }
   if (weeklySummary.total_reports !== undefined) {
     elements.heroChips.append(
-      heroChip("Weekly reports tracked", formatNumber(weeklySummary.total_reports))
+      heroChip("Weekly reports", formatNumber(weeklySummary.total_reports))
     );
   }
+  if (recCounts.urgent) {
+    elements.heroChips.append(heroChip("Urgent sync", formatNumber(recCounts.urgent)));
+  }
+  if (recCounts.plan) {
+    elements.heroChips.append(heroChip("Plan sync", formatNumber(recCounts.plan)));
+  }
   if (gapSummary.total_reports !== undefined) {
-    elements.heroChips.append(
-      heroChip("Backend gap reports", formatNumber(gapSummary.total_reports))
-    );
+    elements.heroChips.append(heroChip("Backend reports", formatNumber(gapSummary.total_reports)));
   }
 }
 
 function renderWeeklyStatRow(payload) {
   elements.weekly.statRow.innerHTML = "";
   const summary = payload && payload.summary ? payload.summary : {};
+  const recCounts = recommendationCounts(summary);
   elements.weekly.statRow.append(
     statTile("Total weekly reports", formatNumber(summary.total_reports || 0))
   );
@@ -194,10 +182,13 @@ function renderWeeklyStatRow(payload) {
     statTile("Merged PRs (latest)", formatNumber(summary.latest_merged_pr_count || 0))
   );
   elements.weekly.statRow.append(
-    statTile(
-      "Tracked drift targets",
-      formatNumber((summary.tracked_drift_targets || []).length)
-    )
+    statTile("Urgent sync", formatNumber(recCounts.urgent))
+  );
+  elements.weekly.statRow.append(
+    statTile("Plan sync", formatNumber(recCounts.plan))
+  );
+  elements.weekly.statRow.append(
+    statTile("Monitor", formatNumber(recCounts.monitor))
   );
 }
 
@@ -215,13 +206,6 @@ function renderWeeklyFeatured(report) {
       ? `${formatDateTime(tw.start)} → ${formatDateTime(tw.end)} (${tw.timezone || "UTC"})`
       : "-";
   elements.weekly.featuredWindow.textContent = `${report.report_id} · ${windowLabel}`;
-
-  if (report.report_github_url) {
-    elements.weekly.featuredLink.href = report.report_github_url;
-    elements.weekly.featuredLink.hidden = false;
-  } else {
-    elements.weekly.featuredLink.hidden = true;
-  }
 
   elements.weekly.featuredPrs.textContent = formatNumber(report.merged_pr_count);
 
@@ -261,6 +245,7 @@ function renderWeeklyFeatured(report) {
     li.textContent = finding;
     elements.weekly.featuredFindings.append(li);
   });
+
 }
 
 function buildWeeklyCard(report) {
@@ -345,6 +330,9 @@ function buildWeeklyCard(report) {
 
 function renderWeeklyList(reports) {
   elements.weekly.list.innerHTML = "";
+  if (elements.weekly.filterRow) {
+    elements.weekly.filterRow.hidden = state.weekly.reports.length <= 1;
+  }
   elements.weekly.resultCount.textContent = `${reports.length} report${
     reports.length === 1 ? "" : "s"
   }`;
@@ -394,48 +382,6 @@ function attachWeeklyFilters() {
 
 // ---------- Backend Gap ----------
 
-function buildBadge(label, className) {
-  const span = document.createElement("span");
-  span.className = `badge ${className}`;
-  span.textContent = label;
-  return span;
-}
-
-function buildMetric(label, value) {
-  const wrapper = document.createElement("div");
-  wrapper.className = "metric";
-
-  const labelNode = document.createElement("span");
-  labelNode.className = "metric__label";
-  labelNode.textContent = label;
-
-  const valueNode = document.createElement("strong");
-  valueNode.textContent = value;
-
-  wrapper.append(labelNode, valueNode);
-  return wrapper;
-}
-
-function createDetailBlock(title, rows) {
-  const block = document.createElement("section");
-  block.className = "detail-block";
-
-  const heading = document.createElement("h3");
-  heading.textContent = title;
-
-  const list = document.createElement("dl");
-  rows.forEach(([label, value]) => {
-    const dt = document.createElement("dt");
-    dt.textContent = label;
-    const dd = document.createElement("dd");
-    dd.textContent = value || "-";
-    list.append(dt, dd);
-  });
-
-  block.append(heading, list);
-  return block;
-}
-
 function createArtifactLink(artifact) {
   const link = document.createElement("a");
   link.className = `artifact-link${artifact.primary ? " artifact-link--primary" : ""}`;
@@ -446,6 +392,84 @@ function createArtifactLink(artifact) {
     link.rel = "noopener noreferrer";
   }
   return link;
+}
+
+function compactFact(label, value, tone) {
+  const item = document.createElement("div");
+  item.className = `compact-fact${tone ? ` compact-fact--${tone}` : ""}`;
+
+  const labelEl = document.createElement("span");
+  labelEl.className = "compact-fact__label";
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement("strong");
+  valueEl.className = "compact-fact__value";
+  valueEl.textContent = value || "-";
+
+  item.append(labelEl, valueEl);
+  return item;
+}
+
+function driftTone(commitGap) {
+  if (commitGap >= 500) return "danger";
+  if (commitGap >= 100) return "warning";
+  return "success";
+}
+
+function buildBackendFocusItems(report) {
+  const summary = report.dashboard_summary || {};
+  if (Array.isArray(summary.why_it_matters) && summary.why_it_matters.length) {
+    return summary.why_it_matters.slice(0, 5);
+  }
+
+  const items = [];
+  const commitGap = report.stats && report.stats.commit_gap;
+  const backendLabel = report.backend && report.backend.label ? report.backend.label : "Backend";
+
+  if (commitGap !== undefined) {
+    items.push(
+      `${backendLabel} is ${formatNumber(commitGap)} upstream commits behind; review upgrade scope before syncing.`
+    );
+  }
+
+  if (report.local && report.upstream) {
+    items.push(
+      `Version position: Primus ${report.local.version || "-"} vs upstream ${
+        report.upstream.version || "-"
+      }.`
+    );
+  }
+
+  (report.highlights || []).forEach((highlight) => items.push(highlight));
+
+  if (report.integration && report.integration.integration_model) {
+    items.push(`Integration surface: ${report.integration.integration_model}.`);
+  }
+
+  return items.slice(0, 5);
+}
+
+function listSection(title, items) {
+  if (!Array.isArray(items) || !items.length) {
+    return null;
+  }
+
+  const section = document.createElement("section");
+  section.className = "backend-card__insight";
+
+  const heading = document.createElement("h4");
+  heading.textContent = title;
+
+  const list = document.createElement("ul");
+  list.className = "compact-list";
+  items.slice(0, 5).forEach((item) => {
+    const li = document.createElement("li");
+    li.textContent = item;
+    list.append(li);
+  });
+
+  section.append(heading, list);
+  return section;
 }
 
 function renderBackendGapStats(payload) {
@@ -465,9 +489,106 @@ function renderBackendGapStats(payload) {
   );
 }
 
+function buildBackendDeepDiveCard(report) {
+  const card = document.createElement("article");
+  card.className = "backend-card";
+
+  const backendLabel = report.backend && report.backend.label ? report.backend.label : "Backend";
+  const stats = report.stats || {};
+  const integration = report.integration || {};
+  const summary = report.dashboard_summary || {};
+
+  const header = document.createElement("header");
+  header.className = "backend-card__header";
+
+  const titleGroup = document.createElement("div");
+  titleGroup.className = "backend-card__title-group";
+
+  const eyebrow = document.createElement("p");
+  eyebrow.className = "backend-card__eyebrow";
+  eyebrow.textContent = backendLabel;
+
+  const title = document.createElement("h3");
+  title.textContent = report.title || backendLabel;
+
+  const scope = document.createElement("p");
+  scope.className = "backend-card__scope";
+  scope.textContent = summary.headline || report.scope || "";
+
+  titleGroup.append(eyebrow, title, scope);
+
+  const gapBadge = document.createElement("div");
+  gapBadge.className = `commit-gap-badge commit-gap-badge--${driftTone(stats.commit_gap || 0)}`;
+  const gapValue = document.createElement("strong");
+  gapValue.textContent = formatNumber(stats.commit_gap);
+  const gapLabel = document.createElement("span");
+  gapLabel.textContent = "commits behind";
+  gapBadge.append(gapValue, gapLabel);
+
+  header.append(titleGroup, gapBadge);
+
+  const facts = document.createElement("div");
+  facts.className = "backend-card__facts";
+  facts.append(
+    compactFact("Primus baseline", report.local && report.local.version),
+    compactFact("Upstream version", report.upstream && report.upstream.version),
+    compactFact("Recommendation", summary.recommendation || report.status),
+    compactFact("Integration files", formatNumber(integration.backend_files))
+  );
+
+  const focus = document.createElement("section");
+  focus.className = "backend-card__focus";
+  const focusTitle = document.createElement("h4");
+  focusTitle.textContent = "What matters";
+  const focusList = document.createElement("ul");
+  focusList.className = "findings-list";
+  buildBackendFocusItems(report).forEach((item) => {
+    const li = document.createElement("li");
+    li.textContent = item;
+    focusList.append(li);
+  });
+  focus.append(focusTitle, focusList);
+
+  const insights = document.createElement("div");
+  insights.className = "backend-card__insights";
+  [
+    listSection("New upstream capabilities", summary.feature_deltas),
+    listSection("Dependency shift", summary.dependency_deltas),
+    listSection("Primus integration risk", summary.integration_risks),
+  ]
+    .filter(Boolean)
+    .forEach((section) => insights.append(section));
+
+  const footer = document.createElement("footer");
+  footer.className = "backend-card__footer";
+  const meta = document.createElement("span");
+  meta.className = "backend-card__meta";
+  meta.textContent = `Updated ${report.generated_at || "-"} · ${report.status || "unknown"}`;
+  footer.append(meta);
+
+  const artifactBar = document.createElement("div");
+  artifactBar.className = "artifacts";
+  (report.artifacts || [])
+    .filter((artifact) => artifact.format === "pdf")
+    .forEach((artifact) => {
+      artifactBar.append(createArtifactLink(artifact));
+    });
+  footer.append(artifactBar);
+
+  card.append(header, facts, focus);
+  if (insights.children.length) {
+    card.append(insights);
+  }
+  card.append(footer);
+  return card;
+}
+
 function renderBackendGapReports(reports) {
   const list = elements.backendGap.reportList;
   list.innerHTML = "";
+  if (elements.backendGap.filterRow) {
+    elements.backendGap.filterRow.hidden = state.backendGap.reports.length <= 1;
+  }
   elements.backendGap.resultCount.textContent = `${reports.length} report${
     reports.length === 1 ? "" : "s"
   }`;
@@ -482,84 +603,7 @@ function renderBackendGapReports(reports) {
   list.hidden = false;
 
   reports.forEach((report) => {
-    const card = document.createElement("article");
-    card.className = "report-card";
-
-    const header = document.createElement("div");
-    header.className = "report-card__header";
-
-    const titleGroup = document.createElement("div");
-    titleGroup.className = "report-card__title-group";
-
-    const title = document.createElement("h2");
-    title.textContent = report.title;
-
-    const scope = document.createElement("p");
-    scope.className = "report-card__scope";
-    scope.textContent = report.scope;
-
-    titleGroup.append(title, scope);
-
-    const badges = document.createElement("div");
-    badges.className = "badges";
-    badges.append(
-      buildBadge(report.backend.label, "badge--backend"),
-      buildBadge(report.status, `badge--${report.status}`)
-    );
-
-    header.append(titleGroup, badges);
-
-    const metrics = document.createElement("div");
-    metrics.className = "metrics";
-    metrics.append(
-      buildMetric("Generated", report.generated_at),
-      buildMetric("Commit Gap", formatNumber(report.stats.commit_gap)),
-      buildMetric("Diff Files", formatNumber(report.stats.diff_files)),
-      buildMetric(
-        "Diff Size",
-        `+${formatNumber(report.stats.insertions)} / -${formatNumber(report.stats.deletions)}`
-      )
-    );
-
-    const detailGrid = document.createElement("div");
-    detailGrid.className = "detail-grid";
-    detailGrid.append(
-      createDetailBlock("Local", [
-        ["Source", report.local.source_path],
-        ["Version", report.local.version],
-        ["Commit", report.local.commit],
-        ["Date", report.local.commit_date],
-      ]),
-      createDetailBlock("Upstream", [
-        ["Repository", report.upstream.repo],
-        ["Ref", report.upstream.ref],
-        ["Version", report.upstream.version],
-        ["Commit", report.upstream.commit],
-      ]),
-      createDetailBlock("Integration", [
-        ["Model", (report.integration && report.integration.integration_model) || "-"],
-        ["Backend Files", formatNumber(report.integration && report.integration.backend_files)],
-        ["Tracked Files", formatNumber(report.integration && report.integration.tracked_files)],
-        ["Status", report.status],
-      ])
-    );
-
-    const highlightList = document.createElement("ul");
-    highlightList.className = "highlights";
-    (report.highlights || []).forEach((highlight) => {
-      const item = document.createElement("li");
-      item.textContent = highlight;
-      highlightList.append(item);
-    });
-
-    const artifactBar = document.createElement("div");
-    artifactBar.className = "artifacts";
-    (report.artifacts || []).forEach((artifact) => {
-      artifactBar.append(createArtifactLink(artifact));
-    });
-
-    card.append(header, metrics, detailGrid, highlightList, artifactBar);
-    list.append(card);
+    list.append(buildBackendDeepDiveCard(report));
   });
 }
 
@@ -575,8 +619,17 @@ function applyBackendGapFilters() {
     const haystack = [
       report.title,
       report.scope,
-      report.backend.label,
-      report.backend.key,
+      report.backend && report.backend.label,
+      report.backend && report.backend.key,
+      report.local && report.local.version,
+      report.upstream && report.upstream.version,
+      report.integration && report.integration.integration_model,
+      report.dashboard_summary && report.dashboard_summary.headline,
+      report.dashboard_summary && report.dashboard_summary.recommendation,
+      ...((report.dashboard_summary && report.dashboard_summary.why_it_matters) || []),
+      ...((report.dashboard_summary && report.dashboard_summary.feature_deltas) || []),
+      ...((report.dashboard_summary && report.dashboard_summary.dependency_deltas) || []),
+      ...((report.dashboard_summary && report.dashboard_summary.integration_risks) || []),
       ...(report.highlights || []),
     ]
       .join(" ")
@@ -620,7 +673,6 @@ async function fetchJsonOptional(url) {
 }
 
 async function loadDashboard() {
-  attachSectionTabs();
   attachWeeklyFilters();
   attachBackendGapFilters();
 
@@ -629,24 +681,6 @@ async function loadDashboard() {
 
   // Hero chips (best effort — show whatever loaded)
   renderHeroChips(weeklyResult.payload, gapResult.payload);
-
-  // Tab subtitles
-  if (weeklyResult.ok && weeklyResult.payload) {
-    const summary = weeklyResult.payload.summary || {};
-    const latest = summary.latest_report_id || "no data";
-    const total = summary.total_reports || 0;
-    elements.tabWeeklySub.textContent = `${total} reports · latest ${latest}`;
-  } else {
-    elements.tabWeeklySub.textContent = "no data";
-  }
-  if (gapResult.ok && gapResult.payload) {
-    const summary = gapResult.payload.summary || {};
-    elements.tabGapSub.textContent = `${summary.total_reports || 0} reports · ${
-      summary.total_backends || 0
-    } backends`;
-  } else {
-    elements.tabGapSub.textContent = "no data";
-  }
 
   // --- Weekly reports section ---
   elements.weekly.loadingState.hidden = true;
@@ -676,9 +710,6 @@ async function loadDashboard() {
     elements.backendGap.reportList.hidden = true;
     elements.backendGap.resultCount.textContent = "0 reports";
   }
-
-  // Default section
-  activateSection(state.weekly.reports.length ? "weekly" : "backend-gap");
 }
 
 loadDashboard();

--- a/tools/backend_gap_report/site/index.html
+++ b/tools/backend_gap_report/site/index.html
@@ -10,41 +10,29 @@
     <header class="hero">
       <div class="hero__inner">
         <div class="hero__content">
-          <p class="eyebrow">Primus Engineering Dashboard</p>
-          <h1>Backend gap reports and weekly engineering updates, in one place.</h1>
+          <p class="eyebrow">Primus Engineering</p>
+          <h1>Primus Dashboard</h1>
           <p class="hero__summary">
-            A single, verified source for the Primus main branch: track backend-to-upstream
-            drift, read every weekly engineering report, and follow key recommendations
-            across Megatron-LM, torchtitan, and Primus-Turbo.
+            Weekly engineering updates, backend drift, and key recommendations for the
+            Primus main branch.
           </p>
           <div class="hero__chips" id="hero-chips"></div>
         </div>
-        <nav class="section-tabs" role="tablist" aria-label="Primus dashboard sections">
-          <button
-            class="section-tab is-active"
-            role="tab"
-            data-section="weekly"
-            aria-selected="true"
-          >
-            <span class="section-tab__label">Weekly Reports</span>
-            <span class="section-tab__sub" id="tab-weekly-sub">-</span>
-          </button>
-          <button
-            class="section-tab"
-            role="tab"
-            data-section="backend-gap"
-            aria-selected="false"
-          >
-            <span class="section-tab__label">Backend Gap</span>
-            <span class="section-tab__sub" id="tab-gap-sub">-</span>
-          </button>
-        </nav>
       </div>
     </header>
 
     <main class="layout">
       <!-- ========== WEEKLY REPORTS SECTION ========== -->
-      <section class="section" data-section-panel="weekly" aria-label="Weekly Reports">
+      <section class="section section--lead" aria-label="Latest weekly update">
+        <div class="section-heading">
+          <p class="section-heading__eyebrow">Weekly update</p>
+          <h2>Latest engineering snapshot</h2>
+          <p>
+            Start here for the current status of main: merged work, drift posture,
+            and recommendations that need attention.
+          </p>
+        </div>
+
         <div class="stat-row" id="weekly-stat-row"></div>
 
         <article class="featured-panel" id="weekly-featured" hidden>
@@ -54,18 +42,14 @@
               <h2 id="weekly-featured-title">-</h2>
               <p class="featured-panel__window" id="weekly-featured-window">-</p>
             </div>
-            <div class="featured-panel__actions">
-              <a
-                id="weekly-featured-link"
-                class="button button--primary"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="#"
-              >Open Markdown report</a>
-            </div>
           </header>
 
           <div class="featured-panel__grid">
+            <section class="featured-panel__card featured-panel__card--wide">
+              <h3>Key findings</h3>
+              <ul class="findings-list" id="weekly-featured-findings"></ul>
+            </section>
+
             <section class="featured-panel__card">
               <h3>Merged PRs</h3>
               <p class="featured-panel__kpi" id="weekly-featured-prs">-</p>
@@ -77,22 +61,71 @@
               <ul class="recommendation-list" id="weekly-featured-recommendations"></ul>
             </section>
 
-            <section class="featured-panel__card featured-panel__card--wide">
-              <h3>Key findings</h3>
-              <ul class="findings-list" id="weekly-featured-findings"></ul>
-            </section>
           </div>
         </article>
+      </section>
 
-        <section class="panel" aria-label="Weekly report history">
+      <!-- ========== BACKEND DEEP DIVES SECTION ========== -->
+      <section class="section" aria-label="Backend deep dives">
+        <div class="section-heading section-heading--split">
+          <div>
+            <p class="section-heading__eyebrow">Backend deep dives</p>
+            <h2>Detailed backend drift reviews</h2>
+            <p>
+              Backend-specific PDF reports generated from structured comparisons.
+              New backends appear here automatically when their metadata is added.
+            </p>
+          </div>
+          <div class="section-heading__meta" id="gap-result-count">0 reports</div>
+        </div>
+
+        <div class="stat-row" id="gap-stat-row"></div>
+
+        <div class="filter-row filter-row--compact" id="gap-filter-row">
+          <label class="field">
+            <span>Backend</span>
+            <select id="backend-filter">
+              <option value="all">All backends</option>
+            </select>
+          </label>
+
+          <label class="field">
+            <span>Status</span>
+            <select id="status-filter">
+              <option value="all">All statuses</option>
+              <option value="verified">Verified</option>
+              <option value="draft">Draft</option>
+              <option value="superseded">Superseded</option>
+            </select>
+          </label>
+
+          <label class="field field--search">
+            <span>Search</span>
+            <input
+              id="search-filter"
+              type="search"
+              placeholder="Search backend, target, risk, dependency..."
+            />
+          </label>
+        </div>
+
+        <div id="loading-state" class="state">Loading backend deep dives...</div>
+        <div id="error-state" class="state state--error" hidden></div>
+        <div id="empty-state" class="state" hidden>No backend reports match.</div>
+        <div id="report-list" class="backend-deep-dive-grid" hidden></div>
+      </section>
+
+      <!-- ========== WEEKLY ARCHIVE SECTION ========== -->
+      <section class="section" aria-label="Weekly report archive">
+        <section class="panel panel--quiet">
           <div class="panel__header">
-            <h2>Weekly report history</h2>
+            <h2>Weekly report archive</h2>
             <p class="panel__subtitle">
-              Newest first. Each entry links to the GitHub-rendered Markdown report.
+              Available weekly Markdown reports. Newest first.
             </p>
           </div>
 
-          <div class="filter-row filter-row--compact">
+          <div class="filter-row filter-row--compact" id="weekly-filter-row">
             <label class="field">
               <span>Status</span>
               <select id="weekly-recommendation-filter">
@@ -119,52 +152,6 @@
           <div id="weekly-error-state" class="state state--error" hidden></div>
           <div id="weekly-empty-state" class="state" hidden>No weekly reports match.</div>
           <div id="weekly-list" class="card-list" hidden></div>
-        </section>
-      </section>
-
-      <!-- ========== BACKEND GAP SECTION ========== -->
-      <section class="section" data-section-panel="backend-gap" aria-label="Backend Gap" hidden>
-        <div class="stat-row" id="gap-stat-row"></div>
-
-        <section class="panel" aria-label="Backend gap filters">
-          <div class="filter-row">
-            <label class="field">
-              <span>Backend</span>
-              <select id="backend-filter">
-                <option value="all">All backends</option>
-              </select>
-            </label>
-
-            <label class="field">
-              <span>Status</span>
-              <select id="status-filter">
-                <option value="all">All statuses</option>
-                <option value="verified">Verified</option>
-                <option value="draft">Draft</option>
-                <option value="superseded">Superseded</option>
-              </select>
-            </label>
-
-            <label class="field field--search">
-              <span>Search</span>
-              <input
-                id="search-filter"
-                type="search"
-                placeholder="Search backend, title, scope, highlight..."
-              />
-            </label>
-          </div>
-
-          <div class="filter-summary">
-            <span id="result-count">0 reports</span>
-          </div>
-        </section>
-
-        <section class="panel" id="reports-panel">
-          <div id="loading-state" class="state">Loading backend gap reports...</div>
-          <div id="error-state" class="state state--error" hidden></div>
-          <div id="empty-state" class="state" hidden>No reports match the current filters.</div>
-          <div id="report-list" class="report-list" hidden></div>
         </section>
       </section>
     </main>


### PR DESCRIPTION
Refocus the shared Primus dashboard around the latest weekly engineering snapshot and backend deep-dive cards instead of a tabbed backend-gap view. Add structured dashboard_summary metadata for backend reports so future backend comparisons can surface feature deltas, dependency shifts, integration risks, and PDF links consistently.