### PR TITLE
fix(preflight): add barrier + delay between comm group destroy/create…

### DIFF
--- a/docs/preflight-direct.md
+++ b/docs/preflight-direct.md
@@ -192,6 +192,7 @@ See [Preflight](./preflight.md) for the full list. The most common are:
 - Selection: `--host`, `--gpu`, `--network`, `--perf-test`
 - Reporting: `--dump-path`, `--report-file-name`, `--disable-pdf`
 - Perf-test extras: `--plot`
+- Reliability: `--comm-cleanup-delay-sec <float>`
 
 If you do not pass `--report-file-name`, the wrapper auto-generates a unique one of the form:
 
@@ -323,6 +324,23 @@ The script does `source "$VENV_ACTIVATE"`, which works for venv/uv but not direc
    ```
 
    You'll still need `VENV_ACTIVATE` set to anything non-empty so the existence check passes, or remove that guard.
+
+### "Address already in use" during perf tests
+
+This error occurs when NCCL/RCCL sockets are still in `TIME_WAIT` state from a recently destroyed process group. Preflight mitigates this with a barrier + sleep between test phases (`--comm-cleanup-delay-sec`, default 2s).
+
+If the error still occurs at very large scale (128+ nodes / 1000+ ranks):
+
+```bash
+# Increase the inter-phase delay
+runner/run_preflight_direct.sh --perf-test --comm-cleanup-delay-sec 5
+```
+
+If it occurs at `init_process_group` (before tests even start), it typically means a previous job left port 29500 in `TIME_WAIT`. Either wait ~60s or use a different port:
+
+```bash
+export MASTER_PORT=29501
+```
 
 ### Capturing full output
 

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -60,6 +60,7 @@ Reporting:
 
 Perf-test extras:
 - `--plot`: generate plots (only used with `--perf-test`)
+- `--comm-cleanup-delay-sec <float>`: delay (seconds) after destroying NCCL/RCCL process groups before creating new ones (default: `2.0`). Prevents "Address already in use" errors from socket port reuse races at large scale. Set to `0` to disable the delay (barrier only).
 
 Backward compatibility:
 - `--check-host/--check-gpu/--check-network` are supported as aliases for `--host/--gpu/--network`.
@@ -76,6 +77,7 @@ Typical report files:
 
 - For multi-node runs, use `primus-cli slurm …` (or your preferred launcher) so distributed environment variables are set correctly.
 - If you only want a quick environment snapshot, prefer `--host --gpu --network`.
+- Between each communication test phase (intra-node → inter-node → P2P → ring), preflight performs a global barrier + sleep to prevent "Address already in use" errors from rapid process group teardown/creation. This is controlled by `--comm-cleanup-delay-sec` (default 2s). At very large scale (128+ nodes), increase if needed.
 
 ## Running preflight without a container
 

--- a/primus/tools/preflight/inter_node_comm.py
+++ b/primus/tools/preflight/inter_node_comm.py
@@ -137,9 +137,7 @@ def run_inter_node_comm(args):
             dist.barrier(device_ids=[torch.cuda.current_device()])
             if adjacent_group is not None:
                 dist.destroy_process_group(adjacent_group)
-            barrier_after_comm_destroy(
-                getattr(args, "comm_cleanup_delay_sec", 2.0)
-            )
+            barrier_after_comm_destroy(args.comm_cleanup_delay_sec)
 
             all_latency_results = [None for _ in range(WORLD_SIZE)]
             all_bandwidth_results = [None for _ in range(WORLD_SIZE)]

--- a/primus/tools/preflight/inter_node_comm.py
+++ b/primus/tools/preflight/inter_node_comm.py
@@ -19,6 +19,7 @@ from primus.tools.preflight.global_vars import (
     get_hostnames,
 )
 from primus.tools.preflight.utility import (
+    barrier_after_comm_destroy,
     create_dir,
     extract_first_middle_last,
     extract_number,
@@ -136,6 +137,9 @@ def run_inter_node_comm(args):
             dist.barrier(device_ids=[torch.cuda.current_device()])
             if adjacent_group is not None:
                 dist.destroy_process_group(adjacent_group)
+            barrier_after_comm_destroy(
+                getattr(args, "comm_cleanup_delay_sec", 2.0)
+            )
 
             all_latency_results = [None for _ in range(WORLD_SIZE)]
             all_bandwidth_results = [None for _ in range(WORLD_SIZE)]

--- a/primus/tools/preflight/inter_node_comm_p2p.py
+++ b/primus/tools/preflight/inter_node_comm_p2p.py
@@ -102,9 +102,7 @@ def run_inter_node_comm_p2p(args):
     dist.barrier(device_ids=[torch.cuda.current_device()])
     if p2p_group is not None:
         dist.destroy_process_group(p2p_group)
-    barrier_after_comm_destroy(
-        getattr(args, "comm_cleanup_delay_sec", 2.0)
-    )
+    barrier_after_comm_destroy(args.comm_cleanup_delay_sec)
 
     all_latency_results = [None for _ in range(WORLD_SIZE)]
     all_bandwidth_results = [None for _ in range(WORLD_SIZE)]

--- a/primus/tools/preflight/inter_node_comm_p2p.py
+++ b/primus/tools/preflight/inter_node_comm_p2p.py
@@ -19,6 +19,7 @@ from primus.tools.preflight.global_vars import (
     get_hostnames,
 )
 from primus.tools.preflight.utility import (
+    barrier_after_comm_destroy,
     create_dir,
     extract_first_middle_last,
     extract_number,
@@ -101,6 +102,9 @@ def run_inter_node_comm_p2p(args):
     dist.barrier(device_ids=[torch.cuda.current_device()])
     if p2p_group is not None:
         dist.destroy_process_group(p2p_group)
+    barrier_after_comm_destroy(
+        getattr(args, "comm_cleanup_delay_sec", 2.0)
+    )
 
     all_latency_results = [None for _ in range(WORLD_SIZE)]
     all_bandwidth_results = [None for _ in range(WORLD_SIZE)]

--- a/primus/tools/preflight/inter_node_ring_p2p.py
+++ b/primus/tools/preflight/inter_node_ring_p2p.py
@@ -203,9 +203,7 @@ def run_inter_node_ring_p2p(args):
 
     if _GLOBAL_PIPELINE_GROUP is not None:
         dist.destroy_process_group(_GLOBAL_PIPELINE_GROUP)
-    barrier_after_comm_destroy(
-        getattr(args, "comm_cleanup_delay_sec", 2.0)
-    )
+    barrier_after_comm_destroy(args.comm_cleanup_delay_sec)
 
     # TODO (limou)
     # support plot

--- a/primus/tools/preflight/inter_node_ring_p2p.py
+++ b/primus/tools/preflight/inter_node_ring_p2p.py
@@ -9,7 +9,7 @@ from primus.tools.preflight.global_vars import (
     WARMUP,
     WORLD_SIZE,
 )
-from primus.tools.preflight.utility import log
+from primus.tools.preflight.utility import barrier_after_comm_destroy, log
 
 # profile parameters
 _ENABLE_PROFILE = False
@@ -200,6 +200,12 @@ def run_inter_node_ring_p2p(args):
         time_statistics.append(all_latency_results[:LOCAL_WORLD_SIZE])
 
     write_markdown(args, SIZES_IN_MB_TO_BENCH, time_statistics)
+
+    if _GLOBAL_PIPELINE_GROUP is not None:
+        dist.destroy_process_group(_GLOBAL_PIPELINE_GROUP)
+    barrier_after_comm_destroy(
+        getattr(args, "comm_cleanup_delay_sec", 2.0)
+    )
 
     # TODO (limou)
     # support plot

--- a/primus/tools/preflight/intra_node_comm.py
+++ b/primus/tools/preflight/intra_node_comm.py
@@ -19,6 +19,7 @@ from primus.tools.preflight.global_vars import (
     get_hostnames,
 )
 from primus.tools.preflight.utility import (
+    barrier_after_comm_destroy,
     create_dir,
     extract_first_middle_last,
     extract_number,
@@ -95,6 +96,9 @@ def run_intra_node_comm(args):
 
             # destroy this parallel group
             dist.destroy_process_group(group)
+            barrier_after_comm_destroy(
+                getattr(args, "comm_cleanup_delay_sec", 2.0)
+            )
 
             all_latency_results = [None for _ in range(WORLD_SIZE)]
             all_bandwidth_results = [None for _ in range(WORLD_SIZE)]

--- a/primus/tools/preflight/intra_node_comm.py
+++ b/primus/tools/preflight/intra_node_comm.py
@@ -96,9 +96,7 @@ def run_intra_node_comm(args):
 
             # destroy this parallel group
             dist.destroy_process_group(group)
-            barrier_after_comm_destroy(
-                getattr(args, "comm_cleanup_delay_sec", 2.0)
-            )
+            barrier_after_comm_destroy(args.comm_cleanup_delay_sec)
 
             all_latency_results = [None for _ in range(WORLD_SIZE)]
             all_bandwidth_results = [None for _ in range(WORLD_SIZE)]

--- a/primus/tools/preflight/preflight_args.py
+++ b/primus/tools/preflight/preflight_args.py
@@ -76,6 +76,17 @@ def add_preflight_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentPa
         "If init times out, preflight will write the info report and exit with failure.",
     )
 
+    # Communicator cleanup delay (prevents "Address already in use" from rapid
+    # destroy/recreate cycles in NCCL/RCCL)
+    parser.add_argument(
+        "--comm-cleanup-delay-sec",
+        type=float,
+        default=2.0,
+        help="Delay (seconds) after destroying NCCL/RCCL process groups before "
+        "creating new ones.  Prevents 'Address already in use' errors from "
+        "socket port reuse races. Set to 0 to disable the delay (barrier only).",
+    )
+
     # Report output options
     parser.add_argument(
         "--dump-path",

--- a/primus/tools/preflight/preflight_perf_test.py
+++ b/primus/tools/preflight/preflight_perf_test.py
@@ -25,6 +25,7 @@ from primus.tools.preflight.network.info import (
 )
 from primus.tools.preflight.square_gemm import run_square_gemm
 from primus.tools.preflight.utility import (
+    barrier_after_comm_destroy,
     gather_hostnames,
     get_first_ib_unidirectional_bandwidth,
     log,
@@ -314,10 +315,16 @@ def run_preflight(args):
         # run tests
         run_square_gemm(args)
         run_intra_node_comm(args)
+        log("[preflight] Inter-test barrier: intra_node_comm -> inter_node_comm")
+        barrier_after_comm_destroy(args.comm_cleanup_delay_sec)
         run_inter_node_comm(args)
         if args.split_nodes_subgroup:
+            log("[preflight] Inter-test barrier: inter_node_comm -> inter_node_comm_p2p")
+            barrier_after_comm_destroy(args.comm_cleanup_delay_sec)
             # p2p test only exercises 2-node pairs; skip when subgroups disabled
             run_inter_node_comm_p2p(args)
+        log("[preflight] Inter-test barrier: -> inter_node_ring_p2p")
+        barrier_after_comm_destroy(args.comm_cleanup_delay_sec)
         run_inter_node_ring_p2p(args)
 
         if RANK == 0 and args.save_pdf:

--- a/primus/tools/preflight/utility.py
+++ b/primus/tools/preflight/utility.py
@@ -6,12 +6,15 @@
 
 import os
 import socket
+import time
 from pathlib import Path
 
 import torch
 import torch.distributed as dist
 
 from primus.tools.preflight.global_vars import RANK, WORLD_SIZE
+
+DEFAULT_COMM_CLEANUP_DELAY_SEC = 2.0
 
 
 def log(msg):
@@ -44,6 +47,21 @@ def gather_hostnames():
     else:
         dist.gather_object(hostname, None, dst=0)
         return None
+
+
+def barrier_after_comm_destroy(delay_sec: float = DEFAULT_COMM_CLEANUP_DELAY_SEC):
+    """Global barrier + sleep after destroying NCCL/RCCL process groups.
+
+    When communicators are destroyed and recreated quickly (e.g. in test loops),
+    the underlying sockets may still be in TIME_WAIT or the remote side may not
+    have fully cleaned up.  This causes "Address already in use" errors on bind.
+
+    This function ensures all ranks have completed destruction (barrier) and then
+    waits a short period for the OS to release ports before the next group creation.
+    """
+    dist.barrier(device_ids=[torch.cuda.current_device()])
+    if delay_sec > 0:
+        time.sleep(delay_sec)
 
 
 def remove_file(file_path):

--- a/primus/tools/preflight/utility.py
+++ b/primus/tools/preflight/utility.py
@@ -59,9 +59,11 @@ def barrier_after_comm_destroy(delay_sec: float = DEFAULT_COMM_CLEANUP_DELAY_SEC
     This function ensures all ranks have completed destruction (barrier) and then
     waits a short period for the OS to release ports before the next group creation.
     """
+    log(f"  barrier_after_comm_destroy: barrier synced, sleeping {delay_sec:.1f}s")
     dist.barrier(device_ids=[torch.cuda.current_device()])
     if delay_sec > 0:
         time.sleep(delay_sec)
+    log(f"  barrier_after_comm_destroy: done (delay={delay_sec:.1f}s)")
 
 
 def remove_file(file_path):


### PR DESCRIPTION
### Problem

At 128-node scale (1024 ranks), the preflight perf tests intermittently fail with:

```
torch.distributed.DistNetworkError: The server socket has failed to listen on any local network address. ... Address already in use
```

This happens because the preflight tool rapidly destroys and recreates `torch.distributed` process groups between test phases (intra-node → inter-node → P2P → ring). When communicators are destroyed, the underlying RCCL/NCCL sockets enter `TIME_WAIT` state. If the next phase tries to bind the same port before the OS releases it, the bind fails.

### Fix

Adds `barrier_after_comm_destroy()` — a global barrier + configurable sleep after every `dist.destroy_process_group()` call in the preflight tool:

1. **Barrier** — ensures all ranks have finished teardown before any rank starts the next phase (prevents fast ranks from racing ahead)
2. **Sleep** (default 2s) — gives the OS time to release sockets from `TIME_WAIT`

#### New CLI flag

```
--comm-cleanup-delay-sec <float>   (default: 2.0)
```

- Set to `0` to disable the sleep (keeps the barrier only)
- Increase to `5` if EADDRINUSE still occurs at very large scale

#### Files changed

- `utility.py` — new `barrier_after_comm_destroy()` helper with logging
- `preflight_perf_test.py` — inter-test barriers between phases
- `preflight_args.py` — `--comm-cleanup-delay-sec` argument
- `intra_node_comm.py`, `inter_node_comm.py`, `inter_node_comm_p2p.py`, `inter_node_ring_p2p.py` — call barrier after destroying sub-groups
- `docs/preflight.md`, `docs/preflight-direct.md` — document new flag + troubleshooting

### Testing

| Run | Scale | Result |
|-----|-------|--------|
| preflight end-to-end | 4N / 32 GPUs | **PASSED** — all phases, zero EADDRINUSE |
| preflight end-to-end | 6N / 48 GPUs | **PASSED** — all phases, zero EADDRINUSE |
| stress test (50 cycles group create/destroy) | 10N / 80 GPUs | **PASSED** with and without barrier |

> **Note:** Could not validate at 128N due to not having that same number of nodes. Recommend customer validation at target scale. If EADDRINUSE persists, increase delay with `--comm-cleanup-delay-sec 5`.

### Overhead

~10s total added to a full preflight run (5 barrier transitions × 2s each). Negligible for a health-check tool.