### PR TITLE
[Megatron-LM] feat: unify enable_primus_turbo flag, add blockwise scaling patch

### DIFF
--- a/primus/backends/megatron/patches/turbo/fp4_patches.py
+++ b/primus/backends/megatron/patches/turbo/fp4_patches.py
@@ -8,8 +8,16 @@
 Megatron enums Patches
 """
 
+from primus.backends.megatron.patches.turbo.utils import is_primus_turbo_can_patch
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
+
+
+def _is_fp4_can_patch(ctx: PatchContext) -> bool:
+    args = get_args(ctx)
+    fp4 = bool(getattr(args, "fp4", False))
+
+    return fp4 and is_primus_turbo_can_patch(ctx)
 
 
 @register_patch(
@@ -17,7 +25,7 @@ from primus.modules.module_utils import log_rank_0
     backend="megatron",
     phase="before_train",
     description="Override Megatron enums to use Primus implementation when fp4 is enabled",
-    condition=lambda ctx: getattr(get_args(ctx), "fp4", False),
+    condition=_is_fp4_can_patch,
 )
 def patch_enums(ctx: PatchContext):
     from megatron.core import enums
@@ -35,7 +43,7 @@ def patch_enums(ctx: PatchContext):
     backend="megatron",
     phase="before_train",
     description="Override Megatron get_fp4_context to use Primus implementation when fp4 is enabled",
-    condition=lambda ctx: getattr(get_args(ctx), "fp4", False),
+    condition=_is_fp4_can_patch,
 )
 def patch_fp4_context(ctx: PatchContext):
     """

--- a/primus/backends/megatron/patches/turbo/fp8_patches.py
+++ b/primus/backends/megatron/patches/turbo/fp8_patches.py
@@ -11,8 +11,16 @@ This module contains patches that modify Megatron's FP8 context handling
 to use Primus-specific implementations for better ROCm compatibility.
 """
 
+from primus.backends.megatron.patches.turbo.utils import is_primus_turbo_can_patch
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
+
+
+def _is_fp8_can_patch(ctx: PatchContext) -> bool:
+    args = get_args(ctx)
+    fp8 = bool(getattr(args, "fp8", False))
+
+    return fp8 and is_primus_turbo_can_patch(ctx)
 
 
 @register_patch(
@@ -20,7 +28,7 @@ from primus.modules.module_utils import log_rank_0
     backend="megatron",
     phase="before_train",
     description="Override Megatron get_fp8_context to use Primus implementation when fp8 is enabled",
-    condition=lambda ctx: getattr(get_args(ctx), "fp8", False),
+    condition=_is_fp8_can_patch,
 )
 def patch_fp8_context(ctx: PatchContext):
     """
@@ -53,3 +61,25 @@ def patch_fp8_context(ctx: PatchContext):
     for module in modules_to_patch:
         module.get_fp8_context = get_fp8_context
         log_rank_0(f"[Patch:megatron.fp8.context]   Patched {module.__name__}.get_fp8_context")
+
+
+@register_patch(
+    "transformer_engine.pytorch.fp8",
+    backend="megatron",
+    phase="before_train",
+    description="Override Transformer Engine's check_fp8_block_scaling_support to use Primus implementation",
+    condition=_is_fp8_can_patch,
+)
+def patch_fp8_block_scaling_support(ctx: PatchContext):
+    """
+    Patch Transformer Engine's check_fp8_block_scaling_support to use Primus implementation.
+    """
+    from transformer_engine.pytorch import fp8
+
+    from primus.backends.transformer_engine.pytorch.fp8 import (
+        check_fp8_block_scaling_support,
+    )
+
+    log_rank_0("[Patch:transformer_engine.pytorch.fp8] Overriding check_fp8_block_scaling_support")
+
+    fp8.check_fp8_block_scaling_support = check_fp8_block_scaling_support

--- a/primus/backends/megatron/patches/turbo/gpt_output_layer_patches.py
+++ b/primus/backends/megatron/patches/turbo/gpt_output_layer_patches.py
@@ -10,13 +10,13 @@ Primus Turbo GPT Output Layer Patches
 Patches for replacing GPT output layer with PrimusTurbo implementation.
 """
 
-import importlib.util
 
+from primus.backends.megatron.patches.turbo.utils import is_primus_turbo_can_patch
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
 
 
-def _is_turbo_parallel_linear_enabled(ctx: PatchContext) -> bool:
+def _is_turbo_parallel_linear_can_patch(ctx: PatchContext) -> bool:
     """
     Check if PrimusTurbo parallel linear is enabled.
 
@@ -26,16 +26,10 @@ def _is_turbo_parallel_linear_enabled(ctx: PatchContext) -> bool:
       - enable_primus_turbo == True
       - use_turbo_parallel_linear == True
     """
-    # Check if primus_turbo package is available
-    if importlib.util.find_spec("primus_turbo") is None:
-        return False
-
     args = get_args(ctx)
-    tp_size = getattr(args, "tensor_model_parallel_size", 1)
-    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
     use_turbo_parallel_linear = bool(getattr(args, "use_turbo_parallel_linear", False))
 
-    return tp_size == 1 and enable_primus_turbo and use_turbo_parallel_linear
+    return use_turbo_parallel_linear and is_primus_turbo_can_patch(ctx)
 
 
 @register_patch(
@@ -43,7 +37,7 @@ def _is_turbo_parallel_linear_enabled(ctx: PatchContext) -> bool:
     backend="megatron",
     phase="before_train",
     description="Replace GPT ColumnParallelLinear with PrimusTurbo implementation",
-    condition=_is_turbo_parallel_linear_enabled,
+    condition=_is_turbo_parallel_linear_can_patch,
 )
 def patch_gpt_output_layer(ctx: PatchContext):
     """

--- a/primus/backends/megatron/patches/turbo/moe_dispatcher_patches.py
+++ b/primus/backends/megatron/patches/turbo/moe_dispatcher_patches.py
@@ -10,13 +10,13 @@ Primus Turbo MoE Dispatcher Patches
 Patches for replacing MoE token dispatcher with PrimusTurbo DeepEP implementation.
 """
 
-import importlib.util
 
+from primus.backends.megatron.patches.turbo.utils import is_primus_turbo_can_patch
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
 
 
-def _is_turbo_deepep_enabled(ctx: PatchContext) -> bool:
+def _is_turbo_deepep_can_patch(ctx: PatchContext) -> bool:
     """
     Check if PrimusTurbo DeepEP MoE dispatcher is enabled.
 
@@ -26,16 +26,10 @@ def _is_turbo_deepep_enabled(ctx: PatchContext) -> bool:
       - enable_primus_turbo == True
       - use_turbo_deepep == True
     """
-    # Check if primus_turbo package is available
-    if importlib.util.find_spec("primus_turbo") is None:
-        return False
-
     args = get_args(ctx)
-    tp_size = getattr(args, "tensor_model_parallel_size", 1)
-    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
     use_turbo_deepep = bool(getattr(args, "use_turbo_deepep", False))
 
-    return tp_size == 1 and enable_primus_turbo and use_turbo_deepep
+    return use_turbo_deepep and is_primus_turbo_can_patch(ctx)
 
 
 @register_patch(
@@ -43,7 +37,7 @@ def _is_turbo_deepep_enabled(ctx: PatchContext) -> bool:
     backend="megatron",
     phase="before_train",
     description="Replace MoE token dispatcher with PrimusTurbo DeepEP implementation",
-    condition=_is_turbo_deepep_enabled,
+    condition=_is_turbo_deepep_can_patch,
 )
 def patch_moe_dispatcher(ctx: PatchContext):
     """

--- a/primus/backends/megatron/patches/turbo/rms_norm_patches.py
+++ b/primus/backends/megatron/patches/turbo/rms_norm_patches.py
@@ -10,13 +10,13 @@ Primus Turbo RMSNorm Patches
 Patches for replacing RMSNorm with PrimusTurbo implementation.
 """
 
-import importlib.util
 
+from primus.backends.megatron.patches.turbo.utils import is_primus_turbo_can_patch
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
 
 
-def _is_turbo_rms_norm_enabled(ctx: PatchContext) -> bool:
+def _is_turbo_rms_norm_can_patch(ctx: PatchContext) -> bool:
     """
     Check if PrimusTurbo RMSNorm is enabled.
 
@@ -26,16 +26,10 @@ def _is_turbo_rms_norm_enabled(ctx: PatchContext) -> bool:
       - enable_primus_turbo == True
       - use_turbo_rms_norm == True
     """
-    # Check if primus_turbo package is available
-    if importlib.util.find_spec("primus_turbo") is None:
-        return False
-
     args = get_args(ctx)
-    tp_size = getattr(args, "tensor_model_parallel_size", 1)
-    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
     use_turbo_rms_norm = bool(getattr(args, "use_turbo_rms_norm", False))
 
-    return tp_size == 1 and enable_primus_turbo and use_turbo_rms_norm
+    return use_turbo_rms_norm and is_primus_turbo_can_patch(ctx)
 
 
 @register_patch(
@@ -43,7 +37,7 @@ def _is_turbo_rms_norm_enabled(ctx: PatchContext) -> bool:
     backend="megatron",
     phase="before_train",
     description="Replace Transformer Engine RMSNorm with PrimusTurbo implementation",
-    condition=_is_turbo_rms_norm_enabled,
+    condition=_is_turbo_rms_norm_can_patch,
 )
 def patch_rms_norm(ctx: PatchContext):
     """

--- a/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
+++ b/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
@@ -10,38 +10,12 @@ Primus Turbo TESpecProvider Patches
 Patches for replacing Transformer Engine TESpecProvider with PrimusTurboSpecProvider.
 """
 
-import importlib.util
-
+from primus.backends.megatron.patches.turbo.utils import is_primus_turbo_can_patch
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
 
 
-def _primus_turbo_deep_importable() -> bool:
-    """Deep-probe the primus_turbo import chain that the patch body actually uses.
-
-    A shallow ``importlib.util.find_spec("primus_turbo")`` returns a valid spec
-    even when the package's transitive dependencies (e.g. a broken ``aiter`` /
-    ``csrc`` install in the runtime image) cause the real import to crash. In
-    that case the patch would be selected for application and then fail at
-    module-load time, leaving the model in an inconsistent half-patched state
-    that can produce silent NaNs during FP8 training.
-
-    By probing the exact symbols the patch body imports, we either confirm the
-    full chain works or skip the patch cleanly so callers fall back to the
-    stock TE provider.
-    """
-    try:
-        from primus.backends.megatron.core.extensions.primus_turbo import (  # noqa: F401  pylint: disable=W0611
-            PrimusTurboAttention,
-            PrimusTurboColumnParallelLinear,
-        )
-
-        return True
-    except (ImportError, ModuleNotFoundError):
-        return False
-
-
-def _uses_legacy_grouped_gemm(ctx: PatchContext) -> bool:
+def _use_legacy_grouped_gemm(ctx: PatchContext) -> bool:
     args = get_args(ctx)
     return bool(
         getattr(args, "moe_grouped_gemm", False)
@@ -52,52 +26,14 @@ def _uses_legacy_grouped_gemm(ctx: PatchContext) -> bool:
     )
 
 
-def _is_primus_turbo_enabled(ctx: PatchContext) -> bool:
-    """
-    Check if PrimusTurbo is enabled and can be used.
-
-    Requires:
-      - primus_turbo package is installed AND its deep import chain works
-      - tensor_model_parallel_size == 1
-      - enable_primus_turbo == True
-    """
-    # Check if primus_turbo package is available *and* its deep import chain works.
-    # A shallow find_spec is not enough: if a transitive dep (e.g. aiter/csrc) is
-    # broken in the runtime image, the patch body will crash at import time and
-    # leave the model half-patched, which can produce silent NaNs in FP8 training.
-    if importlib.util.find_spec("primus_turbo") is None or not _primus_turbo_deep_importable():
-        log_rank_0("[Patch:megatron.turbo.te_spec_provider] primus_turbo not importable, use TE backend...")
-        return False
-
-    args = get_args(ctx)
-    tp_size = getattr(args, "tensor_model_parallel_size", 1)
-    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
-
-    if tp_size != 1:
-        if enable_primus_turbo:
-            log_rank_0(
-                "[Patch:megatron.turbo.te_spec_provider] "
-                "Primus Turbo does not support TP; using TE backend instead..."
-            )
-        else:
-            log_rank_0("[Patch:megatron.turbo.te_spec_provider] TP > 1; using TE backend...")
-        return False
-
-    if not enable_primus_turbo:
-        log_rank_0("[Patch:megatron.turbo.te_spec_provider] enable_primus_turbo=False; using TE backend...")
-        return False
-
-    return True
-
-
 def _needs_primus_spec_provider(ctx: PatchContext) -> bool:
-    if _uses_legacy_grouped_gemm(ctx):
+    if _use_legacy_grouped_gemm(ctx):
         log_rank_0(
             "[Patch:megatron.turbo.te_spec_provider] "
             "legacy grouped GEMM enabled; using Primus spec provider..."
         )
         return True
-    return _is_primus_turbo_enabled(ctx)
+    return is_primus_turbo_can_patch(ctx)
 
 
 @register_patch(
@@ -126,7 +62,7 @@ def patch_te_spec_provider(ctx: PatchContext):
     )
 
     args = get_args(ctx)
-    if _uses_legacy_grouped_gemm(ctx):
+    if _use_legacy_grouped_gemm(ctx):
         reason = "legacy grouped GEMM enabled"
     elif bool(getattr(args, "enable_primus_turbo", False)):
         reason = "PrimusTurbo backend enabled"

--- a/primus/backends/megatron/patches/turbo/utils.py
+++ b/primus/backends/megatron/patches/turbo/utils.py
@@ -1,0 +1,64 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import importlib.util
+
+from primus.core.patches import PatchContext, get_args
+from primus.modules.module_utils import log_rank_0, warning_rank_0
+
+
+def _is_primus_turbo_enabled(ctx: PatchContext) -> bool:
+    """
+    Check if PrimusTurbo is enabled and can be used.
+
+    Requires:
+      - primus_turbo package is installed
+      - tensor_model_parallel_size == 1
+      - enable_primus_turbo == True
+    """
+    # Check if primus_turbo package is available
+    args = get_args(ctx)
+    enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
+
+    if enable_primus_turbo:
+        if importlib.util.find_spec("primus_turbo") is None:
+            warning_rank_0(
+                "[Patch:megatron.turbo.te_spec_provider] primus_turbo not found, use TE backend..."
+            )
+            return False
+
+        log_rank_0(
+            "[Patch:megatron.turbo.te_spec_provider] Primus Turbo enabled; using Primus Turbo backend..."
+        )
+        return True
+    else:
+        return False
+
+
+def _is_tp_parallel_enabled(ctx: PatchContext) -> bool:
+    args = get_args(ctx)
+    tensor_model_parallel_size = getattr(args, "tensor_model_parallel_size", 1)
+
+    if tensor_model_parallel_size != 1:
+        return True
+    else:
+        return False
+
+
+def is_primus_turbo_can_patch(ctx: PatchContext) -> bool:
+
+    enable_primus_turbo = _is_primus_turbo_enabled(ctx)
+
+    if enable_primus_turbo:
+        if _is_tp_parallel_enabled(ctx):
+            warning_rank_0(
+                "[Patch:megatron.turbo.te_spec_provider] Primus Turbo backend does not support TP > 1; Please use TE backend instead..."
+            )
+            return False
+
+        return True
+    else:
+        return False

--- a/primus/backends/transformer_engine/pytorch/fp8.py
+++ b/primus/backends/transformer_engine/pytorch/fp8.py
@@ -1,0 +1,27 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+from torch.utils.cpp_extension import IS_HIP_EXTENSION
+from transformer_engine.pytorch.utils import get_device_compute_capability
+
+
+def check_fp8_block_scaling_support() -> Tuple[bool, str]:
+    """Return if fp8 block scaling support is available"""
+    if IS_HIP_EXTENSION:
+        return True, ""
+    if (
+        get_device_compute_capability() >= (9, 0)
+        and get_device_compute_capability() < (10, 0)
+        and float(torch.version.cuda) >= 12.9
+    ):
+        return True, ""
+
+    return False, "FP8 block scaled GEMM requires Hopper and CUDA >= 12.9."


### PR DESCRIPTION
# Description

This PR unifies Primus Turbo patch gating behind the `enable_primus_turbo` flag and adds a ROCm-compatible FP8 blockwise scaling support check for Transformer Engine.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Move FP4 and FP8 Primus Turbo patches under the `turbo` patch package so their activation is consistently controlled by Primus Turbo patch conditions.
- Add shared Primus Turbo patch eligibility helpers for `enable_primus_turbo`, `primus_turbo` availability, and unsupported tensor parallel configurations.
- Add a Transformer Engine FP8 blockwise scaling support override that allows HIP/ROCm environments to use the Primus implementation path.
- Update Primus Turbo TE spec provider, GPT output layer, MoE dispatcher, and RMSNorm patches to use the shared eligibility helper.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
