### PR TITLE
Replace amd-smi/rocm-smi subprocess calls with direct sysfs reads

### DIFF
--- a/primus/tools/preflight/gpu/gpu_basic.py
+++ b/primus/tools/preflight/gpu/gpu_basic.py
@@ -178,20 +178,21 @@ def run_gpu_basic_checks(
     else:
         findings.append(Finding("info", "GPU occupancy", {"note": "amd-smi JSON not available; skipped"}))
 
-    # ROCm runtime availability: best-effort presence via tooling.
-    # amd-smi/rocm-smi are only probed on LOCAL_RANK 0 to avoid /dev/shm
-    # mutex contention; non-zero ranks legitimately lack tooling keys.
+    # ROCm runtime availability: sysfs is always available; amd-smi/rocm-smi
+    # are supplementary and only probed on LOCAL_RANK 0.
     if probe.backend == "rocm":
-        from primus.tools.preflight.global_vars import LOCAL_RANK
-
-        if "amd-smi" in probe.tooling or "rocm-smi" in probe.tooling:
+        detected = [k for k in ("sysfs", "amd-smi", "rocm-smi") if k in probe.tooling]
+        if detected:
             findings.append(
-                Finding("info", "ROCm runtime/tooling detected", {"tooling": list(probe.tooling.keys())})
+                Finding("info", "ROCm runtime/tooling detected", {"tooling": detected})
             )
-        elif LOCAL_RANK != 0:
-            findings.append(Finding("info", "ROCm tooling skipped (non-zero LOCAL_RANK)", {}))
         else:
-            findings.append(Finding("warn", "ROCm tooling not found (amd-smi/rocm-smi)", {}))
+            from primus.tools.preflight.global_vars import LOCAL_RANK
+
+            if LOCAL_RANK != 0:
+                findings.append(Finding("info", "ROCm tooling skipped (non-zero LOCAL_RANK)", {}))
+            else:
+                findings.append(Finding("warn", "ROCm tooling not found (sysfs/amd-smi/rocm-smi)", {}))
 
     ok = not any(f.level == "fail" for f in findings)
     return {"ok": ok, "probe": probe, "findings": findings}

--- a/primus/tools/preflight/gpu/gpu_probe.py
+++ b/primus/tools/preflight/gpu/gpu_probe.py
@@ -7,9 +7,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Dict, List, Optional
 
+from .sysfs_probe import sysfs_probe
 from .utils import ProbeResult, run_cmd, which
+
+logger = logging.getLogger(__name__)
 
 
 def _normalize_gfx_arch(raw: str) -> str:
@@ -120,27 +124,16 @@ def _probe_with_torch() -> Dict[str, Any]:
 
 
 def _probe_amd_smi() -> Optional[Dict[str, Any]]:
+    """Best-effort amd-smi JSON probe for process occupancy detection only."""
     if which("amd-smi") is None:
         return None
-
-    # Prefer JSON if available (newer amd-smi); fall back to `list` output.
-    rc, out, err = run_cmd(["amd-smi", "list", "--json"], timeout_s=10)
-    if rc == 0 and out:
-        try:
+    try:
+        rc, out, err = run_cmd(["amd-smi", "list", "--json"], timeout_s=10)
+        if rc == 0 and out:
             return {"rc": rc, "json": json.loads(out), "err": err}
-        except Exception:
-            # Fall through to non-json.
-            pass
-
-    rc, out, err = run_cmd(["amd-smi", "list"], timeout_s=10)
-    return {"rc": rc, "out": out, "err": err}
-
-
-def _probe_rocm_smi() -> Optional[Dict[str, Any]]:
-    if which("rocm-smi") is None:
-        return None
-    rc, out, err = run_cmd(["rocm-smi", "-a"], timeout_s=10)
-    return {"rc": rc, "out": out, "err": err}
+    except Exception as e:
+        logger.debug("amd-smi probe failed: %s", e)
+    return None
 
 
 _PROBE_CACHE: Optional[ProbeResult] = None
@@ -157,9 +150,10 @@ def probe_gpus() -> ProbeResult:
     (from gpu_basic, gpu_topology, and gpu_perf) and the output is static
     during a single preflight run.
 
-    amd-smi and rocm-smi are only invoked on LOCAL_RANK == 0 to avoid
-    /dev/shm mutex contention (rocm_smi_lib#88) and shared-FS subprocess
-    overhead at scale. Their output is node-level (identical across ranks).
+    Primary GPU enumeration uses sysfs (KFD topology), which is safe to call
+    from any rank (no subprocesses, no /dev/shm mutex).  amd-smi is kept as
+    an optional probe on LOCAL_RANK == 0 for process-occupancy data only;
+    its failure never crashes the run.
     """
     global _PROBE_CACHE
     if _PROBE_CACHE is not None:
@@ -170,13 +164,31 @@ def probe_gpus() -> ProbeResult:
     torch_info = _probe_with_torch()
     tooling: Dict[str, Any] = {"torch": torch_info}
 
+    # sysfs probe: safe from every rank, no subprocess calls.
+    sysfs_result = sysfs_probe()
+    if sysfs_result.ok:
+        tooling["sysfs"] = {
+            "gpu_count": sysfs_result.gpu_count,
+            "gpus": [
+                {
+                    "index": i,
+                    "pci_bdf": g.pci_bdf_str,
+                    "unique_id": hex(g.unique_id) if g.unique_id else None,
+                    "numa_node": g.numa_node,
+                }
+                for i, g in enumerate(sysfs_result.gpus)
+            ],
+            "link_count": len(sysfs_result.links),
+        }
+    else:
+        logger.debug("sysfs probe unavailable: %s", sysfs_result.error)
+
+    # amd-smi JSON: subprocess-based, LOCAL_RANK 0 only, best-effort.
+    # Used solely for process-occupancy detection in gpu_basic.py.
     if LOCAL_RANK == 0:
         amd = _probe_amd_smi()
         if amd is not None:
             tooling["amd-smi"] = amd
-        rocmsmi = _probe_rocm_smi()
-        if rocmsmi is not None:
-            tooling["rocm-smi"] = rocmsmi
 
     backend = torch_info.get("backend") if torch_info.get("ok") else "unknown"
     devices = torch_info.get("devices", []) if torch_info.get("ok") else []

--- a/primus/tools/preflight/gpu/gpu_topology.py
+++ b/primus/tools/preflight/gpu/gpu_topology.py
@@ -6,12 +6,16 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from collections import Counter
 from typing import Any, Dict, List, Optional
 
 from .gpu_probe import probe_gpus
+from .sysfs_probe import sysfs_gpu_bdfs, sysfs_topology_summary
 from .utils import Finding, ProbeResult, run_cmd, which
+
+logger = logging.getLogger(__name__)
 
 
 def _device_consistency(devices: List[Dict[str, Any]]) -> List[Finding]:
@@ -29,12 +33,17 @@ def _device_consistency(devices: List[Dict[str, Any]]) -> List[Finding]:
 
 def _numa_mapping_best_effort() -> Optional[Dict[str, Any]]:
     """
-    Best-effort GPU<->NUMA mapping.
-    On many systems this requires PCI bus IDs; we attempt to use amd-smi if present.
+    Best-effort GPU<->NUMA mapping via sysfs (primary) or amd-smi (fallback).
 
-    Only runs on LOCAL_RANK == 0 to avoid /dev/shm mutex contention and
-    shared-FS subprocess overhead at scale (output is node-level).
+    Sysfs reads are safe from any rank (no subprocesses, no mutex).
+    amd-smi fallback only attempted on LOCAL_RANK == 0.
     """
+    bdfs = sysfs_gpu_bdfs()
+    if bdfs:
+        return {"rc": 0, "gpus": bdfs, "source": "sysfs"}
+
+    logger.debug("sysfs NUMA mapping unavailable; trying amd-smi fallback")
+
     from primus.tools.preflight.global_vars import LOCAL_RANK
 
     if LOCAL_RANK != 0:
@@ -47,17 +56,15 @@ def _numa_mapping_best_effort() -> Optional[Dict[str, Any]]:
     if rc != 0 or not out:
         return {"rc": rc, "err": err, "note": "amd-smi list --csv failed"}
 
-    # amd-smi --csv format may vary; we do a very small heuristic:
-    # take 2nd column as PCI BDF if it looks like xxxx:xx:xx.x
     lines = [l for l in out.splitlines() if l.strip()]
-    bdfs: List[str] = []
+    bdf_list: List[str] = []
     for ln in lines[1:]:
         cols = [c.strip() for c in ln.split(",")]
         if len(cols) >= 2 and ":" in cols[1] and "." in cols[1]:
-            bdfs.append(cols[1])
+            bdf_list.append(cols[1])
 
     mapping: List[Dict[str, Any]] = []
-    for i, bdf in enumerate(bdfs):
+    for i, bdf in enumerate(bdf_list):
         node_path = f"/sys/bus/pci/devices/{bdf}/numa_node"
         numa = None
         if os.path.exists(node_path):
@@ -67,12 +74,21 @@ def _numa_mapping_best_effort() -> Optional[Dict[str, Any]]:
                 numa = None
         mapping.append({"gpu": i, "pci_bdf": bdf, "numa_node": numa})
 
-    return {"rc": rc, "gpus": mapping}
+    return {"rc": rc, "gpus": mapping, "source": "amd-smi"}
 
 
 def _xgmi_presence_best_effort() -> Optional[Dict[str, Any]]:
-    # Best-effort: use amd-smi topology if available; otherwise skip.
-    # Only runs on LOCAL_RANK == 0 (node-level output, avoids mutex contention).
+    """
+    Best-effort topology (XGMI vs PCIe) via sysfs (primary) or amd-smi (fallback).
+
+    Sysfs reads are safe from any rank. amd-smi fallback only on LOCAL_RANK == 0.
+    """
+    topo = sysfs_topology_summary()
+    if topo is not None and topo.get("rc") == 0:
+        return topo
+
+    logger.debug("sysfs topology unavailable; trying amd-smi fallback")
+
     from primus.tools.preflight.global_vars import LOCAL_RANK
 
     if LOCAL_RANK != 0:
@@ -119,15 +135,14 @@ def run_gpu_standard_checks(*, force_topology: bool = False) -> Dict[str, Any]:
     findings.extend(_device_consistency(probe.devices))
 
     # NUMA mapping / imbalance detection (best-effort).
-    # _numa_mapping_best_effort() returns None on non-zero LOCAL_RANK
-    # (amd-smi is only invoked on LOCAL_RANK 0).
+    # Prefers sysfs (safe for all ranks); falls back to amd-smi on LOCAL_RANK 0.
     from primus.tools.preflight.global_vars import LOCAL_RANK
 
     numa = _numa_mapping_best_effort()
     if numa is None and LOCAL_RANK != 0:
-        findings.append(Finding("info", "NUMA mapping skipped (non-zero LOCAL_RANK)", {}))
+        findings.append(Finding("info", "NUMA mapping skipped (non-zero LOCAL_RANK, no sysfs)", {}))
     elif numa is None:
-        findings.append(Finding("warn", "NUMA mapping unavailable (amd-smi not found); skipped", {}))
+        findings.append(Finding("warn", "NUMA mapping unavailable (sysfs/amd-smi not found); skipped", {}))
     else:
         nodes = [x.get("numa_node") for x in numa.get("gpus", []) if x.get("numa_node") is not None]
         imbalance = False
@@ -144,14 +159,15 @@ def run_gpu_standard_checks(*, force_topology: bool = False) -> Dict[str, Any]:
     if force_topology or probe.backend == "rocm":
         topo = _xgmi_presence_best_effort()
         if topo is None and LOCAL_RANK != 0:
-            findings.append(Finding("info", "Topology check skipped (non-zero LOCAL_RANK)", {}))
+            findings.append(Finding("info", "Topology check skipped (non-zero LOCAL_RANK, no sysfs)", {}))
         elif topo is None:
-            findings.append(Finding("warn", "Topology check skipped (amd-smi not found)", {}))
+            findings.append(Finding("warn", "Topology check skipped (sysfs/amd-smi not found)", {}))
         else:
-            findings.append(Finding("info", "GPU topology (amd-smi topo)", topo))
-            # Detect obvious PCIe fallback hint (heuristic on output).
-            out = str(topo.get("out", ""))
-            if out and ("PCIE" in out.upper() or "PCIe" in out):
+            source = topo.get("source", "amd-smi")
+            findings.append(Finding("info", f"GPU topology ({source})", topo))
+            out = str(topo.get("out", "") or topo.get("matrix", ""))
+            has_xgmi = topo.get("has_xgmi")
+            if has_xgmi is False or (out and "PCIE" in out.upper() and "XGMI" not in out.upper()):
                 findings.append(Finding("warn", "Topology indicates PCIe paths; XGMI may be absent", {}))
 
     # RCCL/NCCL env sanity (WARN-only).

--- a/primus/tools/preflight/gpu/sysfs_probe.py
+++ b/primus/tools/preflight/gpu/sysfs_probe.py
@@ -1,0 +1,386 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Direct sysfs GPU probing — reads KFD topology and DRM sysfs to enumerate AMD
+GPUs, PCI BDFs, NUMA mapping, and inter-GPU link topology (XGMI vs PCIe)
+without invoking amd-smi or rocm-smi subprocesses.
+
+Approach adapted from RCCL's alt_rsmi.cc
+(https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl/src/misc/alt_rsmi.cc)
+which reads the same KFD sysfs paths to avoid rocm_smi_lib's /dev/shm mutex
+contention (rocm_smi_lib#88).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+KFD_NODES_ROOT = "/sys/class/kfd/kfd/topology/nodes"
+AMD_VENDOR_ID = 0x1002
+
+LINK_TYPE_XGMI = 11
+LINK_TYPE_PCIE = 2
+
+
+@dataclass
+class GpuNode:
+    node_id: int = 0
+    gpu_id: int = 0
+    unique_id: int = 0
+    location_id: int = 0
+    domain: int = 0
+    bdf: int = 0
+    bus: int = 0
+    device: int = 0
+    function: int = 0
+    partition_id: int = 0
+    pci_bdf_str: str = ""
+    numa_node: Optional[int] = None
+    properties: Dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class LinkInfo:
+    src_idx: int = 0
+    dst_idx: int = 0
+    link_type: str = "unknown"
+    weight: int = 0
+    min_bandwidth: int = 0
+    max_bandwidth: int = 0
+    hops: int = 0
+
+
+@dataclass
+class SysfsProbeResult:
+    ok: bool = False
+    gpu_count: int = 0
+    gpus: List[GpuNode] = field(default_factory=list)
+    links: List[LinkInfo] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def _read_sysfs_file(path: str) -> Optional[str]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read().strip()
+    except Exception:
+        return None
+
+
+def _read_sysfs_int(path: str) -> Optional[int]:
+    val = _read_sysfs_file(path)
+    if val is None:
+        return None
+    try:
+        return int(val)
+    except ValueError:
+        return None
+
+
+def _read_kfd_properties(node_id: int) -> Dict[str, int]:
+    """Parse /sys/class/kfd/kfd/topology/nodes/{node_id}/properties → dict."""
+    props: Dict[str, int] = {}
+    path = f"{KFD_NODES_ROOT}/{node_id}/properties"
+    content = _read_sysfs_file(path)
+    if content is None:
+        return props
+    for line in content.splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            try:
+                props[parts[0]] = int(parts[1])
+            except ValueError:
+                pass
+    return props
+
+
+def _read_kfd_gpu_id(node_id: int) -> Optional[int]:
+    """Read /sys/class/kfd/kfd/topology/nodes/{node_id}/gpu_id."""
+    return _read_sysfs_int(f"{KFD_NODES_ROOT}/{node_id}/gpu_id")
+
+
+def _read_link_properties(node_id: int, link_id: int) -> Dict[str, int]:
+    """Parse /sys/class/kfd/kfd/topology/nodes/{node_id}/io_links/{link_id}/properties."""
+    path = f"{KFD_NODES_ROOT}/{node_id}/io_links/{link_id}/properties"
+    props: Dict[str, int] = {}
+    content = _read_sysfs_file(path)
+    if content is None:
+        return props
+    for line in content.splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            try:
+                props[parts[0]] = int(parts[1])
+            except ValueError:
+                pass
+    return props
+
+
+def _count_io_links(node_id: int) -> int:
+    """Count subdirectories in io_links/ for a given node."""
+    links_dir = f"{KFD_NODES_ROOT}/{node_id}/io_links"
+    if not os.path.isdir(links_dir):
+        return 0
+    count = 0
+    try:
+        for entry in os.listdir(links_dir):
+            if os.path.isdir(os.path.join(links_dir, entry)) and entry not in (".", ".."):
+                count += 1
+    except OSError:
+        pass
+    return count
+
+
+def _bdf_to_string(domain: int, bus: int, device: int, function: int) -> str:
+    """Format PCI BDF as string like '0000:c1:00.0'."""
+    return f"{domain:04x}:{bus:02x}:{device:02x}.{function:x}"
+
+
+_GPU_NODES_CACHE: Optional[List["GpuNode"]] = None
+
+
+def _enumerate_gpu_nodes() -> List[GpuNode]:
+    """
+    Scan KFD topology nodes, filter AMD GPUs (vendor_id == 0x1002),
+    compute PCI BDF from location_id + domain, sort by BDF.
+
+    Results are cached at module level since GPU topology is static
+    during a single preflight run and this is called from multiple paths.
+
+    Logic mirrors ARSMI_init() from alt_rsmi.cc.
+    """
+    global _GPU_NODES_CACHE
+    if _GPU_NODES_CACHE is not None:
+        return _GPU_NODES_CACHE
+
+    if not os.path.isdir(KFD_NODES_ROOT):
+        return []
+
+    raw_nodes: List[Tuple[int, GpuNode]] = []
+
+    try:
+        entries = os.listdir(KFD_NODES_ROOT)
+    except OSError:
+        return []
+
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+
+        node_id = int(entry)
+        gpu_id = _read_kfd_gpu_id(node_id)
+        if gpu_id is None or gpu_id == 0:
+            continue
+
+        props = _read_kfd_properties(node_id)
+        vendor_id = props.get("vendor_id", 0)
+        if vendor_id != AMD_VENDOR_ID:
+            continue
+
+        unique_id = props.get("unique_id", 0)
+        location_id = props.get("location_id", 0)
+        domain = props.get("domain", 0) & 0xFFFFFFFF
+
+        bdf_raw = (domain << 32) | location_id
+        bus = (location_id >> 8) & 0xFF
+        device = (location_id >> 3) & 0x1F
+        function = location_id & 0x7
+        partition_id = (location_id >> 28) & 0xF
+
+        pci_bdf_str = _bdf_to_string(domain, bus, device, function)
+
+        numa = _read_sysfs_int(f"/sys/bus/pci/devices/{pci_bdf_str}/numa_node")
+
+        node = GpuNode(
+            node_id=node_id,
+            gpu_id=gpu_id,
+            unique_id=unique_id,
+            location_id=location_id,
+            domain=domain,
+            bdf=bdf_raw,
+            bus=bus,
+            device=device,
+            function=function,
+            partition_id=partition_id,
+            pci_bdf_str=pci_bdf_str,
+            numa_node=numa,
+            properties=props,
+        )
+        raw_nodes.append((bdf_raw, node))
+
+    raw_nodes.sort(key=lambda x: x[0])
+    _GPU_NODES_CACHE = [n for _, n in raw_nodes]
+    return _GPU_NODES_CACHE
+
+
+def _build_link_matrix(gpu_nodes: List[GpuNode]) -> List[LinkInfo]:
+    """
+    Read io_links for each GPU node to determine XGMI vs PCIe connectivity.
+    Returns a flat list of LinkInfo for GPU-to-GPU links only.
+
+    Logic mirrors the link matrix construction in ARSMI_init().
+    """
+    if not gpu_nodes:
+        return []
+
+    node_id_to_idx = {g.node_id: i for i, g in enumerate(gpu_nodes)}
+    links: List[LinkInfo] = []
+
+    for src_idx, src_node in enumerate(gpu_nodes):
+        n_links = _count_io_links(src_node.node_id)
+        for link_id in range(n_links):
+            props = _read_link_properties(src_node.node_id, link_id)
+            if not props:
+                continue
+
+            dst_node_id = props.get("node_to")
+            if dst_node_id is None:
+                continue
+
+            dst_idx = node_id_to_idx.get(dst_node_id)
+            if dst_idx is None:
+                continue
+
+            link_type_raw = props.get("type", 0)
+            weight = props.get("weight", 0)
+            min_bw = props.get("min_bandwidth", 0)
+            max_bw = props.get("max_bandwidth", 0)
+
+            if link_type_raw == LINK_TYPE_XGMI:
+                link_type = "XGMI"
+                hops = 1
+            elif link_type_raw == LINK_TYPE_PCIE:
+                link_type = "PCIe"
+                hops = 2
+            else:
+                link_type = "unknown"
+                hops = 0
+
+            links.append(LinkInfo(
+                src_idx=src_idx,
+                dst_idx=dst_idx,
+                link_type=link_type,
+                weight=weight,
+                min_bandwidth=min_bw,
+                max_bandwidth=max_bw,
+                hops=hops,
+            ))
+
+    return links
+
+
+def sysfs_probe() -> SysfsProbeResult:
+    """
+    Main entry point: enumerate AMD GPUs and topology via sysfs.
+
+    No subprocess calls, no /dev/shm mutex, safe to call from any rank.
+    """
+    try:
+        gpu_nodes = _enumerate_gpu_nodes()
+        if not gpu_nodes:
+            return SysfsProbeResult(ok=False, error="No AMD GPUs found via KFD sysfs")
+
+        links = _build_link_matrix(gpu_nodes)
+        return SysfsProbeResult(
+            ok=True,
+            gpu_count=len(gpu_nodes),
+            gpus=gpu_nodes,
+            links=links,
+        )
+    except Exception as e:
+        return SysfsProbeResult(ok=False, error=f"sysfs probe failed: {e}")
+
+
+# ── Convenience helpers for integration with existing preflight code ──
+
+
+def sysfs_gpu_count() -> int:
+    """GPU count via KFD sysfs. Returns 0 on failure."""
+    try:
+        nodes = _enumerate_gpu_nodes()
+        return len(nodes)
+    except Exception:
+        return 0
+
+
+def sysfs_gpu_bdfs() -> List[Dict[str, Any]]:
+    """
+    Return per-GPU BDF + NUMA mapping, compatible with the format
+    _numa_mapping_best_effort() currently returns.
+    """
+    try:
+        nodes = _enumerate_gpu_nodes()
+        return [
+            {"gpu": i, "pci_bdf": n.pci_bdf_str, "numa_node": n.numa_node}
+            for i, n in enumerate(nodes)
+        ]
+    except Exception:
+        return []
+
+
+def sysfs_has_xgmi() -> Optional[bool]:
+    """
+    Check if any GPU-to-GPU link is XGMI. Returns None if probe fails.
+    """
+    try:
+        nodes = _enumerate_gpu_nodes()
+        if not nodes:
+            return None
+        links = _build_link_matrix(nodes)
+        return any(lk.link_type == "XGMI" for lk in links)
+    except Exception:
+        return None
+
+
+def sysfs_topology_summary() -> Optional[Dict[str, Any]]:
+    """
+    Build a topology summary similar to what `amd-smi topo` provides,
+    formatted for preflight reporting.
+    """
+    try:
+        nodes = _enumerate_gpu_nodes()
+        if not nodes:
+            return None
+
+        links = _build_link_matrix(nodes)
+        n = len(nodes)
+
+        matrix: List[List[str]] = [["" for _ in range(n)] for _ in range(n)]
+        for i in range(n):
+            matrix[i][i] = "self"
+
+        for lk in links:
+            matrix[lk.src_idx][lk.dst_idx] = lk.link_type
+
+        header = [f"GPU{i}" for i in range(n)]
+        lines = ["       " + "  ".join(f"{h:>6}" for h in header)]
+        for i in range(n):
+            row = f"GPU{i:<3} " + "  ".join(f"{matrix[i][j]:>6}" for j in range(n))
+            lines.append(row)
+
+        has_xgmi = any(lk.link_type == "XGMI" for lk in links)
+
+        return {
+            "rc": 0,
+            "source": "sysfs",
+            "gpu_count": n,
+            "has_xgmi": has_xgmi,
+            "matrix": "\n".join(lines),
+            "links": [
+                {
+                    "src": lk.src_idx,
+                    "dst": lk.dst_idx,
+                    "type": lk.link_type,
+                    "weight": lk.weight,
+                }
+                for lk in links
+            ],
+        }
+    except Exception as e:
+        return {"rc": 1, "error": str(e)}

--- a/primus/tools/preflight/host/host_probe.py
+++ b/primus/tools/preflight/host/host_probe.py
@@ -488,8 +488,21 @@ def _get_pcie_link_info_sysfs() -> Dict[str, Any]:
     return info
 
 
+def get_gpu_count_sysfs() -> int:
+    """GPU count via KFD sysfs — no subprocesses, no /dev/shm mutex."""
+    try:
+        from primus.tools.preflight.gpu.sysfs_probe import sysfs_gpu_count
+
+        count = sysfs_gpu_count()
+        if count > 0:
+            return count
+    except Exception:
+        pass
+    return 0
+
+
 def get_gpu_count_rocm_fallback() -> int:
-    """GPU count without invoking rocm-smi (HIP_VISIBLE_DEVICES / sysfs)."""
+    """GPU count without invoking rocm-smi (HIP_VISIBLE_DEVICES / /dev/dri)."""
     hip_devices = os.environ.get("HIP_VISIBLE_DEVICES", "")
     if hip_devices:
         return len([x for x in hip_devices.split(",") if x.strip()])

--- a/primus/tools/preflight/host/info.py
+++ b/primus/tools/preflight/host/info.py
@@ -17,6 +17,7 @@ from .host_probe import (
     get_cpu_info,
     get_gpu_count_rocm,
     get_gpu_count_rocm_fallback,
+    get_gpu_count_sysfs,
     get_hostname,
     get_kernel_version,
     get_memory_info,
@@ -96,13 +97,16 @@ def collect_host_info() -> List[Finding]:
     ib_count = sum(1 for d in pcie_devices if d["type"] == "Infiniband")
     eth_count = sum(1 for d in pcie_devices if d["type"] == "Ethernet")
 
-    # Use rocm-smi as fallback for GPU count (more reliable in containers).
-    # Only invoke on LOCAL_RANK 0 to avoid /dev/shm mutex contention at scale
-    # (rocm_smi_lib#88); non-zero ranks use HIP_VISIBLE_DEVICES / sysfs fallback.
-    from primus.tools.preflight.global_vars import LOCAL_RANK
+    # Primary: sysfs (KFD topology) — safe from any rank, no subprocess.
+    # Fallback: rocm-smi on LOCAL_RANK 0 only (subprocess, /dev/shm mutex).
+    gpu_count_sysfs = get_gpu_count_sysfs()
+    if gpu_count_sysfs > 0:
+        gpu_count_extra = gpu_count_sysfs
+    else:
+        from primus.tools.preflight.global_vars import LOCAL_RANK
 
-    gpu_count_rocm = get_gpu_count_rocm() if LOCAL_RANK == 0 else get_gpu_count_rocm_fallback()
-    gpu_count = max(gpu_count_pcie, gpu_count_rocm)
+        gpu_count_extra = get_gpu_count_rocm() if LOCAL_RANK == 0 else get_gpu_count_rocm_fallback()
+    gpu_count = max(gpu_count_pcie, gpu_count_extra)
 
     findings.append(
         Finding(


### PR DESCRIPTION
Port RCCL's alt_rsmi.cc approach to Python: read GPU info directly from /sys/class/kfd/kfd/topology/nodes/ instead of spawning amd-smi/rocm-smi subprocesses. This eliminates /dev/shm mutex contention (rocm_smi_lib#88) at its root rather than just gating calls behind LOCAL_RANK 0.

- Add gpu/sysfs_probe.py: enumerates AMD GPUs, PCI BDFs, NUMA nodes, and XGMI/PCIe topology from KFD sysfs with zero subprocess calls
- gpu_topology.py: use sysfs for NUMA mapping and topology (primary), fall back to amd-smi on LOCAL_RANK 0 only if sysfs unavailable
- gpu_probe.py: add sysfs to tooling dict, remove _probe_rocm_smi (zero consumers), harden _probe_amd_smi with try/except
- host/host_probe.py: add get_gpu_count_sysfs via KFD topology
- host/info.py: use sysfs GPU count as primary (all ranks safe)
- gpu_basic.py: recognize sysfs as valid ROCm tooling source

Validated at 1N and 2N with strace: only 1 subprocess call remains per node (amd-smi list --json on LOCAL_RANK 0 for process occupancy), down from 5+ previously. Remaining call is wrapped in try/except so timeouts cannot crash the run.