### PR TITLE
feat: add turbo attn deterministic support and refine env checker

### DIFF
--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -496,6 +496,9 @@ class PrimusTurboAttention(te.pytorch.DotProductAttention):
             )
             _use_sink_attention = False
 
+        # set deterministic flag
+        self.deterministic_mode = args.deterministic_mode
+
         # Store for later use after super().__init__()
         self._init_sink_attention = _use_sink_attention
         self._num_heads_for_sinks = self.config.num_attention_heads
@@ -654,7 +657,7 @@ class PrimusTurboAttention(te.pytorch.DotProductAttention):
             window_size=window_size,
             bias=None,
             alibi_slopes=None,
-            deterministic=False,
+            deterministic=self.deterministic_mode,
             return_lse=False,
             return_attn_probs=False,
             sink=sink_tensor,  # PR 208: pass sink tensor to Primus-Turbo

--- a/primus/modules/trainer/megatron/utils.py
+++ b/primus/modules/trainer/megatron/utils.py
@@ -482,13 +482,18 @@ def _get_sync_free_moe_options(stage: int) -> dict:
 def validate_args_on_rocm(args):
     # Deterministic mode
     if args.deterministic_mode:
+        # NOTE: Some environment variables affect deterministic mode on ROCm. Need to do extra check.
+        NON_DETERMINISTIC_ENVS = {
+            "TORCH_COMPILE_DISABLE": "1",
+            "ROCBLAS_DEFAULT_ATOMICS_MODE": "0",
+            "PRIMUS_TURBO_AUTO_TUNE": "0",
+            "PRIMUS_DETERMINISTIC": "1",
+        }
         # NOTE: Some version triton compile exist potential racing condition issue.
-        assert (
-            os.environ.get("TORCH_COMPILE_DISABLE", "0") == "1"
-        ), "TORCH_COMPILE_DISABLE must be set to 1 in deterministic mode."
-        assert (
-            os.environ.get("ROCBLAS_DEFAULT_ATOMICS_MODE", "1") == "0"
-        ), "ROCBLAS_DEFAULT_ATOMICS_MODE must be set to 0 in deterministic mode."
+        for env, value in NON_DETERMINISTIC_ENVS.items():
+            assert (
+                os.environ.get(env, None) == value
+            ), f"{env} must be set to {value} in deterministic mode but got {os.environ.get(env, None)} instead."
 
     # Turbo FP8 linear check
     if args.fp8 and args.use_turbo_parallel_linear:

--- a/primus/modules/trainer/megatron/utils.py
+++ b/primus/modules/trainer/megatron/utils.py
@@ -495,6 +495,9 @@ def validate_args_on_rocm(args):
                 os.environ.get(env, None) == value
             ), f"{env} must be set to {value} in deterministic mode but got {os.environ.get(env, None)} instead."
 
+        # Set fill_uninitialized_memory to False to avoid calling extra fill kernel in deterministic mode.
+        torch.utils.deterministic.fill_uninitialized_memory = False
+
     # Turbo FP8 linear check
     if args.fp8 and args.use_turbo_parallel_linear:
         support_fp8_recipe = ["tensorwise", "blockwise", "mxfp8"]

--- a/runner/helpers/envs/base_env.sh
+++ b/runner/helpers/envs/base_env.sh
@@ -245,6 +245,7 @@ if [[ "${PRIMUS_DETERMINISTIC:-0}" == "1" ]]; then
     export ROCBLAS_DEFAULT_ATOMICS_MODE=0
     # Disable torch compile to avoid race issues in some triton versions.
     export TORCH_COMPILE_DISABLE=1
+    export PRIMUS_TURBO_AUTO_TUNE=0
 fi
 # turbo deepep timeout
 export PRIMUS_TURBO_DEEPEP_TIMEOUT=${PRIMUS_TURBO_DEEPEP_TIMEOUT:-600}

--- a/runner/helpers/hooks/05_deterministic.sh
+++ b/runner/helpers/hooks/05_deterministic.sh
@@ -24,3 +24,4 @@ echo "env.NVTE_ALLOW_NONDETERMINISTIC_ALGO=0"
 echo "env.ROCBLAS_DEFAULT_ATOMICS_MODE=0"
 # Disable torch compile to avoid race condition issue in some triton versions.
 echo "env.TORCH_COMPILE_DISABLE=1"
+echo "env.PRIMUS_TURBO_AUTO_TUNE=0"


### PR DESCRIPTION
# Description

This PR enables deterministic execution for the Primus-Turbo attention path and tightens the environment-variable validation used by deterministic mode on ROCm.

Previously, `PrimusTurboAttention` always invoked the underlying flash-attention kernel with `deterministic=False`, which silently broke bit-exact reproducibility when users enabled `--deterministic-mode`. In addition, the deterministic-mode pre-flight check only validated two environment variables and missed several knobs (e.g. Primus-Turbo auto-tuning) that are known to introduce nondeterminism. This PR wires `args.deterministic_mode` through to the Turbo attention kernel and refactors the env checker to cover the full set of required variables.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `primus/backends/megatron/core/extensions/primus_turbo.py`: Capture `args.deterministic_mode` in `PrimusTurboAttention.__init__` and forward it to the flash-attention call instead of the hard-coded `deterministic=False`, so Turbo attention honors deterministic mode end-to-end.
- `primus/modules/trainer/megatron/utils.py`: Refactor `validate_args_on_rocm` to validate deterministic-mode environment variables from a single `NON_DETERMINISTIC_ENVS` mapping. The required set is extended from `{TORCH_COMPILE_DISABLE, ROCBLAS_DEFAULT_ATOMICS_MODE}` to also include `PRIMUS_TURBO_AUTO_TUNE=0` and `PRIMUS_DETERMINISTIC=1`, with clearer assertion messages reporting both the expected and the actual value.
- `runner/helpers/envs/base_env.sh`: When `PRIMUS_DETERMINISTIC=1`, additionally export `PRIMUS_TURBO_AUTO_TUNE=0` to disable Turbo auto-tuning, which is a known source of run-to-run variance.
- `runner/helpers/hooks/05_deterministic.sh`: Log the newly added `PRIMUS_TURBO_AUTO_TUNE=0` so the experiment env dump reflects the actual deterministic configuration.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
