### PR TITLE
fix(arg_utils): parse list/dict/None literals in modern CLI overrides

### DIFF
--- a/primus/core/utils/arg_utils.py
+++ b/primus/core/utils/arg_utils.py
@@ -8,13 +8,21 @@
 Argument parsing utilities for Primus CLI.
 """
 
+import ast
+
 
 def _coerce_cli_value_modern(raw_value):
-    """Convert common CLI literals to bool/int/float/string."""
+    """Convert common CLI literals to bool/int/float/list/dict/None/string."""
     value = raw_value
     try:
         if value.lower() in ("true", "false"):
             return value.lower() == "true"
+        # Container / None literals via ast.literal_eval (safe, no arbitrary code).
+        if value == "None" or value[:1] in "[({":
+            try:
+                return ast.literal_eval(value)
+            except (ValueError, SyntaxError):
+                pass
         if "." in value:
             try:
                 return float(value)
@@ -80,7 +88,7 @@ def parse_cli_overrides(overrides: list, type_mode: str = "modern") -> dict:
         {"use_cache": True, "verbose": False}
 
     Type Inference Rules:
-        - modern: bool/int/float/string
+        - modern: bool/int/float/list/tuple/dict/set/None/string
         - legacy: bool + eval fallback
 
     Nested Keys:

--- a/tests/unit_tests/core/utils/test_arg_utils.py
+++ b/tests/unit_tests/core/utils/test_arg_utils.py
@@ -1,0 +1,109 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+
+import unittest
+
+from primus.core.utils.arg_utils import (
+    _coerce_cli_value_legacy,
+    _coerce_cli_value_modern,
+    parse_cli_overrides,
+)
+
+
+class TestCoerceCliValueModern(unittest.TestCase):
+    def test_bool(self):
+        self.assertIs(_coerce_cli_value_modern("true"), True)
+        self.assertIs(_coerce_cli_value_modern("True"), True)
+        self.assertIs(_coerce_cli_value_modern("false"), False)
+        self.assertIs(_coerce_cli_value_modern("FALSE"), False)
+
+    def test_int(self):
+        self.assertEqual(_coerce_cli_value_modern("0"), 0)
+        self.assertEqual(_coerce_cli_value_modern("42"), 42)
+        self.assertEqual(_coerce_cli_value_modern("-7"), -7)
+
+    def test_float(self):
+        self.assertEqual(_coerce_cli_value_modern("0.001"), 0.001)
+        self.assertEqual(_coerce_cli_value_modern("-1.5"), -1.5)
+
+    def test_string_fallback(self):
+        self.assertEqual(_coerce_cli_value_modern("hello"), "hello")
+        self.assertEqual(_coerce_cli_value_modern("v1.2.3"), "v1.2.3")
+
+    def test_list_literal(self):
+        # Regression: `--profile_ranks '[0]'` used to be kept as raw string,
+        # which broke Megatron's `int in args.profile_ranks` check.
+        self.assertEqual(_coerce_cli_value_modern("[0]"), [0])
+        self.assertEqual(_coerce_cli_value_modern("[0, 1, 2]"), [0, 1, 2])
+        self.assertEqual(_coerce_cli_value_modern("[]"), [])
+        self.assertEqual(_coerce_cli_value_modern('["a", "b"]'), ["a", "b"])
+
+    def test_tuple_literal(self):
+        self.assertEqual(_coerce_cli_value_modern("(1, 2)"), (1, 2))
+
+    def test_dict_literal(self):
+        self.assertEqual(_coerce_cli_value_modern("{'a': 1}"), {"a": 1})
+        self.assertEqual(_coerce_cli_value_modern("{}"), {})
+
+    def test_none_literal(self):
+        self.assertIsNone(_coerce_cli_value_modern("None"))
+
+    def test_malformed_container_falls_back_to_string(self):
+        # If literal_eval fails, keep the original raw string instead of crashing.
+        self.assertEqual(_coerce_cli_value_modern("[0,"), "[0,")
+        self.assertEqual(_coerce_cli_value_modern("{not_a_dict}"), "{not_a_dict}")
+
+
+class TestParseCliOverrides(unittest.TestCase):
+    def test_list_override_via_space(self):
+        result = parse_cli_overrides(["--profile_ranks", "[0]"])
+        self.assertEqual(result, {"profile_ranks": [0]})
+
+    def test_list_override_via_equals(self):
+        result = parse_cli_overrides(["--profile_ranks=[0, 4]"])
+        self.assertEqual(result, {"profile_ranks": [0, 4]})
+
+    def test_mixed_overrides(self):
+        result = parse_cli_overrides(
+            [
+                "--profile",
+                "true",
+                "--profile_ranks",
+                "[0, 1]",
+                "--lr",
+                "0.001",
+                "--train_iters",
+                "10",
+            ]
+        )
+        self.assertEqual(
+            result,
+            {
+                "profile": True,
+                "profile_ranks": [0, 1],
+                "lr": 0.001,
+                "train_iters": 10,
+            },
+        )
+
+    def test_legacy_mode_unchanged(self):
+        # Sanity: legacy eval-based path still works for list literals.
+        result = parse_cli_overrides(["--profile_ranks", "[0, 1]"], type_mode="legacy")
+        self.assertEqual(result, {"profile_ranks": [0, 1]})
+
+
+class TestCoerceCliValueLegacyUnchanged(unittest.TestCase):
+    """Guard against accidental regression in the legacy coerce path."""
+
+    def test_bool_and_list_and_string(self):
+        self.assertIs(_coerce_cli_value_legacy("true"), True)
+        self.assertEqual(_coerce_cli_value_legacy("[0, 1]"), [0, 1])
+        self.assertEqual(_coerce_cli_value_legacy("hello"), "hello")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The modern CLI override parser used to keep container/None literals as raw strings, so --profile_ranks '[0]' was passed through as the string [0] instead of the list [0], breaking downstream consumers such as Megatron's int in args.profile_ranks check.

Use ast.literal_eval (safe, no arbitrary code execution) on values that start with [, (, {, or equal the exact literal None, so they are converted to real list/tuple/dict/set/None objects. The bool / numeric / string fallback paths are unchanged.

Also add tests/unit_tests/core/utils/test_arg_utils.py covering bool (case-insensitive), int, float, string fallback, list / dict / None literals, and the parse_cli_overrides end-to-end behavior. arg_utils.py had no dedicated test file on main prior to this change.