### PR TITLE
feat(torchtitan): SDMA copy-engine all-gather for FSDP

### DIFF
--- a/primus/backends/torchtitan/patches/__init__.py
+++ b/primus/backends/torchtitan/patches/__init__.py
@@ -34,6 +34,7 @@ from primus.backends.torchtitan.patches import (  # noqa: F401
     mock_dataset_patches,
     model_override_patches,
     pipelining_schedule_patches,
+    sdma_symm_mem_collectives,
     turbo,
     wandb_patches,
 )

--- a/primus/backends/torchtitan/patches/sdma_symm_mem_collectives.py
+++ b/primus/backends/torchtitan/patches/sdma_symm_mem_collectives.py
@@ -1,0 +1,166 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+TorchTitan / FSDP2 SDMA-eligible All-Gather Patch
+
+What this patches:
+    Wraps ``torch.distributed.fsdp.fully_shard`` so that every
+    fully-sharded module also gets
+    ``set_custom_all_gather(SymmMemAllGather(...))`` attached
+    immediately after construction.
+
+Activation:
+    Export ``SDMA_ALL_GATHER=1`` in the shell before launching any
+    torchtitan pretrain (e.g. ``primus-cli direct -- train pretrain
+    --config <existing YAML>``). The patch is a no-op otherwise.
+
+    The companion hook
+    ``runner/helpers/hooks/06_enable_sdma_all_gather.sh`` runs at
+    ``primus-cli`` startup and, when ``SDMA_ALL_GATHER=1``, exports
+    the standard zero-CTA env (``NCCL_CTA_POLICY=2``,
+    ``NCCL_CUMEM_ENABLE=1``, ...) and the LD_PRELOAD interposer so no
+    YAML or script changes are required to opt in.
+
+    ``SDMA_ALL_GATHER`` is the only knob; there are no sub-options.
+
+Requirements:
+    - PyTorch >= 2.12 (introduces ``SymmMemAllGather``).
+    - On ROCm, the underlying RCCL transport must be able to take the
+      copy-engine path; FSDP already requests zero-CTA via
+      ``pg_options`` so this is normally automatic. Verify with
+      ``NCCL_CTA_POLICY=2 NCCL_CUMEM_ENABLE=1`` if in doubt; both
+      paths produce correct results either way.
+"""
+
+import os
+
+from primus.core.patches import PatchContext, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _sdma_all_gather_enabled(ctx: PatchContext) -> bool:
+    """Single env-driven gate. Triggered only by ``SDMA_ALL_GATHER=1``."""
+    return os.environ.get("SDMA_ALL_GATHER", "0") == "1"
+
+
+@register_patch(
+    "torchtitan.fsdp.sdma_symm_mem_collectives",
+    backend="torchtitan",
+    phase="setup",
+    description=(
+        "Auto-attach SymmMemAllGather to every fully_shard'd module "
+        "so FSDP's all-gather uses the SDMA (copy-engine) dispatch "
+        "path. Gated on SDMA_ALL_GATHER=1."
+    ),
+    condition=_sdma_all_gather_enabled,
+)
+def patch_torchtitan_fsdp_sdma_symm_mem(ctx: PatchContext) -> None:
+    """
+    Wrap ``torch.distributed.fsdp.fully_shard`` so post-construction we
+    attach ``SymmMemAllGather`` on the FSDP module, routing every
+    all-gather through a cuMem-backed symm_mem buffer that the
+    NCCL/RCCL transport recognizes as eligible for the SDMA dispatch
+    path. Reduce-scatter is left on its FSDP default.
+    """
+    import functools
+
+    import torch.distributed.fsdp as _fsdp_pkg
+    from torch.distributed.fsdp._fully_shard import _fsdp_collectives as _ffsc
+    from torch.distributed.fsdp._fully_shard import _fully_shard as _ffs_mod
+    from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
+        SymmMemAllGather,
+    )
+
+    # Hardcoded sensible defaults. SDMA_ALL_GATHER is the only knob.
+    backend = "NCCL"
+    log_all = False
+
+    orig_fully_shard = _fsdp_pkg.fully_shard
+
+    def _attach_symm_mem_all_gather(fsdp_module) -> None:
+        """Switch a fully_shard'd module's AG comm to the SymmMem flavor."""
+        try:
+            state = fsdp_module._get_fsdp_state()
+        except Exception as e:
+            if log_all:
+                log_rank_0(
+                    f"[Patch:sdma_symm_mem] skip (no _fsdp_state): "
+                    f"{type(fsdp_module).__name__}: {e}"
+                )
+            return
+
+        groups = getattr(state, "_fsdp_param_groups", None) or []
+        if len(groups) != 1:
+            # set_custom_all_gather rejects modules with multiple param
+            # groups (e.g. per-param mesh via shard_placement_fn). Leave
+            # those alone; they will use whatever comm FSDP chose.
+
+            # Lorri: This was tested on Pytorch 2.12, 
+            # other versions may be different.
+            if log_all:
+                log_rank_0(
+                    f"[Patch:sdma_symm_mem] skip multi-group module "
+                    f"({len(groups)} groups): {type(fsdp_module).__name__}"
+                )
+            return
+
+        pg = groups[0]._all_gather_process_group
+        try:
+            fsdp_module.set_custom_all_gather(SymmMemAllGather(pg, backend))
+        except (AttributeError, ValueError, AssertionError) as e:
+            log_rank_0(
+                f"[Patch:sdma_symm_mem] WARN: failed to attach SymmMemAllGather "
+                f"to {type(fsdp_module).__name__}: {e}"
+            )
+            return
+        if log_all:
+            log_rank_0(
+                f"[Patch:sdma_symm_mem] attached SymmMemAllGather "
+                f"to {type(fsdp_module).__name__} (group={pg.group_name})"
+            )
+
+    @functools.wraps(orig_fully_shard)
+    def wrapped_fully_shard(module, *args, **kwargs):
+        result = orig_fully_shard(module, *args, **kwargs)
+        # fully_shard mutates `module` in place and returns it; this is
+        # the FSDP-augmented module.
+        _attach_symm_mem_all_gather(result)
+        return result
+
+    # Copy across any non-dunder attributes from the original function
+    # to the wrapper. In particular, FSDP attaches `fully_shard.state`
+    # (a method) that nested fully_shard()ing reads as
+    # `fully_shard.state(modules[0])` in `_fully_shard.py`. If we don't
+    # propagate it, the first inner call crashes with
+    # `AttributeError: 'function' object has no attribute 'state'`.
+    for _attr in dir(orig_fully_shard):
+        if _attr.startswith("__"):
+            continue
+        try:
+            setattr(wrapped_fully_shard, _attr, getattr(orig_fully_shard, _attr))
+        except (AttributeError, TypeError):
+            pass
+
+    # Patch every alias of fully_shard that torchtitan (or anyone else)
+    # may have already pulled in via `from ... import fully_shard`. We
+    # patch the package re-export AND the inner module's binding; both
+    # are the same function object at this point, and torchtitan
+    # imports happen later (in TorchTitanPretrainTrainer.__init__,
+    # after run_patches('setup') returns).
+    _fsdp_pkg.fully_shard = wrapped_fully_shard
+    if hasattr(_ffs_mod, "fully_shard"):
+        _ffs_mod.fully_shard = wrapped_fully_shard
+
+    log_rank_0(
+        "[Patch:torchtitan.fsdp.sdma_symm_mem_collectives] installed: "
+        f"every fully_shard()-d module will use "
+        f"SymmMemAllGather (backend={backend})."
+    )
+
+    # Convenience: stash references for tests / debugging.
+    _ffsc._primus_sdma_orig_fully_shard = orig_fully_shard
+    _ffsc._primus_sdma_attach = _attach_symm_mem_all_gather

--- a/primus/backends/torchtitan/patches/sdma_symm_mem_collectives.py
+++ b/primus/backends/torchtitan/patches/sdma_symm_mem_collectives.py
@@ -71,9 +71,7 @@ def patch_torchtitan_fsdp_sdma_symm_mem(ctx: PatchContext) -> None:
     import torch.distributed.fsdp as _fsdp_pkg
     from torch.distributed.fsdp._fully_shard import _fsdp_collectives as _ffsc
     from torch.distributed.fsdp._fully_shard import _fully_shard as _ffs_mod
-    from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
-        SymmMemAllGather,
-    )
+    from torch.distributed.fsdp._fully_shard._fsdp_collectives import SymmMemAllGather
 
     # Hardcoded sensible defaults. SDMA_ALL_GATHER is the only knob.
     backend = "NCCL"
@@ -88,8 +86,7 @@ def patch_torchtitan_fsdp_sdma_symm_mem(ctx: PatchContext) -> None:
         except Exception as e:
             if log_all:
                 log_rank_0(
-                    f"[Patch:sdma_symm_mem] skip (no _fsdp_state): "
-                    f"{type(fsdp_module).__name__}: {e}"
+                    f"[Patch:sdma_symm_mem] skip (no _fsdp_state): " f"{type(fsdp_module).__name__}: {e}"
                 )
             return
 
@@ -99,7 +96,7 @@ def patch_torchtitan_fsdp_sdma_symm_mem(ctx: PatchContext) -> None:
             # groups (e.g. per-param mesh via shard_placement_fn). Leave
             # those alone; they will use whatever comm FSDP chose.
 
-            # Lorri: This was tested on Pytorch 2.12, 
+            # Lorri: This was tested on Pytorch 2.12,
             # other versions may be different.
             if log_all:
                 log_rank_0(

--- a/runner/helpers/hooks/06_enable_sdma_all_gather.sh
+++ b/runner/helpers/hooks/06_enable_sdma_all_gather.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+#
+# Global hook: opt into the SDMA/RCCL dispatch path for FSDP
+# all-gather.
+#
+# Single trigger -- the only knob:
+#
+#   export SDMA_ALL_GATHER=1
+#   primus-cli direct -- train pretrain --config <any existing yaml>
+#
+# When SDMA_ALL_GATHER=1, this hook:
+#   1. Exports the zero-CTA env that RCCL needs to actually take the
+#      copy-engine path (NCCL_CTA_POLICY=2, NCCL_CUMEM_ENABLE=1, ...).
+#   2. Propagates SDMA_ALL_GATHER=1 into the launched torchrun children
+#      so the companion Python patch's gate fires there too. See
+#      primus/backends/torchtitan/patches/sdma_symm_mem_collectives.py.
+#   3. Rebuilds the bundled LD_PRELOAD interposer
+#      (hooks/sdma/hip_attr_drain_preload.c) into /tmp and exports
+#      LD_PRELOAD. The interposer is a workaround for the ROCm
+#      cuDeviceGetAttribute hipErrorInvalidValue TLS-leak hit by RCCL's
+#      cuMem code path on builds that don't have the upstream fix.
+#      Recompiled every time so it never goes stale relative to the
+#      source. 
+#      Lorri: Check JIRA ticket ROCM-24832 for more details.
+#
+# Anything else (HSA_SDMA_LINEAR_B2B, NCCL_DEBUG, ...) can be set
+# independently via the normal `export` / `primus-cli --env` flow.
+
+set -euo pipefail
+
+if [[ "${SDMA_ALL_GATHER:-0}" != "1" ]]; then
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 1) Zero-CTA env for the RCCL copy-engine path. FSDP requests CTA=ZERO
+#    via pg_options too, but setting these explicitly here makes the
+#    dispatch path observable. 
+#Lorri: Check the header in sdma_symm_mem_collectives.py for more details.
+echo "env.NCCL_CTA_POLICY=2"
+echo "env.NCCL_CUMEM_ENABLE=1"
+echo "env.NCCL_LOCAL_REGISTER=0"
+echo "env.TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK=true"
+
+# 2) Make the trigger visible to torchrun children so the Python patch
+#    fires there. primus-cli direct doesn't inherit the host env into
+#    the child unless it's either CLI-passed via --env or hook-emitted
+#    via env.*.
+echo "env.SDMA_ALL_GATHER=1"
+
+# 3) Always (re)build the interposer. The source is tiny and gcc is
+#    typically <1s; we don't bother with a staleness check so the .so
+#    can never lag behind the source.
+SRC="${SCRIPT_DIR}/sdma/hip_attr_drain_preload.c"
+SO=/tmp/libhip_attr_drain.so
+if [[ ! -f "${SRC}" ]]; then
+    echo "[ERROR] [Hooks/sdma] interposer source not found: ${SRC}" >&2
+    exit 1
+fi
+gcc -O2 -fPIC -shared "${SRC}" -o "${SO}" -ldl
+echo "env.LD_PRELOAD=${SO}"

--- a/runner/helpers/hooks/06_enable_sdma_all_gather.sh
+++ b/runner/helpers/hooks/06_enable_sdma_all_gather.sh
@@ -25,7 +25,7 @@
 #      cuDeviceGetAttribute hipErrorInvalidValue TLS-leak hit by RCCL's
 #      cuMem code path on builds that don't have the upstream fix.
 #      Recompiled every time so it never goes stale relative to the
-#      source. 
+#      source.
 #      Lorri: Check JIRA ticket ROCM-24832 for more details.
 #
 # Anything else (HSA_SDMA_LINEAR_B2B, NCCL_DEBUG, ...) can be set
@@ -41,7 +41,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 1) Zero-CTA env for the RCCL copy-engine path. FSDP requests CTA=ZERO
 #    via pg_options too, but setting these explicitly here makes the
-#    dispatch path observable. 
+#    dispatch path observable.
 #Lorri: Check the header in sdma_symm_mem_collectives.py for more details.
 echo "env.NCCL_CTA_POLICY=2"
 echo "env.NCCL_CUMEM_ENABLE=1"

--- a/runner/helpers/hooks/sdma/hip_attr_drain_preload.c
+++ b/runner/helpers/hooks/sdma/hip_attr_drain_preload.c
@@ -1,0 +1,176 @@
+/*
+ * hip_attr_drain_preload.c -- user-space LD_PRELOAD workaround for the
+ * "first kernel after ncclMemAlloc fails" bug on ROCm.
+ *
+ * Background:
+ *   RCCL's allocator.cc calls
+ *     (void) cuDeviceGetAttribute(&flag,
+ *              CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, dev);
+ *   inside its cuMem code path (NCCL_CUMEM_ENABLE=1). On ROCm 7.x that
+ *   attribute id (128) is not supported -- the call returns
+ *   hipErrorInvalidValue AND leaves the same error sitting in the HIP
+ *   runtime's per-thread `last_error_` slot. RCCL discards the return
+ *   value, so nothing drains the TLS. The next unrelated HIP API entry
+ *   (e.g. a kernel launch) reads back that stale error and reports it
+ *   as if its own operation failed.
+ *   Lorri: Check JIRA ticket ROCM-24832 for more details.
+ *
+ *   On ROCm the macro CUPFN(x) in rocm-systems/projects/rccl/src/include/
+ *   rocmwrap.h expands to a literal `x`, so the call site goes through
+ *   the normal global symbol -- which makes it directly interposable
+ *   via LD_PRELOAD. No RCCL rebuild required.
+ *
+ * What this interposer does:
+ *   - Wraps  hipDeviceGetAttribute  AND  cuDeviceGetAttribute.
+ *   - Forwards to the real implementation (resolved via RTLD_NEXT).
+ *   - If the real call returns non-success, calls hipGetLastError() to
+ *     drain the TLS error slot so it can't leak into the next HIP call.
+ *   - Returns the original return value untouched -- callers see the
+ *     same failure they would have, they just don't get the TLS pollution.
+ *
+ * Build (inside the ROCm container):
+ *   gcc -O2 -fPIC -shared hip_attr_drain_preload.c -o libhip_attr_drain.so -ldl
+ *
+ * Use:
+ *   LD_PRELOAD=/path/to/libhip_attr_drain.so  <your program>
+ *
+ * Always prints one line per drained call to stderr (intentional --
+ * keeps the workaround visible in logs so it can be retired once the
+ * underlying ROCm fix lands).
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+
+/* Opaque ABI: hipError_t / CUresult are 32-bit ints, attribute enums are
+ * ints, device handles are ints. Using bare int here keeps this .so free
+ * of HIP/CUDA header and link dependencies -- it can be built in any
+ * container with just gcc + libdl. */
+typedef int (*get_attr_fn)(int *, int, int);
+typedef int (*get_last_err_fn)(void);
+
+static get_attr_fn      real_hipDeviceGetAttribute = NULL;
+static get_attr_fn      real_cuDeviceGetAttribute  = NULL;
+static get_last_err_fn  real_hipGetLastError       = NULL;
+static void            *amdhip_handle              = NULL;
+
+/* fwd-decl: defined below the resolver, used by maybe_drain */
+static void *get_amdhip_handle(void);
+
+__attribute__((constructor))
+static void hip_attr_drain_init(void) {
+    real_hipDeviceGetAttribute =
+        (get_attr_fn)     dlsym(RTLD_NEXT, "hipDeviceGetAttribute");
+    real_cuDeviceGetAttribute =
+        (get_attr_fn)     dlsym(RTLD_NEXT, "cuDeviceGetAttribute");
+    real_hipGetLastError =
+        (get_last_err_fn) dlsym(RTLD_NEXT, "hipGetLastError");
+
+    fprintf(stderr,
+        "[hip_attr_drain] loaded. "
+        "hipDeviceGetAttribute=%p cuDeviceGetAttribute=%p "
+        "hipGetLastError=%p\n",
+        (void *)real_hipDeviceGetAttribute,
+        (void *)real_cuDeviceGetAttribute,
+        (void *)real_hipGetLastError);
+}
+
+static inline void maybe_drain(const char *who, int attr, int rc) {
+    if (rc == 0) return;   /* hipSuccess / CUDA_SUCCESS == 0 */
+    if (!real_hipGetLastError) {
+        /* Same handle-based resolution: bypasses our own symbol space,
+         * avoids the RTLD_DEFAULT recursion hazard. */
+        void *h = get_amdhip_handle();
+        if (h) real_hipGetLastError =
+                (get_last_err_fn) dlsym(h, "hipGetLastError");
+        if (!real_hipGetLastError)
+            real_hipGetLastError =
+                (get_last_err_fn) dlsym(RTLD_NEXT, "hipGetLastError");
+    }
+    int drained = -1;
+    if (real_hipGetLastError) drained = real_hipGetLastError();
+    fprintf(stderr,
+        "[hip_attr_drain] %s(attr=%d) -> %d ; drained TLS = %d%s\n",
+        who, attr, rc, drained,
+        real_hipGetLastError ? "" : "  (WARN: hipGetLastError unresolved)");
+}
+
+/* Lazy resolver. Symbol-interposing wrappers need to be careful:
+ *   - dlsym(RTLD_NEXT, ...) is caller-context-sensitive (it returns the
+ *     next definition after the caller in the link order). It works
+ *     reliably from THIS .so as long as libamdhip64.so was loaded
+ *     before us in the loader graph; it can return NULL otherwise.
+ *   - dlsym(RTLD_DEFAULT, ...) searches the global symbol table, which
+ *     contains OUR OWN wrapper symbol (LD_PRELOAD'd shared objects go
+ *     into the global scope). Using it as a fallback would resolve to
+ *     ourselves, giving infinite recursion -> stack overflow -> SEGV.
+ *     PyTorch 2.12's cuda-bindings cython modules hit exactly that path.
+ * So we explicitly dlopen("libamdhip64.so", ...NOLOAD) to get a handle
+ * to the real lib (already resident at this point) and dlsym against
+ * THAT handle -- guaranteed to bypass our own wrapper. */
+static void *get_amdhip_handle(void) {
+    if (amdhip_handle) return amdhip_handle;
+    /* RTLD_NOLOAD: don't trigger a fresh load, just hand back the
+     * existing in-memory handle if libamdhip64 has been loaded by
+     * anyone (PyTorch's libtorch_hip.so depends on it). */
+    amdhip_handle = dlopen("libamdhip64.so",   RTLD_LAZY | RTLD_NOLOAD);
+    if (!amdhip_handle)
+        amdhip_handle = dlopen("libamdhip64.so.7", RTLD_LAZY | RTLD_NOLOAD);
+    if (!amdhip_handle)
+        amdhip_handle = dlopen("libamdhip64.so.6", RTLD_LAZY | RTLD_NOLOAD);
+    /* Last-ditch: NOLOAD off, in case nobody has loaded it yet. */
+    if (!amdhip_handle)
+        amdhip_handle = dlopen("libamdhip64.so",   RTLD_LAZY);
+    return amdhip_handle;
+}
+
+static get_attr_fn resolve_attr(get_attr_fn *cache, const char *name) {
+    get_attr_fn fn = *cache;
+    if (fn) return fn;
+    /* Prefer dlsym(handle): bypasses our own wrapper symbol. */
+    void *h = get_amdhip_handle();
+    if (h) fn = (get_attr_fn) dlsym(h, name);
+    /* Fallback to RTLD_NEXT (caller-relative, but at least also bypasses
+     * us as long as our .so loaded before libamdhip64 in the chain). */
+    if (!fn) fn = (get_attr_fn) dlsym(RTLD_NEXT, name);
+    *cache = fn;
+    return fn;
+}
+
+/* ------------------------------------------------------------------ */
+/* hipDeviceGetAttribute -- caught directly by anyone in user code.   */
+/* ------------------------------------------------------------------ */
+int hipDeviceGetAttribute(int *value, int attrib, int device) {
+    get_attr_fn fn = resolve_attr(&real_hipDeviceGetAttribute,
+                                  "hipDeviceGetAttribute");
+    if (!fn) {
+        fprintf(stderr, "[hip_attr_drain] hipDeviceGetAttribute"
+                " unresolved; faking hipErrorInvalidValue\n");
+        if (value) *value = 0;
+        return 1;   /* hipErrorInvalidValue -- safe, matches behavior for
+                     * unsupported attributes; caller code that ignores
+                     * the return (RCCL's allocator.cc) is unaffected. */
+    }
+    int rc = fn(value, attrib, device);
+    maybe_drain("hipDeviceGetAttribute", attrib, rc);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/* cuDeviceGetAttribute -- the symbol that RCCL's allocator.cc calls
+ *    directly on ROCm (CUPFN(x) expands to `x`). This is the symbol we
+ *    actually need to catch to fix the NCCL_CUMEM_ENABLE=1 bug.       */
+/* ------------------------------------------------------------------ */
+int cuDeviceGetAttribute(int *value, int attrib, int device) {
+    get_attr_fn fn = resolve_attr(&real_cuDeviceGetAttribute,
+                                  "cuDeviceGetAttribute");
+    if (!fn) {
+        fprintf(stderr, "[hip_attr_drain] cuDeviceGetAttribute"
+                " unresolved; faking hipErrorInvalidValue\n");
+        if (value) *value = 0;
+        return 1;
+    }
+    int rc = fn(value, attrib, device);
+    maybe_drain("cuDeviceGetAttribute", attrib, rc);
+    return rc;
+}


### PR DESCRIPTION
This PR adds the SDMA all-gather support for torchtitan.

Command for testing:

```
./primus-cli container --image rocm/pyt-megatron-lm-jax-nightly-private:primus_the_rock_rocm7.14_20260601 \
  --env HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
 --env SDMA_ALL_GATHER=1 \
  -- train pretrain --config examples/torchtitan/configs/MI300X/llama3.1_70B-BF16-pretrain.yaml
```
Example trace
<img width="2149" height="1269" alt="image" src="https://github.com/user-attachments/assets/8bc22015-8538-4253-adc4-f4ba885db1a5" />
