### PR TITLE
[Megatron-LM] fix: primus turbo attn memory footprint issue

### DIFF
--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -1929,6 +1929,8 @@ class PrimusTurboGroupedLinear(TEGroupedLinear):
                 quant_config_internal = quant_config.data()
                 weight_scaling_recipe = ScalingRecipe(use_2d_block=True)
 
+                # NOTE: grouped_gemm_fp8 is called with trans_b=False; weights layout is [G, K, N]
+                # so the forward (row) axis along K is -2 and the trans (col) axis along N is -1.
                 self.quantized_weight_buffer = PrimusTurboQuantizedTensor.quantize(
                     weights,
                     dest_dtype=weight_dtype,

--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -719,6 +719,13 @@ class PrimusTurboAttention(te.pytorch.DotProductAttention):
             OFFLOAD_BUFFER.add_offload_tensor(f"attn_k", key)
             OFFLOAD_BUFFER.add_offload_tensor(f"attn_v", value)
 
+        # NOTE: query, key, value maybe a view of the original tensor, call contiguous to copy a new tensor
+        # and let torch allocator can release the original tensor.
+        if torch.is_grad_enabled():
+            query = query.contiguous() if query.requires_grad else query
+            key = key.contiguous() if key.requires_grad else key
+            value = value.contiguous() if value.requires_grad else value
+
         if qkv_format == "sbhd":
             query = query.permute(1, 0, 2, 3)
             key = key.permute(1, 0, 2, 3)
@@ -1922,8 +1929,6 @@ class PrimusTurboGroupedLinear(TEGroupedLinear):
                 quant_config_internal = quant_config.data()
                 weight_scaling_recipe = ScalingRecipe(use_2d_block=True)
 
-                # NOTE: grouped_gemm_fp8 is called with trans_b=False; weights layout is [G, K, N]
-                # so the forward (row) axis along K is -2 and the trans (col) axis along N is -1.
                 self.quantized_weight_buffer = PrimusTurboQuantizedTensor.quantize(
                     weights,
                     dest_dtype=weight_dtype,


### PR DESCRIPTION
# Description

When `use_turbo_attention=true`, the Primus-Turbo attention path uses a
significantly larger activation-memory footprint than the Transformer-Engine
path (≈7–10 GB extra on Qwen3-30B-A3B FP8 pretraining, which can push the run
into OOM), even though both paths hold identical live tensors at the end of a
step.

Root cause: the `q`/`k`/`v` passed into `PrimusTurboAttention` are **views** of
the fused QKV projection output (`[s, b, (nq + 2*nkv) * hd]`). Primus-Turbo's
flash-attention (`AiterFlashAttnFunc`) calls `save_for_backward(q, k, v, ...)`
and, since head_dim is divisible by 8, it never materializes a contiguous copy.
Saving a view keeps the **entire** fused-QKV buffer alive from the forward all
the way to that layer's backward, so these buffers accumulate at the activation
peak across all decoder layers.

By contrast, `TEDotProductAttention` materializes contiguous q/k/v for its fused
backend, so the original fused-QKV projection output loses its last reference and
is freed right after the forward (observed buffer lifetime ~0.9 ms vs ~53 ms for
the Turbo path). Comparing two PyTorch memory snapshots (TE-attn vs Turbo-attn)
confirmed that the peak-live difference is exactly this per-layer fused-QKV
buffer, which is retained only on the Turbo side.

Fix: in `PrimusTurboAttention.forward`, make `query`/`key`/`value` contiguous
before they are consumed by attention (and saved for backward), so the saved
tensors no longer pin the fused-QKV projection output and the caching allocator
can release it after the forward — matching TE's memory behavior. The copy is
guarded by `torch.is_grad_enabled()` and per-tensor `requires_grad`, so inference
and non-grad tensors are unaffected.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `PrimusTurboAttention.forward` (`primus/backends/megatron/core/extensions/primus_turbo.py`):
  call `.contiguous()` on `query`/`key`/`value` (each only when it `requires_grad`,
  and only under `torch.is_grad_enabled()`) right after the optional offload hook
  and before the layout permute. This detaches the tensors saved for backward from
  the fused QKV projection output's storage, allowing the PyTorch caching allocator
  to free that buffer after the forward and eliminating the extra per-layer
  activation footprint. Inference paths are unaffected.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
