### PR TITLE
feat(megatron): forward last-rank training_log to rank 0 for Megatron-Bridge

### DIFF
--- a/primus/backends/megatron/patches/training_log/print_rank_last_patches.py
+++ b/primus/backends/megatron/patches/training_log/print_rank_last_patches.py
@@ -32,7 +32,7 @@ import torch
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.core.utils import logger as primus_logger
 from primus.core.utils.rocm_mem_info import get_rocm_smi_mem_info
-from primus.modules.module_utils import log_rank_0, log_rank_all, warning_rank_0
+from primus.modules.module_utils import log_rank_0, warning_rank_0
 
 
 @dataclass
@@ -191,15 +191,6 @@ def _forward_single_node_training_log(message: str) -> None:
         if sink_logger is None:
             return
         sink_logger.bind(rank=last_rank, world_size=world_size, console_only=True).debug(payload[0])
-
-
-def _touch_log_rank_all_for_tests() -> None:  # pragma: no cover
-    """
-    Helper to keep ``log_rank_all`` referenced so that it is available for
-    unit tests that monkeypatch this symbol from this module.
-    """
-    if False:
-        log_rank_all("")  # type: ignore[arg-type]
 
 
 class MemoryStatsExtension:
@@ -527,7 +518,11 @@ def patch_training_log_unified(ctx: PatchContext):
             use_rocm_mem or (rocm_iters and len(rocm_iters) > 0)
         )
 
-        if not enable_rocm_stats:
+        # Forwarding the last-rank progress line to rank 0 only needs a
+        # single-node run; it is independent of ROCm/throughput stat injection.
+        should_forward_to_rank_0 = _should_forward_training_log_to_rank_0()
+
+        if not enable_rocm_stats and not should_forward_to_rank_0:
             # Nothing to do; leave Megatron's training_log and print_rank_last untouched.
             return
 
@@ -537,16 +532,18 @@ def patch_training_log_unified(ctx: PatchContext):
         if getattr(original_training_log, "_primus_training_log_print_rank_wrapper", False):
             return
 
-        # Create helper extensions once so they keep state (ROCm cache, avg windows)
-        # across all training_log invocations.
-        mem_ext = MemoryStatsExtension(config)
-        elapsed_ext = ElapsedAverageExtension(config)
-        throughput_ext = ThroughputAverageExtension(config)
+        # Create helper extensions only when stat injection is enabled so they
+        # keep state (ROCm cache, avg windows) across all training_log
+        # invocations. In forwarding-only mode they are not needed.
+        mem_ext = elapsed_ext = throughput_ext = None
+        if enable_rocm_stats:
+            mem_ext = MemoryStatsExtension(config)
+            elapsed_ext = ElapsedAverageExtension(config)
+            throughput_ext = ThroughputAverageExtension(config)
         call_count = 0
         # Capture the original ``print_rank_last`` so we can delegate actual
         # printing back to Megatron after mutating the log string.
         original_print_rank_last = megatron_training.print_rank_last
-        should_forward_to_rank_0 = _should_forward_training_log_to_rank_0()
         source_prefix = ""
         if should_forward_to_rank_0:
             source_prefix = "{}: ".format(
@@ -566,24 +563,28 @@ def patch_training_log_unified(ctx: PatchContext):
                   ``print_rank_last`` implementation.
             """
             nonlocal call_count
-            try:
-                # Track how many times we've seen print_rank_last in this run.
-                call_count += 1
-                # Parse the original log string once and share across extensions.
-                parsed = parse_training_log_line(log_string)
+            if enable_rocm_stats:
+                try:
+                    # Track how many times we've seen print_rank_last in this run.
+                    call_count += 1
+                    # Parse the original log string once and share across extensions.
+                    parsed = parse_training_log_line(log_string)
 
-                # Inject memory statistics, elapsed avg, throughput, and token
-                # throughput by mutating the parsed structure. These calls ignore
-                # their string return value when `parsed` is provided.
-                mem_ext.inject(log_string, call_count, parsed)
-                elapsed_ext.inject(log_string, parsed)
-                throughput_ext.inject(log_string, parsed)
+                    # Inject memory statistics, elapsed avg, throughput, and token
+                    # throughput by mutating the parsed structure. These calls ignore
+                    # their string return value when `parsed` is provided.
+                    mem_ext.inject(log_string, call_count, parsed)
+                    elapsed_ext.inject(log_string, parsed)
+                    throughput_ext.inject(log_string, parsed)
 
-                # Render the final line from the parsed structure.
-                updated = render_training_log_line(parsed)
-            except Exception as e:
-                # Logging must never break training; emit a warning and continue.
-                warning_rank_0(f"[Patch:megatron.training_log] Failed to append training stats: {e}")
+                    # Render the final line from the parsed structure.
+                    updated = render_training_log_line(parsed)
+                except Exception as e:
+                    # Logging must never break training; emit a warning and continue.
+                    warning_rank_0(f"[Patch:megatron.training_log] Failed to append training stats: {e}")
+                    updated = log_string
+            else:
+                # Forwarding-only mode: keep Megatron's original line untouched.
                 updated = log_string
 
             # Keep the runner's console filtering behavior unchanged for all
@@ -617,3 +618,73 @@ def patch_training_log_unified(ctx: PatchContext):
     except Exception as e:
         # Catch-all to make sure patch does not crash training.
         log_rank_0(f"[Patch:megatron.training_log][ERROR] Unexpected error: {e}")
+
+
+@register_patch(
+    "megatron_bridge.training_log.forward_to_rank0",
+    backend="megatron",
+    phase="before_train",
+    description="Forward Megatron-Bridge last-rank training_log line to rank 0 for single-node console visibility.",
+)
+def patch_bridge_training_log_forward(ctx: PatchContext):
+    """
+    Forward Megatron-Bridge's last-rank training_log line to rank 0.
+
+    Megatron-Bridge prints the detailed metric line via ``print_rank_last`` (last
+    rank only), while torchrun typically only exposes local rank 0 on the
+    console. On single-node runs this patch broadcasts that line to rank 0 so it
+    stays visible, mirroring the native Megatron forwarding behavior. The log
+    content itself is left unchanged (forwarding only, no stat injection).
+
+    Note: unlike native Megatron (where ``training_log`` and ``print_rank_last``
+    share one module), Bridge hosts ``training_log`` in
+    ``megatron.bridge.training.train`` (the call site) but resolves
+    ``print_rank_last`` from ``megatron.bridge.training.utils.train_utils``. We
+    therefore wrap the former and temporarily override the latter for the
+    duration of the call.
+    """
+    try:
+        if not _should_forward_training_log_to_rank_0():
+            return
+
+        import megatron.bridge.training.train as bridge_train  # type: ignore
+        import megatron.bridge.training.utils.train_utils as bridge_train_utils  # type: ignore
+
+        original_training_log = bridge_train.training_log
+
+        # Avoid double-wrapping training_log.
+        if getattr(original_training_log, "_primus_bridge_training_log_forward_wrapper", False):
+            return
+
+        original_print_rank_last = bridge_train_utils.print_rank_last
+        source_prefix = "{}: ".format(
+            primus_logger.module_format(
+                getattr(original_print_rank_last, "__module__", __name__).split(".")[-1],
+                getattr(getattr(original_print_rank_last, "__code__", None), "co_firstlineno", 0),
+            )
+        )
+
+        def primus_print_rank_last(log_string: str) -> None:
+            # Forward the last-rank line to rank 0, then delegate the actual
+            # printing back to Bridge's original print_rank_last unchanged.
+            _forward_single_node_training_log(f"{source_prefix}{log_string}")
+            original_print_rank_last(log_string)
+
+        def primus_training_log(*args, **kwargs):
+            saved_print_rank_last = bridge_train_utils.print_rank_last
+            try:
+                bridge_train_utils.print_rank_last = primus_print_rank_last
+                return original_training_log(*args, **kwargs)
+            finally:
+                bridge_train_utils.print_rank_last = saved_print_rank_last
+
+        setattr(primus_training_log, "_primus_bridge_training_log_forward_wrapper", True)
+        bridge_train.training_log = primus_training_log
+
+        log_rank_0("[Patch:megatron_bridge.training_log] Forwarding last-rank training_log to rank 0")
+
+    except ImportError as e:
+        log_rank_0(f"[Patch:megatron_bridge.training_log][SKIP] Import failed: {e}")
+    except Exception as e:
+        # Catch-all to make sure patch does not crash training.
+        log_rank_0(f"[Patch:megatron_bridge.training_log][ERROR] Unexpected error: {e}")

--- a/tests/unit_tests/backends/megatron/test_training_log_patches.py
+++ b/tests/unit_tests/backends/megatron/test_training_log_patches.py
@@ -98,6 +98,12 @@ def test_patch_training_log_skips_when_no_extensions(monkeypatch: pytest.MonkeyP
         "primus.backends.megatron.patches.training_log.print_rank_last_patches.log_rank_0",
         lambda *a, **k: None,
     )
+    # No injection and no forwarding -> patch must be a no-op. Pin forwarding to
+    # False so this test does not depend on the runner's env vars.
+    monkeypatch.setattr(
+        "primus.backends.megatron.patches.training_log.print_rank_last_patches._should_forward_training_log_to_rank_0",
+        lambda: False,
+    )
 
     tl_patches.patch_training_log_unified(ctx)
 
@@ -187,12 +193,7 @@ def test_rocm_monitor_hooked_print_rank_last_injects_stats(monkeypatch: pytest.M
         lambda rank: (8 * 1024**3, 6 * 1024**3, 2 * 1024**3),
     )
 
-    captured = []
     # Avoid real logging via Primus logger during unit tests.
-    monkeypatch.setattr(
-        "primus.backends.megatron.patches.training_log.print_rank_last_patches.log_rank_all",
-        lambda msg, *a, **k: captured.append(msg),
-    )
     monkeypatch.setattr(
         "primus.backends.megatron.patches.training_log.print_rank_last_patches.log_rank_0",
         lambda *a, **k: None,
@@ -215,10 +216,7 @@ def test_rocm_monitor_hooked_print_rank_last_injects_stats(monkeypatch: pytest.M
     parsed = prl_patches.parse_training_log_line("iter 1:")
     mem_ext.inject("iter 1:", call_index=1, parsed=parsed)
     out = prl_patches.render_training_log_line(parsed)
-    prl_patches.log_rank_all(out)
 
-    assert len(captured) == 1
-    out = captured[0]
     assert "iter 1:" in out
     # Basic sanity checks that memory substrings are present.
     assert "hip mem usage/free/total/usage_ratio" in out
@@ -249,12 +247,7 @@ def test_rocm_monitor_hooked_print_rank_last_swallows_errors(monkeypatch: pytest
         lambda rank: _raise_smi(),
     )
 
-    captured = []
     # Avoid real logging via Primus logger during unit tests.
-    monkeypatch.setattr(
-        "primus.backends.megatron.patches.training_log.print_rank_last_patches.log_rank_all",
-        lambda msg, *a, **k: captured.append(msg),
-    )
     monkeypatch.setattr(
         "primus.backends.megatron.patches.training_log.print_rank_last_patches.log_rank_0",
         lambda *a, **k: None,
@@ -274,10 +267,8 @@ def test_rocm_monitor_hooked_print_rank_last_swallows_errors(monkeypatch: pytest
     parsed = prl_patches.parse_training_log_line("iter 2:")
     mem_ext.inject("iter 2:", call_index=1, parsed=parsed)
     out = prl_patches.render_training_log_line(parsed)
-    prl_patches.log_rank_all(out)
 
-    assert len(captured) == 1
-    assert captured[0].startswith("iter 2:")
+    assert out.startswith("iter 2:")
 
 
 def test_parse_training_log_line_does_not_confuse_iteration_and_elapsed():
@@ -306,3 +297,149 @@ def test_parse_training_log_line_does_not_confuse_iteration_and_elapsed():
     # Global batch size and throughput should be populated as well.
     assert info.global_batch_size == 128
     assert info.throughput_tflops == pytest.approx(1255.4)
+
+
+def test_bridge_forward_patch_wraps_and_forwards(monkeypatch: pytest.MonkeyPatch):
+    """
+    Megatron-Bridge forwarding patch.
+
+    Bridge hosts ``training_log`` in ``megatron.bridge.training.train`` (call
+    site) but resolves ``print_rank_last`` from
+    ``megatron.bridge.training.utils.train_utils``. The patch must wrap the
+    former and, only during the call, override the latter so the last-rank line
+    is forwarded to rank 0. The log content must stay unchanged and
+    ``print_rank_last`` must be restored afterwards. Wrapping is idempotent.
+    """
+    import sys
+
+    # Minimal module tree so the patch's ``import megatron.bridge...`` resolves.
+    # ``import ... as`` hits sys.modules directly, so parent wiring is not needed.
+    mods = {
+        name: types.ModuleType(name)
+        for name in (
+            "megatron",
+            "megatron.bridge",
+            "megatron.bridge.training",
+            "megatron.bridge.training.train",
+            "megatron.bridge.training.utils",
+            "megatron.bridge.training.utils.train_utils",
+        )
+    }
+    for name, mod in mods.items():
+        monkeypatch.setitem(sys.modules, name, mod)
+    train_mod = mods["megatron.bridge.training.train"]
+    train_utils_mod = mods["megatron.bridge.training.utils.train_utils"]
+
+    printed = []
+
+    def fake_print_rank_last(msg):
+        printed.append(msg)
+
+    def fake_training_log(line):
+        # Bridge: training_log resolves print_rank_last from train_utils.
+        train_utils_mod.print_rank_last(line)
+        return "done"
+
+    train_utils_mod.print_rank_last = fake_print_rank_last
+    train_mod.training_log = fake_training_log
+
+    forwarded = []
+    monkeypatch.setattr(
+        "primus.backends.megatron.patches.training_log.print_rank_last_patches._should_forward_training_log_to_rank_0",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "primus.backends.megatron.patches.training_log.print_rank_last_patches._forward_single_node_training_log",
+        lambda msg: forwarded.append(msg),
+    )
+    monkeypatch.setattr(
+        "primus.backends.megatron.patches.training_log.print_rank_last_patches.log_rank_0",
+        lambda *a, **k: None,
+    )
+
+    ctx = SimpleNamespace(extra={})
+    tl_patches.patch_bridge_training_log_forward(ctx)
+
+    # Call-site training_log is wrapped; print_rank_last untouched until called.
+    assert train_mod.training_log is not fake_training_log
+    assert train_utils_mod.print_rank_last is fake_print_rank_last
+
+    line = "[ts] iteration 1/10 | lm loss: 1.0 |"
+    result = train_mod.training_log(line)
+
+    assert result == "done"
+    assert printed == [line]  # forwarding only: content is unchanged
+    assert len(forwarded) == 1
+    assert forwarded[0].endswith(line)
+    # print_rank_last must be restored after the call.
+    assert train_utils_mod.print_rank_last is fake_print_rank_last
+
+    # Idempotent: a second application is a no-op.
+    wrapped_once = train_mod.training_log
+    tl_patches.patch_bridge_training_log_forward(ctx)
+    assert train_mod.training_log is wrapped_once
+
+
+def test_native_forwarding_only_without_injection(monkeypatch: pytest.MonkeyPatch):
+    """
+    Decoupling: with ROCm/throughput injection disabled but single-node
+    forwarding active, the native patch must still wrap training_log and forward
+    the last-rank line to rank 0 -- without altering the log content.
+    """
+    import sys
+
+    megatron_mod = types.ModuleType("megatron")
+    training_pkg = types.ModuleType("megatron.training")
+    training_mod = types.ModuleType("megatron.training.training")
+
+    printed = []
+
+    def fake_print_rank_last(msg):
+        printed.append(msg)
+
+    def fake_training_log(line):
+        # Native: training_log resolves print_rank_last from the same module.
+        training_mod.print_rank_last(line)
+        return "ok"
+
+    training_mod.print_rank_last = fake_print_rank_last
+    training_mod.training_log = fake_training_log
+    training_pkg.training = training_mod
+    megatron_mod.training = training_pkg
+    for name, mod in [
+        ("megatron", megatron_mod),
+        ("megatron.training", training_pkg),
+        ("megatron.training.training", training_mod),
+    ]:
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    forwarded = []
+    monkeypatch.setattr(
+        "primus.backends.megatron.patches.training_log.print_rank_last_patches._should_forward_training_log_to_rank_0",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "primus.backends.megatron.patches.training_log.print_rank_last_patches._forward_single_node_training_log",
+        lambda msg: forwarded.append(msg),
+    )
+    monkeypatch.setattr(
+        "primus.backends.megatron.patches.training_log.print_rank_last_patches.log_rank_0",
+        lambda *a, **k: None,
+    )
+
+    # log_throughput=False -> enable_rocm_stats is False -> injection disabled.
+    ctx = _make_ctx(args=SimpleNamespace(log_throughput=False), config={})
+    tl_patches.patch_training_log_unified(ctx)
+
+    # Even without injection, forwarding alone causes training_log to be wrapped.
+    assert training_mod.training_log is not fake_training_log
+
+    line = "[ts] iteration        1/      10 | lm loss: 1.0 |"
+    result = training_mod.training_log(line)
+
+    assert result == "ok"
+    assert printed == [line]  # content unchanged (no injection)
+    assert len(forwarded) == 1
+    assert forwarded[0].endswith(line)
+    # print_rank_last must be restored after the call.
+    assert training_mod.print_rank_last is fake_print_rank_last


### PR DESCRIPTION
Megatron-Bridge prints the detailed per-iteration metric line (loss, grad norm, throughput, etc.) via print_rank_last, i.e. on the last rank only, while torchrun typically exposes just local rank 0 on the console. As a result the progress line landed only in rank-N/debug.log and never showed up on the console.

Add a dedicated patch (megatron_bridge.training_log.forward_to_rank0) that broadcasts Bridge's last-rank training_log line to rank 0 on single-node runs.

Also decouple forwarding from ROCm/throughput stat injection in the native patch: forwarding now depends only on a single-node run, not on log_throughput/use_rocm_mem_info.

Cleanup: drop the unused log_rank_all import and the _touch_log_rank_all_for_tests autoflake guard it required; the ROCm injection tests now assert render_training_log_line output directly.