### PR TITLE
Add llama3.1 8b mxfp4 support

### DIFF
--- a/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
@@ -27,7 +27,7 @@ modules:
       train_iters: ${PRIMUS_TRAIN_ITERS:50}
       micro_batch_size: 2               # grad_acc = global_batch_size / (micro_batch_size * num_gpus) = 32 / (2 * 8) = 2
       global_batch_size: 32
-      
+
       seq_length: 8192
       max_position_embeddings: 8192
 
@@ -35,7 +35,7 @@ modules:
 
       lr: 0.0008          # 8e-4
       min_lr: 0.00008     # 10% of lr
-      lr_warmup_iters: 128  
+      lr_warmup_iters: 128
       lr_decay_iters: 1199872 # 1200000 - 128
       lr_decay_style: cosine
       weight_decay: 0.1
@@ -45,7 +45,7 @@ modules:
       init_method_std: 0.02
       norm_epsilon: 1.0e-5
 
-      adam_eps: 1.0e-5 
+      adam_eps: 1.0e-5
 
       check_for_nan_in_loss_and_grad: false # default true
       check_for_spiky_loss: false # default false, but setting it here explicitly
@@ -115,6 +115,3 @@ modules:
       use_turbo_grouped_mlp: false
       moe_use_fused_router_with_aux_score: false
       enable_turbo_attention_float8 : false
-
-
-

--- a/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
@@ -1,6 +1,6 @@
 work_group: ${PRIMUS_TEAM:amd}
 user_name: ${PRIMUS_USER:root}
-exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain-mxfp8}
+exp_name: ${PRIMUS_EXP_NAME:llama3.1_8B-pretrain-mxfp4}
 workspace: ${PRIMUS_WORKSPACE:./output}
 
 modules:
@@ -20,7 +20,7 @@ modules:
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
 
-      eval_iters: 32  # 32 * GBS = 1024 eval samples
+      eval_iters: 0  # change this to non-zero to enable evaluation. Eg: 32 * GBS = 1024 eval samples
       eval_interval: ${PRIMUS_EVAL_INTERVAL:10} # 10 * GBS = 320 eval samples perform evaluation.
 
       # --- Training Config ---
@@ -35,7 +35,7 @@ modules:
 
       lr: 0.0008          # 8e-4
       min_lr: 0.00008     # 10% of lr
-      lr_warmup_iters: 128  # TODO: lr warmup steps should be 128.
+      lr_warmup_iters: 128  
       lr_decay_iters: 1199872 # 1200000 - 128
       lr_decay_style: cosine
       weight_decay: 0.1
@@ -45,7 +45,7 @@ modules:
       init_method_std: 0.02
       norm_epsilon: 1.0e-5
 
-      adam_eps: 1.0e-5 # TODO, find out what is the correct key to this parameter.
+      adam_eps: 1.0e-5 
 
       check_for_nan_in_loss_and_grad: false # default true
       check_for_spiky_loss: false # default false, but setting it here explicitly
@@ -71,12 +71,12 @@ modules:
       profile: false
       use_pytorch_profiler: true
       profile_ranks: [0]           # Only profile rank 0 to save disk space
-      profile_step_start: 8        # Start after warmup (step 8)
-      profile_step_end: 13        # Profile 5 iterations (8-12)
+      profile_step_start: 9        # Start after warmup (step 8)
+      profile_step_end: 11        # Profile 5 iterations (8-12)
       disable_profiler_activity_cpu: false     # GPU kernels only (smaller files)
       torch_profiler_record_shapes: false     # Disable for smaller traces
       torch_profiler_with_stack: false        # Disable for smaller traces
-      torch_profiler_use_gzip: true           # Compress output
+      torch_profiler_use_gzip: false           # Compress output
 
       # --- Checkpointing Config ---
       finetune: false
@@ -100,9 +100,8 @@ modules:
       cross_entropy_loss_fusion: true
 
       # --- Mixed Precision Config ---
-      fp8: e4m3
-      fp8_recipe: mxfp8  
-
+      fp4: e2m1
+      fp4_recipe: mxfp4
       accumulate_allreduce_grads_in_fp32: false
       grad_reduce_in_bf16: true
       attention_softmax_in_fp32: false
@@ -111,7 +110,11 @@ modules:
       # --- Primus Turbo Config ---
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_parallel_linear: true              # can't use together with fp8 delayed recipe
+      use_turbo_fp4_autocast: false                 # TE mxfp4 recipe should set it to false
+      use_turbo_parallel_linear: false              # can't use together with delayed recipe
       use_turbo_grouped_mlp: false
       moe_use_fused_router_with_aux_score: false
       enable_turbo_attention_float8 : false
+
+
+

--- a/examples/megatron/configs/MI355X/llama3.1_8B-MXFP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.1_8B-MXFP8-pretrain.yaml
@@ -27,7 +27,7 @@ modules:
       train_iters: ${PRIMUS_TRAIN_ITERS:50}
       micro_batch_size: 2               # grad_acc = global_batch_size / (micro_batch_size * num_gpus) = 32 / (2 * 8) = 2
       global_batch_size: 32
-      
+
       seq_length: 8192
       max_position_embeddings: 8192
 
@@ -101,7 +101,7 @@ modules:
 
       # --- Mixed Precision Config ---
       fp8: e4m3
-      fp8_recipe: mxfp8  
+      fp8_recipe: mxfp8
 
       accumulate_allreduce_grads_in_fp32: false
       grad_reduce_in_bf16: true

--- a/examples/megatron/configs/MI355X/llama3.1_8B-MXFP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.1_8B-MXFP8-pretrain.yaml
@@ -1,0 +1,118 @@
+work_group: ${TEAM:amd}
+user_name: ${USER:root}
+exp_name: ${EXP_NAME:llama3.1_8B-pretrain-mxfp8}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3.1_8B.yaml
+    overrides:
+      # --- Logging Config ---
+      wandb_project: "Primus-llama3.1-8B-pretrain"
+      disable_wandb: true
+      disable_tensorboard: true
+      stderr_sink_level: DEBUG
+      log_interval: 1
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      eval_iters: 32  # 32 * GBS = 1024 eval samples
+      eval_interval: ${PRIMUS_EVAL_INTERVAL:10} # 10 * GBS = 320 eval samples perform evaluation.
+
+      # --- Training Config ---
+      train_iters: ${PRIMUS_TRAIN_ITERS:50}
+      micro_batch_size: 2               # grad_acc = global_batch_size / (micro_batch_size * num_gpus) = 32 / (2 * 8) = 2
+      global_batch_size: 32
+      
+      seq_length: 8192
+      max_position_embeddings: 8192
+
+      seed: ${SEED:1234}
+
+      lr: 0.0008          # 8e-4
+      min_lr: 0.00008     # 10% of lr
+      lr_warmup_iters: 128  # TODO: lr warmup steps should be 128.
+      lr_decay_iters: 1199872 # 1200000 - 128
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: false
+      init_method_std: 0.02
+      norm_epsilon: 1.0e-5
+
+      adam_eps: 1.0e-5 # TODO, find out what is the correct key to this parameter.
+
+      check_for_nan_in_loss_and_grad: false # default true
+      check_for_spiky_loss: false # default false, but setting it here explicitly
+      check_for_large_grads: false # default false, but setting it here explicitly
+
+      # --- Model Parallel Config ---
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: true
+
+      # --- Data Config ---
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+      seq_length: 8192
+      data_cache_path: null
+      mmap_bin_files: true
+
+      # --- Profiling Config ---
+      profile: false
+      use_pytorch_profiler: true
+      profile_ranks: [0]           # Only profile rank 0 to save disk space
+      profile_step_start: 8        # Start after warmup (step 8)
+      profile_step_end: 13        # Profile 5 iterations (8-12)
+      disable_profiler_activity_cpu: false     # GPU kernels only (smaller files)
+      torch_profiler_record_shapes: false     # Disable for smaller traces
+      torch_profiler_with_stack: false        # Disable for smaller traces
+      torch_profiler_use_gzip: true           # Compress output
+
+      # --- Checkpointing Config ---
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 2000000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+
+      # --- FSDP Config ---
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true # this is needed for fsdp2
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # --- Mixed Precision Config ---
+      fp8: e4m3
+      fp8_recipe: mxfp8  
+
+      accumulate_allreduce_grads_in_fp32: false
+      grad_reduce_in_bf16: true
+      attention_softmax_in_fp32: false
+
+
+      # --- Primus Turbo Config ---
+      enable_primus_turbo: true
+      use_turbo_attention: true
+      use_turbo_parallel_linear: true              # can't use together with fp8 delayed recipe
+      use_turbo_grouped_mlp: false
+      moe_use_fused_router_with_aux_score: false
+      enable_turbo_attention_float8 : false

--- a/primus/backends/megatron/core/fp4_utils.py
+++ b/primus/backends/megatron/core/fp4_utils.py
@@ -14,9 +14,6 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import is_te_min_version
 
 from primus.backends.megatron.core.enums import Fp4Recipe
-from primus.backends.megatron.core.extensions.primus_turbo import (
-    primus_turbo_fp4_autocast,
-)
 from primus.modules.module_utils import warning_rank_0
 
 # Check if Transformer Engine is installed
@@ -39,21 +36,27 @@ except (ImportError, ModuleNotFoundError):
     # Primus-Turbo not found
     pass
 
+
+def _primus_turbo_enabled() -> bool:
+    if not HAVE_TURBO:
+        return False
+    try:
+        from megatron.training.global_vars import get_args
+
+        args = get_args()
+        enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
+        use_turbo_fp4_autocast = bool(getattr(args, "use_turbo_fp4_autocast", False))
+        return enable_primus_turbo and use_turbo_fp4_autocast
+    except Exception:
+        return False
+
+
 MXFP4_SCALING_BLOCK_SIZE = 32
 
 WARN_ONCE = True
 
 
 if HAVE_TE and HAVE_TURBO:
-    from primus_turbo.pytorch.core.low_precision import (
-        Format,
-        ScaleDtype,
-        ScalingGranularity,
-    )
-
-    from primus.backends.megatron.core.extensions.primus_turbo import (
-        PrimusTurboQuantConfig,
-    )
 
     def get_fp4_recipe(config: TransformerConfig):
         """Return fp4 recipe."""
@@ -64,31 +67,52 @@ if HAVE_TE and HAVE_TURBO:
                 try:
                     fp4_recipe = transformer_engine.common.recipe.NVFP4BlockScaling()
                 except AttributeError:
-                    fp4_recipe_none_reason = "NVFP4BlockScaling recipe is not available in this version of Transformer Engine. Please make sure you are using TE version >= 2.7.0.dev0."
+                    fp4_recipe_none_reason = "NVFP4BlockScaling recipe is not available in this version of Transformer Engine."
+            elif config.fp4_recipe == Fp4Recipe.mxfp4:
+                try:
+                    import os
+                    fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
+                    fp4_recipe.use_hadamard = os.environ.get("NVTE_MXFP4_USE_HADAMARD", "0") == "1"
+                except AttributeError:
+                    fp4_recipe_none_reason = "MXFP4BlockScaling recipe is not available in this version of Transformer Engine."
             else:
-                fp4_recipe_none_reason = "NVFP4BlockScaling is the only supported FP4 recipe. Please make sure you are using a compatible TE version >= 2.7.0.dev0."
+                fp4_recipe_none_reason = f"Unsupported FP4 recipe: {config.fp4_recipe}."
         else:
-            fp4_recipe_none_reason = (
-                "FP4 support requires TransformerEngine version >= 2.7.0.dev0 for NVFP4BlockScaling."
-            )
+            fp4_recipe_none_reason = "FP4 support requires TransformerEngine version >= 2.7.0.dev0."
 
         return fp4_recipe, fp4_recipe_none_reason
 
     def get_fp4_quant_config(config: TransformerConfig):
-        """Return fp4 quant config."""
-        fp4_quant_config = None
-        fp4_quant_config_none_reason = ""
-        if config.fp4_recipe == Fp4Recipe.mxfp4:
-            fp4_quant_config = PrimusTurboQuantConfig(
-                granularity=ScalingGranularity.MX_BLOCKWISE,
-                format=Format.E2M1_X2,
-                block_size=MXFP4_SCALING_BLOCK_SIZE,
-                scale_dtype=ScaleDtype.E8M0,
-            )
-        else:
-            fp4_quant_config_none_reason = "Only MXFP4 is supported in Primus-Turbo."
+        """Return Primus-Turbo fp4 quant config.
 
-        return fp4_quant_config, fp4_quant_config_none_reason
+        The Primus-Turbo extension is imported lazily here so that a missing or
+        incompatible ``primus_turbo`` API only affects the Turbo FP4 path and
+        cannot break module import (which would silently disable the FP4 patch
+        and fall back to upstream Megatron's nvfp4-only recipe handling).
+        """
+        if config.fp4_recipe != Fp4Recipe.mxfp4:
+            return None, "Only MXFP4 is supported in Primus-Turbo."
+
+        try:
+            from primus_turbo.pytorch.core.low_precision import (
+                Format,
+                ScaleDtype,
+                ScalingGranularity,
+            )
+
+            from primus.backends.megatron.core.extensions.primus_turbo import (
+                PrimusTurboQuantConfig,
+            )
+        except (ImportError, ModuleNotFoundError) as e:
+            return None, f"Primus-Turbo FP4 quant config unavailable: {e}"
+
+        fp4_quant_config = PrimusTurboQuantConfig(
+            granularity=ScalingGranularity.MX_BLOCKWISE,
+            format=Format.E2M1_X2,
+            block_size=MXFP4_SCALING_BLOCK_SIZE,
+            scale_dtype=ScaleDtype.E8M0,
+        )
+        return fp4_quant_config, ""
 
     def get_fp4_context(config: TransformerConfig, layer_no: int = -1, is_init: bool = False):
         """Return fp4 context manager."""
@@ -105,17 +129,13 @@ if HAVE_TE and HAVE_TURBO:
             fp4_context = nullcontext()
         else:
             fp4_recipe, fp4_recipe_none_reason = get_fp4_recipe(config)
-            fp4_quant_config, fp4_quant_config_none_reason = get_fp4_quant_config(config)
+            turbo_enabled = _primus_turbo_enabled() and not is_init
 
             global WARN_ONCE
             if WARN_ONCE:
                 if fp4_recipe is None:
                     warning_rank_0(
                         f"TransformerEngine FP4 {config.fp4_recipe} not work since {fp4_recipe_none_reason}"
-                    )
-                if fp4_quant_config is None:
-                    warning_rank_0(
-                        f"Primus-Turbo FP4 {config.fp4_recipe} not work since {fp4_quant_config_none_reason}"
                     )
                 if is_init:
                     warning_rank_0(
@@ -130,13 +150,31 @@ if HAVE_TE and HAVE_TURBO:
                 )
 
             if not is_init:
-                fp4_context = primus_turbo_fp4_autocast(
-                    enabled=True if fp4_recipe is not None else False,
-                    fp4_recipe=fp4_recipe,
-                    fp4_group=fp4_group,
-                    enabled_turbo=True if fp4_quant_config is not None else False,
-                    turbo_quant_config=fp4_quant_config,
-                )
+                # Only touch the Primus-Turbo extension when the Turbo FP4
+                # autocast path is explicitly enabled; otherwise use TE directly.
+                if turbo_enabled:
+                    fp4_quant_config, fp4_quant_config_none_reason = get_fp4_quant_config(config)
+                    if WARN_ONCE and fp4_quant_config is None:
+                        warning_rank_0(
+                            f"Primus-Turbo FP4 {config.fp4_recipe} not work since {fp4_quant_config_none_reason}"
+                        )
+
+                    from primus.backends.megatron.core.extensions.primus_turbo import (
+                        primus_turbo_fp4_autocast,
+                    )
+
+                    fp4_context = primus_turbo_fp4_autocast(
+                        enabled=True if fp4_recipe is not None else False,
+                        fp4_recipe=fp4_recipe,
+                        fp4_group=fp4_group,
+                        enabled_turbo=True if fp4_quant_config is not None else False,
+                        turbo_quant_config=fp4_quant_config,
+                    )
+                else:
+                    # TE currently uses fp8_autocast for fp8 and fp4 quantization.
+                    fp4_context = transformer_engine.pytorch.fp8_autocast(
+                        enabled=True, fp8_recipe=fp4_recipe, fp8_group=fp4_group
+                    )
             else:
                 import inspect
 
@@ -151,25 +189,24 @@ elif HAVE_TE:
 
     def get_fp4_recipe(config: TransformerConfig):
         """Return fp4 recipe."""
-        if is_te_min_version("2.7.0.dev0"):
-            if config.fp4_recipe == Fp4Recipe.nvfp4:
-                try:
-                    fp4_recipe = transformer_engine.common.recipe.NVFP4BlockScaling()
-                except AttributeError:
-                    raise ValueError(
-                        """NVFP4BlockScaling recipe is not available in this version of
-                        Transformer Engine. Please make sure you are using TE version
-                        >= 2.7.0.dev0."""
-                    )
-            else:
+        if config.fp4_recipe == Fp4Recipe.nvfp4:
+            if not is_te_min_version("2.7.0.dev0"):
                 raise ValueError(
-                    "NVFP4BlockScaling is the only supported FP4 recipe. "
-                    "Please make sure you are using a compatible TE version >= 2.7.0.dev0."
+                    "NVFP4BlockScaling requires TransformerEngine >= 2.7.0.dev0."
                 )
+            fp4_recipe = transformer_engine.common.recipe.NVFP4BlockScaling()
+        elif config.fp4_recipe == Fp4Recipe.mxfp4:
+            if not is_te_min_version("2.8.0"):
+                raise ValueError(
+                    "MXFP4BlockScaling requires TransformerEngine >= 2.8.0."
+            )
+            import os       
+            fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
+            fp4_recipe.use_hadamard = os.environ.get("NVTE_MXFP4_USE_HADAMARD", "0") == "1"
         else:
             raise ValueError(
-                """FP4 support requires TransformerEngine version >= 2.7.0.dev0
-                for NVFP4BlockScaling."""
+                f"Unsupported FP4 recipe: {config.fp4_recipe}. "
+                "Supported: nvfp4, mxfp4."
             )
         return fp4_recipe
 

--- a/primus/backends/megatron/core/fp4_utils.py
+++ b/primus/backends/megatron/core/fp4_utils.py
@@ -67,14 +67,19 @@ if HAVE_TE and HAVE_TURBO:
                 try:
                     fp4_recipe = transformer_engine.common.recipe.NVFP4BlockScaling()
                 except AttributeError:
-                    fp4_recipe_none_reason = "NVFP4BlockScaling recipe is not available in this version of Transformer Engine."
+                    fp4_recipe_none_reason = (
+                        "NVFP4BlockScaling recipe is not available in this version of Transformer Engine."
+                    )
             elif config.fp4_recipe == Fp4Recipe.mxfp4:
                 try:
                     import os
+
                     fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
                     fp4_recipe.use_hadamard = os.environ.get("NVTE_MXFP4_USE_HADAMARD", "0") == "1"
                 except AttributeError:
-                    fp4_recipe_none_reason = "MXFP4BlockScaling recipe is not available in this version of Transformer Engine."
+                    fp4_recipe_none_reason = (
+                        "MXFP4BlockScaling recipe is not available in this version of Transformer Engine."
+                    )
             else:
                 fp4_recipe_none_reason = f"Unsupported FP4 recipe: {config.fp4_recipe}."
         else:
@@ -175,7 +180,7 @@ if HAVE_TE and HAVE_TURBO:
                     fp4_context = transformer_engine.pytorch.fp8_autocast(
                         enabled=True if fp4_recipe is not None else False,
                         fp8_recipe=fp4_recipe,
-                        fp8_group=fp4_group
+                        fp8_group=fp4_group,
                     )
             else:
                 import inspect
@@ -193,13 +198,12 @@ elif HAVE_TE:
         """Return fp4 recipe."""
         if config.fp4_recipe == Fp4Recipe.nvfp4:
             if not is_te_min_version("2.7.0.dev0"):
-                raise ValueError(
-                    "NVFP4BlockScaling requires TransformerEngine >= 2.7.0.dev0."
-                )
+                raise ValueError("NVFP4BlockScaling requires TransformerEngine >= 2.7.0.dev0.")
             fp4_recipe = transformer_engine.common.recipe.NVFP4BlockScaling()
         elif config.fp4_recipe == Fp4Recipe.mxfp4:
             try:
                 import os
+
                 fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
                 fp4_recipe.use_hadamard = os.environ.get("NVTE_MXFP4_USE_HADAMARD", "0") == "1"
             except AttributeError:
@@ -207,10 +211,7 @@ elif HAVE_TE:
                     "MXFP4BlockScaling recipe is not available in this version of Transformer Engine."
                 )
         else:
-            raise ValueError(
-                f"Unsupported FP4 recipe: {config.fp4_recipe}. "
-                "Supported: nvfp4, mxfp4."
-            )
+            raise ValueError(f"Unsupported FP4 recipe: {config.fp4_recipe}. " "Supported: nvfp4, mxfp4.")
         return fp4_recipe
 
     def get_fp4_context(config: TransformerConfig, layer_no: int = -1, is_init: bool = False):

--- a/primus/backends/megatron/core/fp4_utils.py
+++ b/primus/backends/megatron/core/fp4_utils.py
@@ -129,7 +129,7 @@ if HAVE_TE and HAVE_TURBO:
             fp4_context = nullcontext()
         else:
             fp4_recipe, fp4_recipe_none_reason = get_fp4_recipe(config)
-            turbo_enabled = _primus_turbo_enabled() and not is_init
+            turbo_enabled = _primus_turbo_enabled()
 
             global WARN_ONCE
             if WARN_ONCE:
@@ -173,7 +173,9 @@ if HAVE_TE and HAVE_TURBO:
                 else:
                     # TE currently uses fp8_autocast for fp8 and fp4 quantization.
                     fp4_context = transformer_engine.pytorch.fp8_autocast(
-                        enabled=True, fp8_recipe=fp4_recipe, fp8_group=fp4_group
+                        enabled=True if fp4_recipe is not None else False,
+                        fp8_recipe=fp4_recipe,
+                        fp8_group=fp4_group
                     )
             else:
                 import inspect
@@ -196,13 +198,14 @@ elif HAVE_TE:
                 )
             fp4_recipe = transformer_engine.common.recipe.NVFP4BlockScaling()
         elif config.fp4_recipe == Fp4Recipe.mxfp4:
-            if not is_te_min_version("2.8.0"):
+            try:
+                import os
+                fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
+                fp4_recipe.use_hadamard = os.environ.get("NVTE_MXFP4_USE_HADAMARD", "0") == "1"
+            except AttributeError:
                 raise ValueError(
-                    "MXFP4BlockScaling requires TransformerEngine >= 2.8.0."
-            )
-            import os       
-            fp4_recipe = transformer_engine.common.recipe.MXFP4BlockScaling()
-            fp4_recipe.use_hadamard = os.environ.get("NVTE_MXFP4_USE_HADAMARD", "0") == "1"
+                    "MXFP4BlockScaling recipe is not available in this version of Transformer Engine."
+                )
         else:
             raise ValueError(
                 f"Unsupported FP4 recipe: {config.fp4_recipe}. "

--- a/primus/backends/megatron/patches/turbo/fp4_patches.py
+++ b/primus/backends/megatron/patches/turbo/fp4_patches.py
@@ -20,12 +20,17 @@ def _is_fp4_can_patch(ctx: PatchContext) -> bool:
     return fp4 and is_primus_turbo_can_patch(ctx)
 
 
+def _is_fp4_enabled(ctx: PatchContext) -> bool:
+    args = get_args(ctx)
+    return bool(getattr(args, "fp4", False))
+
+
 @register_patch(
     "megatron.core.enums",
     backend="megatron",
     phase="before_train",
     description="Override Megatron enums to use Primus implementation when fp4 is enabled",
-    condition=_is_fp4_can_patch,
+    condition=_is_fp4_enabled,
 )
 def patch_enums(ctx: PatchContext):
     from megatron.core import enums
@@ -43,7 +48,7 @@ def patch_enums(ctx: PatchContext):
     backend="megatron",
     phase="before_train",
     description="Override Megatron get_fp4_context to use Primus implementation when fp4 is enabled",
-    condition=_is_fp4_can_patch,
+    condition=_is_fp4_enabled,
 )
 def patch_fp4_context(ctx: PatchContext):
     """

--- a/primus/backends/megatron/training/evaluator.py
+++ b/primus/backends/megatron/training/evaluator.py
@@ -106,6 +106,10 @@ def primus_evaluate(
                         if isinstance(val, tuple) or isinstance(val, list):
                             numerator += val[0]
                             denominator += val[1]
+                        elif isinstance(val, torch.Tensor) and val.numel() == 2:
+                            # [loss, num_tokens] from pretrain_gpt loss_func (Megatron default)
+                            numerator += val[0]
+                            denominator += val[1]
                         else:
                             # legacy behavior. we average over the number of microbatches,
                             # and so the denominator is 1.

--- a/primus/configs/modules/megatron/primus_turbo.yaml
+++ b/primus/configs/modules/megatron/primus_turbo.yaml
@@ -1,6 +1,8 @@
 # ===== Global =====
 # main control flag
 enable_primus_turbo: false
+# use primus_turbo_fp4_autocast instead of TE fp8_autocast for FP4 (requires enable_primus_turbo)
+use_turbo_fp4_autocast: false
 
 # ===== Attention =====
 # operator switch


### PR DESCRIPTION
Add support for llama3.1 8b mxfp4 through TE backend.

Training loss curve comparing fp8, mxfp8 and mxfp4 following closely and converging. Used c4 dataset

<img width="1507" height="812" alt="image" src="https://github.com/user-attachments/assets/537515ad-a76e-447b-9720-757c210a7089" />

Training cmd:
`NVTE_USE_CAST_TRANSPOSE=0 NVTE_MXFP4_USE_HADAMARD=1 bash runner/primus-cli direct   -- train pretrain   --config examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml --train_iters 50 `