### PR TITLE
[Fix] pin down dependnecies for megatron

### DIFF
--- a/runner/helpers/hooks/train/pretrain/megatron/requirements-megatron.txt
+++ b/runner/helpers/hooks/train/pretrain/megatron/requirements-megatron.txt
@@ -1,4 +1,4 @@
 # Add Megatron pretrain hook private Python deps here when needed.
 # Qwen3.5 / gated-delta-net attention (Megatron core GatedDeltaNet) needs FLA.
-flash-linear-attention #~=0.4.0
-causal-conv1d #~=1.5
+flash-linear-attention~=0.4.0
+causal-conv1d~=1.5


### PR DESCRIPTION
This is causing some tests to hang due to some bug in fla 0.5.0. Applied the suggestion in the original PR to ensure the right version of dependencies were installed https://github.com/AMD-AGI/Primus/pull/709#discussion_r3167325230