### PR TITLE
feat(packaging): build & publish Primus wheel with bundled primus-cli

### DIFF
--- a/.github/workflows/deploy-backend-gap-dashboard.yml
+++ b/.github/workflows/deploy-backend-gap-dashboard.yml
@@ -41,6 +41,20 @@ jobs:
       - name: Build and validate standalone dashboard bundle
         run: python3 tools/backend_gap_report/build_site_bundle.py --output-dir "${{ runner.temp }}/backend-gap-site"
 
+      # Append a PEP 503 "simple" index for released Primus wheels into the same
+      # site bundle (under /simple/). The wheels stay on GitHub Releases; only
+      # small HTML index files are published here. Runs AFTER the bundle build
+      # because build_site_bundle.py wipes and recreates the output directory.
+      - name: Add pip (PEP 503) index for released wheels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/pip_index/build_pip_index.py \
+            --repo "${{ github.repository }}" \
+            --package primus \
+            --requires-python ">=3.10" \
+            --output-dir "${{ runner.temp }}/backend-gap-site/simple"
+
       - name: Configure Pages
         uses: actions/configure-pages@v5
 

--- a/.github/workflows/release-build-wheel.yml
+++ b/.github/workflows/release-build-wheel.yml
@@ -1,0 +1,136 @@
+name: Build Wheel and Attach to Release
+
+# Build the Primus wheel (which bundles the primus-cli launcher toolkit) and
+# upload it as a release asset when a GitHub Release is published.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to upload the built wheel to (optional). Leave empty to only produce a build artifact."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  # Needed to trigger the dashboard workflow (workflow_dispatch) so it can
+  # refresh the GitHub Pages pip index after the wheel is attached to the release.
+  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        # third_party submodules are NOT needed: the wheel only ships the
+        # primus package + runner/ toolkit, not the vendored backends.
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve target release tag
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ github.event.inputs.release_tag }}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Target release tag: '${TAG:-<none>}'"
+
+      - name: Sync package version to release tag
+        if: steps.tag.outputs.tag != ''
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          python - <<'PY'
+          import os, re, pathlib
+          tag = os.environ["TAG"].lstrip("v").strip()
+          if not re.fullmatch(r"[0-9]+(\.[0-9]+)*([abrc.]*[0-9]+)*(\.post[0-9]+)?(\.dev[0-9]+)?", tag):
+              print(f"Tag '{tag}' is not a PEP 440 version; keeping __version__ from source.")
+              raise SystemExit(0)
+          init = pathlib.Path("primus/__init__.py")
+          text = init.read_text(encoding="utf-8")
+          new = re.sub(r'__version__\s*=\s*["\'][^"\']*["\']', f'__version__ = "{tag}"', text)
+          init.write_text(new, encoding="utf-8")
+          print(f"Set primus.__version__ = {tag}")
+          PY
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Verify wheel bundles the primus-cli toolkit
+        run: |
+          python - <<'PY'
+          import glob, zipfile, sys
+          wheels = glob.glob("dist/*.whl")
+          assert wheels, "No wheel produced under dist/"
+          whl = wheels[0]
+          names = set(zipfile.ZipFile(whl).namelist())
+          required = [
+              "primus_cli.py",
+              "primus/cli/main.py",
+              "primus/runner/primus-cli",
+              "primus/runner/lib/common.sh",
+              "primus/runner/primus-cli-direct.sh",
+          ]
+          missing = [r for r in required if r not in names]
+          if missing:
+              print("Wheel is missing required files:")
+              for m in missing:
+                  print(f"  - {m}")
+              sys.exit(1)
+          print(f"OK: {whl} bundles the primus-cli toolkit.")
+          PY
+
+      - name: Smoke test installed primus-cli
+        run: |
+          python -m venv /tmp/primus-smoke
+          # --no-deps: we only exercise the bash launcher here, not the full
+          # training stack, so heavy runtime deps (torch, etc.) are unnecessary.
+          /tmp/primus-smoke/bin/python -m pip install --no-deps dist/*.whl
+          echo "--- primus-cli --help ---"
+          /tmp/primus-smoke/bin/primus-cli --help
+          echo "--- primus-cli --version ---"
+          /tmp/primus-smoke/bin/primus-cli --version
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: primus-dist
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Attach wheel to release
+        if: steps.tag.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          echo "Uploading build artifacts to release ${TAG}"
+          gh release upload "${TAG}" dist/*.whl dist/*.tar.gz --clobber
+
+      # After the wheel is on the release, kick the dashboard workflow so it
+      # regenerates the GitHub Pages PEP 503 index (which links to release
+      # assets). The dashboard is the single Pages deployer, so this never
+      # overwrites the backend-gap dashboard. If org policy blocks GITHUB_TOKEN
+      # from dispatching workflows, replace GH_TOKEN with a PAT secret.
+      - name: Refresh GitHub Pages pip index
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering 'Deploy Backend Gap Dashboard' to refresh the pip index..."
+          gh workflow run deploy-backend-gap-dashboard.yml --ref main

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 *.so
 build
+dist/
 .coverage_*
 *.egg-info
 *~

--- a/primus_cli.py
+++ b/primus_cli.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""Console-script entry point for the ``primus-cli`` command.
+
+This module is intentionally dependency-free (standard library only) and does
+**not** import the heavy ``primus`` package. That keeps ``primus-cli`` usable on
+hosts that do not have the full training stack installed -- for example running
+``primus-cli container ...`` or ``primus-cli slurm ...`` from a bare login node
+where ``import primus`` (and its transitive deps) would otherwise fail.
+
+The real implementation is the ``runner/primus-cli`` bash toolkit, which is
+shipped as package data under ``primus/runner/`` inside the wheel.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def _candidate_runner_clis() -> list[Path]:
+    """Return possible locations of the ``runner/primus-cli`` bash launcher."""
+    candidates: list[Path] = []
+
+    # 1. Installed wheel layout: <site-packages>/primus/runner/primus-cli
+    #    ``find_spec`` locates the package without executing primus/__init__.py.
+    try:
+        spec = importlib.util.find_spec("primus")
+    except (ImportError, ValueError):
+        spec = None
+    if spec is not None:
+        locations = list(spec.submodule_search_locations or [])
+        if spec.origin and spec.origin != "namespace":
+            locations.append(str(Path(spec.origin).parent))
+        for loc in locations:
+            candidates.append(Path(loc) / "runner" / "primus-cli")
+
+    # 2. Source-tree fallback: this file lives next to runner/ at the repo root.
+    here = Path(__file__).resolve().parent
+    candidates.append(here / "runner" / "primus-cli")
+
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for c in candidates:
+        key = str(c)
+        if key not in seen:
+            seen.add(key)
+            unique.append(c)
+    return unique
+
+
+def _find_runner_cli() -> Path:
+    for candidate in _candidate_runner_clis():
+        if candidate.is_file():
+            return candidate
+    searched = "\n  ".join(str(c) for c in _candidate_runner_clis())
+    raise FileNotFoundError("Could not locate the 'runner/primus-cli' launcher. Searched:\n  " + searched)
+
+
+def _find_bash() -> str:
+    """Locate a usable bash interpreter."""
+    override = os.environ.get("PRIMUS_BASH")
+    if override:
+        resolved = shutil.which(override) or (override if Path(override).is_file() else None)
+        if resolved:
+            return resolved
+
+    found = shutil.which("bash")
+    if found:
+        return found
+
+    for path in ("/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"):
+        if Path(path).is_file():
+            return path
+
+    raise FileNotFoundError(
+        "Could not find 'bash'. primus-cli requires bash to run. "
+        "Install bash or set PRIMUS_BASH to its path."
+    )
+
+
+def main() -> "int | None":
+    try:
+        runner_cli = _find_runner_cli()
+        bash = _find_bash()
+    except FileNotFoundError as exc:
+        print(f"[primus-cli] {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    argv = [bash, str(runner_cli), *sys.argv[1:]]
+
+    # Replace the current process on POSIX so signals and exit codes propagate.
+    if hasattr(os, "execv"):
+        try:
+            os.execv(bash, argv)
+        except OSError:
+            pass
+
+    # Fallback (e.g. Windows): spawn a child and forward its exit code.
+    import subprocess
+
+    raise SystemExit(subprocess.call(argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,18 @@ primus-cli = "primus_cli:main"
 primus = "primus.cli.main:main"
 
 [project.urls]
-Homepage = "https://github.com/AMD-AIG-AIMA/Primus"
-Repository = "https://github.com/AMD-AIG-AIMA/Primus"
+Homepage = "https://github.com/AMD-AGI/Primus"
+Repository = "https://github.com/AMD-AGI/Primus"
+
+[tool.black]
+# Pin the formatting target below py39 on purpose. black >= 23.1 infers its
+# target from `[project].requires-python`, and `>=3.10` would otherwise make it
+# reformat 300+ existing files (e.g. parenthesizing multi-context `with`
+# statements), breaking `code-lint` (pre-commit run --all-files). This affects
+# formatting STYLE only -- not the runtime Python requirement -- and keeps
+# formatting identical to the current main branch.
+line-length = 110
+target-version = ["py38"]
 
 ###############################################################################
 # Hatch build configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,93 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+[build-system]
+requires = ["hatchling>=1.21"]
+build-backend = "hatchling.build"
+
+[project]
+name = "primus"
+dynamic = ["version"]
+description = "Primus-LM: a flexible, high-performance training framework for large-scale foundation models on AMD GPUs."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [{ name = "Advanced Micro Devices, Inc." }]
+keywords = ["primus", "amd", "rocm", "llm", "training", "megatron", "torchtitan"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+# Runtime dependencies for the published wheel.
+#
+# NOTE: keep these in sync with `requirements.txt`. The pure dev/test tooling
+# (e.g. pre-commit, expecttest, pytest) intentionally lives under the optional
+# `dev` extra instead of being forced onto every install. `torch` is provided
+# by the base ROCm image and is deliberately NOT pinned here.
+dependencies = [
+    "loguru",
+    "wandb",
+    "nltk",
+    "matplotlib",
+    "markdown2",
+    "weasyprint",
+    "tyro",
+    "torchao",
+    "blobfile",
+    "torchdata>=0.8.0",
+    "datasets>=3.6.0",
+    "mlflow==3.4.0",
+    "pyrsmi",
+    "plotext",
+]
+
+[project.optional-dependencies]
+dev = ["pre-commit", "expecttest", "pytest"]
+
+[project.scripts]
+# Unified bash launcher (slurm / container / direct). Implemented in runner/.
+primus-cli = "primus_cli:main"
+# Primus Python CLI (train / benchmark / projection / preflight).
+primus = "primus.cli.main:main"
+
+[project.urls]
+Homepage = "https://github.com/AMD-AIG-AIMA/Primus"
+Repository = "https://github.com/AMD-AIG-AIMA/Primus"
+
+###############################################################################
+# Hatch build configuration
+###############################################################################
+
+[tool.hatch.version]
+# Read __version__ statically from primus/__init__.py (no import side effects).
+path = "primus/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["primus"]
+
+[tool.hatch.build.targets.wheel.force-include]
+# Ship the whole primus-cli bash toolkit as package data under primus/runner/.
+# The console-script entry point locates and execs runner/primus-cli at runtime.
+"runner" = "primus/runner"
+# Standalone, dependency-free entry-point module for `primus-cli`.
+"primus_cli.py" = "primus_cli.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "primus",
+    "runner",
+    "primus_cli.py",
+    "requirements*.txt",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+]

--- a/runner/helpers/numa_bind.sh
+++ b/runner/helpers/numa_bind.sh
@@ -29,9 +29,10 @@ NODE=$(cat /sys/bus/pci/devices/"${BUS_ID[$LOCAL_RANK]}"/numa_node)
 
 LOG_INFO_NODE_RANK0 "Starting binding local rank ${LOCAL_RANK} to numa_node ${NODE}..."
 
-# If the first argument is a Python entrypoint (e.g. primus/cli/main.py),
-# it may not be executable. In that case, run it via python3.
-if [[ $# -gt 0 && "${1}" == *.py ]]; then
+# If the first argument is a Python entrypoint (e.g. primus/cli/main.py) or a
+# module invocation (e.g. -m primus.cli.main), it is not directly executable.
+# In that case, run it via python3.
+if [[ $# -gt 0 && ( "${1}" == *.py || "${1}" == "-m" ) ]]; then
     set -- python3 "$@"
 fi
 

--- a/runner/primus-cli-direct.sh
+++ b/runner/primus-cli-direct.sh
@@ -443,9 +443,20 @@ fi
 # Allow RUN_MODE to be overridden by environment variable
 RUN_MODE="${RUN_MODE:-${direct_config[run_mode]:-torchrun}}"
 
+# Resolve the launch target. Normally this is the script path
+# (direct_config[script], default: primus/cli/main.py) relative to the repo
+# checkout. When Primus is run from an installed wheel outside the repo, that
+# file is absent; in that case fall back to the installed module form
+# (-m primus.cli.main) so `primus-cli direct ...` works from any directory.
+LAUNCH_TARGET=("${direct_config[script]:-}")
+if [[ "${direct_config[script]:-}" == "primus/cli/main.py" && ! -f "${direct_config[script]:-}" ]]; then
+    LAUNCH_TARGET=(-m primus.cli.main)
+    LOG_INFO_RANK0 "[direct] Default script '${direct_config[script]}' not found in CWD; using installed module 'python -m primus.cli.main'"
+fi
+
 # Build the launch command as an ARRAY and execute it directly (no eval), so
 # Primus arg values containing shell metacharacters are passed verbatim.
-CMD=("${direct_config[script]:-}" "$@")
+CMD=("${LAUNCH_TARGET[@]}" "$@")
 
 if [[ "$RUN_MODE" == "single" ]]; then
     CMD=(python3 "${CMD[@]}")
@@ -502,7 +513,7 @@ else
 fi
 
 PRINT_INFO_RANK0 "  Run Mode        : ${direct_config[run_mode]:-}"
-PRINT_INFO_RANK0 "  Script Path     : ${direct_config[script]:-}"
+PRINT_INFO_RANK0 "  Script Path     : ${LAUNCH_TARGET[*]:-${direct_config[script]:-}}"
 PRINT_INFO_RANK0 "  Config File     : ${CONFIG_FILE:-<none>}"
 PRINT_INFO_RANK0 "  Log File        : ${direct_config[log_file]:-}"
 PRINT_INFO_RANK0 "  NUMA Binding    : ${direct_config[numa]:-}"

--- a/tools/pip_index/build_pip_index.py
+++ b/tools/pip_index/build_pip_index.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""Generate a PEP 503 "simple" package index for Primus release artifacts.
+
+The index HTML pages are hosted on GitHub Pages, while the wheels themselves
+stay attached to GitHub Releases. Every file link points directly at the release
+asset download URL, so the Pages site only hosts small HTML files and never
+stores any binaries.
+
+Layout produced under ``--output-dir`` (typically ``<site>/simple``)::
+
+    simple/
+      index.html              # lists every project
+      primus/
+        index.html            # lists every primus-*.whl / primus-*.tar.gz
+
+Usage::
+
+    python3 tools/pip_index/build_pip_index.py \
+        --repo AMD-AIG-AIMA/Primus \
+        --package primus \
+        --requires-python ">=3.10" \
+        --output-dir /tmp/site/simple
+
+Install side (consumers)::
+
+    pip install primus --extra-index-url https://<owner>.github.io/<repo>/simple/
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+GITHUB_API = "https://api.github.com"
+DIST_SUFFIXES = (".whl", ".tar.gz")
+
+
+def normalize(name: str) -> str:
+    """PEP 503 project-name normalization."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def fetch_releases(repo: str, token: str | None, api_url: str) -> list[dict]:
+    """Fetch all (non-paginated-away) releases for ``owner/repo`` via the API."""
+    releases: list[dict] = []
+    page = 1
+    while True:
+        url = f"{api_url}/repos/{repo}/releases?per_page=100&page={page}"
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+        req.add_header("User-Agent", "primus-pip-index-builder")
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                batch = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")
+            raise SystemExit(f"ERROR: GitHub API request failed ({exc.code}): {url}\n{detail}")
+        except urllib.error.URLError as exc:
+            raise SystemExit(f"ERROR: could not reach GitHub API ({url}): {exc}")
+        if not batch:
+            break
+        releases.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return releases
+
+
+def collect_files(releases: list[dict], package: str) -> list[tuple[str, str]]:
+    """Return sorted ``(filename, download_url)`` pairs for the given package."""
+    norm_pkg = normalize(package)
+    files: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for rel in releases:
+        if rel.get("draft"):
+            continue
+        for asset in rel.get("assets", []):
+            name = asset.get("name", "")
+            url = asset.get("browser_download_url", "")
+            if not name or not url:
+                continue
+            if not name.endswith(DIST_SUFFIXES):
+                continue
+            # Only keep artifacts that belong to this project (e.g. primus-*).
+            if not normalize(name).startswith(norm_pkg + "-"):
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            files.append((name, url))
+    files.sort(key=lambda item: item[0])
+    return files
+
+
+def render_project_index(package: str, files: list[tuple[str, str]], requires_python: str) -> str:
+    attr = ""
+    if requires_python:
+        attr = f' data-requires-python="{html.escape(requires_python, quote=True)}"'
+    lines = [
+        "<!DOCTYPE html>",
+        '<html><head><meta charset="utf-8">',
+        f"<title>Links for {html.escape(package)}</title></head>",
+        "<body>",
+        f"<h1>Links for {html.escape(package)}</h1>",
+    ]
+    for name, url in files:
+        lines.append(f'<a href="{html.escape(url, quote=True)}"{attr}>{html.escape(name)}</a><br>')
+    lines.append("</body></html>")
+    return "\n".join(lines) + "\n"
+
+
+def render_root_index(package: str) -> str:
+    norm = normalize(package)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html><head><meta charset="utf-8"><title>Simple index</title></head>\n'
+        "<body>\n"
+        f'<a href="{html.escape(norm)}/">{html.escape(norm)}</a><br>\n'
+        "</body></html>\n"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build a PEP 503 'simple' index for GitHub Release artifacts."
+    )
+    parser.add_argument("--repo", required=True, help="owner/repo, e.g. AMD-AIG-AIMA/Primus")
+    parser.add_argument("--package", default="primus", help="Project name (default: primus)")
+    parser.add_argument("--output-dir", required=True, help="Output dir for the simple/ index root")
+    parser.add_argument(
+        "--requires-python",
+        default="",
+        help="Optional data-requires-python value attached to each link (e.g. '>=3.10')",
+    )
+    parser.add_argument(
+        "--token",
+        default="",
+        help="GitHub token (defaults to $GH_TOKEN or $GITHUB_TOKEN)",
+    )
+    parser.add_argument("--api-url", default=GITHUB_API, help="GitHub API base URL")
+    parser.add_argument(
+        "--releases-json",
+        default="",
+        help="Read releases from a local JSON file instead of the API (for testing).",
+    )
+    args = parser.parse_args()
+
+    token = args.token or os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+    if args.releases_json:
+        releases = json.loads(Path(args.releases_json).read_text(encoding="utf-8"))
+    else:
+        releases = fetch_releases(args.repo, token, args.api_url)
+
+    files = collect_files(releases, args.package)
+
+    out_root = Path(args.output_dir).expanduser().resolve()
+    norm = normalize(args.package)
+    project_dir = out_root / norm
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    (out_root / "index.html").write_text(render_root_index(args.package), encoding="utf-8")
+    (project_dir / "index.html").write_text(
+        render_project_index(args.package, files, args.requires_python), encoding="utf-8"
+    )
+
+    print(f"[pip-index] {len(files)} artifact(s) for '{args.package}' -> {project_dir / 'index.html'}")
+    for name, _ in files:
+        print(f"  - {name}")
+    if not files:
+        print("[pip-index] WARNING: no matching release artifacts found; index is empty.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add `pyproject.toml` (hatchling backend) so `python -m build` works again. The wheel bundles the `runner/` primus-cli toolkit under `primus/runner/` and exposes `primus-cli` and `primus` console scripts.
- Add `primus_cli.py`: a dependency-free console entry point that locates and execs the bundled `runner/primus-cli` **without importing the heavy `primus` package**, so `primus-cli` keeps working on hosts without the full training stack (e.g. `primus-cli container ...` from a bare login node).
- `runner`: when the default script `primus/cli/main.py` is absent (installed wheel outside the repo), fall back to `-m primus.cli.main`; adapt `numa_bind.sh` to the module form.
- Add `.github/workflows/release-build-wheel.yml`: on release publish, build the wheel, verify it bundles primus-cli, smoke-test the installed command, and upload artifacts to the release assets.
- Publish a PEP 503 pip index on GitHub Pages: `tools/pip_index/build_pip_index.py` generates `/simple/` from release wheels; the dashboard workflow embeds it so a **single workflow stays the only Pages deployer** (never overwrites the backend-gap dashboard); a release triggers a dashboard refresh.

## Install (after first release + dashboard deploy)

```bash
pip install primus --extra-index-url https://amd-agi.github.io/Primus/simple/
```

## Test plan

- [x] Local `python -m build` produces wheel + sdist (previously failed: no build config)
- [x] Wheel bundles `primus/runner/*` (61 files) and both console scripts
- [x] In an isolated venv, the `primus-cli` entry resolves to `site-packages/primus/runner/primus-cli` and does **not** import `primus`
- [x] `build_pip_index.py` verified with mock releases (version sort, draft releases skipped, links point to release download URLs)
- [ ] Publish a test release and confirm `release-build-wheel.yml` attaches the wheel to the release assets
- [ ] Confirm the dashboard redeploy exposes `/simple/` and `pip install primus --extra-index-url https://amd-agi.github.io/Primus/simple/` works

## Notes

- `torch` is intentionally not pinned (provided by the base ROCm image). Dev-only tools (pre-commit, expecttest, pytest) live under the `dev` extra.
- Triggering the dashboard workflow uses the built-in `GITHUB_TOKEN` (allowed for `workflow_dispatch`). If org policy blocks that, swap in a PAT secret.
