### PR TITLE
[Fix] unsupported `moe_use_legacy_grouped_gemm` arg in Mamba models

### DIFF
--- a/primus/backends/megatron/core/models/hybrid/hybrid_mamba_mla_layer_specs.py
+++ b/primus/backends/megatron/core/models/hybrid/hybrid_mamba_mla_layer_specs.py
@@ -52,7 +52,6 @@ moe = get_moe_module_spec(
     use_te=True,
     num_experts=8,  # Can be any positive integer (must not be None).
     moe_grouped_gemm=True,
-    moe_use_legacy_grouped_gemm=False,
 )
 
 hybrid_stack_spec = ModuleSpec(


### PR DESCRIPTION
RE: https://github.com/AMD-AGI/Primus/pull/587/changes The original PR wasn't tested after rebasing to main and not tested against the current version of Megatron. `moe_use_legacy_grouped_gemm` have been deprecated since, and would cause runtime error when passing