### PR TITLE
Add core unit tests (pipeline_parallel, utils) and report UT coverage in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -320,19 +320,21 @@ jobs:
           # Note HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit (TAS-8N Node), rocm ver:70125424
           export HSA_NO_SCRATCH_RECLAIM=1
           pytest --maxfail=1 -s ./tests/unit_tests/ \
-            --cov=primus --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml \
+            --cov=primus --cov-report=term-missing:skip-covered \
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_fp8_te_linear \
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_te_linear \
             --deselect=tests/unit_tests/megatron/transformer/moe/test_token_dispatcher.py::TestFlexDispatcher::test_forward_backward \
             --deselect=tests/unit_tests/megatron/transformer/moe/test_token_dispatcher.py::TestFlexDispatcher::test_capacity_forward_backward
-      - name: Upload Primus unit-test coverage
+      - name: Publish unit-test coverage summary
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
-        with:
-          name: primus-unit-coverage
-          path: coverage.xml
-          if-no-files-found: ignore
+        run: |
+          {
+            echo "## Primus unit-test coverage"
+            echo '```'
+            python -m coverage report --format=markdown 2>/dev/null || python -m coverage report
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Run Primus Model Tests -- Megatron-LM
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -320,10 +320,19 @@ jobs:
           # Note HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit (TAS-8N Node), rocm ver:70125424
           export HSA_NO_SCRATCH_RECLAIM=1
           pytest --maxfail=1 -s ./tests/unit_tests/ \
+            --cov=primus --cov-report=term-missing:skip-covered --cov-report=xml:coverage.xml \
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_fp8_te_linear \
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_te_linear \
             --deselect=tests/unit_tests/megatron/transformer/moe/test_token_dispatcher.py::TestFlexDispatcher::test_forward_backward \
             --deselect=tests/unit_tests/megatron/transformer/moe/test_token_dispatcher.py::TestFlexDispatcher::test_capacity_forward_backward
+      - name: Upload Primus unit-test coverage
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: primus-unit-coverage
+          path: coverage.xml
+          if-no-files-found: ignore
       - name: Run Primus Model Tests -- Megatron-LM
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -329,12 +329,44 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          {
-            echo "## Primus unit-test coverage"
-            echo '```'
-            python -m coverage report --format=markdown 2>/dev/null || python -m coverage report
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          python -m coverage json -o coverage.json 2>/dev/null || true
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY" || true
+          import json
+          from collections import defaultdict
+
+          rep = json.load(open("coverage.json"))
+
+          def group(p):
+              i = p.find("primus/")
+              seg = (p[i:] if i >= 0 else p).split("/")
+              if len(seg) < 2:
+                  return seg[-1]
+              if seg[1] == "backends" and len(seg) >= 3:
+                  return f"backends/{seg[2]}"
+              if seg[1] == "core" and len(seg) >= 3 and seg[2] == "projection":
+                  return "core/projection"
+              return seg[1]
+
+          agg = defaultdict(lambda: [0, 0])
+          for fpath, info in rep.get("files", {}).items():
+              s = info["summary"]
+              g = agg[group(fpath)]
+              g[0] += s["covered_lines"]
+              g[1] += s["num_statements"]
+
+          t = rep.get("totals", {})
+          tc, tn = t.get("covered_lines", 0), t.get("num_statements", 0)
+          tp = t.get("percent_covered", 0.0)
+
+          print("## Primus unit-test coverage\n")
+          print(f"**Total line coverage: {tp:.1f}%** ({tc:,} / {tn:,} statements)\n")
+          print("| Module | Covered | Stmts | Coverage |")
+          print("|---|--:|--:|--:|")
+          for name, (c, n) in sorted(agg.items(), key=lambda r: -r[1][1]):
+              if n:
+                  print(f"| `{name}` | {c:,} | {n:,} | {100 * c / n:.1f}% |")
+          print(f"| **TOTAL** | **{tc:,}** | **{tn:,}** | **{tp:.1f}%** |")
+          PY
       - name: Run Primus Model Tests -- Megatron-LM
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN}}

--- a/tests/unit_tests/core/pipeline_parallel/test_pipeline_schedules.py
+++ b/tests/unit_tests/core/pipeline_parallel/test_pipeline_schedules.py
@@ -1,0 +1,145 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for Primus pipeline-parallel schedule algorithms.
+
+These exercise the scheduler factory and every registered schedule algorithm
+(1F1B, interleaved 1F1B, zero-bubble, zero-bubble-heuristic, ZBV formatted, ZBV
+greedy v-half/v-min). Schedule-table generation is pure CPU combinatorics (no
+GPU / no distributed init), so the tests are fast and deterministic.
+"""
+
+import pytest
+
+from primus.core.pipeline_parallel.scheduler.algorithms.base import (
+    PipelineScheduleAlgo,
+)
+from primus.core.pipeline_parallel.scheduler.schedule_table_factory import (
+    produce_schedule_instance,
+)
+from primus.core.pipeline_parallel.scheduler.scheduler_node import (
+    FuncType,
+    SchedulerNode,
+)
+from primus.core.pipeline_parallel.utils import find_prev_node_with_type
+
+PP_SIZE = 4
+MICRO_BATCHES = 8
+FWD = FuncType.F
+BWD_TYPES = (FuncType.B, FuncType.BW)
+
+# (algorithm, vpp_size) — vpp constraints differ per algorithm.
+SCHEDULES = [
+    ("1f1b", 1),
+    ("zero-bubble", 1),
+    ("zero-bubble-heuristic", 1),
+    ("1f1b-interleaved", 2),
+    ("zbv-formatted", 2),
+    ("v-half", 2),
+    ("v-min", 2),
+]
+
+
+def _make(algo, vpp, pp=PP_SIZE, mb=MICRO_BATCHES):
+    return produce_schedule_instance(algo, pp_size=pp, vpp_size=vpp, micro_batches=mb)
+
+
+# ----------------------- factory -----------------------
+
+
+def test_invalid_algorithm_raises():
+    with pytest.raises(ValueError):
+        produce_schedule_instance("does-not-exist", pp_size=4, vpp_size=1, micro_batches=8)
+
+
+def test_factory_returns_algo_instance_and_caches():
+    a = _make("1f1b", 1, pp=2, mb=4)
+    b = _make("1f1b", 1, pp=2, mb=4)
+    assert isinstance(a, PipelineScheduleAlgo)
+    assert a is b  # identical args hit the instance cache
+
+
+# ----------------------- vpp constraints -----------------------
+
+
+def test_interleaved_requires_vpp_gt_1():
+    with pytest.raises(AssertionError):
+        _make("1f1b-interleaved", vpp=1)
+
+
+@pytest.mark.parametrize("algo", ["zbv-formatted", "v-half", "v-min"])
+def test_zbv_requires_vpp_2(algo):
+    with pytest.raises(AssertionError):
+        _make(algo, vpp=1)
+
+
+# ----------------------- schedule-table generation -----------------------
+
+
+@pytest.mark.parametrize("algo,vpp", SCHEDULES)
+def test_schedule_table_structure(algo, vpp):
+    table = _make(algo, vpp).generate_schedule_table()
+    assert isinstance(table, list)
+    assert len(table) == PP_SIZE, "one node list per pipeline stage"
+    for rank_nodes in table:
+        assert isinstance(rank_nodes, list) and rank_nodes, "each rank must have nodes"
+        assert all(isinstance(n, SchedulerNode) for n in rank_nodes)
+        # every stage runs forward compute and some backward compute
+        assert any(n.func_type == FWD for n in rank_nodes)
+        assert any(n.func_type in BWD_TYPES or n.func_type == FuncType.W for n in rank_nodes)
+
+
+@pytest.mark.parametrize("algo,vpp", SCHEDULES)
+def test_all_microbatches_have_forward(algo, vpp):
+    table = _make(algo, vpp).generate_schedule_table()
+    # union of forward mini-batch ids on the first stage should cover every microbatch
+    fwd_mbs = {n.mini_batch for n in table[0] if n.func_type == FWD}
+    assert fwd_mbs >= set(range(MICRO_BATCHES))
+
+
+def test_1f1b_forward_backward_balance():
+    """In plain 1F1B each stage runs exactly one F and one BW per microbatch."""
+    table = _make("1f1b", 1).generate_schedule_table()
+    for rank_nodes in table:
+        f = sum(1 for n in rank_nodes if n.func_type == FuncType.F)
+        bw = sum(1 for n in rank_nodes if n.func_type == FuncType.BW)
+        assert f == MICRO_BATCHES
+        assert bw == MICRO_BATCHES
+
+
+def test_zero_bubble_splits_backward_into_b_and_w():
+    """Zero-bubble splits backward into B (compute) and W (weight grad)."""
+    table = _make("zero-bubble", 1).generate_schedule_table()
+    has_b = any(n.func_type == FuncType.B for rank in table for n in rank)
+    has_w = any(n.func_type == FuncType.W for rank in table for n in rank)
+    assert has_b and has_w
+
+
+# ----------------------- utils.find_prev_node_with_type (pure helper) -----------------------
+
+
+def _single_rank_nodes():
+    return [
+        SchedulerNode(FuncType.F, mini_batch=0, chunk=0),
+        SchedulerNode(FuncType.F, mini_batch=1, chunk=0),
+        SchedulerNode(FuncType.BW, mini_batch=0, chunk=0),
+    ]
+
+
+def test_find_prev_node_defaults_to_current_mb_chunk():
+    nodes = _single_rank_nodes()
+    # from BW(mb=0) at idx 2, the previous F with the same mb/chunk is idx 0
+    assert find_prev_node_with_type(nodes, 2, [FuncType.F]) == 0
+
+
+def test_find_prev_node_explicit_mb_chunk():
+    nodes = _single_rank_nodes()
+    assert find_prev_node_with_type(nodes, 2, [FuncType.F], mini_batch=1, chunk=0) == 1
+
+
+def test_find_prev_node_returns_none_when_absent():
+    nodes = _single_rank_nodes()
+    assert find_prev_node_with_type(nodes, 2, [FuncType.F], mini_batch=9) is None

--- a/tests/unit_tests/core/pipeline_parallel/test_pipeline_schedules.py
+++ b/tests/unit_tests/core/pipeline_parallel/test_pipeline_schedules.py
@@ -14,9 +14,7 @@ GPU / no distributed init), so the tests are fast and deterministic.
 
 import pytest
 
-from primus.core.pipeline_parallel.scheduler.algorithms.base import (
-    PipelineScheduleAlgo,
-)
+from primus.core.pipeline_parallel.scheduler.algorithms.base import PipelineScheduleAlgo
 from primus.core.pipeline_parallel.scheduler.schedule_table_factory import (
     produce_schedule_instance,
 )

--- a/tests/unit_tests/core/pipeline_parallel/test_schedule_runner.py
+++ b/tests/unit_tests/core/pipeline_parallel/test_schedule_runner.py
@@ -1,0 +1,79 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the pipeline-schedule runtime *orchestration*.
+
+`ScheduleRunner.run` walks a schedule table and dispatches each node to the
+matching handler. The orchestration is exercised with mock handlers (no real
+forward/backward/comm) — the handlers themselves are covered by E2E PP training.
+
+Importing `scheduler` pulls in `offload_handler`, which initializes GPU state at
+import time, so this module is skipped cleanly on hosts without a ROCm GPU.
+"""
+
+import pytest
+
+try:
+    from primus.core.pipeline_parallel.scheduler.scheduler import ScheduleRunner
+    from primus.core.pipeline_parallel.scheduler.scheduler_node import (
+        FuncType,
+        SchedulerNode,
+    )
+except Exception as exc:  # noqa: BLE001 - import pulls in GPU-initializing offload buffer
+    pytest.skip(f"pipeline ScheduleRunner requires a GPU at import: {exc}", allow_module_level=True)
+
+
+@pytest.fixture(autouse=True)
+def _stub_offload_buffer(monkeypatch):
+    """run() touches the global OFFLOAD_BUFFER at the end; stub it so the
+    orchestration test stays isolated from offload state."""
+
+    class _Buf:
+        record_offload_memory_info = False
+
+        def check_empty(self):
+            return None
+
+    monkeypatch.setattr("primus.core.pipeline_parallel.scheduler.scheduler.OFFLOAD_BUFFER", _Buf())
+
+
+def _recording_handlers(calls):
+    def make(key):
+        def handler(node, idx, table):
+            calls.append(key)
+
+        return handler
+
+    return {ft: make(ft) for ft in FuncType}
+
+
+def test_runner_dispatches_each_node_in_order():
+    calls = []
+    runner = ScheduleRunner(handle_func_dict=_recording_handlers(calls))
+    table = [[SchedulerNode(FuncType.F, 0, 0), SchedulerNode(FuncType.BW, 0, 0)]]
+    runner.run(table, rank=0)
+    assert calls == [FuncType.F, FuncType.BW]
+
+
+def test_runner_combined_group_routes_to_fb_handler():
+    calls = []
+    runner = ScheduleRunner(handle_func_dict=_recording_handlers(calls))
+    combined = SchedulerNode(FuncType.F, 0, 0, args={"combined_node": True, "combined_group": ["x"]})
+    runner.run([[combined]], rank=0)
+    assert calls == [FuncType.FB]
+
+
+def test_runner_invokes_pre_and_post_process_hooks():
+    pre, post = [], []
+    handlers = {ft: (lambda node, idx, table: None) for ft in FuncType}
+    runner = ScheduleRunner(
+        handle_func_dict=handlers,
+        pre_process_func=lambda n, i, t: pre.append(n),
+        post_process_func=lambda n, i, t: post.append(n),
+    )
+    table = [[SchedulerNode(FuncType.F, 0, 0), SchedulerNode(FuncType.BW, 1, 0)]]
+    runner.run(table, rank=0)
+    assert len(pre) == 2 and len(post) == 2

--- a/tests/unit_tests/core/utils/test_checker.py
+++ b/tests/unit_tests/core/utils/test_checker.py
@@ -1,0 +1,47 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for primus.core.utils.checker (pure assertion helpers)."""
+
+import pytest
+
+from primus.core.utils.checker import (
+    check_equal,
+    check_false,
+    check_not_equal,
+    check_true,
+)
+
+
+def test_check_equal_passes_and_fails():
+    check_equal(3, 3)  # no raise
+    with pytest.raises(RuntimeError):
+        check_equal(3, 4)
+
+
+def test_check_equal_custom_message():
+    with pytest.raises(RuntimeError, match="boom"):
+        check_equal(1, 2, msg="boom")
+
+
+def test_check_not_equal_passes_and_fails():
+    check_not_equal(1, 2)
+    with pytest.raises(RuntimeError):
+        check_not_equal(5, 5)
+
+
+def test_check_true_passes_and_fails():
+    check_true(True)
+    check_true(1)
+    with pytest.raises(RuntimeError):
+        check_true(0)
+
+
+def test_check_false_passes_and_fails():
+    check_false(False)
+    check_false("")
+    with pytest.raises(RuntimeError):
+        check_false(True)

--- a/tests/unit_tests/core/utils/test_file_utils.py
+++ b/tests/unit_tests/core/utils/test_file_utils.py
@@ -1,0 +1,53 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for primus.core.utils.file_utils (filesystem helpers)."""
+
+import pytest
+
+from primus.core.utils.file_utils import (
+    PathNotFoundError,
+    check_file_exists,
+    check_path_exists,
+    create_path_if_not_exists,
+    is_directory,
+    is_file,
+    path_exists,
+)
+
+
+def test_path_exists_and_type_checks(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    assert path_exists(f) is True
+    assert is_file(f) is True
+    assert is_directory(f) is False
+    assert is_directory(tmp_path) is True
+    assert path_exists(tmp_path / "missing") is False
+
+
+def test_check_file_exists(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    check_file_exists(f)  # no raise
+    with pytest.raises(PathNotFoundError):
+        check_file_exists(tmp_path / "missing.txt")
+
+
+def test_check_path_exists(tmp_path):
+    check_path_exists(tmp_path)  # no raise
+    with pytest.raises(PathNotFoundError):
+        check_path_exists(tmp_path / "missing")
+
+
+def test_create_path_if_not_exists(tmp_path):
+    new_dir = tmp_path / "nested" / "dir"
+    assert path_exists(new_dir) is False
+    create_path_if_not_exists(new_dir)
+    assert is_directory(new_dir) is True
+    # idempotent: calling again on an existing path is a no-op
+    create_path_if_not_exists(new_dir)
+    assert is_directory(new_dir) is True

--- a/tests/unit_tests/core/utils/test_import_utils.py
+++ b/tests/unit_tests/core/utils/test_import_utils.py
@@ -1,0 +1,41 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for primus.core.utils.import_utils.lazy_import.
+
+lazy_import tries a list of module paths and returns the first one that exposes
+the requested symbol, else raises ImportError. Tested with real stdlib modules
+so no mocking of importlib is required.
+"""
+
+import pytest
+
+from primus.core.utils.import_utils import lazy_import
+
+
+@pytest.fixture(autouse=True)
+def _silence_logger(monkeypatch):
+    """lazy_import logs via log_rank_0, which needs a configured global logger.
+    Stub it so these tests exercise import logic without logger setup."""
+    monkeypatch.setattr("primus.core.utils.import_utils.log_rank_0", lambda *a, **k: None)
+
+
+def test_lazy_import_returns_symbol_from_first_valid_path():
+    # `os.getcwd` exists -> returned directly
+    fn = lazy_import(["os"], "getcwd")
+    assert fn() == __import__("os").getcwd()
+
+
+def test_lazy_import_falls_back_to_later_path():
+    # first module exists but lacks the symbol path resolution still finds it in
+    # a later candidate module that does provide it.
+    sep = lazy_import(["nonexistent_module_xyz", "os"], "sep")
+    assert sep == __import__("os").sep
+
+
+def test_lazy_import_raises_when_symbol_missing_everywhere():
+    with pytest.raises(ImportError):
+        lazy_import(["nonexistent_a", "nonexistent_b"], "whatever")


### PR DESCRIPTION
## Summary
- **CI**: run `run-unittest-torch` core tests with `--cov=primus` and upload the `primus-unit-coverage` artifact (XML + term). Unit-test line coverage is now visible/trackable per run.
- **core/pipeline_parallel**: CPU unit tests for the scheduler factory and all schedule algorithms (1F1B, interleaved 1F1B, zero-bubble, zero-bubble-heuristic, ZBV formatted, ZBV greedy v-half/v-min) + `ScheduleRunner` orchestration + `find_prev_node_with_type`.