### PR TITLE
refactor(turbo): rename deprecated turbo flags and hard-assert on rem…

### DIFF
--- a/examples/customer_package/run_qwen3_235b_a22b_pretrain_mi355x.sh
+++ b/examples/customer_package/run_qwen3_235b_a22b_pretrain_mi355x.sh
@@ -108,7 +108,7 @@ for feature in "${MoE_Features[@]}"; do
         ;;
     2)
         ensure_primus_turbo
-        FEATURE_ARGS+=("--use_turbo_grouped_mlp" "True")
+        FEATURE_ARGS+=("--use_turbo_grouped_gemm" "True")
         ;;
     3)
         FEATURE_ARGS+=("--cross_entropy_fusion_impl" "te")

--- a/examples/customer_package/run_qwen3_30b_a3b_pretrain_mi355x.sh
+++ b/examples/customer_package/run_qwen3_30b_a3b_pretrain_mi355x.sh
@@ -102,7 +102,7 @@ for feature in "${MoE_Features[@]}"; do
         ;;
     2)
         ensure_primus_turbo
-        FEATURE_ARGS+=("--use_turbo_grouped_mlp" "True")
+        FEATURE_ARGS+=("--use_turbo_grouped_gemm" "True")
         ;;
     3)
         FEATURE_ARGS+=("--cross_entropy_fusion_impl" "te")

--- a/examples/megatron/configs/MI300X/deepseek_v2-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/deepseek_v2-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/deepseek_v2-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/deepseek_v2-FP8-pretrain.yaml
@@ -77,7 +77,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/deepseek_v2_lite-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/deepseek_v2_lite-BF16-pretrain.yaml
@@ -72,7 +72,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/deepseek_v2_lite-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/deepseek_v2_lite-FP8-pretrain.yaml
@@ -72,7 +72,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/deepseek_v3-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/deepseek_v3-BF16-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/deepseek_v3-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/deepseek_v3-FP8-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/gpt_oss_20B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/gpt_oss_20B-BF16-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/gpt_oss_20B-FP8-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/llama2_13B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama2_13B-BF16-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI300X/llama2_13B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama2_13B-FP8-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI300X/llama2_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama2_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama2_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama2_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI300X/llama2_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama2_7B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml
@@ -69,7 +69,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3.1_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.1_8B-FP8-pretrain.yaml
@@ -69,7 +69,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3.2_1B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.2_1B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3.2_1B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.2_1B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3.2_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.2_3B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3.2_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.2_3B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3.3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.3_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3.3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3.3_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3_8B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama3_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama3_8B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/llama4_17B128E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama4_17B128E-BF16-pretrain.yaml
@@ -71,8 +71,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI300X/llama4_17B128E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama4_17B128E-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI300X/llama4_17B16E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama4_17B16E-BF16-pretrain.yaml
@@ -71,8 +71,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI300X/llama4_17B16E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/llama4_17B16E-FP8-pretrain.yaml
@@ -70,8 +70,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI300X/mamba_370M-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/mamba_370M-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo - may need to disable for Mamba if not supported
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "native"

--- a/examples/megatron/configs/MI300X/qwen2.5_14B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_14B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_14B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_14B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_32B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_32B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_32B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_32B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_3B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_3B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_72B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_72B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_72B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_72B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_7B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen2.5_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen2.5_7B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI300X/qwen3_235B_A22B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen3_235B_A22B-BF16-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/qwen3_235B_A22B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen3_235B_A22B-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/qwen3_30B_A3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen3_30B_A3B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/qwen3_30B_A3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen3_30B_A3B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/qwen3_5_35B_A3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen3_5_35B_A3B-BF16-pretrain.yaml
@@ -75,7 +75,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI300X/qwen3_5_35B_A3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI300X/qwen3_5_35B_A3B-FP8-pretrain.yaml
@@ -75,7 +75,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/deepseek_v2-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/deepseek_v2-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/deepseek_v2-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/deepseek_v2-FP8-pretrain.yaml
@@ -77,7 +77,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/deepseek_v2_lite-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/deepseek_v2_lite-BF16-pretrain.yaml
@@ -73,7 +73,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/deepseek_v2_lite-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/deepseek_v2_lite-FP8-pretrain.yaml
@@ -72,7 +72,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/deepseek_v3-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/deepseek_v3-BF16-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/deepseek_v3-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/deepseek_v3-FP8-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/gpt_oss_20B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/gpt_oss_20B-BF16-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/gpt_oss_20B-FP8-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/llama2_13B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama2_13B-BF16-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI325X/llama2_13B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama2_13B-FP8-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI325X/llama2_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama2_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama2_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama2_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama2_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama2_7B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI325X/llama2_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama2_7B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI325X/llama3.1_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.1_8B-BF16-pretrain.yaml
@@ -69,7 +69,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3.1_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.1_8B-FP8-pretrain.yaml
@@ -69,7 +69,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3.2_1B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.2_1B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3.2_1B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.2_1B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3.2_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.2_3B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3.2_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.2_3B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3.3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.3_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3.3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3.3_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3_8B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama3_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama3_8B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/llama4_17B128E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama4_17B128E-BF16-pretrain.yaml
@@ -71,8 +71,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI325X/llama4_17B128E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama4_17B128E-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI325X/llama4_17B16E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama4_17B16E-BF16-pretrain.yaml
@@ -71,8 +71,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI325X/llama4_17B16E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/llama4_17B16E-FP8-pretrain.yaml
@@ -70,8 +70,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI325X/mamba_370M-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/mamba_370M-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo - may need to disable for Mamba if not supported
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "native"

--- a/examples/megatron/configs/MI325X/qwen2.5_14B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_14B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_14B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_14B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_32B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_32B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_32B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_32B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_3B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_3B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_72B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_72B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_72B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_72B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_7B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen2.5_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen2.5_7B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI325X/qwen3_235B_A22B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen3_235B_A22B-BF16-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/qwen3_235B_A22B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen3_235B_A22B-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/qwen3_30B_A3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen3_30B_A3B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI325X/qwen3_30B_A3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/qwen3_30B_A3B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/deepseek_v2-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v2-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/deepseek_v2-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v2-FP8-pretrain.yaml
@@ -77,7 +77,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-pretrain.yaml
@@ -73,7 +73,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-sft-packed-bridge_aligned.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-sft-packed-bridge_aligned.yaml
@@ -244,7 +244,7 @@ modules:
       # on both sides.
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false
       use_turbo_deepep: false
       moe_shared_expert_overlap: false

--- a/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-sft-packed.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-sft-packed.yaml
@@ -168,7 +168,7 @@ modules:
       # comparison stays clean.
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-sft.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-sft.yaml
@@ -96,7 +96,7 @@ modules:
       # Turbo optimizations
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/deepseek_v2_lite-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v2_lite-FP8-pretrain.yaml
@@ -72,7 +72,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/deepseek_v3-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v3-BF16-pretrain.yaml
@@ -89,7 +89,7 @@ modules:
 
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: true
 
       # deepep

--- a/examples/megatron/configs/MI355X/deepseek_v3-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v3-FP8-pretrain.yaml
@@ -89,7 +89,7 @@ modules:
 
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: true
 
       # deepep

--- a/examples/megatron/configs/MI355X/glm5-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/glm5-BF16-pretrain.yaml
@@ -84,7 +84,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: true
 
       # deepep

--- a/examples/megatron/configs/MI355X/glm5-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/glm5-FP8-pretrain.yaml
@@ -82,7 +82,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: true
 
       # deepep

--- a/examples/megatron/configs/MI355X/gpt_oss_120B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gpt_oss_120B-BF16-pretrain.yaml
@@ -27,7 +27,7 @@ modules:
 
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Sink attention (PR 208) - GPT-OSS style learned sinks
       # Reference: gpt-oss/gpt_oss/triton/attention.py
@@ -117,7 +117,7 @@ modules:
       # fp8: hybrid
       # enable_primus_turbo: true
       # use_turbo_attention: true
-      # use_turbo_grouped_mlp: false
+      # use_turbo_grouped_gemm: false
       # enable_primus_turbo: false
       # enable_turbo_attention_float8 : false
       # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/MI355X/gpt_oss_120B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gpt_oss_120B-FP8-pretrain.yaml
@@ -27,7 +27,7 @@ modules:
 
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Sink attention (PR 208) - GPT-OSS style learned sinks
       # Reference: gpt-oss/gpt_oss/triton/attention.py
@@ -116,7 +116,7 @@ modules:
       fp8: hybrid
       # enable_primus_turbo: true
       # use_turbo_attention: true
-      # use_turbo_grouped_mlp: false
+      # use_turbo_grouped_gemm: false
       # enable_primus_turbo: false
       # enable_turbo_attention_float8 : false
       # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/MI355X/gpt_oss_20B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gpt_oss_20B-BF16-pretrain.yaml
@@ -27,7 +27,7 @@ modules:
 
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Sink attention (PR 208) - GPT-OSS style learned sinks
       # Reference: gpt-oss/gpt_oss/triton/attention.py
@@ -110,7 +110,7 @@ modules:
       # fp8: hybrid
       # enable_primus_turbo: true
       # use_turbo_attention: true
-      # use_turbo_grouped_mlp: false
+      # use_turbo_grouped_gemm: false
       # enable_primus_turbo: false
       # enable_turbo_attention_float8 : false
       # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-pretrain.yaml
@@ -27,7 +27,7 @@ modules:
 
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Sink attention (PR 208) - GPT-OSS style learned sinks
       # Reference: gpt-oss/gpt_oss/triton/attention.py
@@ -110,7 +110,7 @@ modules:
       fp8: hybrid
       # enable_primus_turbo: true
       # use_turbo_attention: true
-      # use_turbo_grouped_mlp: false
+      # use_turbo_grouped_gemm: false
       # enable_primus_turbo: false
       # enable_turbo_attention_float8 : false
       # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/MI355X/kimi_k2-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/kimi_k2-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/kimi_k2-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/kimi_k2-FP8-pretrain.yaml
@@ -73,7 +73,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/lfm2_8B_A1B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/lfm2_8B_A1B-BF16-pretrain.yaml
@@ -81,7 +81,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/lfm2_8B_A1B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/lfm2_8B_A1B-FP8-pretrain.yaml
@@ -81,7 +81,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true
@@ -104,7 +104,7 @@ modules:
       fp8_recipe: delayed # 'tensorwise', 'delayed', 'mxfp8', 'blockwise', 'custom'
       # enable_primus_turbo: true
       # use_turbo_attention: true
-      # use_turbo_grouped_mlp: false
+      # use_turbo_grouped_gemm: false
       # enable_primus_turbo: false
       # enable_turbo_attention_float8 : false
       # enable_turbo_gemm_float8 : false

--- a/examples/megatron/configs/MI355X/llama2_13B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama2_13B-BF16-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI355X/llama2_13B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama2_13B-FP8-pretrain.yaml
@@ -76,7 +76,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI355X/llama2_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama2_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama2_70B-BF16-sft-packed-bridge_aligned.yaml
+++ b/examples/megatron/configs/MI355X/llama2_70B-BF16-sft-packed-bridge_aligned.yaml
@@ -250,7 +250,7 @@ modules:
       # both sides.
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false
 
       # ---------- Cross-entropy fusion (ALIGN WITH BRIDGE RECIPE) ----------

--- a/examples/megatron/configs/MI355X/llama2_70B-BF16-sft-packed-mlperf_aligned.yaml
+++ b/examples/megatron/configs/MI355X/llama2_70B-BF16-sft-packed-mlperf_aligned.yaml
@@ -248,7 +248,7 @@ modules:
       # ============================================================
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false
 
       # ============================================================

--- a/examples/megatron/configs/MI355X/llama2_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama2_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama2_70B-FP8-sft-packed-perf.yaml
+++ b/examples/megatron/configs/MI355X/llama2_70B-FP8-sft-packed-perf.yaml
@@ -148,7 +148,7 @@ modules:
       # =====================================================================
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false
 
       # ---------- Cross-entropy fusion ----

--- a/examples/megatron/configs/MI355X/llama2_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama2_7B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI355X/llama2_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama2_7B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # use_torch_fsdp2: true
       # use_distributed_optimizer: false

--- a/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
@@ -111,7 +111,7 @@ modules:
       enable_primus_turbo: true
       use_turbo_attention: true
       use_turbo_fp4_autocast: false                 # TE mxfp4 recipe should set it to false
-      use_turbo_parallel_linear: false              # can't use together with delayed recipe
-      use_turbo_grouped_mlp: false
+      use_turbo_gemm: false              # can't use together with delayed recipe
+      use_turbo_grouped_gemm: false
       moe_use_fused_router_with_aux_score: false
       enable_turbo_attention_float8 : false

--- a/examples/megatron/configs/MI355X/llama3.1_8B-MXFP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.1_8B-MXFP8-pretrain.yaml
@@ -111,7 +111,7 @@ modules:
       # --- Primus Turbo Config ---
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_parallel_linear: true              # can't use together with fp8 delayed recipe
-      use_turbo_grouped_mlp: false
+      use_turbo_gemm: true              # can't use together with fp8 delayed recipe
+      use_turbo_grouped_gemm: false
       moe_use_fused_router_with_aux_score: false
       enable_turbo_attention_float8 : false

--- a/examples/megatron/configs/MI355X/llama3.2_1B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.2_1B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3.2_1B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.2_1B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3.2_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.2_3B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3.2_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.2_3B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3.3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.3_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3.3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.3_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3_70B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3_70B-BF16-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3_70B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3_70B-FP8-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3_8B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3_8B-BF16-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama3_8B-BF16-sft-packed-bridge_aligned.yaml
+++ b/examples/megatron/configs/MI355X/llama3_8B-BF16-sft-packed-bridge_aligned.yaml
@@ -150,7 +150,7 @@ modules:
       # Disabling these on Native side keeps the kernel set identical.
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false
 
       # Bridge llama3_8b_peft_config explicitly disables CE fusion:

--- a/examples/megatron/configs/MI355X/llama3_8B-BF16-sft-packed-squad.yaml
+++ b/examples/megatron/configs/MI355X/llama3_8B-BF16-sft-packed-squad.yaml
@@ -96,7 +96,7 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false
 
 

--- a/examples/megatron/configs/MI355X/llama3_8B-BF16-sft-packed.yaml
+++ b/examples/megatron/configs/MI355X/llama3_8B-BF16-sft-packed.yaml
@@ -109,7 +109,7 @@ modules:
       # config; flipping it on here would make the apples-to-apples comparison
       # noisy (different attention kernel selection).
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       eval_iters: 10
 

--- a/examples/megatron/configs/MI355X/llama3_8B-BF16-sft.yaml
+++ b/examples/megatron/configs/MI355X/llama3_8B-BF16-sft.yaml
@@ -92,7 +92,7 @@ modules:
       # Turbo optimizations
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Validation
       eval_iters: 10

--- a/examples/megatron/configs/MI355X/llama3_8B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3_8B-FP8-pretrain.yaml
@@ -70,7 +70,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/llama4_17B128E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama4_17B128E-BF16-pretrain.yaml
@@ -71,8 +71,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI355X/llama4_17B128E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama4_17B128E-FP8-pretrain.yaml
@@ -70,8 +70,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI355X/llama4_17B16E-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama4_17B16E-BF16-pretrain.yaml
@@ -71,8 +71,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI355X/llama4_17B16E-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama4_17B16E-FP8-pretrain.yaml
@@ -70,8 +70,8 @@ modules:
 
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       enable_turbo_attention_float8 : false
 
       # recompute

--- a/examples/megatron/configs/MI355X/mamba_370M-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/mamba_370M-pretrain.yaml
@@ -74,7 +74,7 @@ modules:
       # Turbo - may need to disable for Mamba if not supported
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       # cross_entropy_fusion_impl: "native"

--- a/examples/megatron/configs/MI355X/minimax_m2.5-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/minimax_m2.5-BF16-pretrain.yaml
@@ -82,7 +82,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: true
 
       # deepep

--- a/examples/megatron/configs/MI355X/minimax_m2.5-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/minimax_m2.5-FP8-pretrain.yaml
@@ -81,7 +81,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: true
 
       # deepep

--- a/examples/megatron/configs/MI355X/mixtral_8x22B_v0.1-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/mixtral_8x22B_v0.1-BF16-pretrain.yaml
@@ -79,4 +79,4 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false

--- a/examples/megatron/configs/MI355X/mixtral_8x22B_v0.1-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/mixtral_8x22B_v0.1-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # enable fp8 training
       fp8: hybrid

--- a/examples/megatron/configs/MI355X/mixtral_8x7B_v0.1-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/mixtral_8x7B_v0.1-BF16-pretrain.yaml
@@ -74,4 +74,4 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false

--- a/examples/megatron/configs/MI355X/mixtral_8x7B_v0.1-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/mixtral_8x7B_v0.1-FP8-pretrain.yaml
@@ -73,7 +73,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # enable fp8 training
       fp8: hybrid

--- a/examples/megatron/configs/MI355X/qwen2.5_14B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_14B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_14B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_14B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_32B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_32B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_32B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_32B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_3B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_3B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_72B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_72B-BF16-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_72B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_72B-FP8-pretrain.yaml
@@ -78,7 +78,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_7B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_7B-BF16-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen2.5_7B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_7B-FP8-pretrain.yaml
@@ -71,7 +71,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"

--- a/examples/megatron/configs/MI355X/qwen3_235B_A22B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_235B_A22B-BF16-pretrain.yaml
@@ -93,7 +93,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/qwen3_235B_A22B-BF16-sft.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_235B_A22B-BF16-sft.yaml
@@ -84,7 +84,7 @@ modules:
       # Turbo optimizations
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/qwen3_235B_A22B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_235B_A22B-FP8-pretrain.yaml
@@ -93,7 +93,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/qwen3_235B_A22B_4layer-BF16-sft.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_235B_A22B_4layer-BF16-sft.yaml
@@ -71,7 +71,7 @@ modules:
 
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
 
       use_turbo_deepep: true
       moe_shared_expert_overlap: false

--- a/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-pretrain.yaml
@@ -83,7 +83,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false # bug
 
       # deepep

--- a/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-sft-packed-bridge_aligned.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-sft-packed-bridge_aligned.yaml
@@ -273,7 +273,7 @@ modules:
       # flag flips.
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false
       # CRITICAL: disable ROCm-DeepEP fast path. This is the dominant
       # source of the Bridge-vs-Native gap on the production yaml --

--- a/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-sft-packed.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-sft-packed.yaml
@@ -195,7 +195,7 @@ modules:
       # use_turbo_attention currently has a bug on Qwen3 GQA path; pretrain
       # already disables it. Will re-enable once primus-turbo lands the fix.
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false   # bug; pretrain disables
 
       # ---- DeepEP -------------------------------------------------------

--- a/examples/megatron/configs/MI355X/qwen3_30B_A3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_30B_A3B-FP8-pretrain.yaml
@@ -83,7 +83,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false
       use_turbo_rms_norm: false # bug
 
       # deepep

--- a/examples/megatron/configs/MI355X/qwen3_5_35B_A3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_5_35B_A3B-BF16-pretrain.yaml
@@ -75,7 +75,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron/configs/MI355X/qwen3_5_35B_A3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_5_35B_A3B-FP8-pretrain.yaml
@@ -75,7 +75,7 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
+      use_turbo_grouped_gemm: true
 
       # deepep
       use_turbo_deepep: true

--- a/examples/megatron_bridge/configs/MI300X/mamba_370M_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI300X/mamba_370M_sft_posttrain.yaml
@@ -54,4 +54,4 @@ modules:
       # Turbo - disabled for Mamba (not supported)
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false

--- a/examples/megatron_bridge/configs/MI300X/zebra_llama_1B_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI300X/zebra_llama_1B_sft_posttrain.yaml
@@ -54,4 +54,4 @@ modules:
       # Turbo - disabled for hybrid Mamba+MLA (not supported)
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false

--- a/examples/megatron_bridge/configs/MI300X/zebra_llama_3B_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI300X/zebra_llama_3B_sft_posttrain.yaml
@@ -54,4 +54,4 @@ modules:
       # Turbo - disabled for hybrid Mamba+MLA (not supported)
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false

--- a/examples/megatron_bridge/configs/MI300X/zebra_llama_8B_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI300X/zebra_llama_8B_sft_posttrain.yaml
@@ -54,4 +54,4 @@ modules:
       # Turbo - disabled for hybrid Mamba+MLA (not supported)
       enable_primus_turbo: false
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
+      use_turbo_grouped_gemm: false

--- a/examples/moe_package/run_deepseek_v2_lite_pretrain_mi355x.sh
+++ b/examples/moe_package/run_deepseek_v2_lite_pretrain_mi355x.sh
@@ -98,7 +98,7 @@ for feature in "${MoE_Features[@]}"; do
         ;;
     2)
         ensure_primus_turbo
-        FEATURE_ARGS+=("--use_turbo_grouped_mlp" "True")
+        FEATURE_ARGS+=("--use_turbo_grouped_gemm" "True")
         ;;
     3)
         FEATURE_ARGS+=("--cross_entropy_fusion_impl" "te")

--- a/examples/moe_package/run_deepseek_v2_pretrain_mi355x.sh
+++ b/examples/moe_package/run_deepseek_v2_pretrain_mi355x.sh
@@ -101,7 +101,7 @@ for feature in "${MoE_Features[@]}"; do
         ;;
     2)
         ensure_primus_turbo
-        FEATURE_ARGS+=("--use_turbo_grouped_mlp" "True")
+        FEATURE_ARGS+=("--use_turbo_grouped_gemm" "True")
         ;;
     3)
         FEATURE_ARGS+=("--cross_entropy_fusion_impl" "te")

--- a/examples/moe_package/run_deepseek_v3_4layers_proxy_pretrain_mi355x.sh
+++ b/examples/moe_package/run_deepseek_v3_4layers_proxy_pretrain_mi355x.sh
@@ -44,7 +44,7 @@ export PROFILE=False
 export TURBO_ATTENTION=${TURBO_ATTENTION:-True}
 export TURBO_DEEPEEP=${TURBO_DEEPEEP:-True}
 export LEGACY_GG=${LEGACY_GG:-True}
-export TURBO_GROUPED_MLP=${TURBO_GROUPED_MLP:-True}
+export TURBO_GROUPED_GEMM=${TURBO_GROUPED_GEMM:-True}
 export PRIMUS_DETERMINISTIC=0
 export PRIMUS_TURBO_DEEPEP_TIMEOUT=600
 
@@ -59,7 +59,7 @@ export EXP=examples/megatron/configs/MI355X/deepseek_v3-${PRETRAIN_TYPE}-pretrai
 export PRIMUS_TEAM=amd
 PRIMUS_USER="tas-$(date +%Y%m%d)"
 export PRIMUS_USER
-export PRIMUS_EXP_NAME=debug_4layers-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_MLP
+export PRIMUS_EXP_NAME=debug_4layers-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_GEMM
 
 
 mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
@@ -70,7 +70,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --micro_batch_size $MBS \
   --global_batch_size $GBS \
   --use_turbo_deepep "$TURBO_DEEPEEP" \
-  --use_turbo_grouped_mlp "$TURBO_GROUPED_MLP" \
+  --use_turbo_grouped_gemm "$TURBO_GROUPED_GEMM" \
   --moe_use_legacy_grouped_gemm "$LEGACY_GG" \
   --pipeline_model_parallel_size $PRIMUS_PP \
   --expert_model_parallel_size $PRIMUS_EP \

--- a/examples/moe_package/run_deepseek_v3_pretrain_mi355x.sh
+++ b/examples/moe_package/run_deepseek_v3_pretrain_mi355x.sh
@@ -31,7 +31,7 @@ export PROFILE=False
 export TURBO_ATTENTION=${TURBO_ATTENTION:-False}
 export TURBO_DEEPEEP=${TURBO_DEEPEEP:-True}
 export LEGACY_GG=${LEGACY_GG:-True}
-export TURBO_GROUPED_MLP=${TURBO_GROUPED_MLP:-False}
+export TURBO_GROUPED_GEMM=${TURBO_GROUPED_GEMM:-False}
 export TURBO_RMS_NORM=${TURBO_RMS_NORM:-True}
 export APPLY_ROPE_FUSION=True
 export HSA_NO_SCRATCH_RECLAIM=1
@@ -87,7 +87,7 @@ export PRIMUS_TEAM
 PRIMUS_USER="${WORKLOAD_ID:-tas}"
 export PRIMUS_USER
 export PRIMUS_TOKENIZED_DATA_PATH=/shared_aig/c4/tokenized/c4_en_train_text_document # this is the tokenized data path for the training
-export PRIMUS_EXP_NAME=dsv3-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_MLP-turbodeepep_$TURBO_DEEPEEP-turboattn_$TURBO_ATTENTION-autotune_$PRIMUS_TURBO_AUTO_TUNE
+export PRIMUS_EXP_NAME=dsv3-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_GEMM-turbodeepep_$TURBO_DEEPEEP-turboattn_$TURBO_ATTENTION-autotune_$PRIMUS_TURBO_AUTO_TUNE
 
 if [ -n "$DUMP_PP_DATA" ]; then
   export DUMP_PP_DIR=output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME/pp_data
@@ -111,7 +111,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --global_batch_size "$GBS" \
   --use_turbo_attention "$TURBO_ATTENTION" \
   --use_turbo_deepep "$TURBO_DEEPEEP" \
-  --use_turbo_grouped_mlp "$TURBO_GROUPED_MLP" \
+  --use_turbo_grouped_gemm "$TURBO_GROUPED_GEMM" \
   --use_turbo_rms_norm "$TURBO_RMS_NORM" \
   --lr 2.2e-4 \
   --min_lr 2.2e-5 \

--- a/examples/moe_package/run_glm5_4layers_proxy.sh
+++ b/examples/moe_package/run_glm5_4layers_proxy.sh
@@ -42,7 +42,7 @@ export PROFILE=False
 export TURBO_ATTENTION=${TURBO_ATTENTION:-True}
 export TURBO_DEEPEEP=${TURBO_DEEPEEP:-True}
 export LEGACY_GG=${LEGACY_GG:-True}
-export TURBO_GROUPED_MLP=${TURBO_GROUPED_MLP:-True}
+export TURBO_GROUPED_GEMM=${TURBO_GROUPED_GEMM:-True}
 export PRIMUS_DETERMINISTIC=0
 export PRIMUS_TURBO_DEEPEP_TIMEOUT=600
 
@@ -58,7 +58,7 @@ export PRIMUS_TEAM=amd
 PRIMUS_USER="tas-$(date +%Y%m%d)"
 export PRIMUS_USER
 export PRIMUS_EXP_NAME=glm5-pretrain-platform_$PLATFORM-layers_$PRIMUS_TOTAL_LAYERS-type_$PRETRAIN_TYPE-mbs_$MBS-gbs_$GBS-legacygg_$LEGACY_GG
-export PRIMUS_EXP_NAME=debug_glm5_4layers-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_MLP
+export PRIMUS_EXP_NAME=debug_glm5_4layers-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_GEMM
 
 
 mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
@@ -70,7 +70,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --global_batch_size $GBS \
   --use_turbo_attention "$TURBO_ATTENTION" \
   --use_turbo_deepep "$TURBO_DEEPEEP" \
-  --use_turbo_grouped_mlp "$TURBO_GROUPED_MLP" \
+  --use_turbo_grouped_gemm "$TURBO_GROUPED_GEMM" \
   --moe_use_legacy_grouped_gemm "$LEGACY_GG" \
   --pipeline_model_parallel_size $PRIMUS_PP \
   --expert_model_parallel_size $PRIMUS_EP \

--- a/examples/moe_package/run_glm5_pretrain_mi355x.sh
+++ b/examples/moe_package/run_glm5_pretrain_mi355x.sh
@@ -36,7 +36,7 @@ export PROFILE=False
 export TURBO_ATTENTION=${TURBO_ATTENTION:-True}
 export TURBO_DEEPEEP=${TURBO_DEEPEEP:-True}
 export LEGACY_GG=${LEGACY_GG:-True}
-export TURBO_GROUPED_MLP=${TURBO_GROUPED_MLP:-False}
+export TURBO_GROUPED_GEMM=${TURBO_GROUPED_GEMM:-False}
 export TURBO_RMS_NORM=${TURBO_RMS_NORM:-True}
 # MLA does not support rope fusion
 export APPLY_ROPE_FUSION=False
@@ -101,7 +101,7 @@ export PRIMUS_TEAM
 PRIMUS_USER="${WORKLOAD_ID:-tas}"
 export PRIMUS_USER
 export PRIMUS_TOKENIZED_DATA_PATH=/shared_aig/c4/tokenized/c4_en_train_text_document
-export PRIMUS_EXP_NAME=glm5-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_MLP-turbodeepep_$TURBO_DEEPEEP-turboattn_$TURBO_ATTENTION-autotune_$PRIMUS_TURBO_AUTO_TUNE
+export PRIMUS_EXP_NAME=glm5-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_GEMM-turbodeepep_$TURBO_DEEPEEP-turboattn_$TURBO_ATTENTION-autotune_$PRIMUS_TURBO_AUTO_TUNE
 
 mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
 ./primus-cli direct --numa \
@@ -112,7 +112,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --global_batch_size "$GBS" \
   --use_turbo_attention "$TURBO_ATTENTION" \
   --use_turbo_deepep "$TURBO_DEEPEEP" \
-  --use_turbo_grouped_mlp "$TURBO_GROUPED_MLP" \
+  --use_turbo_grouped_gemm "$TURBO_GROUPED_GEMM" \
   --use_turbo_rms_norm "$TURBO_RMS_NORM" \
   --lr 2.2e-4 \
   --min_lr 2.2e-5 \

--- a/examples/moe_package/run_gpt_oss_120B_mi355x.sh
+++ b/examples/moe_package/run_gpt_oss_120B_mi355x.sh
@@ -100,7 +100,7 @@ for feature in "${MoE_Features[@]}"; do
         ;;
     2)
         ensure_primus_turbo
-        FEATURE_ARGS+=("--use_turbo_grouped_mlp" "True")
+        FEATURE_ARGS+=("--use_turbo_grouped_gemm" "True")
         ;;
     3)
         FEATURE_ARGS+=("--cross_entropy_fusion_impl" "te")

--- a/examples/moe_package/run_minimax_m2.5_4layers_proxy.sh
+++ b/examples/moe_package/run_minimax_m2.5_4layers_proxy.sh
@@ -42,7 +42,7 @@ export PRIMUS_VPP=1
 export PROFILE=False
 export TURBO_DEEPEEP=${TURBO_DEEPEEP:-True}
 export LEGACY_GG=${LEGACY_GG:-True}
-export TURBO_GROUPED_MLP=${TURBO_GROUPED_MLP:-True}
+export TURBO_GROUPED_GEMM=${TURBO_GROUPED_GEMM:-True}
 export PRIMUS_DETERMINISTIC=0
 export PRIMUS_TURBO_DEEPEP_TIMEOUT=600
 
@@ -57,7 +57,7 @@ export EXP=examples/megatron/configs/MI355X/minimax_m2.5-${PRETRAIN_TYPE}-pretra
 export PRIMUS_TEAM=amd
 PRIMUS_USER="tas-$(date +%Y%m%d)"
 export PRIMUS_USER
-export PRIMUS_EXP_NAME=minimax_m2.5_4layers-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_MLP
+export PRIMUS_EXP_NAME=minimax_m2.5_4layers-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_GEMM
 
 
 mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
@@ -68,7 +68,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --micro_batch_size $MBS \
   --global_batch_size $GBS \
   --use_turbo_deepep "$TURBO_DEEPEEP" \
-  --use_turbo_grouped_mlp "$TURBO_GROUPED_MLP" \
+  --use_turbo_grouped_gemm "$TURBO_GROUPED_GEMM" \
   --moe_use_legacy_grouped_gemm "$LEGACY_GG" \
   --pipeline_model_parallel_size $PRIMUS_PP \
   --expert_model_parallel_size $PRIMUS_EP \

--- a/examples/moe_package/run_minimax_m2.5_pretrain_mi355x_pretrain_mi355x.sh
+++ b/examples/moe_package/run_minimax_m2.5_pretrain_mi355x_pretrain_mi355x.sh
@@ -37,7 +37,7 @@ export PROFILE=False
 export TURBO_ATTENTION=${TURBO_ATTENTION:-False}
 export TURBO_DEEPEEP=${TURBO_DEEPEEP:-True}
 export LEGACY_GG=${LEGACY_GG:-True}
-export TURBO_GROUPED_MLP=${TURBO_GROUPED_MLP:-False}
+export TURBO_GROUPED_GEMM=${TURBO_GROUPED_GEMM:-False}
 export TURBO_RMS_NORM=${TURBO_RMS_NORM:-True}
 export APPLY_ROPE_FUSION=True
 export PRIMUS_TURBO_AUTO_TUNE=${PRIMUS_TURBO_AUTO_TUNE:-0}
@@ -95,7 +95,7 @@ export PRIMUS_TEAM
 PRIMUS_USER="${WORKLOAD_ID:-tas}"
 export PRIMUS_USER
 export PRIMUS_TOKENIZED_DATA_PATH=/shared_aig/c4/tokenized/c4_en_train_text_document
-export PRIMUS_EXP_NAME=minimax_m2.5-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_MLP-turbodeepep_$TURBO_DEEPEEP-turboattn_$TURBO_ATTENTION-autotune_$PRIMUS_TURBO_AUTO_TUNE
+export PRIMUS_EXP_NAME=minimax_m2.5-type_$PRETRAIN_TYPE-legacygg_$LEGACY_GG-turbogg_$TURBO_GROUPED_GEMM-turbodeepep_$TURBO_DEEPEEP-turboattn_$TURBO_ATTENTION-autotune_$PRIMUS_TURBO_AUTO_TUNE
 
 mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
 ./primus-cli direct --numa \
@@ -106,7 +106,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --global_batch_size "$GBS" \
   --use_turbo_attention "$TURBO_ATTENTION" \
   --use_turbo_deepep "$TURBO_DEEPEEP" \
-  --use_turbo_grouped_mlp "$TURBO_GROUPED_MLP" \
+  --use_turbo_grouped_gemm "$TURBO_GROUPED_GEMM" \
   --use_turbo_rms_norm "$TURBO_RMS_NORM" \
   --lr 2.2e-4 \
   --min_lr 2.2e-5 \

--- a/examples/moe_package/run_qwen_235B_a22B_pretrain_mi355x.sh
+++ b/examples/moe_package/run_qwen_235B_a22B_pretrain_mi355x.sh
@@ -33,7 +33,7 @@ export PROFILE=False
 export TURBO_DEEPEEP=True
 export TURBO_ATTENTION=${TURBO_ATTENTION:-False}
 export PRIMUS_TURBO_DEEPEP_TIMEOUT=600
-export TURBO_GROUPED_MLP=${TURBO_GROUPED_MLP:-False}
+export TURBO_GROUPED_GEMM=${TURBO_GROUPED_GEMM:-False}
 export TURBO_RMS_NORM=${TURBO_RMS_NORM:-False}
 export PRIMUS_TURBO_AUTO_TUNE=${PRIMUS_TURBO_AUTO_TUNE:-0}
 export APPLY_ROPE_FUSION=True
@@ -118,7 +118,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --global_batch_size "$GBS" \
   --use_turbo_attention "$TURBO_ATTENTION" \
   --use_turbo_deepep "$TURBO_DEEPEEP" \
-  --use_turbo_grouped_mlp "$TURBO_GROUPED_MLP" \
+  --use_turbo_grouped_gemm "$TURBO_GROUPED_GEMM" \
   --moe_use_legacy_grouped_gemm "$LEGACY_GG" \
   --pipeline_model_parallel_size "$PRIMUS_PP" \
   --expert_model_parallel_size "$PRIMUS_EP" \

--- a/examples/moe_package/start_training_dsv2_lite.sh
+++ b/examples/moe_package/start_training_dsv2_lite.sh
@@ -32,7 +32,7 @@ export CLEAN_DOCKER_CONTAINER=1
 export MBS=8   #12
 export GBS=$((128 * NNODES)) # 96
 export PROFILE=True
-export TURBO_GROUPED_MLP=False
+export TURBO_GROUPED_GEMM=False
 export TURBO_DEEPEEP=True
 export LEGACY_GG=True
 export PRIMUS_DETERMINISTIC=0
@@ -41,7 +41,7 @@ export PRIMUS_DETERMINISTIC=0
 export EXP=examples/megatron/configs/MI355X/deepseek_v2_lite-BF16-pretrain.yaml
 export PRIMUS_TEAM=amd
 export PRIMUS_USER=tas
-export PRIMUS_EXP_NAME=dsv2_lite-pretrain-mbs_$MBS-gbs_$GBS-turbogg_$TURBO_GROUPED_MLP-turbodeepep_$TURBO_DEEPEEP-legacygg_$LEGACY_GG-profile_$PROFILE
+export PRIMUS_EXP_NAME=dsv2_lite-pretrain-mbs_$MBS-gbs_$GBS-turbogg_$TURBO_GROUPED_GEMM-turbodeepep_$TURBO_DEEPEEP-legacygg_$LEGACY_GG-profile_$PROFILE
 
 mkdir -p output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME
 
@@ -60,7 +60,7 @@ bash ./primus-cli direct -- train pretrain --config "$EXP" \
   --global_batch_size $GBS \
   --seq_length 4096 \
   --max_position_embeddings 4096 \
-  --use_turbo_grouped_mlp $TURBO_GROUPED_MLP \
+  --use_turbo_grouped_gemm $TURBO_GROUPED_GEMM \
   --use_turbo_deepep $TURBO_DEEPEEP \
   --moe_use_legacy_grouped_gemm $LEGACY_GG \
   --cross_entropy_fusion_impl "te" \

--- a/primus/agents/tuning_agent/evaluator.py
+++ b/primus/agents/tuning_agent/evaluator.py
@@ -224,7 +224,7 @@ def write_trial_yaml(arch: ArchitectureRecord, cfg: TrialConfig, out_dir: Path, 
         overrides["fp8"] = cfg.fp8
 
     # Multi-Latent-Attention models (DeepSeek V2/V3, Kimi-K2, Qwen-V2) auto-
-    # enable ``use_turbo_parallel_linear`` inside Primus's projection. Two
+    # enable ``use_turbo_gemm`` inside Primus's projection. Two
     # things go wrong on the v26.2 container ``primus_turbo==0.2.0``:
     #   * The default ``fp8_recipe: delayed`` is incompatible with that path
     #     (``primus/modules/trainer/megatron/utils.py:464`` asserts).
@@ -232,7 +232,7 @@ def write_trial_yaml(arch: ArchitectureRecord, cfg: TrialConfig, out_dir: Path, 
     #     this version raises ``ValueError: Unsupported FP8 format: HYBRID``
     #     for ``fp8: hybrid`` (a common DSv3 / Kimi-K2 configuration).
     # We disable the MLA-specific turbo dense linear path while keeping
-    # ``use_turbo_grouped_mlp`` (which DOES support HYBRID) so MoE grouped
+    # ``use_turbo_grouped_gemm`` (which DOES support HYBRID) so MoE grouped
     # GEMMs still benefit from FP8. This costs a few % of dense-linear FP8
     # speedup vs. a fully turbo'd path, but lets the agent actually
     # benchmark MLA + FP8 workloads on v26.2.

--- a/primus/backends/megatron/core/extensions/transformer_engine_spec_provider.py
+++ b/primus/backends/megatron/core/extensions/transformer_engine_spec_provider.py
@@ -111,7 +111,7 @@ class PrimusTurboSpecProvider(BackendSpecProvider):
         """Which linear module TE backend uses"""
         return (
             _require_primus_turbo(PrimusTurboLinear, "parallel linear")
-            if self.cfg.use_turbo_gemm or self.cfg.use_turbo_parallel_linear
+            if self.cfg.use_turbo_gemm
             else TELinear
         )
 
@@ -119,7 +119,7 @@ class PrimusTurboSpecProvider(BackendSpecProvider):
         """Which column parallel linear module TE backend uses"""
         return (
             _require_primus_turbo(PrimusTurboColumnParallelLinear, "column parallel linear")
-            if self.cfg.use_turbo_gemm or self.cfg.use_turbo_parallel_linear
+            if self.cfg.use_turbo_gemm
             else TEColumnParallelLinear
         )
 
@@ -127,7 +127,7 @@ class PrimusTurboSpecProvider(BackendSpecProvider):
         """Which row parallel linear module TE backend uses"""
         return (
             _require_primus_turbo(PrimusTurboRowParallelLinear, "row parallel linear")
-            if self.cfg.use_turbo_gemm or self.cfg.use_turbo_parallel_linear
+            if self.cfg.use_turbo_gemm
             else TERowParallelLinear
         )
 
@@ -141,7 +141,7 @@ class PrimusTurboSpecProvider(BackendSpecProvider):
             _require_primus_turbo(
                 PrimusTurboLayerNormColumnParallelLinear, "layernorm column parallel linear"
             )
-            if self.cfg.use_turbo_gemm or self.cfg.use_turbo_parallel_linear
+            if self.cfg.use_turbo_gemm
             else TELayerNormColumnParallelLinear
         )
 

--- a/primus/backends/megatron/patches/te_patches/legacy_grouped_mlp_wgrad_patches.py
+++ b/primus/backends/megatron/patches/te_patches/legacy_grouped_mlp_wgrad_patches.py
@@ -216,7 +216,6 @@ def _make_patched_forward():
             or getattr(get_args(ctx), "patch_zero_bubble", False)
         )
         and getattr(get_args(ctx), "moe_use_legacy_grouped_gemm", False)
-        and not getattr(get_args(ctx), "use_turbo_grouped_mlp", False)
         and not getattr(get_args(ctx), "use_turbo_grouped_gemm", False)
     ),
 )

--- a/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
+++ b/primus/backends/megatron/patches/turbo/te_spec_provider_patches.py
@@ -20,9 +20,7 @@ def _use_legacy_grouped_gemm(ctx: PatchContext) -> bool:
     return bool(
         getattr(args, "moe_grouped_gemm", False)
         and getattr(args, "moe_use_legacy_grouped_gemm", False)
-        and not (
-            getattr(args, "use_turbo_grouped_gemm", False) or getattr(args, "use_turbo_grouped_mlp", False)
-        )
+        and not getattr(args, "use_turbo_grouped_gemm", False)
     )
 
 

--- a/primus/configs/modules/megatron/primus_turbo.yaml
+++ b/primus/configs/modules/megatron/primus_turbo.yaml
@@ -19,8 +19,6 @@ enable_turbo_attention_float8: false
 
 # ===== Parallel Linear =====
 # operator switch
-# deprecated, use use_turbo_gemm instead
-use_turbo_parallel_linear: false
 # use turbo gemm
 use_turbo_gemm: false
 
@@ -28,8 +26,6 @@ use_turbo_gemm: false
 use_turbo_permute_padding: false
 
 # ===== Grouped MLP =====
-# deprecated, use use_turbo_grouped_gemm instead
-use_turbo_grouped_mlp: false
 # use turbo grouped gemm
 use_turbo_grouped_gemm: false
 # fused activation_with_probs to reduce redundant computation

--- a/primus/configs/modules/megatron_bridge/pretrain_trainer.yaml
+++ b/primus/configs/modules/megatron_bridge/pretrain_trainer.yaml
@@ -16,8 +16,8 @@ enable_primus_turbo: true
 
 # feature control flags
 use_turbo_attention: false
-use_turbo_parallel_linear: false
-use_turbo_grouped_mlp: false
+use_turbo_gemm: false
+use_turbo_grouped_gemm: false
 moe_use_fused_router_with_aux_score: false
 
 # inner features flags

--- a/primus/configs/modules/megatron_bridge/sft_trainer.yaml
+++ b/primus/configs/modules/megatron_bridge/sft_trainer.yaml
@@ -16,8 +16,8 @@ enable_primus_turbo: true
 
 # feature control flags
 use_turbo_attention: false
-use_turbo_parallel_linear: false
-use_turbo_grouped_mlp: false
+use_turbo_gemm: false
+use_turbo_grouped_gemm: false
 moe_use_fused_router_with_aux_score: false
 
 # inner features flags

--- a/primus/core/projection/performance_projection/projection.py
+++ b/primus/core/projection/performance_projection/projection.py
@@ -2580,12 +2580,12 @@ def _run_layer_benchmark(primus_config, unknown_overrides, reduction_info=None):
         for flag, val in _turbo_candidates.items():
             if not val:
                 continue
-            if flag == "use_turbo_grouped_mlp" and wants_legacy_grouped:
+            if flag == "use_turbo_grouped_gemm" and wants_legacy_grouped:
                 if not getattr(cfg, flag, False):
                     print(
                         "[Primus:Performance Projection] Respecting "
                         "moe_use_legacy_grouped_gemm=true: NOT auto-enabling "
-                        "use_turbo_grouped_mlp"
+                        "use_turbo_grouped_gemm"
                     )
                 continue
             if not getattr(cfg, flag, False):

--- a/primus/core/projection/training_config.py
+++ b/primus/core/projection/training_config.py
@@ -80,7 +80,7 @@ class ModelConfig:
 
     # Primus Turbo flags — used to select the grouped-GEMM performance model
     enable_primus_turbo: bool = False
-    use_turbo_grouped_mlp: bool = False
+    use_turbo_grouped_gemm: bool = False
     use_turbo_deepep: bool = False  # DeepEP enables async A2A with compute overlap
     turbo_sync_free_moe_stage: int = 0  # 0=off, 1=fused router, 2=+DeepEP+grouped, 3=+fused act
 

--- a/primus/modules/trainer/megatron/utils.py
+++ b/primus/modules/trainer/megatron/utils.py
@@ -504,11 +504,10 @@ def validate_args_on_rocm(args):
         # Set fill_uninitialized_memory to False to avoid calling extra fill kernel in deterministic mode.
         torch.utils.deterministic.fill_uninitialized_memory = False
 
-    if getattr(args, "use_turbo_parallel_linear", False):
-        print_rank_last("use_turbo_parallel_linear is deprecated, please use use_turbo_gemm instead.")
-    use_turbo_gemm = getattr(args, "use_turbo_gemm", False) or getattr(
+    assert not getattr(
         args, "use_turbo_parallel_linear", False
-    )
+    ), "use_turbo_parallel_linear has been removed; please use use_turbo_gemm instead."
+    use_turbo_gemm = getattr(args, "use_turbo_gemm", False)
     # Turbo FP8 linear check
     if args.fp8 and use_turbo_gemm:
         support_fp8_recipe = ["tensorwise", "blockwise", "mxfp8"]
@@ -536,15 +535,14 @@ def validate_args_on_rocm(args):
 
     # PrimusTurboGroupedMLP no longer depends on legacy GroupedMLP; the two
     # flags are mutually exclusive when turbo is enabled.
-    if getattr(args, "use_turbo_grouped_mlp", False):
-        print_rank_last("use_turbo_grouped_mlp is deprecated, please use use_turbo_grouped_gemm instead.")
-    use_turbo_grouped_gemm = getattr(args, "use_turbo_grouped_gemm", False) or getattr(
+    assert not getattr(
         args, "use_turbo_grouped_mlp", False
-    )
+    ), "use_turbo_grouped_mlp has been removed; please use use_turbo_grouped_gemm instead."
+    use_turbo_grouped_gemm = getattr(args, "use_turbo_grouped_gemm", False)
     if use_turbo_grouped_gemm:
         if getattr(args, "moe_use_legacy_grouped_gemm", False):
             raise ValueError(
-                "use_turbo_grouped_gemm=True or use_turbo_grouped_mlp=True is incompatible with moe_use_legacy_grouped_gemm=True. "
+                "use_turbo_grouped_gemm=True is incompatible with moe_use_legacy_grouped_gemm=True. "
                 "please set moe_use_legacy_grouped_gemm=False."
             )
 

--- a/tests/trainer/test_megatron_trainer_zbv_fp8.yaml
+++ b/tests/trainer/test_megatron_trainer_zbv_fp8.yaml
@@ -83,8 +83,8 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: false
-      use_turbo_grouped_mlp: false
-      use_turbo_parallel_linear: false
+      use_turbo_grouped_gemm: false
+      use_turbo_gemm: false
       use_turbo_deepep: false
       moe_shared_expert_overlap: false
 

--- a/tests/trainer/test_megatron_trainer_zero_bubble.yaml
+++ b/tests/trainer/test_megatron_trainer_zero_bubble.yaml
@@ -70,8 +70,8 @@ modules:
       # Turbo
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_grouped_mlp: true
-      use_turbo_parallel_linear: true
+      use_turbo_grouped_gemm: true
+      use_turbo_gemm: true
 
       # transformer_impl: local
       overlap_grad_reduce: false

--- a/tests/unit_tests/core/projection/test_projection_profilers.py
+++ b/tests/unit_tests/core/projection/test_projection_profilers.py
@@ -219,7 +219,7 @@ def test_dense_mlp_simulated_path():
 
 @pytest.mark.parametrize("turbo", [False, True])
 def test_moe_mlp_simulated_path(turbo):
-    cfg = _training_config(moe=True, enable_primus_turbo=turbo, use_turbo_grouped_mlp=turbo)
+    cfg = _training_config(moe=True, enable_primus_turbo=turbo, use_turbo_grouped_gemm=turbo)
     p = MoEMLPProfiler(cfg)
     p.set_gemm_backend(_FakeGemmBackend())
     # routed experts + router + permute + activation overheads -> strictly positive


### PR DESCRIPTION
## Summary

Removes two deprecated Primus-Turbo flags and replaces them with their canonical names across the entire repo:

- `use_turbo_grouped_mlp` → **`use_turbo_grouped_gemm`**
- `use_turbo_parallel_linear` → **`use_turbo_gemm`**

Previously these deprecated flags only emitted a warning and were silently OR'd into the new flags inside `validate_args_on_rocm`, but the value was **never written back to `args`**. As a result, setting `use_turbo_grouped_mlp=True` (or `use_turbo_parallel_linear=True`) did **not** actually activate the Primus-Turbo grouped-GEMM / dense-GEMM kernel paths — the spec provider keys off `use_turbo_grouped_gemm` / `use_turbo_gemm`, which stayed `False`. This silently masked the turbo kernels and made A/B comparisons misleading.

This PR makes the deprecated flags hard errors so the misconfiguration can't slip through unnoticed.

## Changes

- **Configs**: renamed the flags in all `examples/**` and `tests/**` YAMLs. Dropped the deprecated keys entirely from the base `primus/configs/modules/megatron/primus_turbo.yaml` (kept only the canonical `use_turbo_gemm` / `use_turbo_grouped_gemm`).
- **Validation** (`primus/modules/trainer/megatron/utils.py`): replaced the deprecation warning + silent aliasing with a hard `assert` that points users to the new flag when either removed flag is set.
- **Spec provider** (`transformer_engine_spec_provider.py`): removed the now-dead `or use_turbo_parallel_linear` fallbacks in the linear module selection.
- **Patches** (`te_spec_provider_patches.py`, `legacy_grouped_mlp_wgrad_patches.py`): removed the dead `use_turbo_grouped_mlp` getattr fallbacks in patch conditions.
- **Projection** (`training_config.py`, `performance_projection/projection.py`): renamed the `ModelConfig` field and the auto-enable logic. This also fixes a latent bug where the projection's `ModelConfig.use_turbo_grouped_mlp` field name no longer matched the runtime arg, so the turbo grouped-GEMM performance model was never selected.
- **Examples & tests**: aligned `examples/moe_package/**`, `examples/customer_package/**` launch scripts and the projection profiler unit test to the new flag names.

## Behavior change

Setting `use_turbo_grouped_mlp` or `use_turbo_parallel_linear` now raises:

use_turbo_grouped_mlp has been removed; please use use_turbo_grouped_gemm instead. use_turbo_parallel_linear has been removed; please use use_turbo_gemm instead.


Existing configs that relied on the deprecated names must migrate to the new flags.
