### PR TITLE
Add unit-vs-E2E coverage comparison, patch tests, JUnit reports, and CI hardening

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 16 * * *'
 
+# Default to read-only; this scheduled benchmark only checks out code and runs,
+# it never needs GITHUB_TOKEN write access.
+permissions:
+  contents: read
+
 env:
   PRIMUS_TURBO_COMMIT: 3c39ef259aa6d724c77c481e926466e7a167e938 # fix(moe): declare probs layout explicitly in moe_permute (#355)
   BENCHMARK_ROOT_DIR: /wekafs/primus/benchmark

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Default to read-only. No job uses GITHUB_TOKEN for writes (Docker Hub push
+# uses a dedicated PAT secret), so this is behavior-neutral. Jobs that need
+# more must opt in at the job level.
+permissions:
+  contents: read
+
 env:
   PRIMUS_TURBO_COMMIT: 3c39ef259aa6d724c77c481e926466e7a167e938 # fix(moe): declare probs layout explicitly in moe_permute (#355)
   PRIMUS_TURBO_AITER_COMMIT: b5e03ed191fca11ee423226537ef8d9435e432a6 # Fix dsink bf16 noise in Triton MHA one-kernel backward (#3070)
@@ -31,10 +37,10 @@ jobs:
     steps:
       - run: echo "🎉 Begin Primus Python Lint."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: git config --global --add safe.directory /github/workspace
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
@@ -53,7 +59,7 @@ jobs:
         python-version: ["3.12"]
     steps:
       - run: echo "🎉 Begin Build Primus Docker Image."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Show Environment Info
@@ -208,7 +214,7 @@ jobs:
       - name: Set commit hash to env
         run: echo "PRIMUS_TURBO_COMMIT=${PRIMUS_TURBO_COMMIT}" >> $GITHUB_ENV
       - name: Checkout Repo Primus-Turbo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AMD-AIG-AIMA/Primus-Turbo
           submodules: "recursive"
@@ -256,7 +262,7 @@ jobs:
           echo "✅ [build primus-turbo] ended at: $(date)"
           echo "⏱️ [build primus-turbo] Total elapsed time: ${elapsed} seconds"
       - run: echo "🎉 Begin Primus Unit Test."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Show Environment Info
@@ -310,8 +316,10 @@ jobs:
           # Note: The tests `test_fp8_te_linear` and `test_te_linear` are temporarily skipped due to intermittent failures.
           # Note HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit (TAS-8N Node), rocm ver:70125424
           export HSA_NO_SCRATCH_RECLAIM=1
+          mkdir -p "${GITHUB_WORKSPACE}/test-reports"
           pytest --maxfail=1 -s ./tests/unit_tests/ \
             --cov=primus --cov-report=term-missing:skip-covered \
+            --junitxml="${GITHUB_WORKSPACE}/test-reports/core-unit.xml" \
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_fp8_te_linear \
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_te_linear \
             --deselect=tests/unit_tests/megatron/transformer/moe/test_token_dispatcher.py::TestFlexDispatcher::test_forward_backward \
@@ -349,7 +357,8 @@ jobs:
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data HSA_NO_SCRATCH_RECLAIM=1 \
           GPU_ARCHS=gfx942 \
-          pytest  --maxfail=1 -s ./tests/trainer/test_megatron_trainer.py
+          pytest  --maxfail=1 -s ./tests/trainer/test_megatron_trainer.py \
+            --junitxml="${GITHUB_WORKSPACE}/test-reports/megatron-e2e.xml"
       - name: Run Primus Model Tests -- TorchTitan
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN}}
@@ -359,7 +368,16 @@ jobs:
           mkdir -p "${{ env.UT_LOG_PATH }}"
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data HSA_NO_SCRATCH_RECLAIM=1 \
-          pytest  --maxfail=1 -s ./tests/trainer/test_torchtitan_trainer.py
+          pytest  --maxfail=1 -s ./tests/trainer/test_torchtitan_trainer.py \
+            --junitxml="${GITHUB_WORKSPACE}/test-reports/torchtitan-e2e.xml"
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: torch-test-reports
+          path: test-reports/
+          if-no-files-found: warn
+          retention-days: 14
       - name: Build torch coverage json (unit + E2E)
         if: always()
         continue-on-error: true
@@ -375,7 +393,7 @@ jobs:
       - name: Upload torch coverage json
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-torch
           path: |
@@ -405,7 +423,7 @@ jobs:
       - name: Set commit hash to env
         run: echo "PRIMUS_TURBO_COMMIT=${PRIMUS_TURBO_COMMIT}" >> $GITHUB_ENV
       - name: Checkout Repo Primus-Turbo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AMD-AIG-AIMA/Primus-Turbo
           path: Primus-Turbo
@@ -439,7 +457,7 @@ jobs:
           echo "✅ [build primus-turbo] ended at: $(date)"
           echo "⏱️ [build primus-turbo] Torch installation causes segfault, so we skip it and actually not install turbo. Total elapsed time: ${elapsed} seconds"
       - run: echo "🎉 Begin Primus Unit Test."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Show Environment Info
@@ -492,9 +510,21 @@ jobs:
           echo "Set UT_LOG_PATH: ${{ env.UT_LOG_PATH }}"
           rm -rf "${{ env.UT_LOG_PATH }}"
           mkdir -p "${{ env.UT_LOG_PATH }}"
+          mkdir -p "${GITHUB_WORKSPACE}/test-reports"
+          # run_unit_tests.py shells out to pytest; PYTEST_ADDOPTS injects the
+          # JUnit report without having to touch the wrapper script.
+          export PYTEST_ADDOPTS="--junitxml=${GITHUB_WORKSPACE}/test-reports/maxtext-e2e.xml"
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data \
           JAX_SKIP_UT=1 python ./tests/run_unit_tests.py --jax
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: jax-test-reports
+          path: test-reports/
+          if-no-files-found: warn
+          retention-days: 14
       - name: Build jax coverage json (MaxText E2E)
         if: always()
         continue-on-error: true
@@ -506,7 +536,7 @@ jobs:
       - name: Upload jax coverage json
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-jax
           path: coverage_maxtext_e2e.json
@@ -529,9 +559,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         continue-on-error: true
         with:
           path: cov-artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -378,6 +378,10 @@ jobs:
           path: test-reports/
           if-no-files-found: warn
           retention-days: 14
+      - name: Write test summary
+        if: always()
+        run: |
+          python tools/ci/junit_summary.py --title torch test-reports/*.xml >> "$GITHUB_STEP_SUMMARY" || true
       - name: Build torch coverage json (unit + E2E)
         if: always()
         continue-on-error: true
@@ -525,6 +529,10 @@ jobs:
           path: test-reports/
           if-no-files-found: warn
           retention-days: 14
+      - name: Write test summary
+        if: always()
+        run: |
+          python tools/ci/junit_summary.py --title jax test-reports/*.xml >> "$GITHUB_STEP_SUMMARY" || true
       - name: Build jax coverage json (MaxText E2E)
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -360,24 +360,28 @@ jobs:
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data HSA_NO_SCRATCH_RECLAIM=1 \
           pytest  --maxfail=1 -s ./tests/trainer/test_torchtitan_trainer.py
-      - name: Publish coverage comparison (unit vs unit+E2E)
+      - name: Build torch coverage json (unit + E2E)
         if: always()
         continue-on-error: true
         run: |
           # Don't instrument coverage's own helper processes here.
           unset COVERAGE_PROCESS_START
-          # 1) Merge the per-rank E2E data files (COVERAGE_FILE=.coverage_e2e).
+          # Merge per-rank E2E data, then line-merge unit + E2E into one dataset.
+          # The JSON is consumed by the coverage-summary job (no per-job summary).
           python -m coverage combine 2>/dev/null || true
-          # 2) Line-merge unit + E2E into one dataset (can't add two percentages).
           COVERAGE_FILE="$GITHUB_WORKSPACE/.coverage_all" python -m coverage combine --keep \
             "$GITHUB_WORKSPACE/.coverage.unit" "$GITHUB_WORKSPACE/.coverage_e2e" 2>/dev/null || true
           COVERAGE_FILE="$GITHUB_WORKSPACE/.coverage_all" python -m coverage json -o coverage_combined.json 2>/dev/null || true
-          # Two-column comparison when E2E data exists, else fall back to unit-only.
-          if [ -s coverage_combined.json ]; then
-            python tools/ci/coverage_summary.py coverage_unit.json "Unit vs Unit+E2E (torch)" coverage_combined.json >> "$GITHUB_STEP_SUMMARY" || true
-          else
-            python tools/ci/coverage_summary.py coverage_unit.json "Unit tests (torch)" >> "$GITHUB_STEP_SUMMARY" || true
-          fi
+      - name: Upload torch coverage json
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-torch
+          path: |
+            coverage_unit.json
+            coverage_combined.json
+          if-no-files-found: ignore
       - name: Clean
         if: always()
         run: |
@@ -491,16 +495,22 @@ jobs:
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data \
           JAX_SKIP_UT=1 python ./tests/run_unit_tests.py --jax
-      - name: Publish MaxText E2E coverage summary
+      - name: Build jax coverage json (MaxText E2E)
         if: always()
         continue-on-error: true
         run: |
           unset COVERAGE_PROCESS_START
+          # The JSON is consumed by the coverage-summary job (no per-job summary).
           python -m coverage combine 2>/dev/null || true
           python -m coverage json -o coverage_maxtext_e2e.json 2>/dev/null || true
-          if [ -s coverage_maxtext_e2e.json ]; then
-            python tools/ci/coverage_summary.py coverage_maxtext_e2e.json "MaxText E2E training (executed, not asserted)" >> "$GITHUB_STEP_SUMMARY" || true
-          fi
+      - name: Upload jax coverage json
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-jax
+          path: coverage_maxtext_e2e.json
+          if-no-files-found: ignore
       - name: Clean
         if: always()
         run: |
@@ -509,3 +519,30 @@ jobs:
           # Remove E2E coverage artifacts + the injection .pth (persistent runner).
           rm -f "${GITHUB_WORKSPACE}/.coverage_e2e"* "${GITHUB_WORKSPACE}/.coveragerc_e2e" coverage_maxtext_e2e.json || true
           SP=$(python -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) && rm -f "$SP/primus_e2e_coverage.pth" || true
+
+  coverage-summary:
+    # Combine the torch and jax coverage JSON artifacts into one unit-vs-E2E
+    # table. Uses module-level JSON (not coverage data), so no cross-runner path
+    # mapping is needed: torch (megatron/torchtitan) and jax (maxtext) E2E cover
+    # near-disjoint modules and are merged per module by max covered lines.
+    needs: [run-unittest-torch, run-unittest-jax]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          path: cov-artifacts
+      - name: Render combined coverage summary
+        continue-on-error: true
+        run: |
+          unit=$(find cov-artifacts -name coverage_unit.json | head -1)
+          torch=$(find cov-artifacts -name coverage_combined.json | head -1)
+          jax=$(find cov-artifacts -name coverage_maxtext_e2e.json | head -1)
+          if [ -n "$unit" ]; then
+            python tools/ci/coverage_summary.py "$unit" "Unit vs Unit+E2E (torch + jax)" $torch $jax >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No unit coverage artifact found; skipping combined summary." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -316,48 +316,29 @@ jobs:
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_te_linear \
             --deselect=tests/unit_tests/megatron/transformer/moe/test_token_dispatcher.py::TestFlexDispatcher::test_forward_backward \
             --deselect=tests/unit_tests/megatron/transformer/moe/test_token_dispatcher.py::TestFlexDispatcher::test_capacity_forward_backward
-      - name: Publish unit-test coverage summary
+      - name: Snapshot unit-test coverage
         if: always()
         continue-on-error: true
         run: |
-          python -m coverage json -o coverage.json 2>/dev/null || true
-          python - <<'PY' >> "$GITHUB_STEP_SUMMARY" || true
-          import json
-          from collections import defaultdict
-
-          rep = json.load(open("coverage.json"))
-
-          def group(p):
-              i = p.find("primus/")
-              seg = (p[i:] if i >= 0 else p).split("/")
-              if len(seg) < 2:
-                  return seg[-1]
-              if seg[1] == "backends" and len(seg) >= 3:
-                  return f"backends/{seg[2]}"
-              if seg[1] == "core" and len(seg) >= 3 and seg[2] == "projection":
-                  return "core/projection"
-              return seg[1]
-
-          agg = defaultdict(lambda: [0, 0])
-          for fpath, info in rep.get("files", {}).items():
-              s = info["summary"]
-              g = agg[group(fpath)]
-              g[0] += s["covered_lines"]
-              g[1] += s["num_statements"]
-
-          t = rep.get("totals", {})
-          tc, tn = t.get("covered_lines", 0), t.get("num_statements", 0)
-          tp = t.get("percent_covered", 0.0)
-
-          print("## Primus unit-test coverage\n")
-          print(f"**Total line coverage: {tp:.1f}%** ({tc:,} / {tn:,} statements)\n")
-          print("| Module | Covered | Stmts | Coverage |")
-          print("|---|--:|--:|--:|")
-          for name, (c, n) in sorted(agg.items(), key=lambda r: -r[1][1]):
-              if n:
-                  print(f"| `{name}` | {c:,} | {n:,} | {100 * c / n:.1f}% |")
-          print(f"| **TOTAL** | **{tc:,}** | **{tn:,}** | **{tp:.1f}%** |")
-          PY
+          # Keep the unit data for the final unit-vs-E2E comparison table
+          # (.coverage.unit is fed to `coverage combine` after the E2E steps).
+          python -m coverage json -o coverage_unit.json 2>/dev/null || true
+          cp .coverage "$GITHUB_WORKSPACE/.coverage.unit" 2>/dev/null || true
+      - name: Setup E2E training coverage
+        if: always()
+        continue-on-error: true
+        run: |
+          # Record coverage of the training subprocesses (primus-cli -> torchrun
+          # -> python). A .pth makes every new interpreter call
+          # coverage.process_startup(); COVERAGE_PROCESS_START points it at the rc
+          # and COVERAGE_FILE keeps E2E data separate from the unit .coverage.
+          # parallel=true -> one data file per rank; sigterm=true captures ranks
+          # killed on teardown. These env vars are inherited by the E2E steps.
+          SP=$(python -c "import site; print(site.getsitepackages()[0])")
+          echo "import coverage; coverage.process_startup()" > "$SP/primus_e2e_coverage.pth"
+          printf '[run]\nparallel = true\nsource = primus\nsigterm = true\n' > "$GITHUB_WORKSPACE/.coveragerc_e2e"
+          echo "COVERAGE_PROCESS_START=$GITHUB_WORKSPACE/.coveragerc_e2e" >> "$GITHUB_ENV"
+          echo "COVERAGE_FILE=$GITHUB_WORKSPACE/.coverage_e2e" >> "$GITHUB_ENV"
       - name: Run Primus Model Tests -- Megatron-LM
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN}}
@@ -379,10 +360,33 @@ jobs:
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data HSA_NO_SCRATCH_RECLAIM=1 \
           pytest  --maxfail=1 -s ./tests/trainer/test_torchtitan_trainer.py
+      - name: Publish coverage comparison (unit vs unit+E2E)
+        if: always()
+        continue-on-error: true
+        run: |
+          # Don't instrument coverage's own helper processes here.
+          unset COVERAGE_PROCESS_START
+          # 1) Merge the per-rank E2E data files (COVERAGE_FILE=.coverage_e2e).
+          python -m coverage combine 2>/dev/null || true
+          # 2) Line-merge unit + E2E into one dataset (can't add two percentages).
+          COVERAGE_FILE="$GITHUB_WORKSPACE/.coverage_all" python -m coverage combine --keep \
+            "$GITHUB_WORKSPACE/.coverage.unit" "$GITHUB_WORKSPACE/.coverage_e2e" 2>/dev/null || true
+          COVERAGE_FILE="$GITHUB_WORKSPACE/.coverage_all" python -m coverage json -o coverage_combined.json 2>/dev/null || true
+          # Two-column comparison when E2E data exists, else fall back to unit-only.
+          if [ -s coverage_combined.json ]; then
+            python tools/ci/coverage_summary.py coverage_unit.json "Unit vs Unit+E2E (torch)" coverage_combined.json >> "$GITHUB_STEP_SUMMARY" || true
+          else
+            python tools/ci/coverage_summary.py coverage_unit.json "Unit tests (torch)" >> "$GITHUB_STEP_SUMMARY" || true
+          fi
       - name: Clean
+        if: always()
         run: |
           rm -rf ${PRIMUS_WORKDIR}/Primus-Turbo
           rm -rf ${PRIMUS_WORKDIR}/Primus
+          # Remove E2E coverage artifacts and, importantly, the subprocess
+          # injection .pth so it never leaks into later jobs on this persistent runner.
+          rm -f "${GITHUB_WORKSPACE}/.coverage_e2e"* "${GITHUB_WORKSPACE}/.coverage.unit" "${GITHUB_WORKSPACE}/.coverage_all" "${GITHUB_WORKSPACE}/.coveragerc_e2e" coverage_unit.json coverage_combined.json || true
+          SP=$(python -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) && rm -f "$SP/primus_e2e_coverage.pth" || true
 
   run-unittest-jax:
     env:
@@ -464,6 +468,19 @@ jobs:
         run: |
           echo "Running Primus CLI shell tests..."
           bash ./tests/runner/run_all_tests.sh
+      - name: Setup MaxText E2E coverage
+        if: always()
+        continue-on-error: true
+        run: |
+          # Instrument the MaxText (JAX) training subprocesses so their coverage
+          # of primus/ (notably backends/maxtext) is recorded. Same mechanism as
+          # the torch job: a .pth runs coverage.process_startup() in every child.
+          pip install coverage >/dev/null 2>&1 || true
+          SP=$(python -c "import site; print(site.getsitepackages()[0])")
+          echo "import coverage; coverage.process_startup()" > "$SP/primus_e2e_coverage.pth"
+          printf '[run]\nparallel = true\nsource = primus\nsigterm = true\n' > "$GITHUB_WORKSPACE/.coveragerc_e2e"
+          echo "COVERAGE_PROCESS_START=$GITHUB_WORKSPACE/.coveragerc_e2e" >> "$GITHUB_ENV"
+          echo "COVERAGE_FILE=$GITHUB_WORKSPACE/.coverage_e2e" >> "$GITHUB_ENV"
       - name: Run Unit Tests
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN}}
@@ -474,7 +491,21 @@ jobs:
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data \
           JAX_SKIP_UT=1 python ./tests/run_unit_tests.py --jax
+      - name: Publish MaxText E2E coverage summary
+        if: always()
+        continue-on-error: true
+        run: |
+          unset COVERAGE_PROCESS_START
+          python -m coverage combine 2>/dev/null || true
+          python -m coverage json -o coverage_maxtext_e2e.json 2>/dev/null || true
+          if [ -s coverage_maxtext_e2e.json ]; then
+            python tools/ci/coverage_summary.py coverage_maxtext_e2e.json "MaxText E2E training (executed, not asserted)" >> "$GITHUB_STEP_SUMMARY" || true
+          fi
       - name: Clean
+        if: always()
         run: |
           rm -rf ${PRIMUS_WORKDIR}/Primus-Turbo
           rm -rf ${PRIMUS_WORKDIR}/Primus
+          # Remove E2E coverage artifacts + the injection .pth (persistent runner).
+          rm -f "${GITHUB_WORKSPACE}/.coverage_e2e"* "${GITHUB_WORKSPACE}/.coveragerc_e2e" coverage_maxtext_e2e.json || true
+          SP=$(python -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) && rm -f "$SP/primus_e2e_coverage.pth" || true

--- a/primus/backends/megatron/megatron_base_trainer.py
+++ b/primus/backends/megatron/megatron_base_trainer.py
@@ -14,6 +14,7 @@ from primus.backends.megatron.training.global_vars import (
 )
 from primus.backends.megatron.training.mlflow_setup import upload_mlflow_artifacts
 from primus.core.trainer.base_trainer import BaseTrainer
+from primus.core.utils.env import flush_before_hard_exit
 from primus.modules.module_utils import log_rank_0, warning_rank_0
 
 
@@ -52,14 +53,7 @@ class MegatronBaseTrainer(BaseTrainer):
 
         if exit_fast and not on_error:
             log_rank_0("[MegatronBaseTrainer] PRIMUS_EXIT_FAST=1 -> os._exit(0)")
-            # Flush stdout/stderr so the final log lines are not lost.
-            try:
-                import sys
-
-                sys.stdout.flush()
-                sys.stderr.flush()
-            except Exception:  # pragma: no cover
-                pass
+            flush_before_hard_exit()
             os._exit(0)
 
     def _finalize_mlflow_artifacts(self):

--- a/primus/core/utils/env.py
+++ b/primus/core/utils/env.py
@@ -5,8 +5,37 @@
 ###############################################################################
 
 import os
+import sys
 
 from primus.core.utils import constant_vars as const
+
+
+def flush_before_hard_exit() -> None:
+    """Persist buffered output and coverage data before an ``os._exit()``.
+
+    ``os._exit()`` (fast shutdown) bypasses ``atexit`` and buffer flushing, so
+    flush manually first:
+    - stdout/stderr, so final log lines are not lost;
+    - coverage.py data when subprocess coverage is active (CI), so a
+      hard-exiting process still contributes its line coverage.
+    Both are best-effort and never raise.
+    """
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:  # pragma: no cover
+        pass
+
+    # os._exit bypasses atexit, which is how coverage.py writes its data.
+    if os.environ.get("COVERAGE_PROCESS_START"):
+        try:
+            import coverage
+
+            cov = coverage.Coverage.current()
+            if cov is not None:
+                cov.save()
+        except Exception:  # pragma: no cover
+            pass
 
 
 def get_torchrun_env():

--- a/tests/unit_tests/backends/megatron/conftest.py
+++ b/tests/unit_tests/backends/megatron/conftest.py
@@ -12,11 +12,23 @@ components that require distributed setup.
 """
 
 import os
-import random
+import socket
 
 import pytest
 import torch
 import torch.distributed as dist
+
+
+def _find_free_port() -> int:
+    """Ask the kernel for a free TCP port on localhost.
+
+    Binding to port 0 lets the OS pick a port that is guaranteed free at this
+    instant, which avoids the EADDRINUSE failures seen when guessing a random
+    port out of a fixed range that overlaps the ephemeral port range.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
 
 @pytest.fixture(scope="function")
@@ -45,10 +57,12 @@ def init_parallel_state():
 
     # Initialize torch.distributed if not already initialized
     if not dist.is_initialized():
-        # Use dynamic port to avoid conflicts with other running tests
-        port = random.randint(29500, 39500)
-        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", str(port))
+        # Use a kernel-assigned free port to avoid conflicts with other running
+        # tests. Set MASTER_PORT explicitly (not setdefault) so a stale value
+        # left in the environment cannot diverge from the port we actually use.
+        port = _find_free_port()
+        os.environ["MASTER_ADDR"] = "127.0.0.1"
+        os.environ["MASTER_PORT"] = str(port)
 
         dist.init_process_group(
             backend="nccl" if torch.cuda.is_available() else "gloo",

--- a/tests/unit_tests/core/patches/test_patch_registration.py
+++ b/tests/unit_tests/core/patches/test_patch_registration.py
@@ -1,0 +1,38 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Registration-completeness tests for the real backend patches.
+
+Importing the backend patch packages triggers every ``@register_patch``; we then
+assert the registry is populated, ids are unique, and anchor patches are present.
+Guards against a patch silently not being applied at training time (import
+failure, decorator regression, id collision). Pure CPU - no GPU needed.
+"""
+
+
+def _registered_ids(prefix: str):
+    from primus.core.patches.patch_registry import PatchRegistry
+
+    return [pid for pid in PatchRegistry.list_ids() if pid.startswith(prefix)]
+
+
+def test_megatron_patches_auto_register():
+    import primus.backends.megatron.patches  # noqa: F401 (import triggers registration)
+
+    ids = _registered_ids("megatron.")
+    assert len(ids) >= 30, f"too few megatron patches registered ({len(ids)}); auto-import may have broken"
+    assert len(ids) == len(set(ids)), "duplicate megatron patch ids in registry"
+    # Long-lived core patches that must always be applied for Megatron training.
+    for must in ("megatron.args.mock_data", "megatron.checkpoint.save_checkpoint"):
+        assert must in ids, f"expected patch '{must}' is not registered"
+
+
+def test_torchtitan_patches_auto_register():
+    import primus.backends.torchtitan.patches  # noqa: F401
+
+    ids = _registered_ids("torchtitan.")
+    assert len(ids) >= 8, f"too few torchtitan patches registered ({len(ids)})"
+    assert len(ids) == len(set(ids)), "duplicate torchtitan patch ids in registry"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,11 +10,17 @@ import subprocess
 import sys
 import time
 import unittest
+import warnings
 from typing import Optional
 
 from primus.core.utils import logger
 
 TRAINING_COMPLETED_MARKER = "Training completed."
+
+# run_patcher's failure line ("[Patch] \u2717 Patch '<id>' failed..."); distinct
+# from a patch's own graceful "[SKIP]". run_patches doesn't fail training on it
+# (stop_on_error=False), so we surface it ourselves.
+PATCH_FAILURE_MARKER = "\u2717 Patch '"
 
 
 class PrimusUT(unittest.TestCase):
@@ -43,6 +49,25 @@ class PrimusUT(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+
+def _warn_on_patch_failures(tag: str, stdout_output: str) -> None:
+    """Warn (don't fail) when patches failed to apply during training.
+
+    A failed patch doesn't crash training and a 3-step smoke run can't prove it
+    was harmless, so we emit a GitHub Actions warning to keep it visible without
+    blocking CI. No-op for backends that don't emit the marker.
+    """
+    if PATCH_FAILURE_MARKER not in stdout_output:
+        return
+    failed = [ln.strip() for ln in stdout_output.splitlines() if PATCH_FAILURE_MARKER in ln]
+    msg = (
+        f"[{tag}] {len(failed)} patch(es) failed to apply during training "
+        f"(training still completed): " + " | ".join(failed[:10])
+    )
+    # GitHub Actions annotation: shows on the run/PR without failing the job.
+    print(f"::warning title=Primus patch failed to apply::{msg}")
+    warnings.warn(msg)
 
 
 def run_training_script(
@@ -103,6 +128,8 @@ def run_training_script(
                 f"not found in log output. Training may have failed silently.\n"
                 f"Log file: {train_log_path}"
             )
+
+        _warn_on_patch_failures(tag, stdout_output)
 
         return stdout_output, ""
 

--- a/tools/ci/coverage_summary.py
+++ b/tools/ci/coverage_summary.py
@@ -12,10 +12,17 @@ Modes:
                `coverage combine` of the unit + E2E data (line-level merge);
                two summary percentages cannot simply be added.
 
-Grouping: core/* and backends/* get a bold subtotal row; other modules are
-listed flat. __init__.py is dropped; tools/ and platforms/ are excluded (ops
-tooling / env abstraction, not unit-testable). runner/ is bash, covered by the
-tests/runner/ shell tests.
+Layout: top-level groups (core, backends, modules, agents, cli, pretrain.py, ...)
+are bold rows at the same level, sorted by coverage. core/ and backends/ also
+get indented sub-rows per area, sorted by coverage. __init__.py is dropped;
+tools/ and platforms/ are excluded (ops tooling / env abstraction, not
+unit-testable). runner/ is bash, covered by the tests/runner/ shell tests.
+
+Single-report mode reflects what a partial run (e.g. MaxText E2E) actually
+executed: modules with zero covered lines are hidden and the total is computed
+over the executed modules only, so the headline number is meaningful instead of
+diluted by code that run can never touch. The two-report comparison keeps every
+module (unit gives the full denominator).
 """
 
 import json
@@ -23,20 +30,27 @@ import sys
 from collections import defaultdict
 
 OMIT_MODULES = {"tools", "platforms"}
+# Top-level groups whose sub-packages are shown as indented detail rows; every
+# other group (modules, agents, cli, pretrain.py, ...) is a single bold row.
+DETAILED_GROUPS = ("core", "backends")
 
 
 def classify(path: str):
-    """Return (section, module_name) for a covered file, or None to skip it."""
+    """Return (group, detail) for a covered file, or None to skip it.
+
+    group is the top-level row key; detail is the sub-row key for
+    DETAILED_GROUPS (e.g. core/projection), else None.
+    """
     seg = (path[path.find("primus/") :] if "primus/" in path else path).split("/")
     if seg[-1] == "__init__.py":
         return None
     if len(seg) < 2:
-        return "other", "(top-level)"
+        return "(top-level)", None
     if len(seg) == 2:  # primus/<file>.py, e.g. pretrain.py
-        return "other", seg[1]
-    if seg[1] in ("core", "backends"):
+        return seg[1], None
+    if seg[1] in DETAILED_GROUPS:
         return seg[1], seg[1] + "/" + seg[2]
-    return "other", seg[1]
+    return seg[1], None
 
 
 def _pct(covered: int, total: int) -> float:
@@ -44,20 +58,19 @@ def _pct(covered: int, total: int) -> float:
 
 
 def _aggregate(report: dict):
-    """Return {module_name: [covered, statements, section]} for kept modules."""
-    agg = defaultdict(lambda: [0, 0, ""])
+    """Return {group: {detail|group: [covered, statements]}} for kept modules."""
+    agg = defaultdict(lambda: defaultdict(lambda: [0, 0]))
     for fpath, info in report.get("files", {}).items():
         result = classify(fpath)
         if result is None:
             continue
-        sec, name = result
-        if name in OMIT_MODULES:
+        group, detail = result
+        if group in OMIT_MODULES:
             continue
         s = info["summary"]
-        a = agg[name]
+        a = agg[group][detail or group]
         a[0] += s["covered_lines"]
         a[1] += s["num_statements"]
-        a[2] = sec
     return agg
 
 
@@ -66,31 +79,44 @@ def render(primary: dict, title: str, secondary: dict = None) -> str:
     sa = _aggregate(secondary) if secondary is not None else None
     two = sa is not None
 
-    def e2e_cov(names):
-        return sum(sa.get(n, [0])[0] for n in names) if two else 0
+    def e2e_cov(group, key):
+        return sa.get(group, {}).get(key, [0])[0] if two else 0
 
-    def row(label, names, bold=False):
-        """One Markdown row. `label` is rendered as-is (caller adds backticks)."""
-        c = sum(pa[n][0] for n in names)
-        n = sum(pa[n][1] for n in names)
+    def row(label, cov, stmts, e2e, bold=False):
         if two:
-            vals = [format(n, ","), "%.1f%%" % _pct(c, n), "%.1f%%" % _pct(e2e_cov(names), n)]
+            vals = [format(stmts, ","), "%.1f%%" % _pct(cov, stmts), "%.1f%%" % _pct(e2e, stmts)]
         else:
-            vals = [format(c, ","), format(n, ","), "%.1f%%" % _pct(c, n)]
+            vals = [format(cov, ","), format(stmts, ","), "%.1f%%" % _pct(cov, stmts)]
         w = "**" if bold else ""
-        cells = ["%s%s%s" % (w, x, w) for x in [label] + vals]
-        return "| " + " | ".join(cells) + " |"
+        return "| " + " | ".join("%s%s%s" % (w, x, w) for x in [label] + vals) + " |"
 
-    names_all = [n for n in pa if pa[n][1] > 0]
-    tc = sum(pa[n][0] for n in names_all)
-    tn = sum(pa[n][1] for n in names_all)
+    def group_totals(group):
+        # Single-report mode counts only executed entries (cov > 0) so a partial
+        # run isn't diluted by sub-modules it never touched; two-report keeps all.
+        entries = [(k, v) for k, v in pa[group].items() if two or v[0] > 0]
+        cov = sum(v[0] for _, v in entries)
+        stmts = sum(v[1] for _, v in entries)
+        e2e = sum(e2e_cov(group, k) for k, _ in entries) if two else 0
+        return cov, stmts, e2e
+
+    # Single-report mode hides modules with zero coverage and totals over the
+    # executed modules only, so a partial run (e.g. MaxText E2E) isn't diluted by
+    # code it can never touch. The two-report comparison keeps the full denominator.
+    def group_executed(group):
+        return group_totals(group)[0] > 0 if not two else True
+
+    groups = [g for g in pa if group_totals(g)[1] > 0 and group_executed(g)]
+
+    tc = sum(group_totals(g)[0] for g in groups)
+    tn = sum(group_totals(g)[1] for g in groups)
+    te = sum(group_totals(g)[2] for g in groups) if two else 0
     excl = ", ".join(sorted(OMIT_MODULES))
 
     out = ["## Primus coverage - %s\n" % title]
     if two:
         out.append(
             "**Unit %.1f%% -> Unit+E2E %.1f%%** (%s statements; excludes %s)\n"
-            % (_pct(tc, tn), _pct(e2e_cov(names_all), tn), format(tn, ","), excl)
+            % (_pct(tc, tn), _pct(te, tn), format(tn, ","), excl)
         )
         out += ["| Module | Stmts | Unit | Unit+E2E |", "|---|--:|--:|--:|"]
     else:
@@ -100,17 +126,17 @@ def render(primary: dict, title: str, secondary: dict = None) -> str:
         )
         out += ["| Module | Covered | Stmts | Coverage |", "|---|--:|--:|--:|"]
 
-    for sec, stitle in [("core", "Core (framework)"), ("backends", "Backends")]:
-        names = sorted([n for n in names_all if pa[n][2] == sec], key=lambda n: -pa[n][1])
-        if names:
-            out.append(row(stitle, names, bold=True))
-            out += [row("`%s`" % n, [n]) for n in names]
+    # Top-level groups, sorted by coverage (desc).
+    for group in sorted(groups, key=lambda g: -_pct(group_totals(g)[0], group_totals(g)[1])):
+        cov, stmts, e2e = group_totals(group)
+        out.append(row("`%s`" % group, cov, stmts, e2e, bold=True))
+        if group in DETAILED_GROUPS:
+            # In single-report mode, hide sub-rows that were never executed.
+            details = ((k, v) for k, v in pa[group].items() if v[1] > 0 and (two or v[0] > 0))
+            for k, v in sorted(details, key=lambda kv: -_pct(kv[1][0], kv[1][1])):
+                out.append(row("&emsp;`%s`" % k, v[0], v[1], e2e_cov(group, k)))
 
-    # other modules (modules, agents, cli, pretrain.py, ...) listed flat
-    others = sorted([n for n in names_all if pa[n][2] == "other"], key=lambda n: -pa[n][1])
-    out += [row("`%s`" % n, [n]) for n in others]
-
-    out.append(row("TOTAL", names_all, bold=True))
+    out.append(row("TOTAL", tc, tn, te, bold=True))
     return "\n".join(out)
 
 

--- a/tools/ci/coverage_summary.py
+++ b/tools/ci/coverage_summary.py
@@ -15,11 +15,13 @@ Modes (by number of report arguments):
                 counting and lets torch (megatron/torchtitan) and jax (maxtext)
                 E2E - which cover near-disjoint modules - share one table.
 
-Layout: top-level groups (core, backends, modules, agents, cli, pretrain.py, ...)
-are bold rows at the same level, sorted by coverage. core/ and backends/ also
-get indented sub-rows per area, sorted by coverage. __init__.py is dropped;
-tools/ and platforms/ are excluded (ops tooling / env abstraction, not
-unit-testable). runner/ is bash, covered by the tests/runner/ shell tests.
+Layout: top-level groups (core, backends, modules, agents, cli, ...) are bold
+rows at the same level, sorted by coverage. core/ and backends/ also get
+indented sub-rows per area, sorted by coverage. __init__.py is dropped;
+tools/, platforms/ and the top-level pretrain.py entrypoint are excluded (ops
+tooling / env abstraction / thin CLI glue, exercised by E2E and shell tests
+rather than unit tests). runner/ is bash, covered by the tests/runner/ shell
+tests.
 
 Single-report mode reflects what a partial run (e.g. MaxText E2E) actually
 executed: modules with zero covered lines are hidden and the total is computed
@@ -32,9 +34,9 @@ import json
 import sys
 from collections import defaultdict
 
-OMIT_MODULES = {"tools", "platforms"}
+OMIT_MODULES = {"tools", "platforms", "pretrain.py"}
 # Top-level groups whose sub-packages are shown as indented detail rows; every
-# other group (modules, agents, cli, pretrain.py, ...) is a single bold row.
+# other group (modules, agents, cli, ...) is a single bold row.
 DETAILED_GROUPS = ("core", "backends")
 
 

--- a/tools/ci/coverage_summary.py
+++ b/tools/ci/coverage_summary.py
@@ -6,11 +6,14 @@
 
 """Render coverage.py JSON as a compact Markdown table for the CI run summary.
 
-Modes:
-  1 report  -> single "Coverage" column (e.g. JAX MaxText E2E).
-  2 reports -> "Unit" vs "Unit+E2E" columns. The 2nd report must come from
-               `coverage combine` of the unit + E2E data (line-level merge);
-               two summary percentages cannot simply be added.
+Modes (by number of report arguments):
+  1 report   -> single "Coverage" column (e.g. JAX MaxText E2E).
+  2+ reports -> "Unit" vs "Unit+E2E". The 1st is unit; the rest are E2E reports,
+                merged per module by taking the max covered lines. Each E2E
+                report should be a `coverage combine` of unit + that job's E2E
+                data (line-level). Taking the max across jobs avoids double
+                counting and lets torch (megatron/torchtitan) and jax (maxtext)
+                E2E - which cover near-disjoint modules - share one table.
 
 Layout: top-level groups (core, backends, modules, agents, cli, pretrain.py, ...)
 are bold rows at the same level, sorted by coverage. core/ and backends/ also
@@ -74,13 +77,15 @@ def _aggregate(report: dict):
     return agg
 
 
-def render(primary: dict, title: str, secondary: dict = None) -> str:
+def render(primary: dict, title: str, secondaries: list = None) -> str:
     pa = _aggregate(primary)
-    sa = _aggregate(secondary) if secondary is not None else None
-    two = sa is not None
+    sas = [_aggregate(s) for s in (secondaries or [])]
+    two = bool(sas)
 
     def e2e_cov(group, key):
-        return sa.get(group, {}).get(key, [0])[0] if two else 0
+        # Merge E2E reports by max covered lines (jobs cover near-disjoint
+        # modules, so max avoids double counting the shared core code).
+        return max((sa.get(group, {}).get(key, [0])[0] for sa in sas), default=0) if two else 0
 
     def row(label, cov, stmts, e2e, bold=False):
         if two:
@@ -112,11 +117,22 @@ def render(primary: dict, title: str, secondary: dict = None) -> str:
     te = sum(group_totals(g)[2] for g in groups) if two else 0
     excl = ", ".join(sorted(OMIT_MODULES))
 
+    # coverage's own totals over every primus file (nothing excluded), for context.
+    p_all = primary.get("totals", {}).get("percent_covered", 0.0)
+    s_all = (
+        max((s.get("totals", {}).get("percent_covered", 0.0) for s in secondaries), default=0.0)
+        if two
+        else 0.0
+    )
+
     out = ["## Primus coverage - %s\n" % title]
     if two:
         out.append(
             "**Unit %.1f%% -> Unit+E2E %.1f%%** (%s statements; excludes %s)\n"
             % (_pct(tc, tn), _pct(te, tn), format(tn, ","), excl)
+        )
+        out.append(
+            "_Including all modules (nothing excluded): Unit %.1f%% -> Unit+E2E %.1f%%._\n" % (p_all, s_all)
         )
         out += ["| Module | Stmts | Unit | Unit+E2E |", "|---|--:|--:|--:|"]
     else:
@@ -148,8 +164,8 @@ def _load(path: str) -> dict:
 def main() -> int:
     primary = _load(sys.argv[1])
     title = sys.argv[2] if len(sys.argv) > 2 else "tests"
-    secondary = _load(sys.argv[3]) if len(sys.argv) > 3 else None
-    print(render(primary, title, secondary))
+    secondaries = [_load(p) for p in sys.argv[3:]]
+    print(render(primary, title, secondaries or None))
     return 0
 
 

--- a/tools/ci/coverage_summary.py
+++ b/tools/ci/coverage_summary.py
@@ -27,7 +27,7 @@ OMIT_MODULES = {"tools", "platforms"}
 
 def classify(path: str):
     """Return (section, module_name) for a covered file, or None to skip it."""
-    seg = (path[path.find("primus/"):] if "primus/" in path else path).split("/")
+    seg = (path[path.find("primus/") :] if "primus/" in path else path).split("/")
     if seg[-1] == "__init__.py":
         return None
     if len(seg) < 2:

--- a/tools/ci/coverage_summary.py
+++ b/tools/ci/coverage_summary.py
@@ -1,0 +1,131 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Render coverage.py JSON as a compact Markdown table for the CI run summary.
+
+Modes:
+  1 report  -> single "Coverage" column (e.g. JAX MaxText E2E).
+  2 reports -> "Unit" vs "Unit+E2E" columns. The 2nd report must come from
+               `coverage combine` of the unit + E2E data (line-level merge);
+               two summary percentages cannot simply be added.
+
+Grouping: core/* and backends/* get a bold subtotal row; other modules are
+listed flat. __init__.py is dropped; tools/ and platforms/ are excluded (ops
+tooling / env abstraction, not unit-testable). runner/ is bash, covered by the
+tests/runner/ shell tests.
+"""
+
+import json
+import sys
+from collections import defaultdict
+
+OMIT_MODULES = {"tools", "platforms"}
+
+
+def classify(path: str):
+    """Return (section, module_name) for a covered file, or None to skip it."""
+    seg = (path[path.find("primus/"):] if "primus/" in path else path).split("/")
+    if seg[-1] == "__init__.py":
+        return None
+    if len(seg) < 2:
+        return "other", "(top-level)"
+    if len(seg) == 2:  # primus/<file>.py, e.g. pretrain.py
+        return "other", seg[1]
+    if seg[1] in ("core", "backends"):
+        return seg[1], seg[1] + "/" + seg[2]
+    return "other", seg[1]
+
+
+def _pct(covered: int, total: int) -> float:
+    return (100.0 * covered / total) if total else 0.0
+
+
+def _aggregate(report: dict):
+    """Return {module_name: [covered, statements, section]} for kept modules."""
+    agg = defaultdict(lambda: [0, 0, ""])
+    for fpath, info in report.get("files", {}).items():
+        result = classify(fpath)
+        if result is None:
+            continue
+        sec, name = result
+        if name in OMIT_MODULES:
+            continue
+        s = info["summary"]
+        a = agg[name]
+        a[0] += s["covered_lines"]
+        a[1] += s["num_statements"]
+        a[2] = sec
+    return agg
+
+
+def render(primary: dict, title: str, secondary: dict = None) -> str:
+    pa = _aggregate(primary)
+    sa = _aggregate(secondary) if secondary is not None else None
+    two = sa is not None
+
+    def e2e_cov(names):
+        return sum(sa.get(n, [0])[0] for n in names) if two else 0
+
+    def row(label, names, bold=False):
+        """One Markdown row. `label` is rendered as-is (caller adds backticks)."""
+        c = sum(pa[n][0] for n in names)
+        n = sum(pa[n][1] for n in names)
+        if two:
+            vals = [format(n, ","), "%.1f%%" % _pct(c, n), "%.1f%%" % _pct(e2e_cov(names), n)]
+        else:
+            vals = [format(c, ","), format(n, ","), "%.1f%%" % _pct(c, n)]
+        w = "**" if bold else ""
+        cells = ["%s%s%s" % (w, x, w) for x in [label] + vals]
+        return "| " + " | ".join(cells) + " |"
+
+    names_all = [n for n in pa if pa[n][1] > 0]
+    tc = sum(pa[n][0] for n in names_all)
+    tn = sum(pa[n][1] for n in names_all)
+    excl = ", ".join(sorted(OMIT_MODULES))
+
+    out = ["## Primus coverage - %s\n" % title]
+    if two:
+        out.append(
+            "**Unit %.1f%% -> Unit+E2E %.1f%%** (%s statements; excludes %s)\n"
+            % (_pct(tc, tn), _pct(e2e_cov(names_all), tn), format(tn, ","), excl)
+        )
+        out += ["| Module | Stmts | Unit | Unit+E2E |", "|---|--:|--:|--:|"]
+    else:
+        out.append(
+            "**Total line coverage: %.1f%%** (%s / %s statements; excludes %s)\n"
+            % (_pct(tc, tn), format(tc, ","), format(tn, ","), excl)
+        )
+        out += ["| Module | Covered | Stmts | Coverage |", "|---|--:|--:|--:|"]
+
+    for sec, stitle in [("core", "Core (framework)"), ("backends", "Backends")]:
+        names = sorted([n for n in names_all if pa[n][2] == sec], key=lambda n: -pa[n][1])
+        if names:
+            out.append(row(stitle, names, bold=True))
+            out += [row("`%s`" % n, [n]) for n in names]
+
+    # other modules (modules, agents, cli, pretrain.py, ...) listed flat
+    others = sorted([n for n in names_all if pa[n][2] == "other"], key=lambda n: -pa[n][1])
+    out += [row("`%s`" % n, [n]) for n in others]
+
+    out.append(row("TOTAL", names_all, bold=True))
+    return "\n".join(out)
+
+
+def _load(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def main() -> int:
+    primary = _load(sys.argv[1])
+    title = sys.argv[2] if len(sys.argv) > 2 else "tests"
+    secondary = _load(sys.argv[3]) if len(sys.argv) > 3 else None
+    print(render(primary, title, secondary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/junit_summary.py
+++ b/tools/ci/junit_summary.py
@@ -1,0 +1,108 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Render pytest JUnit XML as a Markdown table for the CI run summary.
+
+GitHub does not render JUnit on its own, so uploading it only yields a download
+link. This turns one or more reports into a per-suite pass/fail/error/skip/time
+table (plus a collapsible list of failures) to append next to the coverage
+table:
+
+    python junit_summary.py --title torch test-reports/*.xml >> "$GITHUB_STEP_SUMMARY"
+
+Each report is labelled by its filename stem; a missing/unparseable file
+renders as a "no report" row instead of failing the step.
+"""
+
+import argparse
+import glob
+import os
+import xml.etree.ElementTree as ET
+
+COLUMNS = ("tests", "passed", "failed", "errors", "skipped")
+
+
+def parse_file(path):
+    """Return (label, stats|None, failures) for one JUnit XML file."""
+    label = os.path.splitext(os.path.basename(path))[0]
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError):
+        return label, None, []
+
+    stats = dict.fromkeys(COLUMNS, 0)
+    stats["time"] = 0.0
+    failures = []
+    for suite in root.iter("testsuite"):  # root is <testsuites> or a lone <testsuite>
+        stats["tests"] += int(suite.get("tests", 0) or 0)
+        stats["failed"] += int(suite.get("failures", 0) or 0)
+        stats["errors"] += int(suite.get("errors", 0) or 0)
+        stats["skipped"] += int(suite.get("skipped", 0) or 0)
+        stats["time"] += float(suite.get("time", 0) or 0)
+        for case in suite.iter("testcase"):
+            # find(...) "or" is unsafe: an empty Element is falsy, so test explicitly.
+            bad, kind = case.find("failure"), "failure"
+            if bad is None:
+                bad, kind = case.find("error"), "error"
+            if bad is not None:
+                name = (case.get("classname", "") + "::" + case.get("name", "")).strip(":")
+                msg = (bad.get("message") or "").strip().splitlines()
+                failures.append((name, kind, msg[0] if msg else ""))
+    stats["passed"] = stats["tests"] - stats["failed"] - stats["errors"] - stats["skipped"]
+    return label, stats, failures
+
+
+def render(reports, title=None):
+    lines = ["## Test results - %s\n" % title] if title else []
+    lines += [
+        "| Suite | Tests | Passed | Failed | Errors | Skipped | Time |",
+        "|---|--:|--:|--:|--:|--:|--:|",
+    ]
+    total = dict.fromkeys(COLUMNS, 0)
+    total["time"] = 0.0
+    failures = []
+    for label, st, fails in reports:
+        if st is None:
+            lines.append("| `%s` | _no report_ |  |  |  |  |  |" % label)
+            continue
+        lines.append(
+            "| `%s` | %d | %d | %d | %d | %d | %.1fs |"
+            % (label, st["tests"], st["passed"], st["failed"], st["errors"], st["skipped"], st["time"])
+        )
+        for k in total:
+            total[k] += st[k]
+        failures += [(label, *f) for f in fails]
+    lines.append(
+        "| **TOTAL** | **%d** | **%d** | **%d** | **%d** | **%d** | **%.1fs** |"
+        % (total["tests"], total["passed"], total["failed"], total["errors"], total["skipped"], total["time"])
+    )
+    lines.append("")
+
+    if failures:
+        lines.append("<details><summary>%d failing test(s)</summary>\n" % len(failures))
+        for label, name, kind, msg in failures:
+            lines.append(("- `%s` **%s** (%s): %s" % (label, name, kind, msg))[:300])
+        lines.append("\n</details>")
+    else:
+        lines.append("_All tests passed._")
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render JUnit XML as a Markdown CI summary.")
+    ap.add_argument("xml", nargs="+", help="JUnit XML file(s) or glob(s).")
+    ap.add_argument("--title", default=None, help="Optional section title (e.g. torch).")
+    args = ap.parse_args()
+
+    paths = []
+    for pat in args.xml:
+        paths += sorted(glob.glob(pat)) or [pat]  # keep literal -> "no report" row
+    print(render([parse_file(p) for p in paths], args.title))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

### Coverage & tests
- **Coverage summary**: new `tools/ci/coverage_summary.py` renders `coverage.json`
  as a module-grouped Markdown table (Core/Backends subtotals; `tools/` &
  `platforms/` excluded; `runner/` is bash, covered by shell tests). Supports a
  single column or a **Unit vs Unit+E2E** side-by-side comparison.
- **E2E coverage**: instrument training subprocesses (coverage `.pth` +
  `COVERAGE_PROCESS_START`) in both jobs:
  - torch job line-merges unit + Megatron/TorchTitan E2E and publishes the
    Unit-vs-Unit+E2E comparison (shows training-stack modules with low unit
    coverage, e.g. `backends/transformer_engine`, are actually exercised by E2E);
  - jax job records MaxText E2E (covers `backends/maxtext`) as a single column;
  - Clean uses `if: always()` and removes the injected `.pth` so it can't leak
    into later jobs on the persistent runners.
- **Patch tests**: `test_patch_registration.py` asserts the real backend patches
  register (unique ids, anchors present); `tests/utils.py` surfaces `run_patcher`
  `✗ Patch '<id>' failed` lines as a GitHub Actions warning after each E2E run
  (`run_patches` swallows them, so they were previously invisible).

### Stability fixes
- **Megatron E2E coverage**: `MegatronBaseTrainer` fast-exit called `os._exit(0)`,
  which bypassed `atexit` and dropped **all** Megatron E2E coverage (TorchTitan,
  a different trainer, was unaffected). Flush coverage first via a neutral
  `env.flush_before_hard_exit()` helper; no-op outside CI.
- **Flaky port**: the `init_parallel_state` fixture picked a random port in
  [29500, 39500], overlapping the ephemeral range and unchecked for availability,
  causing intermittent `EADDRINUSE`. Bind to port 0 (kernel-assigned) and set
  `MASTER_PORT` explicitly.

### CI reporting & hardening
- **JUnit reports**: JUnit XML for torch (core unit + Megatron/TorchTitan E2E)
  and jax (MaxText E2E), uploaded as `torch-test-reports` / `jax-test-reports`
  artifacts (machine-readable per-test pass/fail/duration, complementing the
  coverage summary). The jax suite runs via `run_unit_tests.py`, so
  `PYTEST_ADDOPTS` injects `--junitxml` without changing that wrapper.
- **Pinned actions**: every action (`checkout`/`setup-python`/`upload-artifact`/
  `download-artifact`) is pinned to a full commit SHA; Dependabot keeps them fresh.
- **Least-privilege token**: default `GITHUB_TOKEN` to read-only in `ci.yaml` and
  `benchmark.yaml` (behavior-neutral; Docker Hub push uses a dedicated PAT).
- **Summary tweak**: exclude the top-level `pretrain.py` entrypoint from the
  coverage table (thin CLI glue, like `tools/` & `platforms/`).