### PR TITLE
fix(megatron): don't log from spawned async-checkpoint worker

### DIFF
--- a/primus/backends/megatron/core/dist_checkpointing/strategies/filesystem_async.py
+++ b/primus/backends/megatron/core/dist_checkpointing/strategies/filesystem_async.py
@@ -11,12 +11,20 @@ from megatron.core.dist_checkpointing.strategies.filesystem_async import (
     FileSystemWriterAsync,
 )
 
-from primus.modules.module_utils import log_rank_0, warning_rank_0
+from primus.modules.module_utils import log_rank_0
 
 
 class PrimusFileSystemWriterAsync(FileSystemWriterAsync):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Log here, in the main process where the Primus logger is initialized.
+        # preload_tensors must not log: it runs in the 'spawn'ed async-save
+        # worker where the process-global logger is None (logging crashes it).
+        if torch.version.hip:
+            major, minor = self.get_hip_runtime_version()
+            log_rank_0(f"hip runtime version : {major}.{minor}")
+            if major < 7 or (major == 7 and minor < 1):
+                log_rank_0("HIP env detected, change argument non_blocking in FileSystemWriterAsync to False")
 
     @staticmethod
     def preload_tensors(*args, **kwargs):
@@ -27,17 +35,13 @@ class PrimusFileSystemWriterAsync(FileSystemWriterAsync):
         # forking a subprocess afterward with pinned_memory=True will trigger segmentation fault
         if torch.version.hip:
             major, minor = PrimusFileSystemWriterAsync.get_hip_runtime_version()
-            log_rank_0(f"hip runtime version : {major}.{minor}")
             if major < 7 or (major == 7 and minor < 1):
-                log_rank_0("HIP env detected, change argument non_blocking in FileSystemWriterAsync to False")
                 if "non_blocking" in kwargs:
                     kwargs["non_blocking"] = False
                 elif len(args) > 0 and type(args[-1]) == type(True):
                     # TODO (limou)
                     # non_blocking may NOT always be the last argument in the future
                     args = args[:-1] + (False,)
-                else:
-                    warning_rank_0("found argument non_blocking failed")
 
         return super(PrimusFileSystemWriterAsync, PrimusFileSystemWriterAsync).preload_tensors(
             *args, **kwargs


### PR DESCRIPTION
The current checkpointing saving crash with:

    AttributeError: 'NoneType' object has no attribute 'info'

This is triggered by async distributed checkpointing (ckpt_format=torch_dist, async_save=true, use_persistent_ckpt_worker=true). 

**Root cause:**
The logger is only avail through the main process, but the checkpointing worker is a spawned process without any logger inited.

**Summary of fix:**
Move the HIP-runtime probe + logging + the non_blocking decision into __init__, which runs in the main process. preload_tensors no longer touches the logger.

**Internal tech document:**
https://amd.atlassian.net/wiki/spaces/~712020ea4fade82ae94a95b7c0ba1cb554d2a8/pages/1750271001/Megatron+async+checkpointing+bug