### PR TITLE
DSv4: support in the performance-projection benchmark

### DIFF
--- a/primus/configs/models/megatron/deepseek_v4_base.yaml
+++ b/primus/configs/models/megatron/deepseek_v4_base.yaml
@@ -121,6 +121,7 @@ swiglu: true
 swiglu_limit: 10.0                         # clamped SwiGLU (FP4/FP8 stability)
 activation_func_clamp_value: 10.0          # clamp swiglu parameter (Megatron config field)
 bias_swiglu_fusion: false                   # fused path lacks clamp; revisit in perf phase
+v4_grouped_experts_support_clamped_swiglu: true  # grouped (TEGroupedMLP) backend honors the clamped SwiGLU above (training sets this too)
 
 # ---------- Parallelism defaults ----------
 expert_model_parallel_size: 1

--- a/primus/core/projection/module_profilers/attention.py
+++ b/primus/core/projection/module_profilers/attention.py
@@ -10,7 +10,7 @@ import torch
 
 from primus.core.projection.base_module_profiler import BaseModuleProfiler
 
-from .utils import benchmark_layer
+from .utils import benchmark_layer, v4_module_inputs
 
 
 class AttentionProfiler(BaseModuleProfiler):
@@ -333,13 +333,27 @@ class AttentionProfiler(BaseModuleProfiler):
                 # Effective sequence length per rank if CP is used
                 slen_per_cp = seq_len // cp_size
 
-                self._cached_results = benchmark_layer(
-                    self.module,
-                    [
-                        (seq_len, batch_size, self.config.model_config.hidden_size),
-                        ((1, 1, slen_per_cp, seq_len), torch.bool),
-                    ],
-                )
+                hidden = self.config.model_config.hidden_size
+                tcfg = getattr(self.module, "config", None)
+                hc_mult = getattr(tcfg, "hc_mult", 1)
+                # DeepSeek-V4 attention has a different signature
+                # (forward(hidden[B,S,D], position_ids[B,S])); feed V4-aware
+                # inputs so the real V4 attention path is exercised instead of
+                # crashing / falling back. Non-V4 modules use the stock inputs.
+                v4 = v4_module_inputs(self.module, batch_size, seq_len, hidden, hc_mult, "attention")
+                if v4 is not None:
+                    ishapes, fkwargs = v4
+                    self._cached_results = benchmark_layer(
+                        self.module, ishapes, transformer_config=tcfg, forward_kwargs=fkwargs
+                    )
+                else:
+                    self._cached_results = benchmark_layer(
+                        self.module,
+                        [
+                            (seq_len, batch_size, hidden),
+                            ((1, 1, slen_per_cp, seq_len), torch.bool),
+                        ],
+                    )
             self._cache_key = cache_key
         return self._cached_results
 

--- a/primus/core/projection/module_profilers/moe_mlp.py
+++ b/primus/core/projection/module_profilers/moe_mlp.py
@@ -11,7 +11,7 @@ from primus.core.projection.base_module_profiler import BaseModuleProfiler
 from primus.core.projection.profiler_spec import ModuleProfilerSpec
 from primus.core.projection.training_config import TrainingConfig
 
-from .utils import benchmark_moe_layer_decomposed
+from .utils import benchmark_layer, benchmark_moe_layer_decomposed, v4_module_inputs
 
 # Efficiency fractions for non-GEMM MoE overhead estimation.
 # These express achievable bandwidth as a fraction of peak HBM bandwidth.
@@ -349,10 +349,25 @@ class MoEMLPProfiler(BaseModuleProfiler):
                 self._a2a_fwd_ms = 0.0
                 self._a2a_bwd_ms = 0.0
             else:
-                fwd, bwd, act_mem, a2a_fwd, a2a_bwd = benchmark_moe_layer_decomposed(
-                    self.module,
-                    [(seq_len, batch_size, self.config.model_config.hidden_size)],
-                )
+                hidden = self.config.model_config.hidden_size
+                tcfg = getattr(self.module, "config", None)
+                # DeepSeek-V4 MoE: forward(hidden[B,S,D], *, token_ids[B,S]).
+                # Feed V4-aware inputs (right layout + token_ids for hash routing).
+                v4 = v4_module_inputs(self.module, batch_size, seq_len, hidden, 1, "moe")
+                if v4 is not None:
+                    # DeepseekV4MoE has no stock .dispatch/.combine to decompose
+                    # A2A; benchmark the whole MoE forward. At EP=1 (single-GPU
+                    # benchmark) A2A is ~0 and is restored analytically later.
+                    ishapes, fkwargs = v4
+                    fwd, bwd, act_mem = benchmark_layer(
+                        self.module, ishapes, transformer_config=tcfg, forward_kwargs=fkwargs
+                    )
+                    a2a_fwd = a2a_bwd = 0.0
+                else:
+                    fwd, bwd, act_mem, a2a_fwd, a2a_bwd = benchmark_moe_layer_decomposed(
+                        self.module,
+                        [(seq_len, batch_size, hidden)],
+                    )
                 self._cached_results = (fwd, bwd, act_mem)
                 self._a2a_fwd_ms = a2a_fwd
                 self._a2a_bwd_ms = a2a_bwd

--- a/primus/core/projection/module_profilers/transformer_layer.py
+++ b/primus/core/projection/module_profilers/transformer_layer.py
@@ -19,7 +19,7 @@ from .layer_norm import LayerNormProfiler
 from .moe_mlp import MoEMLPProfiler
 from .residual_add import ResidualAddProfiler
 from .router import RouterProfiler
-from .utils import benchmark_layer
+from .utils import benchmark_layer, v4_module_inputs
 
 # ── Fallback HBM bandwidth for elementwise overhead estimation ──
 _FALLBACK_HBM_BW_GBPS = 5300.0  # MI300X default
@@ -315,11 +315,27 @@ class DenseTransformerLayerProfiler(BaseModuleProfiler):
             else:
                 # Get TransformerConfig from the layer module itself (has fp8 setting)
                 transformer_config = getattr(self.layer_module, "config", None)
-                self._cached_results = benchmark_layer(
-                    self.layer_module,
-                    [(seq_len, batch_size, self.config.model_config.hidden_size)],
-                    transformer_config=transformer_config,
-                )
+                hidden = self.config.model_config.hidden_size
+                hc_mult = getattr(transformer_config, "hc_mult", 1)
+                # DeepSeek-V4 hybrid layer needs K-stream input [B,S,K,D] and a
+                # keyword position_ids; feed V4-aware inputs so the real V4 layer
+                # (mHC + V4 attention) is benchmarked. Non-V4 layers use the stock
+                # [S,B,D] input.
+                v4 = v4_module_inputs(self.layer_module, batch_size, seq_len, hidden, hc_mult, "layer")
+                if v4 is not None:
+                    ishapes, fkwargs = v4
+                    self._cached_results = benchmark_layer(
+                        self.layer_module,
+                        ishapes,
+                        transformer_config=transformer_config,
+                        forward_kwargs=fkwargs,
+                    )
+                else:
+                    self._cached_results = benchmark_layer(
+                        self.layer_module,
+                        [(seq_len, batch_size, hidden)],
+                        transformer_config=transformer_config,
+                    )
             self._cache_key = cache_key
         return self._cached_results
 
@@ -443,11 +459,27 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
             else:
                 # Get TransformerConfig from the layer module itself (has fp8 setting)
                 transformer_config = getattr(self.layer_module, "config", None)
-                self._cached_results = benchmark_layer(
-                    self.layer_module,
-                    [(seq_len, batch_size, self.config.model_config.hidden_size)],
-                    transformer_config=transformer_config,
-                )
+                hidden = self.config.model_config.hidden_size
+                hc_mult = getattr(transformer_config, "hc_mult", 1)
+                # DeepSeek-V4 hybrid layer needs K-stream input [B,S,K,D] and a
+                # keyword position_ids; feed V4-aware inputs so the real V4 layer
+                # (mHC + V4 attention) is benchmarked. Non-V4 layers use the stock
+                # [S,B,D] input.
+                v4 = v4_module_inputs(self.layer_module, batch_size, seq_len, hidden, hc_mult, "layer")
+                if v4 is not None:
+                    ishapes, fkwargs = v4
+                    self._cached_results = benchmark_layer(
+                        self.layer_module,
+                        ishapes,
+                        transformer_config=transformer_config,
+                        forward_kwargs=fkwargs,
+                    )
+                else:
+                    self._cached_results = benchmark_layer(
+                        self.layer_module,
+                        [(seq_len, batch_size, hidden)],
+                        transformer_config=transformer_config,
+                    )
             self._cache_key = cache_key
         return self._cached_results
 

--- a/primus/core/projection/module_profilers/utils.py
+++ b/primus/core/projection/module_profilers/utils.py
@@ -55,11 +55,57 @@ def _get_fp8_context_for_benchmark(transformer_config):
     return _FP8ContextFactory(transformer_config)
 
 
+def v4_module_inputs(module, batch_size, seq_len, hidden_size, hc_mult, kind):
+    """Build DeepSeek-V4-aware benchmark inputs, or None for non-V4 modules.
+
+    The generic harness feeds stock-attention inputs ``(hidden[S,B,D],
+    bool attention_mask)``, but the V4 modules have different signatures:
+
+    * ``DeepseekV4Attention.forward(hidden[B,S,D], position_ids[B,S])`` —
+      both positional; needs integer position_ids (not a bool mask).
+    * ``DeepseekV4HybridLayer.forward(hidden[B,S,K,D], attention_mask=None,
+      *, position_ids[B,S])`` — K=hc_mult parallel mHC streams, and
+      position_ids is keyword-only.
+
+    Returns ``(input_shapes, forward_kwargs)`` or ``None``.
+    """
+    cls = type(module).__name__
+    if kind == "attention" and "DeepseekV4Attention" in cls:
+        return (
+            [(batch_size, seq_len, hidden_size), ((batch_size, seq_len), torch.int64)],
+            None,
+        )
+    if kind == "layer" and "DeepseekV4HybridLayer" in cls:
+        k = max(1, int(hc_mult or 1))
+        ishapes = (
+            [(batch_size, seq_len, k, hidden_size)]
+            if k > 1
+            else [(batch_size, seq_len, hidden_size)]
+        )
+        # position_ids for RoPE; token_ids required by hash-routed MoE layers
+        # (ignored by non-hash layers). Both keyword-only on the V4 layer forward.
+        return (
+            ishapes,
+            {
+                "position_ids": ((batch_size, seq_len), torch.int64),
+                "token_ids": ((batch_size, seq_len), torch.int64),
+            },
+        )
+    if kind == "moe" and "DeepseekV4MoE" in cls:
+        # forward(hidden[B,S,D], *, token_ids[B,S]) -> [B,S,D]
+        return (
+            [(batch_size, seq_len, hidden_size)],
+            {"token_ids": ((batch_size, seq_len), torch.int64)},
+        )
+    return None
+
+
 def benchmark_layer(
     layer_module: torch.nn.Module,
     input_shapes: List[Union[Tuple[int, ...], Tuple[Tuple[int, ...], torch.dtype]]],
     num_iterations: int = 64,  # Match typical microbatch count
     transformer_config=None,  # Optional: pass config to enable FP8 context
+    forward_kwargs=None,  # Optional: dict name -> shape/(shape,dtype) passed as keywords
 ) -> tuple[float, float, int]:
     """
     Benchmark both forward and backward passes of a transformer layer using CUDA events.
@@ -110,6 +156,7 @@ def benchmark_layer(
             )
 
     inputs = [create_input(spec) for spec in input_shapes]
+    kwargs = {name: create_input(spec) for name, spec in (forward_kwargs or {}).items()}
 
     # ===========================================================================
     # Get FP8 context - CRITICAL for accurate FP8 timing!
@@ -126,7 +173,7 @@ def benchmark_layer(
 
     with fp8_context:
         for _ in range(num_warmup):
-            outputs = layer_module(*inputs)
+            outputs = layer_module(*inputs, **kwargs)
             if not isinstance(outputs, (tuple, list)):
                 outputs = (outputs,)
 
@@ -160,7 +207,7 @@ def benchmark_layer(
 
     with fp8_context:
         for _ in range(num_iterations):
-            outputs = layer_module(*inputs)
+            outputs = layer_module(*inputs, **kwargs)
 
     if device.type == "cuda":
         torch.cuda.synchronize(device)
@@ -184,7 +231,7 @@ def benchmark_layer(
             forward_end = torch.cuda.Event(enable_timing=True)
 
             forward_start.record()
-            outputs = layer_module(*inputs)
+            outputs = layer_module(*inputs, **kwargs)
             forward_end.record()
 
             # --- Backward pass ---
@@ -221,6 +268,7 @@ def benchmark_moe_layer_decomposed(
     input_shapes: List[Union[Tuple[int, ...], Tuple[Tuple[int, ...], torch.dtype]]],
     num_iterations: int = 64,
     transformer_config=None,
+    forward_kwargs=None,  # Optional: dict name -> shape/(shape,dtype) passed as keywords
 ) -> tuple[float, float, int, float, float]:
     """
     Benchmark an MoE layer with decomposed A2A timing.
@@ -273,6 +321,7 @@ def benchmark_moe_layer_decomposed(
             )
 
     inputs = [create_input(spec) for spec in input_shapes]
+    kwargs = {name: create_input(spec) for name, spec in (forward_kwargs or {}).items()}
     fp8_context = _get_fp8_context_for_benchmark(transformer_config)
 
     # =========================================================================
@@ -284,7 +333,7 @@ def benchmark_moe_layer_decomposed(
 
     with fp8_context:
         for _ in range(num_warmup):
-            outputs = moe_module(*inputs)
+            outputs = moe_module(*inputs, **kwargs)
             if not isinstance(outputs, (tuple, list)):
                 outputs = (outputs,)
 
@@ -316,7 +365,7 @@ def benchmark_moe_layer_decomposed(
 
     with fp8_context:
         for _ in range(num_iterations):
-            outputs = moe_module(*inputs)
+            outputs = moe_module(*inputs, **kwargs)
 
     if device.type == "cuda":
         torch.cuda.synchronize(device)
@@ -372,7 +421,7 @@ def benchmark_moe_layer_decomposed(
                 forward_end = torch.cuda.Event(enable_timing=True)
 
                 forward_start.record()
-                outputs = moe_module(*inputs)
+                outputs = moe_module(*inputs, **kwargs)
                 forward_end.record()
 
                 # --- Backward pass ---

--- a/primus/core/projection/performance_projection/projection.py
+++ b/primus/core/projection/performance_projection/projection.py
@@ -521,10 +521,22 @@ def _limit_layers_for_projection(module_config):
     original_moe_layout = getattr(module_config, "moe_layer_freq", None)
     dense_layers_present = _has_dense_layers(original_moe_layout)
     # Use 1 layer for fast profiling - results are extrapolated to full model
-    # Increase to 2-4 for better accuracy if needed
-    max_layers = 1
+    # Increase to 2-4 for better accuracy if needed. PRIMUS_PROJ_MAX_LAYERS lets
+    # the caller benchmark more representative layers (e.g. =2 to capture both the
+    # DeepSeek-V4 HCA(cr=128) and CSA(cr=4) attention kinds, which alternate).
+    max_layers = int(os.environ.get("PRIMUS_PROJ_MAX_LAYERS", "1"))
     target_layers = max(1, min(original_layers, max_layers))
     module_config.num_layers = target_layers
+    # Set the benchmarked layers' attention kinds. PRIMUS_PROJ_COMPRESS_RATIOS
+    # (e.g. "128,4") picks exactly one HCA + one CSA; otherwise trim the model's
+    # own schedule to the benchmarked layer count.
+    _cr_env = os.environ.get("PRIMUS_PROJ_COMPRESS_RATIOS", "").strip("[] ")
+    if _cr_env and hasattr(module_config, "compress_ratios"):
+        module_config.compress_ratios = [int(x) for x in _cr_env.split(",")][:target_layers]
+    else:
+        _cr = getattr(module_config, "compress_ratios", None)
+        if isinstance(_cr, (list, tuple)) and len(_cr) >= target_layers:
+            module_config.compress_ratios = list(_cr[:target_layers])
 
     if has_moe:
         if not dense_layers_present:

--- a/primus/modules/module_utils.py
+++ b/primus/modules/module_utils.py
@@ -86,7 +86,7 @@ def debug_rank_0(msg, *args, **kwargs):
         log_func(msg, module_name, function_name, line)
 
 
-def debug_rank_all(msg, *args, **kwargs):
+def debug_rank_all(msg="", *args, **kwargs):
     log_func = logger.debug_with_caller
 
     caller = inspect.stack()[1]

--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -512,14 +512,19 @@ class MegatronTrainer(BaseTrainer, BaseModule):
         # with main branch behavior for "gpt" (default) case
         if args.final_logit_softcapping is not None and args.final_logit_softcapping > 0.0:
             log_rank_0(f"-enable final_logit_softcapping: {args.final_logit_softcapping}")
-            if model_type == "mamba":
+            if model_type != "gpt":
                 self.model_provider = functools.partial(
                     primus_model_provider, get_model_provider(model_type=model_type)
                 )
             else:
                 self.model_provider = functools.partial(primus_model_provider, get_model_provider())
         else:
-            if model_type == "mamba":
+            # Pass model_type through for any non-gpt model (mamba, deepseek_v4, ...)
+            # so the correct builder is selected. Without this, deepseek_v4 falls
+            # back to the stock GPT builder (SelfAttention instead of
+            # DeepseekV4Attention) — which is what made the projection benchmark
+            # stock attention and ignore use_v4_triton_attention / compress_ratios.
+            if model_type != "gpt":
                 log_rank_0(f"-getting model provider for model_type={model_type}")
                 model_provider = get_model_provider(model_type=model_type)
                 log_rank_0(f"-model_provider: {model_provider}")
@@ -610,8 +615,6 @@ class MegatronTrainer(BaseTrainer, BaseModule):
             args.do_valid,
             args.do_test,
             args.dataloader_type,
-            args.retro_project_dir,
-            args.retro_cyclic_train_iters,
         )
 
         # Print setup timing.
@@ -916,9 +919,6 @@ class MegatronTrainer(BaseTrainer, BaseModule):
             optimizer = get_megatron_optimizer(
                 config,
                 model,
-                no_wd_decay_cond,
-                scale_lr_cond,
-                lr_mult,
                 use_gloo_process_groups=args.enable_gloo_process_groups,
             )
         else:
@@ -931,9 +931,6 @@ class MegatronTrainer(BaseTrainer, BaseModule):
             optimizer = get_megatron_muon_optimizer(
                 config,
                 model,
-                no_wd_decay_cond,
-                scale_lr_cond,
-                lr_mult,
                 use_gloo_process_groups=args.enable_gloo_process_groups,
                 layer_wise_distributed_optimizer="dist" in config.optimizer,
             )

--- a/run_dsv4_projection_1gpu.sh
+++ b/run_dsv4_projection_1gpu.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+###############################################################################
+# Primus PROJECTION (memory / performance) for DeepSeek-V4 on one gfx1250 GPU.
+#
+# Sibling of run_deepseek_v4_pro_muon_1gpu.sh. Same validated gfx1250 docker
+# recipe and the same required workarounds, but instead of pretraining it runs
+# the Primus projection tool (docs/projection.md): benchmark a couple of layers
+# on this single GPU and analytically project memory + training performance to
+# a multi-node target cluster.
+#
+# Usage:
+#   ./run_dsv4_projection_1gpu.sh                       # performance, pro, ->8 nodes
+#   MODE=memory ./run_dsv4_projection_1gpu.sh           # memory projection only
+#   PRIMUS_MODEL=deepseek_v4_flash ./run_dsv4_projection_1gpu.sh   # flash model
+#   TARGET_NODES=16 ./run_dsv4_projection_1gpu.sh       # project to 16 nodes
+#   PROFILING_MODE=simulate GPU_ARCH=mi355x MODE=performance ./run_dsv4_projection_1gpu.sh  # CPU-only
+###############################################################################
+set -eo pipefail
+
+SCRIPT_DIR=$(realpath -m "$(dirname "$0")")
+export DOCKER_IMAGE=${DOCKER_IMAGE:-registry-sc-harbor.amd.com/framework/therock-npi@sha256:feba897e2a32a2465b8b296ed2662b2ad6136b5f1cf6f6c2716a3674aafc30f3}
+export TE_WHEEL_DIR=${TE_WHEEL_DIR:-$(realpath -m "$SCRIPT_DIR/../../mi450/dist/feba897")}
+
+# ---------- What to project -------------------------------------------------
+export MODE=${MODE:-performance}                       # memory | performance
+export PRIMUS_MODEL=${PRIMUS_MODEL:-deepseek_v4_pro}   # deepseek_v4_pro | deepseek_v4_flash
+export EXP=${EXP:-examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml}
+export BENCHMARK_GPUS=${BENCHMARK_GPUS:-1}             # benchmark on this many GPUs (1 here)
+# This box has ONE physical GPU. We invoke `primus-cli direct --single`
+# (ONE python3 process, NOT torchrun) —
+# the same trick the validated run_dsv3_projection script uses. In --single mode
+# torchrun is not used, so GPUS_PER_NODE no longer drives --nproc_per_node; it
+# serves ONLY as the TARGET node size (8 GPUs/node), while the projection spawns
+# its own nproc=1 benchmark subprocess pinned to the single physical GPU. This
+# gives correct intra-/inter-node comm modeling for the real 8-GPU-node cluster.
+export GPUS_PER_NODE=8                                  # TARGET node size (8 nodes x 8 = 64 GPUs)
+export TARGET_NODES=${TARGET_NODES:-8}                  # production TP1*PP8*EP8 = 64 GPUs = 8 nodes
+export PROFILING_MODE=${PROFILING_MODE:-benchmark}     # benchmark | simulate | both
+export GPU_ARCH=${GPU_ARCH:-}                          # e.g. mi355x for --profiling-mode simulate
+
+# ---------- Required gfx1250 workarounds (see the pretrain launcher) ---------
+export HSA_NO_SCRATCH_RECLAIM=1
+# gfx1250 MES async-queue hang workaround — matched EXACTLY to the training
+# launcher (run_deepseek_v4_pro_muon_1gpu.sh): AMD_SERIALIZE_COPY=3 alone, which
+# was bisected sufficient for the V4-Pro proxy (KERNEL serialize + LAUNCH_BLOCKING
+# found unnecessary, default off). If the projection still hangs with this, the
+# cause is the full-model build (all 61 layers on one rank), not these knobs.
+export AMD_SERIALIZE_COPY=${AMD_SERIALIZE_COPY:-3}
+export AMD_SERIALIZE_KERNEL=${AMD_SERIALIZE_KERNEL:-0}
+export HIP_LAUNCH_BLOCKING=${HIP_LAUNCH_BLOCKING:-0}
+export HSA_ENABLE_SDMA=${HSA_ENABLE_SDMA:-0}           # flaky SDMA completion-signal workaround
+# Turbo-free TE-native FP8 (tensorwise / Float8CurrentScaling), matching the
+# training launcher. Without this the model uses TE DelayedScaling, which asserts
+# against the V4 attention's save_original_input. fp8_utils.py reads this env.
+export PRIMUS_FP8_DISABLE_TURBO=${PRIMUS_FP8_DISABLE_TURBO:-1}
+export NVTE_ROCM_ENABLE_MXFP8=${NVTE_ROCM_ENABLE_MXFP8:-1}
+# RCCL all_reduce(AVG) hangs even at world_size=1 -> sitecustomize rewrites AVG->SUM/ws.
+# Also put the vendored Emerging-Optimizers on PYTHONPATH so the muon optimizer
+# (emerging_optimizers.*) imports — required for OPTIMIZER=muon.
+export PYTHONPATH_IN="$SCRIPT_DIR/rccl_avg_workaround:$SCRIPT_DIR/third_party/Emerging-Optimizers"
+
+LOG=${LOG:-dsv4-projection-${MODE}.log}
+
+# Config overrides appended as trailing CLI key/value pairs. V4 uses its OWN
+# attention (multi_latent_attention=false + yarn via dual_rope), but Megatron's
+# stock validate_args rejects rope_type=yarn unless MLA is on. The projection
+# benchmarks a stock-Megatron layer (not the V4 custom attention), so force
+# rope_type=rope at the Megatron-arg level — V4 applies yarn internally and
+# rope-vs-yarn is a cheap elementwise op (negligible for timing).
+# (moe_router_score_function: V4 uses sqrtsoftplus, but Megatron's stock
+# validate requires sigmoid for expert-bias aux-loss-free routing; the score
+# function is a pointwise on router logits and does not change GEMM timing.)
+# (moe_token_dispatcher_type: V4 uses the turbo "flex" dispatcher, which asserts
+# TPxEP>1; the single-GPU benchmark runs at EP=1. Force "alltoall" — dispatcher
+# type only affects MoE *communication* (modeled analytically), not expert-GEMM
+# compute, so benchmarked layer time is unchanged.)
+# (enable_primus_turbo / use_turbo_deepep: a Primus patch [moe_dispatcher_patches]
+# force-replaces the dispatcher with the turbo DeepEP "flex" one when BOTH are
+# true, and flex asserts TPxEP>1 (can't benchmark on 1 GPU). gfx1250 runs
+# turbo-free anyway (training disables it), so force them off -> standard
+# alltoall dispatcher, single-GPU-benchmarkable.)
+# (gradient_accumulation_fusion: needs APEX fused_weight_gradient_mlp_cuda, not
+# in this container; off here exactly as in the training launcher.)
+# (optimizer: use the yaml default adam — the projection only benchmarks layer
+# fwd/bwd, so the optimizer choice doesn't affect timing, and adam avoids muon's
+# "Emerging Optimizers" package dependency that isn't in this container. The
+# trainer.py adam/muon get_*_optimizer call sites were patched to match the
+# bundled Megatron signature [dropped the removed no_wd_decay_cond/scale_lr_cond/
+# lr_mult positionals that collided with use_gloo_process_groups].)
+# (tokenizer NullTokenizer: the benchmark builds a mock dataset; Megatron's
+# MockGPTDataset JSON-serializes the tokenizer via .unique_identifiers, which the
+# DeepSeekV4 HuggingFace tokenizer lacks -> crash. NullTokenizer has it, needs no
+# HF download, and preserves vocab_size (129280) so embedding/LM-head GEMM dims
+# are unchanged. Layer compute is tokenizer-independent.)
+# (use_v4_triton_attention/csa: enable the fused flash-style V4 attention kernels
+# instead of eager attention so the benchmarked attention time is representative
+# of the real training config — eager materializes [B,H,S,S] and hugely inflates
+# attention at seq 4096. Verified working on gfx1250.)
+# V4-specific flags mirrored from the training launcher (now that the V4 builder
+# is used, the real DeepseekV4MoE/HybridLayer is built and needs these): clamped
+# SwiGLU support on the grouped backend, turbo off, legacy/permute-fusion off.
+EXTRA_OVERRIDES=${EXTRA_OVERRIDES:---rope_type rope --moe_router_score_function sigmoid --moe_token_dispatcher_type alltoall --enable_primus_turbo false --use_turbo_deepep false --use_turbo_grouped_mlp false --use_turbo_parallel_linear false --use_v4_compiled_sinkhorn false --moe_use_legacy_grouped_gemm false --moe_permute_fusion false --gradient_accumulation_fusion false --mtp_num_layers 0 --tokenizer_type NullTokenizer --use_v4_triton_attention true --use_v4_triton_csa_attention true}
+
+# ---------- Build the projection CLI args -----------------------------------
+PROJ_ARGS="projection $MODE --config $EXP"
+if [ "$MODE" = "performance" ]; then
+    PROJ_ARGS="$PROJ_ARGS --benchmark-gpus $BENCHMARK_GPUS --target-nodes $TARGET_NODES --profiling-mode $PROFILING_MODE"
+    [ -n "$GPU_ARCH" ] && PROJ_ARGS="$PROJ_ARGS --gpu-arch $GPU_ARCH"
+fi
+PROJ_ARGS="$PROJ_ARGS $EXTRA_OVERRIDES"
+
+# TE wheel install prefix (same as pretrain launcher)
+TE_INSTALL="true"
+if ls ${TE_WHEEL_DIR}/transformer_engine-*.whl >/dev/null 2>&1; then
+    TE_INSTALL="pip install --quiet --force-reinstall --no-deps ${TE_WHEEL_DIR}/transformer_engine-*.whl && \
+        pip install --quiet einops nvdlfw-inspect onnxscript onnx pydantic importlib-metadata packaging transformers pybind11"
+fi
+# simulate mode (CPU-only, no model instantiation) needs the Origami GEMM model.
+ORIGAMI_INSTALL="true"
+if [ "$PROFILING_MODE" = "simulate" ] || [ "$PROFILING_MODE" = "both" ]; then
+    ORIGAMI_INSTALL="pip install --quiet 'git+https://github.com/ROCm/rocm-libraries.git#subdirectory=shared/origami/python' || echo '[warn] origami install failed'"
+fi
+
+VOLUME_ARGS=(-v "$SCRIPT_DIR":"$SCRIPT_DIR")
+[[ -d "$TE_WHEEL_DIR" ]] && VOLUME_ARGS+=(-v "$TE_WHEEL_DIR":"$TE_WHEEL_DIR")
+
+echo "[projection] mode=$MODE model=$PRIMUS_MODEL target_nodes=$TARGET_NODES profiling_mode=$PROFILING_MODE config=$EXP"
+
+# Same docker invocation as run_deepseek_v4_pro_muon_1gpu.sh (validated gfx1250 recipe).
+docker run --rm \
+    --ipc=host --network=host \
+    --device=/dev/kfd --device=/dev/dri \
+    --cap-add=SYS_PTRACE --cap-add=CAP_SYS_ADMIN \
+    --security-opt seccomp=unconfined --group-add video \
+    --privileged \
+    --name primus-v4-projection \
+    -e NNODES=1 -e GPUS_PER_NODE="$GPUS_PER_NODE" \
+    -e MASTER_ADDR=localhost -e MASTER_PORT=1234 \
+    -e GLOO_SOCKET_IFNAME=lo -e NCCL_SOCKET_IFNAME=lo \
+    -e NCCL_IB_DISABLE=1 -e NCCL_P2P_DISABLE=1 \
+    -e HSA_NO_SCRATCH_RECLAIM="$HSA_NO_SCRATCH_RECLAIM" \
+    -e AMD_SERIALIZE_COPY="$AMD_SERIALIZE_COPY" -e AMD_SERIALIZE_KERNEL="$AMD_SERIALIZE_KERNEL" \
+    -e HIP_LAUNCH_BLOCKING="$HIP_LAUNCH_BLOCKING" -e HSA_ENABLE_SDMA="$HSA_ENABLE_SDMA" \
+    -e PRIMUS_FP8_DISABLE_TURBO="$PRIMUS_FP8_DISABLE_TURBO" -e NVTE_ROCM_ENABLE_MXFP8="$NVTE_ROCM_ENABLE_MXFP8" \
+    -e PRIMUS_PROJ_MAX_LAYERS="${PRIMUS_PROJ_MAX_LAYERS:-1}" -e PRIMUS_PROJ_COMPRESS_RATIOS="${PRIMUS_PROJ_COMPRESS_RATIOS:-}" \
+    -e PRIMUS_MODEL="$PRIMUS_MODEL" -e PYTHONUNBUFFERED=1 \
+    "${VOLUME_ARGS[@]}" \
+    "$DOCKER_IMAGE" /bin/bash -c "\
+        set -e && cd $SCRIPT_DIR && \
+        export PYTHONPATH=$PYTHONPATH_IN:\${PYTHONPATH:-} && \
+        ${TE_INSTALL} && \
+        ${ORIGAMI_INSTALL} && \
+        pip install --quiet -r requirements.txt && \
+        echo '==================== DSV4 PROJECTION ($MODE) ====================' && \
+        bash runner/primus-cli direct --single -- $PROJ_ARGS" \
+    2>&1 | tee "$LOG"


### PR DESCRIPTION
Ports the perf-projection benchmark V4 support from dev/john/dsv4 (64407fe4).

The in-repo benchmark built a stock GPT model (SelfAttention) instead of the V4 model, so use_v4_triton_attention / compress_ratios were ignored and attention timing was unrepresentative. Routes non-gpt model_type to its builder and makes the harness V4-aware:
- V4 model routing in trainer.py (!= "gpt" instead of == "mamba").
- v4_module_inputs helper for V4 forward signatures (K-stream mHC [B,S,K,D], keyword-only position_ids/token_ids).
- per-cr representative layer selection (PRIMUS_PROJ_MAX_LAYERS / PRIMUS_PROJ_COMPRESS_RATIOS) -- one HCA (cr=128) + one CSA (cr=4).
- run_dsv4_projection_1gpu.sh.

This is the in-repo module-benchmark projection (primus/core/projection/), a separate subsystem from the trace-based projection site (deepseek-v4/projection/); they share no code and coexist.