### PR TITLE
DSv4: FP8/FP4 low-precision training recipe + Muon mxfp8 fix + launchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ pp_simulation_result
 # GitHub Pages) despite the generic `data` ignore above.
 !deepseek-v4/projection/site/data/
 !deepseek-v4/projection/site/data/*.json
+
+*.log
+*.nohup
+*.zip

--- a/examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml
@@ -1,0 +1,165 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v4_flash-fp8-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+# DeepSeek-V4 Flash FP8 pretraining config tuned for MI355X.
+# Derived from deepseek_v4_flash-BF16-pretrain.yaml; the ONLY substantive
+# delta is the FP8 training block at the bottom.
+#
+# Precision recipe (paper §4.x quantization / techblog §9.6):
+#   Paper = "FP4 + FP8 Mixed": MoE experts + CSA-Indexer QK in FP4 (MXFP4),
+#   EVERYTHING ELSE in FP8, all with the **ue8m0** microscaling scale format.
+#   ue8m0 = OCP Microscaling (MX) block scale → on this stack that is
+#   `fp8_recipe: mxfp8` → TE MXFP8BlockScaling → Primus-Turbo MX_BLOCKWISE
+#   with scale_dtype=E8M0 (fp8_utils.py:148), native on MI355X/CDNA4.
+#
+# Integration gap vs the paper (NOT config — Primus V4 TODO, techblog item 10
+# "Phase 2 FP4/FP8 Mixed"): the FP4 expert / FP4-Indexer path is not yet wired
+# in V4, so experts run at FP8 here (FP8 everywhere) rather than FP4. This is
+# the closest supported step toward the paper recipe. FP8 is highly outlier-
+# sensitive, which is why the paper pairs it with clamped SwiGLU (swiglu_limit,
+# set below) — keep that on whenever FP8 is enabled.
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    model: ${PRIMUS_MODEL:deepseek_v4_flash}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_DeepSeek_V4_Pretrain"
+      stderr_sink_level: DEBUG
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 1
+      global_batch_size: 256
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1.0e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+
+      # parallel — scaffold defaults; will be retuned in Phase 6.
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:8}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      gradient_accumulation_fusion: true
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # ---------- DeepSeek-V4 specific ----------
+      hybrid_attention_enabled: true
+      attn_sink: true
+      hc_use_sinkhorn: true
+      mtp_use_separate_hc_head: true
+      moe_router_score_function: sqrtsoftplus
+      swiglu_limit: 10.0
+
+      # ---------- Optimizer ----------
+      # NOTE: Phase 7 will add Muon for the latent / hidden projections.
+      #       Until then we run plain BF16 AdamW (precision-aware).
+      use_precision_aware_optimizer: true
+      main_grads_dtype: bf16
+      exp_avg_dtype: bf16
+      exp_avg_sq_dtype: bf16
+
+      # rope fusion
+      enable_experimental: true
+      apply_rope_fusion: false   # V4 uses partial RoPE on a 512-dim head
+
+      # recompute
+      recompute_granularity: full
+      recompute_method: uniform
+      recompute_num_layers: 1
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # turbo / deepep — keep off by default; enable via env vars when
+      # benchmarking the Turbo path (see run_deepseek_v4.sh).  Plan-3 P22
+      # routes the dense (compress_ratio == 0) attention layers through
+      # PrimusTurboAttention when ``use_turbo_attention=true``; the V4
+      # builder auto-derives ``use_sink_attention`` /
+      # ``sink_sliding_window`` from ``attn_sink`` / ``attn_sliding_window``
+      # so the YAML stays free of Turbo-internal knobs.
+      enable_primus_turbo: ${PRIMUS_ENABLE_TURBO:false}
+      use_turbo_attention: ${PRIMUS_USE_TURBO_ATTENTION:false}
+      use_turbo_grouped_mlp: false
+      use_turbo_rms_norm: false
+      use_turbo_deepep: ${PRIMUS_USE_TURBO_DEEPEP:false}
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+
+      # plan-4 P25 / P26: in-tree Primus Triton kernels for V4 attention.
+      # Precedence in DeepseekV4Attention.forward:
+      #   use_turbo_attention > use_v4_tilelang_attention > use_v4_triton_attention > eager   (cr ∈ {0, 128})
+      #   use_v4_tilelang_csa_attention > use_v4_triton_csa_attention > eager                 (cr == 4)
+      use_v4_triton_attention: ${PRIMUS_USE_V4_TRITON_ATTENTION:false}
+      use_v4_triton_csa_attention: ${PRIMUS_USE_V4_TRITON_CSA_ATTENTION:false}
+
+      # Plan-8 tilelang attention kernels (OPTIONAL — tilelang is NOT
+      # bundled in the default Primus container). When enabled, the
+      # V4 attention dispatcher routes through the tilelang FWD/BWD;
+      # when tilelang is not installed, the dispatcher prints a single
+      # rank-0 warning and falls back to Triton -- training continues
+      # without error. Replaces the legacy PRIMUS_V4_TILELANG_ATTN env
+      # knob (no longer consulted).
+      use_v4_tilelang_attention: ${PRIMUS_USE_V4_TILELANG_ATTENTION:false}
+      use_v4_tilelang_csa_attention: ${PRIMUS_USE_V4_TILELANG_CSA_ATTENTION:false}
+
+      # plan-5 P29 (RESCOPED): wrap sinkhorn_normalize with a cached
+      # torch.compile(fullgraph=True, dynamic=False) build. Default
+      # false until G32 (parity) + G33b (trace) flip it on.
+      use_v4_compiled_sinkhorn: ${PRIMUS_USE_V4_COMPILED_SINKHORN:false}
+
+      moe_use_fused_router_with_aux_score: false
+      moe_permute_fusion: true
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # ---------- FP8 training ----------
+      # fp8 = number format (E4M3); fp8_recipe = scaling strategy.
+      # The paper uses ue8m0 microscaling (= mxfp8, 1x32 block / E8M0 scale), but
+      # mxfp8 is NOT runnable on this gfx950 build: turbo grouped-GEMM has no MX
+      # path, and TE's ROCm MXFP8 GEMM requires K%128==0 (V4 has a K=224 proj).
+      # So we use `tensorwise` (per-tensor scale) — the working recipe. This gives
+      # the paper's fp8 *layout* (all weight GEMMs fp8) with a non-ue8m0 scale.
+      # Override via FP8 / FP8_RECIPE env knobs (CLI wins); FP8=null => BF16.
+      fp8: e4m3
+      fp8_recipe: tensorwise
+      # Route the attention/dense linear projections through PrimusTurboLinear so
+      # they quantize to fp8 too (not just the MoE experts) — matches the paper's
+      # "fp8 on all weight GEMMs". Without this the projections stay bf16.
+      use_turbo_parallel_linear: true

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -292,8 +292,11 @@ LOG_INFO ""
 
 # ----------------- AMD-specific GPU optimizations -----------------
 
-# Enable system DMA engine (SDMA) on AMD GPUs for better IO throughput
-export HSA_ENABLE_SDMA=1
+# Enable system DMA engine (SDMA) on AMD GPUs for better IO throughput.
+# ${:-} guarded so a caller can set HSA_ENABLE_SDMA=0 to route copies through
+# blit/compute kernels instead — workaround for hosts where an SDMA H2D copy
+# intermittently never signals completion (hangs in BusyWaitSignal).
+export HSA_ENABLE_SDMA=${HSA_ENABLE_SDMA:-1}
 
 # Prevent scratch memory from being reclaimed to stabilize large memory usage patterns (e.g., KV cache, MoE experts)
 # NOTE: Must disable scratch reclaim to avoid MoE training crash on AMD GPUs

--- a/phase5_fp4_indexer_probe.py
+++ b/phase5_fp4_indexer_probe.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Phase 5 probe: FP4 CSA-indexer QK selection-quality + grad-flow check.
+
+Runs the V4 Indexer in BF16 vs MXFP4-QK (PRIMUS_INDEXER_FP4) on identical
+weights/inputs and reports:
+  * top-k selection OVERLAP (paper's quality metric: do we pick the same
+    compressed positions?), per query, averaged.
+  * score cosine (numerical drift of I_{t,s}).
+  * STE backward sanity (grads finite, non-zero through the FP4 quant).
+
+Usage:
+  PRIMUS_INDEXER_FP4=0 not needed — the probe toggles the env itself.
+  python phase5_fp4_indexer_probe.py
+"""
+import os
+
+import torch
+
+# Import after we can toggle env per-call.
+from primus.backends.megatron.core.transformer import indexer as idx_mod
+from primus.backends.megatron.core.transformer.indexer import Indexer
+
+torch.manual_seed(0)
+
+DEV = "cuda"
+DT = torch.bfloat16
+
+B, S, D = 2, 2048, 2048
+COMPRESS_RATIO = 4
+INDEX_HEAD_DIM = 128
+INDEX_N_HEADS = 64
+INDEX_TOPK = 64
+
+
+def build():
+    torch.manual_seed(0)
+    m = Indexer(
+        hidden_size=D,
+        index_head_dim=INDEX_HEAD_DIM,
+        index_n_heads=INDEX_N_HEADS,
+        index_topk=INDEX_TOPK,
+        compress_ratio=COMPRESS_RATIO,
+    ).to(DEV, DT)
+    return m
+
+
+def run(m, hidden, fp4: bool):
+    os.environ["PRIMUS_INDEXER_FP4"] = "1" if fp4 else "0"
+    assert idx_mod._indexer_fp4_enabled() is fp4
+    h = hidden.clone().requires_grad_(True)
+    topk_idxs, topk_scores = m(h)
+    return topk_idxs, topk_scores, h
+
+
+def main():
+    assert torch.cuda.is_available(), "needs MI355X (gfx950) for MXFP4"
+    m = build()
+    hidden = torch.randn(B, S, D, device=DEV, dtype=DT) * 0.5
+
+    idx_bf16, sc_bf16, _ = run(m, hidden, fp4=False)
+    idx_fp4, sc_fp4, h_fp4 = run(m, hidden, fp4=True)
+
+    # ---- selection overlap (ignore -1 padding/masked slots) ----
+    valid = idx_bf16 >= 0  # [B,S,K]
+    overlaps = []
+    Bn, Sn, K = idx_bf16.shape
+    a = idx_bf16.reshape(-1, K)
+    b = idx_fp4.reshape(-1, K)
+    v = valid.reshape(-1, K)
+    for i in range(a.shape[0]):
+        sa = set(a[i][v[i]].tolist())
+        if not sa:
+            continue
+        sb = set(b[i][b[i] >= 0].tolist())
+        overlaps.append(len(sa & sb) / len(sa))
+    overlap = sum(overlaps) / max(len(overlaps), 1)
+
+    # ---- score cosine on valid (finite) entries ----
+    fa = sc_bf16.reshape(-1).float()
+    fb = sc_fp4.reshape(-1).float()
+    fin = torch.isfinite(fa) & torch.isfinite(fb)
+    cos = torch.nn.functional.cosine_similarity(fa[fin], fb[fin], dim=0).item()
+
+    # ---- STE backward sanity through the FP4 quant ----
+    loss = sc_fp4[torch.isfinite(sc_fp4)].sum()
+    loss.backward()
+    g = h_fp4.grad
+    grad_ok = bool(torch.isfinite(g).all()) and g.abs().sum().item() > 0
+
+    print(f"[phase5] shapes: idx {tuple(idx_bf16.shape)}  P={S // COMPRESS_RATIO}  topk={INDEX_TOPK}")
+    print(f"[phase5] top-k selection overlap (FP4 vs BF16): {overlap:.4f}")
+    print(f"[phase5] score cosine (FP4 vs BF16):            {cos:.4f}")
+    print(f"[phase5] STE grad through FP4 QK finite+nonzero: {grad_ok}")
+    # Selection quality is the gate; the indexer only needs the same top-k.
+    print(f"[phase5] VERDICT: {'PASS' if overlap > 0.9 and grad_ok else 'CHECK'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -3,6 +3,7 @@
 #
 # See LICENSE for license information.
 ###############################################################################
+import os
 from contextlib import contextmanager
 from typing import Callable, List, Optional, Tuple
 
@@ -48,6 +49,21 @@ from primus_turbo.pytorch.core.low_precision import (
 from torch import Tensor
 from transformer_engine.pytorch.constants import dist_group_type
 from transformer_engine.pytorch.fp8 import DelayedScaling, FP8GlobalStateManager, Recipe
+
+# MXFP8 weight pre-quantization (cache the fp8 weight once per optimizer step
+# instead of re-quantizing every microbatch + recompute forward). Optional —
+# guarded so older primus_turbo builds without it fall back to per-forward quant.
+try:
+    from primus_turbo.triton.quantization.mxfp8_quant_kernels import (
+        MXFP8WeightPrequant,
+        prequant_mxfp8_weights,
+    )
+
+    _HAS_MXFP8_PREQUANT = True
+except Exception:  # pragma: no cover - depends on primus_turbo version
+    MXFP8WeightPrequant = None
+    prequant_mxfp8_weights = None
+    _HAS_MXFP8_PREQUANT = False
 
 from primus.backends.megatron.core.extensions._triton.stack_grouped_weight import (
     stack_grouped_weight,
@@ -101,6 +117,20 @@ def use_split_wgrad_op():
     elif args.patch_zero_bubble and args.enable_zero_bubble:
         return True
     return False
+
+
+def _dbg_fp8_first_seen(module, input_, weights, quant_config):
+    """Print each fp8 GEMM (in/weight) shape once per class, gated by PRIMUS_DEBUG_FP8=1."""
+    if os.environ.get("PRIMUS_DEBUG_FP8") != "1":
+        return
+    cls = type(module)
+    seen = cls.__dict__.get("_dbg_fp8_shapes")
+    if seen is None:
+        seen = set(); cls._dbg_fp8_shapes = seen
+    k = (tuple(input_.shape[-1:]), tuple(weights.shape))
+    if k not in seen:
+        seen.add(k)
+        print(f"[PRIMUS_DEBUG_FP8] {cls.__name__} fp8 in={tuple(input_.shape)} w={tuple(weights.shape)} gran={quant_config.data().granularity}", flush=True)
 
 
 class PrimusTurboQuantConfig:
@@ -658,6 +688,8 @@ class PrimusTurboLinear(TELinear):
             else:
                 raise ValueError("Not support quant config.")
 
+            _dbg_fp8_first_seen(self, input_, weights, quant_config)
+
             out = fp8_gemm(
                 input_, weights, trans_a=False, trans_b=True, out_dtype=None, config=quant_config.data()
             )
@@ -810,6 +842,8 @@ class PrimusTurboRowParallelLinear(TELinear):
             else:
                 raise ValueError("Not support quant config.")
 
+            _dbg_fp8_first_seen(self, input_, weights, quant_config)
+
             out = fp8_gemm(
                 input_, weights, trans_a=False, trans_b=True, out_dtype=None, config=quant_config.data()
             )
@@ -954,6 +988,8 @@ class PrimusTurboColumnParallelLinear(TELinear):
                 fp8_gemm = pt.ops.gemm_fp8
             else:
                 raise ValueError("Not support quant config.")
+
+            _dbg_fp8_first_seen(self, input_, weights, quant_config)
 
             out = fp8_gemm(
                 input_, weights, trans_a=False, trans_b=True, out_dtype=None, config=quant_config.data()
@@ -1254,6 +1290,40 @@ class PrimusTurboLayerNormColumnParallelLinear(te.pytorch.LayerNormLinear):
         return out, None
 
 
+_FP4_TOKEN_PAD = 16
+
+
+def _grouped_gemm_fp4_per_group(a, b, group_lens, out_dtype, config):
+    """Per-group native MXFP4 grouped GEMM (drop-in for grouped_gemm_fp8, trans_b=False).
+
+    There is no fused grouped FP4 gemm, so loop the dense FP4 training gemm
+    (``pt.ops.gemm_fp4`` / FP4GemmMXFunction, hipBLASLt backend) over experts.
+    ``a``:[M,K], ``b``:[G,K,N] -> ``out``:[M,N] with out_g = a_g @ b_g.
+    The FP4 hipBLASLt path is NT-only (so b_g[K,N] is transposed to [N,K] and
+    trans_b=True) and needs the token dim a multiple of 16 (zero-pad, slice back).
+    fwd+dgrad+wgrad come from the gemm_fp4 autograd.
+    """
+    G, K, N = b.shape
+    gl = [int(x) for x in group_lens.tolist()]
+    offs = [0]
+    for m in gl:
+        offs.append(offs[-1] + m)
+    outs = []
+    for g in range(G):
+        m = gl[g]
+        if m == 0:
+            outs.append(a.new_zeros((0, N), dtype=out_dtype))
+            continue
+        a_g = a[offs[g]:offs[g] + m]
+        mp = (m + _FP4_TOKEN_PAD - 1) // _FP4_TOKEN_PAD * _FP4_TOKEN_PAD
+        if mp != m:
+            a_g = torch.cat([a_g, a_g.new_zeros((mp - m, K))], dim=0)
+        w = b[g].transpose(0, 1).contiguous()  # [K,N] -> [N,K] for NT
+        o = pt.ops.gemm_fp4(a_g.contiguous(), w, False, True, out_dtype, config)
+        outs.append(o[:m])
+    return torch.cat(outs, dim=0)
+
+
 class PrimusTurboGroupedMLP(TEGroupedMLP):
     """
     Compatibility GroupedMLP for legacy turbo grouped-gemm paths.
@@ -1285,6 +1355,38 @@ class PrimusTurboGroupedMLP(TEGroupedMLP):
         self.disable_turbo_grouped_mlp_low_precision = args.disable_turbo_grouped_mlp_low_precision
         self.patch_zero_bubble = args.patch_zero_bubble
         self.patch_primus_pipeline = args.patch_primus_pipeline
+        # Per-module recipe (paper): routed experts in MXFP4 while the rest of the
+        # layer runs FP8. Decided by this flag (not the global recipe), so it works
+        # under a global FP8 context without the mutually-exclusive --fp4/--fp8 flags.
+        self.moe_experts_fp4 = bool(getattr(config, "moe_experts_fp4", False))
+        # MXFP8 weight caching: expert weights only change at optimizer.step, so
+        # re-quantizing them on every microbatch + recompute forward (the large
+        # _mxfp8_quant_weight_fwd kernel) is redundant. When enabled, prequant the
+        # stacked weight once per step and reuse the fp8 buffers (a fresh bf16 is
+        # still threaded each call so wgrad flows to the per-expert leaves).
+        # Default off (extra ~2 bytes/param resident); enable per run.
+        self._cache_mxfp8_weight = (
+            _HAS_MXFP8_PREQUANT and os.environ.get("PRIMUS_TURBO_CACHE_MXFP8_WEIGHT", "0") == "1"
+        )
+        self._w1_mx_cache = None  # (b_fp8_fwd, b_scale_fwd, b_fp8_dgrad, b_scale_dgrad)
+        self._w2_mx_cache = None
+        # Re-quantize the cached fp8 weight on the first microbatch of each step.
+        # MegatronModule.set_is_first_microbatch() (called by the schedule each
+        # step when config.fp8 is set) flips this to True on every submodule that
+        # has the attribute; we clear it after the forward consumes the weights —
+        # the same contract TE's GroupedLinear fp8 weight cache uses (exact,
+        # sync-free, no value heuristic).
+        self.is_first_microbatch = True
+        self._experts_fp4_config = (
+            Float4QuantConfig(
+                format=Format.E2M1_X2,
+                granularity=ScalingGranularity.MX_BLOCKWISE,
+                block_size=32,
+                scale_dtype=ScaleDtype.E8M0,
+            )
+            if self.moe_experts_fp4
+            else None
+        )
 
         if self.config.add_bias_linear:
             raise ValueError("PrimusTurboGroupedMLP does not support add_bias_linear=True")
@@ -1325,6 +1427,29 @@ class PrimusTurboGroupedMLP(TEGroupedMLP):
         weights = [getattr(module, f"weight{i}") for i in range(self.num_local_experts)]
         return stack_grouped_weight(weights)
 
+    def _mxfp8_weight_arg(self, module, w_bf16, cache_attr, quant_config_data):
+        """GEMM ``b`` arg with the MXFP8 weight quantization cached per optimizer step.
+
+        The expert weight is constant within a step, so its fp8 buffers are
+        quantized once and reused. Rebuild MXFP8WeightPrequant with a *fresh*
+        differentiable ``w_bf16`` each call (wgrad must flow to the per-expert
+        leaves) over the *cached* fp8 fwd/dgrad buffers; caching the whole
+        container would point grad at a stale graph. MX_BLOCKWISE only.
+        Invalidated once per step via ``is_first_microbatch`` (set at the first
+        microbatch, cleared in ``forward``); ``cache is None`` covers first fwd.
+        """
+        if not self._cache_mxfp8_weight:
+            return w_bf16
+        if quant_config_data.granularity != ScalingGranularity.MX_BLOCKWISE:
+            return w_bf16
+        cache = getattr(self, cache_attr)
+        if self.is_first_microbatch or cache is None:
+            prq = prequant_mxfp8_weights(w_bf16.detach())
+            cache = (prq.b_fp8_fwd, prq.b_scale_fwd, prq.b_fp8_dgrad, prq.b_scale_dgrad)
+            setattr(self, cache_attr, cache)
+        # Fresh differentiable bf16 + cached fp8 buffers.
+        return MXFP8WeightPrequant(w_bf16, cache[0], cache[1], cache[2], cache[3])
+
     def forward(
         self,
         permuted_local_hidden_states: torch.Tensor,
@@ -1352,21 +1477,43 @@ class PrimusTurboGroupedMLP(TEGroupedMLP):
         w2 = self._stack_grouped_linear_weight(self.linear_fc2)
         tokens_per_expert = tokens_per_expert.to(w1.device)
 
-        use_grouped_gemm_low_precision = (
-            PrimusTurboLowPrecisionGlobalStateManager.is_turbo_fp8_enabled()
-            and not self.disable_turbo_grouped_mlp_low_precision
-        )
+        _low_prec = not self.disable_turbo_grouped_mlp_low_precision
+        _fp8_on = PrimusTurboLowPrecisionGlobalStateManager.is_turbo_fp8_enabled()
+        _fp4_on = PrimusTurboLowPrecisionGlobalStateManager.is_turbo_fp4_enabled()
+        # Experts go MXFP4 either with a global FP4 recipe, or — the paper's
+        # per-module recipe — when moe_experts_fp4 is set while the layer runs FP8
+        # (experts FP4 / everything-else FP8). No fused grouped FP4 gemm exists,
+        # so _grouped_gemm_fp4_per_group loops the native FP4 (hipBLASLt) dense gemm.
+        use_grouped_gemm_fp4 = _low_prec and (_fp4_on or (self.moe_experts_fp4 and _fp8_on))
+        # FP8 experts only when not going FP4.
+        use_grouped_gemm_low_precision = _low_prec and _fp8_on and not use_grouped_gemm_fp4
         probs_for_activation = permuted_probs.unsqueeze(-1)
 
         if permuted_local_hidden_states.nelement() != 0:
             if use_grouped_gemm_low_precision:
                 quant_config = PrimusTurboLowPrecisionGlobalStateManager.get_turbo_quant_config()
+                w1_arg = self._mxfp8_weight_arg(
+                    self.linear_fc1, w1, "_w1_mx_cache", quant_config.data()
+                )
                 fc1_output = pt.ops.grouped_gemm_fp8(
                     permuted_local_hidden_states,
-                    w1,
+                    w1_arg,
                     tokens_per_expert,
                     trans_b=False,
                     config=quant_config.data(),
+                )
+            elif use_grouped_gemm_fp4:
+                fp4_config = (
+                    PrimusTurboLowPrecisionGlobalStateManager.get_turbo_quant_config().data()
+                    if _fp4_on
+                    else self._experts_fp4_config
+                )
+                fc1_output = _grouped_gemm_fp4_per_group(
+                    permuted_local_hidden_states,
+                    w1,
+                    tokens_per_expert,
+                    permuted_local_hidden_states.dtype,
+                    fp4_config,
                 )
             else:
                 fc1_output = pt.ops.grouped_gemm(
@@ -1395,12 +1542,32 @@ class PrimusTurboGroupedMLP(TEGroupedMLP):
 
             if use_grouped_gemm_low_precision:
                 quant_config = PrimusTurboLowPrecisionGlobalStateManager.get_turbo_quant_config()
+                w2_arg = self._mxfp8_weight_arg(
+                    self.linear_fc2, w2, "_w2_mx_cache", quant_config.data()
+                )
+                # Both expert weights have now been (re)quantized for this step;
+                # clear so the remaining microbatches + recompute reuse the cache
+                # until set_is_first_microbatch() flips it again next step.
+                self.is_first_microbatch = False
                 output = pt.ops.grouped_gemm_fp8(
                     intermediate_parallel,
-                    w2,
+                    w2_arg,
                     tokens_per_expert,
                     trans_b=False,
                     config=quant_config.data(),
+                )
+            elif use_grouped_gemm_fp4:
+                fp4_config = (
+                    PrimusTurboLowPrecisionGlobalStateManager.get_turbo_quant_config().data()
+                    if _fp4_on
+                    else self._experts_fp4_config
+                )
+                output = _grouped_gemm_fp4_per_group(
+                    intermediate_parallel,
+                    w2,
+                    tokens_per_expert,
+                    intermediate_parallel.dtype,
+                    fp4_config,
                 )
             else:
                 output = pt.ops.grouped_gemm(intermediate_parallel, w2, tokens_per_expert, trans_b=False)

--- a/primus/backends/megatron/core/fp8_utils.py
+++ b/primus/backends/megatron/core/fp8_utils.py
@@ -34,6 +34,16 @@ except (ImportError, ModuleNotFoundError):
     # Primus-Turbo not found
     pass
 
+# gfx1250 / turbo-free FP8: on builds where primus_turbo is only an import shim
+# (not a real install), the turbo FP8 path (PrimusTurboQuantConfig +
+# primus_turbo_fp8_autocast) cannot run. Set PRIMUS_FP8_DISABLE_TURBO=1 to force
+# the TE-native FP8 branch (transformer_engine.pytorch.fp8_autocast), which needs
+# no turbo. Opt-in; the production turbo path is unaffected when unset.
+import os as _os
+
+if _os.environ.get("PRIMUS_FP8_DISABLE_TURBO", "0") == "1":
+    HAVE_TURBO = False
+
 
 SCALING_BLOCK_SIZE = 128
 MX_SCALING_BLOCK_SIZE = 32

--- a/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_block.py
+++ b/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_block.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import ast
 import logging
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Union
 
@@ -999,7 +1000,38 @@ class DeepseekV4TransformerBlock(TransformerBlock):
             return set(range(n_local))
         raise ValueError(f"Invalid recompute_method for DeepSeek-V4: {method!r}")
 
-    def _forward_layer_checkpointed(self, layer, x, position_ids, token_ids):
+    def _layer_fp8_context(self, global_idx: int):
+        """FP8 autocast for a single V4 layer (no-op when fp8 is off).
+
+        DeepseekV4TransformerBlock.forward overrides Megatron's
+        TransformerBlock.forward with a custom layer loop, so the per-layer
+        ``get_fp8_context`` wrapping that Megatron's stock forward uses to
+        activate fp8 — and, via Primus's ``fp8_patches``, Primus-Turbo fp8 —
+        is not inherited and must be re-applied here. Without it the
+        ``primus_turbo_fp8_autocast`` context is never entered, so
+        ``PRIMUS_TURBO_FP8_ENABLED`` stays False and every GEMM silently runs
+        bf16 regardless of ``--fp8`` / ``--fp8_recipe``.
+
+        ``get_fp8_context`` is resolved as a module attribute at call time so
+        the ``before_train`` fp8 patch (which rebinds
+        ``megatron.core.fp8_utils.get_fp8_context``) is honored. ``global_idx``
+        is the 0-based global layer index (matches the function's ``layer_no``
+        contract / ``is_first_last_bf16_layer`` gating).
+        """
+        # FP4 (mxfp4) path: enter the Primus-Turbo fp4 autocast so is_turbo_fp4_enabled()
+        # is set for the layer (drives the grouped-MLP MXFP4 expert path and the
+        # fp4 turbo linears). fp4 and fp8 are mutually exclusive (global recipe).
+        if getattr(self.config, "fp4", None):
+            from megatron.core import fp4_utils
+
+            return fp4_utils.get_fp4_context(self.config, global_idx)
+        if not self.config.fp8:
+            return nullcontext()
+        from megatron.core import fp8_utils
+
+        return fp8_utils.get_fp8_context(self.config, global_idx)
+
+    def _forward_layer_checkpointed(self, layer, x, position_ids, token_ids, global_idx):
         """Run one V4 layer under activation checkpointing.
 
         Only the hidden-state tensor ``x`` is passed as the checkpointed
@@ -1007,11 +1039,16 @@ class DeepseekV4TransformerBlock(TransformerBlock):
         tensors that need no grad and are captured by closure. The closure
         returns just the hidden tensor (V4 layers return ``(hidden, None)``)
         so the checkpoint backward sees a single grad-requiring output.
+
+        The fp8 context is entered *inside* the checkpointed closure so it is
+        re-established on recompute (backward), keeping the recomputed forward
+        in fp8 to match the original pass.
         """
         from megatron.core import tensor_parallel
 
         def _run(hidden):
-            out, _ = layer(hidden, position_ids=position_ids, token_ids=token_ids)
+            with self._layer_fp8_context(global_idx):
+                out, _ = layer(hidden, position_ids=position_ids, token_ids=token_ids)
             return out
 
         return tensor_parallel.checkpoint(
@@ -1112,14 +1149,16 @@ class DeepseekV4TransformerBlock(TransformerBlock):
         # upstream-tuple compatibility (see DeepseekV4HybridLayer.forward).
         recompute_local = self._recompute_local_layer_indices()
         for local_idx, layer in enumerate(self.layers):
+            global_idx = self.global_layer_indices[local_idx]
             if recompute_local is not None and local_idx in recompute_local:
-                x = self._forward_layer_checkpointed(layer, x, position_ids, token_ids)
+                x = self._forward_layer_checkpointed(layer, x, position_ids, token_ids, global_idx)
             else:
-                x, _ = layer(
-                    x,
-                    position_ids=position_ids,
-                    token_ids=token_ids,
-                )
+                with self._layer_fp8_context(global_idx):
+                    x, _ = layer(
+                        x,
+                        position_ids=position_ids,
+                        token_ids=token_ids,
+                    )
 
         # Final HC collapse on post_process stage; non-final stages
         # forward the multi-stream form through PP P2P.

--- a/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_layer_specs.py
+++ b/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_layer_specs.py
@@ -13,6 +13,7 @@ This module only defines DeepSeek-native runtime specs.
 import importlib
 import importlib.util
 import logging
+import os
 from typing import List, Optional, Tuple
 
 from megatron.core.transformer.enums import AttnMaskType
@@ -220,6 +221,19 @@ def _default_init_method(_weight) -> None:
     return None
 
 
+def _v4_fp8_attn_proj(config: "DeepSeekV4TransformerConfig") -> bool:
+    """FP8-ify the attention projections (q-up / o-proj) that otherwise fall
+    back to bf16 because the TE/Turbo fp8 linear rejects gather_output /
+    scatter-input. Only safe at TP=1, where gather/scatter are no-ops — so
+    we keep the bf16 gather/scatter native path for TP>1. Opt-in via
+    PRIMUS_V4_FP8_ATTN_PROJ=1.
+    """
+    return (
+        os.environ.get("PRIMUS_V4_FP8_ATTN_PROJ", "0") == "1"
+        and getattr(config, "tensor_model_parallel_size", 1) == 1
+    )
+
+
 def _build_linear_projection_spec(
     *,
     config: DeepSeekV4TransformerConfig,
@@ -279,7 +293,15 @@ def _build_column_parallel_spec(
     gather-then-shard variant for full sharded heads is tracked in P14
     once the grouped-O TP plan lands.
     """
-    if gather_output:
+    # FP8 attention projections (paper recipe): the TE/Turbo fp8 column linear
+    # rejects gather_output=True, so q-up normally falls back to bf16 native.
+    # But at TP=1 the gather is a no-op, so we can route q-up through the fp8
+    # turbo linear (gather_output=False ≡ True) to capture it in mxfp8.
+    # Gated by PRIMUS_V4_FP8_ATTN_PROJ=1 and only when TP==1. Default off.
+    if gather_output and _v4_fp8_attn_proj(config):
+        module_cls = provider.column_parallel_linear()
+        gather_output = False
+    elif gather_output:
         module_cls = provider.column_parallel_linear_with_gather_output()
     else:
         module_cls = provider.column_parallel_linear()
@@ -324,7 +346,14 @@ def _build_row_parallel_spec(
     ``provider.row_parallel_linear_with_scatter_input()``; the
     standard TE path stays for ``input_is_parallel=True``.
     """
-    if not input_is_parallel:
+    # FP8 attention projections: the TE/Turbo fp8 row linear rejects
+    # input_is_parallel=False, so o-proj normally falls back to bf16 native.
+    # At TP=1 the scatter is a no-op, so route through the fp8 turbo linear
+    # (input_is_parallel=True ≡ False). Gated by PRIMUS_V4_FP8_ATTN_PROJ + TP==1.
+    if not input_is_parallel and _v4_fp8_attn_proj(config):
+        module_cls = provider.row_parallel_linear()
+        input_is_parallel = True
+    elif not input_is_parallel:
         module_cls = provider.row_parallel_linear_with_scatter_input()
     else:
         module_cls = provider.row_parallel_linear()

--- a/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
+++ b/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
@@ -124,6 +124,12 @@ class DeepSeekV4TransformerConfig(MLATransformerConfig):
     use_v4_triton_attention: bool = False
     use_v4_triton_csa_attention: bool = False
 
+    # ---- Per-module precision (paper recipe): routed experts in MXFP4 while the
+    # rest of the layer runs FP8. Decoupled from the global --fp4/--fp8 recipe
+    # (which are mutually exclusive): with FP8 on, the PrimusTurbo grouped MLP
+    # routes the expert GEMMs through the native FP4 (hipBLASLt) path. Default OFF.
+    moe_experts_fp4: bool = False
+
     # ---- DeepSeek-V4 plan-8 tilelang attention kernels (default OFF) ----
     # Plan-8 P57 close-out 2 (2026-05-15): tilelang is an OPTIONAL
     # dependency.  When the container has tilelang installed at the

--- a/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
+++ b/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
@@ -241,6 +241,54 @@ def _projection_forward(proj: nn.Module, x: torch.Tensor) -> torch.Tensor:
     return out
 
 
+def _v4_o_a_fp8_enabled(config) -> bool:
+    """Whether to run the grouped-O ``o_a`` down-projection in MXFP8.
+
+    ``o_a`` is a per-group (batched) matmul done as a manual einsum on
+    ``linear_o_a.weight``, so it bypasses the fp8 linear path and stays bf16.
+    When PRIMUS_V4_FP8_ATTN_PROJ is set (and TP=1, where the surrounding
+    projections are already routed to fp8) and the layer is in turbo-fp8, run
+    it as per-group fp8 GEMMs instead. Default off.
+    """
+    if os.environ.get("PRIMUS_V4_FP8_ATTN_PROJ", "0") != "1":
+        return False
+    if getattr(config, "tensor_model_parallel_size", 1) != 1:
+        return False
+    try:
+        from primus.backends.megatron.core.extensions.primus_turbo import (
+            PrimusTurboLowPrecisionGlobalStateManager as _M,
+        )
+
+        return _M.is_turbo_fp8_enabled()
+    except Exception:
+        return False
+
+
+def _fp8_grouped_o_a(attn_g: torch.Tensor, wo_a_w: torch.Tensor) -> torch.Tensor:
+    """Fused MXFP8 grouped-O ``o_a`` down-projection (replaces the bf16 einsum).
+
+    ``attn_g`` [B,S,G,d], ``wo_a_w`` [G,r,d] -> [B,S,G,r]. The G groups are an
+    independent batched matmul ``[B*S,d] @ [d,r]`` per group; we run them as a
+    SINGLE ``grouped_gemm_fp8`` (one fused Triton launch) instead of a per-group
+    ``gemm_fp8`` loop (G launches + G× quant). Stack tokens group-major into
+    ``[G*B*S, d]`` with ``group_lens=[B*S]*G``; weight ``[G,d,r]`` (trans_b=False).
+    d=(H*head_dim)/G and B*S are multiples of 32, so the MX block scale is clean.
+    """
+    import primus_turbo.pytorch as pt
+    from primus.backends.megatron.core.extensions.primus_turbo import (
+        PrimusTurboLowPrecisionGlobalStateManager as _M,
+    )
+
+    cfg = _M.get_turbo_quant_config().data()
+    B, S, G, d = attn_g.shape
+    r = wo_a_w.shape[1]
+    a = attn_g.permute(2, 0, 1, 3).reshape(G * B * S, d).contiguous()  # [G*BS, d], group-major
+    b = wo_a_w.transpose(1, 2).contiguous()  # [G, d, r]  (K=d, N=r, trans_b=False)
+    group_lens = torch.full((G,), B * S, dtype=torch.int64, device=a.device)
+    out = pt.ops.grouped_gemm_fp8(a, b, group_lens, trans_b=False, config=cfg)  # [G*BS, r]
+    return out.reshape(G, B, S, r).permute(1, 2, 0, 3)  # [B, S, G, r]
+
+
 def _coerce_optional_bool_flag(value: object, *, field_name: str) -> bool:
     """Coerce a possibly-stringified yaml flag to a clean ``bool``.
 
@@ -1090,7 +1138,10 @@ class DeepseekV4Attention(MLASelfAttention):
             o = o.view(B, S, G * self.o_lora_rank)
         else:
             wo_a_w = weight.view(G, self.o_lora_rank, (H * Dh) // G)
-            o = torch.einsum("bsgd,grd->bsgr", attn_g, wo_a_w)
+            if _v4_o_a_fp8_enabled(self.config):
+                o = _fp8_grouped_o_a(attn_g, wo_a_w)  # per-group MXFP8
+            else:
+                o = torch.einsum("bsgd,grd->bsgr", attn_g, wo_a_w)
             o = o.flatten(2)
         return _projection_forward(self.linear_o_b, o)
 

--- a/primus/backends/megatron/core/transformer/indexer.py
+++ b/primus/backends/megatron/core/transformer/indexer.py
@@ -45,6 +45,7 @@ Phase 4 contract:
 from __future__ import annotations
 
 import logging
+import os
 from typing import Tuple
 
 import torch
@@ -106,6 +107,76 @@ from primus.backends.megatron.core.transformer.v4_attention_kernels._triton.inde
 from primus.backends.megatron.core.transformer.v4_attention_kernels._triton.indexer_score_post import (
     is_triton_path_enabled as _indexer_tail_triton_enabled,
 )
+
+# MXFP4 block size (E2M1 data + E8M0 per-32 block scales).
+_MXFP4_BLOCK = 32
+
+
+def _indexer_fp4_enabled() -> bool:
+    """True iff PRIMUS_INDEXER_FP4 == "1" (default off): run the CSA-indexer QK in MXFP4."""
+    return os.environ.get("PRIMUS_INDEXER_FP4", "0") == "1"
+
+
+def _fp4_qk_gemm(q_i: torch.Tensor, k_icomp: torch.Tensor) -> torch.Tensor:
+    """Real MXFP4 indexer QK: per-batch [S*H,Hd] @ [P,Hd]^T (NT, trans_b) -> [B,S,H,P].
+
+    hipBLASLt FP4 needs K=Hd%128, M,N%16; force PRIMUS_TURBO_GEMM_BACKEND=FP4:HIPBLASLT.
+    """
+    import primus_turbo.pytorch as pt
+    from primus_turbo.pytorch.core.low_precision import (
+        Format,
+        Float4QuantConfig,
+        ScaleDtype,
+        ScalingGranularity,
+    )
+
+    cfg = Float4QuantConfig(
+        format=Format.E2M1_X2,
+        granularity=ScalingGranularity.MX_BLOCKWISE,
+        block_size=_MXFP4_BLOCK,
+        scale_dtype=ScaleDtype.E8M0,
+    )
+    B, S, H, Hd = q_i.shape
+    P = k_icomp.shape[1]
+    outs = []
+    for b in range(B):
+        a = q_i[b].reshape(S * H, Hd).contiguous()  # [S*H, Hd]
+        bk = k_icomp[b].contiguous()  # [P, Hd]
+        o = pt.ops.gemm_fp4(a, bk, trans_b=True, config=cfg)  # [S*H, P]
+        outs.append(o.view(1, S, H, P))
+    return torch.cat(outs, dim=0)
+
+
+def _indexer_fp8_proj_enabled() -> bool:
+    """Run the indexer projections (w_dq/w_iuq/w_w) in MXFP8 (default off).
+
+    Reuses the attention-proj flag PRIMUS_V4_FP8_ATTN_PROJ; only fires inside
+    turbo-fp8. The linears are duplicated (no TP shard), so fp8 is safe at any TP.
+    """
+    if os.environ.get("PRIMUS_V4_FP8_ATTN_PROJ", "0") != "1":
+        return False
+    try:
+        from primus.backends.megatron.core.extensions.primus_turbo import (
+            PrimusTurboLowPrecisionGlobalStateManager as _M,
+        )
+
+        return _M.is_turbo_fp8_enabled()
+    except Exception:
+        return False
+
+
+def _fp8_linear(lin: nn.Linear, x: torch.Tensor) -> torch.Tensor:
+    """MXFP8 apply of an ``nn.Linear`` (weight [out,in], no bias): y = x @ Wᵀ."""
+    import primus_turbo.pytorch as pt
+    from primus.backends.megatron.core.extensions.primus_turbo import (
+        PrimusTurboLowPrecisionGlobalStateManager as _M,
+    )
+
+    cfg = _M.get_turbo_quant_config().data()
+    orig = x.shape
+    x2 = x.reshape(-1, orig[-1]).contiguous()
+    out = pt.ops.gemm_fp8(x2, lin.weight, trans_b=True, config=cfg)  # [*, out]
+    return out.reshape(*orig[:-1], out.shape[-1])
 
 
 class Indexer(nn.Module):
@@ -219,9 +290,13 @@ class Indexer(nn.Module):
         k_icomp = k_icomp.unsqueeze(2)  # [B, P, 1, Hd]
 
         # 2) Per-head query and per-head weight.
-        q_q = self.w_dq(hidden)  # [B, S, dq_rank]
-        q_i = self.w_iuq(q_q).view(B, S, H, Hd)  # [B, S, H, Hd]
-        w_i = self.w_w(hidden)  # [B, S, H]
+        # Indexer projections: FP8 (paper / NVIDIA backend.linear) when enabled,
+        # else the bf16 nn.Linear. No TP gather/scatter (duplicated linears).
+        # FP8 (paper / NVIDIA backend.linear) when enabled, else the bf16 nn.Linear.
+        proj = _fp8_linear if _indexer_fp8_proj_enabled() else (lambda lin, x: lin(x))
+        q_q = proj(self.w_dq, hidden)  # [B, S, dq_rank]
+        q_i = proj(self.w_iuq, q_q).view(B, S, H, Hd)  # [B, S, H, Hd]
+        w_i = proj(self.w_w, hidden)  # [B, S, H]
 
         # 3) Score I_{t,s} = Σ_h w_i[t,h] * ReLU(q_i[t,h] · k_icomp[s])
         #    q_i [B,S,H,Hd] · k_icomp[B,P,Hd] → relu[B,S,H,P]; w_i[B,S,H,1] → sum over H
@@ -235,18 +310,25 @@ class Indexer(nn.Module):
         #   else                          → fully eager.
         k_icomp_2d = k_icomp.squeeze(2)
 
-        # FP8 (E4M3) QK path: fake-quantize the query / compressed-key
-        # activations BEFORE the scoring einsum so every dispatch path
-        # (full-fuse Triton, post-einsum-tail Triton, eager) consumes the
-        # FP8-rounded values. The ReLU + per-head weight + sum + causal mask +
-        # top-k stay in the activation dtype (BF16 index-score path). ``w_i``
-        # (per-head score weights) is left in BF16 — it is not part of the QK
-        # GEMM the report quantizes.
-        if self.use_fp8_qk:
+        # Indexer QK precision (both default OFF -> BF16 QK). FP8 (E4M3) fake-
+        # quantizes the operands before the normal score dispatch; FP4 (below)
+        # is a dedicated real-GEMM branch and takes precedence when both are set.
+        # The ReLU + per-head weight (``w_i``) + sum + causal mask + top-k stay
+        # in the activation dtype — only the QK operands are quantized.
+        if self.use_fp8_qk and not _indexer_fp4_enabled():
             q_i = fake_quantize_fp8_e4m3(q_i)
             k_icomp_2d = fake_quantize_fp8_e4m3(k_icomp_2d)
 
-        if _indexer_triton_full_enabled() and _indexer_triton_full_supported(q_i, k_icomp_2d, w_i):
+        # Phase 5: FP4 CSA-indexer QK. Real MXFP4 GEMM for the QK product (paper
+        # §2.3.4/§5.2.1: "QK multiplied entirely in FP4"), then the eager
+        # ReLU/weight/sum tail (w_i + tail stay BF16/FP32 — only the QK is FP4).
+        if _indexer_fp4_enabled():
+            dot = _fp4_qk_gemm(q_i, k_icomp_2d)  # [B, S, H, P], real FP4 matmul
+            relu = F.relu(dot)
+            scores = (relu * w_i.unsqueeze(-1)).sum(dim=2)  # [B, S, P]
+            mask = self._causal_mask(S, P, scores.device, scores.dtype)  # [S, P]
+            scores = scores + mask.unsqueeze(0)  # [B, S, P]
+        elif _indexer_triton_full_enabled() and _indexer_triton_full_supported(q_i, k_icomp_2d, w_i):
             scores = indexer_score_triton(
                 q_i,
                 k_icomp_2d,

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/v4_csa_attention.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/v4_csa_attention.py
@@ -357,6 +357,7 @@ def v4_csa_attention_from_pool(
     training: bool,
     scale: float,
     use_tilelang: bool = False,
+    use_flydsl: bool = False,  # accepted for call-site parity; no from-pool FlyDSL kernel, Triton path
 ) -> torch.Tensor:
     """Triton-backed CSA attention that gathers sparse keys in-kernel.
 

--- a/primus/backends/megatron/patches/mla_patches.py
+++ b/primus/backends/megatron/patches/mla_patches.py
@@ -21,9 +21,25 @@ from primus.modules.module_utils import log_rank_0
     phase="before_train",
     description=(
         "Monkey patch MLA attention to use PrimusMLASelfAttention "
-        "when use_turbo_parallel_linear is enabled."
+        "when use_turbo_parallel_linear is enabled (skipped for DeepSeek-V4)."
     ),
-    condition=lambda ctx: getattr(get_args(ctx), "use_turbo_parallel_linear", False),
+    # Skip for DeepSeek-V4: its DeepseekV4Attention subclasses MLASelfAttention,
+    # and PrimusMLASelfAttention deliberately bypasses MLASelfAttention.__init__
+    # (calls the grandparent), which would break V4's super().__init__ chain if
+    # the base class were swapped. V4 builds DeepseekV4Attention directly and does
+    # not need the padded-fusion MLA path, so this patch must not fire for it.
+    condition=lambda ctx: (
+        getattr(get_args(ctx), "use_turbo_parallel_linear", False)
+        and not any(
+            getattr(get_args(ctx), _f, False)
+            for _f in (
+                "use_v4_triton_attention",
+                "use_v4_triton_csa_attention",
+                "use_v4_tilelang_attention",
+                "use_v4_tilelang_csa_attention",
+            )
+        )
+    ),
 )
 def patch_mla_attention(ctx: PatchContext):
     """

--- a/rccl_avg_workaround/.gitignore
+++ b/rccl_avg_workaround/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/rccl_avg_workaround/sitecustomize.py
+++ b/rccl_avg_workaround/sitecustomize.py
@@ -1,0 +1,136 @@
+"""gfx1250 single-GPU bring-up workarounds, auto-imported in every Python
+worker via sitecustomize (this dir is on PYTHONPATH). Two independent fixes:
+
+1. RCCL AVG hang: torch.distributed.all_reduce(op=AVG) HANGS on this build for
+   (at least) single-rank process groups, while SUM works fine (verified by
+   collective microbench). Megatron's MoE aux-loss metric reduction
+   (moe_utils.reduce_aux_losses_tracker_across_ranks) uses op=AVG and
+   deadlocks. Replace AVG with SUM + divide-by-world-size, which is
+   mathematically identical for any world size.
+
+2. primus_turbo import shim: the MI355X production containers bundle the
+   `primus_turbo` package; the gfx1250 therock container does not. Most Primus
+   call-sites guard the import (try/except -> HAVE_TURBO=False), but the V4
+   model path imports it unconditionally:
+     deepseek_v4_layer_specs.py -> transformer_engine_spec_provider.py
+       (DeepSeekV4SpecProvider subclasses PrimusTurboSpecProvider)
+       -> extensions/primus_turbo.py -> `import primus_turbo.pytorch`
+   and backends/megatron/core/utils.py -> primus_turbo...attention_utils.
+   With every use_turbo_* flag False the turbo classes are never SELECTED
+   (the spec provider returns the TE classes), so a pure import-shim is safe:
+   install a meta-path finder that fabricates stub modules for primus_turbo.*
+   whose attributes are auto-generated dummy classes. Attribute chains
+   evaluated at class-definition time (e.g. the ScalingGranularity.TENSORWISE
+   default arg in PrimusTurboQuantConfig) resolve fine; actually CALLING or
+   instantiating any stub raises RuntimeError, so a misrouted turbo path fails
+   loudly instead of computing garbage. The shim only installs when the real
+   package is absent, so it can never shadow a real primus_turbo install.
+"""
+import sys
+
+
+def _install_rccl_avg_workaround():
+    import torch.distributed as dist
+
+    orig_all_reduce = dist.all_reduce
+    avg_op = dist.ReduceOp.AVG
+
+    def all_reduce_avg_safe(tensor, op=dist.ReduceOp.SUM, group=None, async_op=False):
+        is_avg = False
+        try:
+            is_avg = (op == avg_op)
+        except Exception:
+            is_avg = str(op) == str(avg_op)
+        if is_avg:
+            work = orig_all_reduce(tensor, op=dist.ReduceOp.SUM, group=group, async_op=async_op)
+            try:
+                ws = dist.get_world_size(group)
+            except Exception:
+                ws = 1
+            if ws and ws > 1:
+                # Enqueued on the same stream after the all_reduce, so ordering holds.
+                tensor.div_(ws)
+            return work
+        return orig_all_reduce(tensor, op=op, group=group, async_op=async_op)
+
+    dist.all_reduce = all_reduce_avg_safe
+    print("[rccl_avg_workaround] patched torch.distributed.all_reduce (AVG -> SUM/ws)",
+          file=sys.stderr, flush=True)
+
+
+def _install_primus_turbo_stub():
+    import importlib.abc
+    import importlib.machinery
+    import importlib.util
+    import types
+
+    # Never shadow a real install.
+    if importlib.util.find_spec("primus_turbo") is not None:
+        return
+
+    class _StubMeta(type):
+        """Dummy-class metaclass: any attribute access mints another dummy
+        class (covers enum-style chains like ScalingGranularity.TENSORWISE)."""
+
+        def __getattr__(cls, name):
+            if name.startswith("__"):
+                raise AttributeError(name)
+            dummy = _make_dummy(f"{cls._stub_qual}.{name}")
+            setattr(cls, name, dummy)
+            return dummy
+
+    def _make_dummy(qual):
+        def _raise(self, *args, **kwargs):
+            raise RuntimeError(
+                f"primus_turbo stub: {qual} was invoked, but primus_turbo is NOT "
+                "installed in this container. A turbo code path ran despite all "
+                "use_turbo_*/enable_primus_turbo flags being False — fix the flags "
+                "instead of installing primus_turbo."
+            )
+
+        return _StubMeta(qual.rsplit(".", 1)[-1], (), {"__init__": _raise, "_stub_qual": qual})
+
+    class _StubModule(types.ModuleType):
+        def __getattr__(self, name):
+            if name.startswith("__"):
+                raise AttributeError(name)
+            dummy = _make_dummy(f"{self.__name__}.{name}")
+            setattr(self, name, dummy)
+            return dummy
+
+    class _Finder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "primus_turbo" or fullname.startswith("primus_turbo."):
+                return importlib.machinery.ModuleSpec(fullname, self, is_package=True)
+            return None
+
+        def create_module(self, spec):
+            return _StubModule(spec.name)
+
+        def exec_module(self, module):
+            module.__path__ = []
+            module._primus_turbo_stub = True
+
+    sys.meta_path.append(_Finder())
+    print("[primus_turbo_stub] primus_turbo not installed -> import shim active "
+          "(turbo classes import as raising stubs; all use_turbo_* must stay False)",
+          file=sys.stderr, flush=True)
+
+
+# Only patch the actual training worker. Importing torch here is heavy, so we
+# must NOT do it for pip/offload-arch/build helper invocations (they stall and
+# block setup). Gate on the training entrypoint appearing in argv.
+def _is_training_worker():
+    argv = " ".join(sys.argv)
+    return ("primus/cli/main.py" in argv) or ("run_pretrain" in argv) or ("pretrain" in argv)
+
+
+if _is_training_worker():
+    try:
+        _install_rccl_avg_workaround()
+    except Exception as e:  # noqa: BLE001
+        print(f"[rccl_avg_workaround] install FAILED: {e}", file=sys.stderr, flush=True)
+    try:
+        _install_primus_turbo_stub()
+    except Exception as e:  # noqa: BLE001
+        print(f"[primus_turbo_stub] install FAILED: {e}", file=sys.stderr, flush=True)

--- a/run_deepseek_v4.sh
+++ b/run_deepseek_v4.sh
@@ -31,8 +31,11 @@ export MASTER_PORT=${MASTER_PORT:-29500}
 
 export USING_AINIC=${USING_AINIC:-1}
 export NCCL_IB_HCA="ionic_0:1,ionic_1:1,ionic_2:1,ionic_3:1,ionic_4:1,ionic_5:1,ionic_6:1,ionic_7:1"
-export GLOO_SOCKET_IFNAME=fenic
-export NCCL_SOCKET_IFNAME=fenic
+# "fenic" is the cluster NIC; honor inherited values so a non-cluster / direct
+# run (e.g. local single-node smoke) can point these at a real interface
+# (e.g. lo) — otherwise gloo aborts with "Unable to find address for: fenic".
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-fenic}
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-fenic}
 export NCCL_IB_GID_INDEX=1
 export HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-1}
 export NVTE_CK_USES_BWD_V3=${NVTE_CK_USES_BWD_V3:-1}
@@ -187,8 +190,11 @@ if { [ "$USE_V4_TRITON_ATTENTION" = "True" ] || [ "$USE_V4_TRITON_CSA_ATTENTION"
 fi
 
 if [ "$PRECISION_TYPE" = "FP8" ]; then
-  export FP8=${FP8:-hybrid}
-  export FP8_RECIPE=${FP8_RECIPE:-delayed}
+  # Default to the paper's ue8m0 microscaling (e4m3 + mxfp8); honor explicit
+  # FP8 / FP8_RECIPE overrides. Sentinel-aware because "null" is non-empty, so
+  # a plain ${FP8:-...} would keep the off-sentinel instead of defaulting.
+  [ "$FP8" = "null" ] && export FP8=e4m3
+  [ "$FP8_RECIPE" = "null" ] && export FP8_RECIPE=mxfp8
 fi
 
 # ---------- MXFP8 + FP8 param-gather (Muon path; Megatron #4987 analogue) ----
@@ -234,10 +240,20 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
 
 export PRIMUS_EXIT_FAST=1
 
-./primus-cli slurm -N "$NNODES" \
-  ${SLURM_PARTITION:+--partition="${SLURM_PARTITION}"} \
-  ${SLURM_NODELIST:+--nodelist="${SLURM_NODELIST}"} \
-  -- --image "${DOCKER_IMAGE}" --clean -- --numa \
+# Launcher: slurm (default, multi-node cluster) or direct (single-node, already
+# inside the container — e.g. local smoke on one box). PRIMUS_LAUNCHER=direct
+# drops the SLURM/srun + docker-image wrap that 'direct' doesn't use.
+export PRIMUS_LAUNCHER=${PRIMUS_LAUNCHER:-slurm}
+if [ "$PRIMUS_LAUNCHER" = "direct" ]; then
+  LAUNCHER_ARGS=(direct)
+else
+  LAUNCHER_ARGS=(slurm -N "$NNODES")
+  [ -n "${SLURM_PARTITION:-}" ] && LAUNCHER_ARGS+=(--partition="${SLURM_PARTITION}")
+  [ -n "${SLURM_NODELIST:-}" ] && LAUNCHER_ARGS+=(--nodelist="${SLURM_NODELIST}")
+  LAUNCHER_ARGS+=(-- --image "${DOCKER_IMAGE}" --clean -- --numa)
+fi
+
+./primus-cli "${LAUNCHER_ARGS[@]}" \
   -- train pretrain --config "$EXP" \
   --manual_gc True \
   --manual_gc_interval 100 \

--- a/run_deepseek_v4_flash_proxy.sh
+++ b/run_deepseek_v4_flash_proxy.sh
@@ -242,6 +242,17 @@ export PRIMUS_INDEXER_TRITON_FULL=${PRIMUS_INDEXER_TRITON_FULL:-0}
 #   path.  Set PRIMUS_V4_ROUTER_TRITON=0 to revert to the eager body.
 export PRIMUS_V4_ROUTER_TRITON=${PRIMUS_V4_ROUTER_TRITON:-1}
 
+# ---------- Precision: FP8 training (paper ue8m0 microscaling) --------------
+# V4-Flash trains in FP8 by default. PRECISION_TYPE=FP8 makes run_deepseek_v4.sh
+# emit --fp8 e4m3 --fp8_recipe mxfp8 (mxfp8 = the paper's ue8m0 microscaling,
+# E8M0 block scale, native on MI355X/CDNA4). The FP4 expert / FP4-Indexer path
+# is not yet wired in the Primus V4 integration ("Phase 2"), so experts run FP8
+# here (FP8-everywhere) rather than FP4 — the closest supported step. FP8 is
+# outlier-sensitive, hence the clamped SwiGLU (swiglu_limit) in the EXP yaml.
+# A/B back to BF16 with PRECISION_TYPE=BF16; override the recipe via FP8_RECIPE.
+export PRECISION_TYPE=${PRECISION_TYPE:-FP8}
+export EXP=${EXP:-examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml}
+
 # ---------- Profile OFF in the proxy smoke runner ---------------------------
 # This script is the steady-state perf / smoke runner — kineto profiling
 # stays OFF to avoid contaminating the iter timer with profiler-collection

--- a/run_deepseek_v4_flash_proxy_1gpu.sh
+++ b/run_deepseek_v4_flash_proxy_1gpu.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+###############################################################################
+# DeepSeek-V4-Flash single-GPU bring-up proxy on mi455 / gfx1250 (1 GPU).
+#
+# The upstream launchers (run_deepseek_v4.sh / run_deepseek_v4_flash_proxy.sh)
+# go through `primus-cli slurm ...` against a 15-node MI355X SLURM cluster at
+# TP=1 PP=1..8 EP=8. That doesn't apply here: this host is a single gfx1250
+# box (no SLURM, one GPU we want to use). So this script instead drives the
+# SAME `examples/run_pretrain.sh` entrypoint directly inside a local
+# `docker run`, mirroring the validated gfx1250 docker / TransformerEngine
+# recipe from ../../mi450/Primus/run_dsv3_proxy_4L.sh, and wraps the V4-Flash
+# BF16 config with a MINIMUM-size single-GPU proxy:
+#
+#   - parallel        TP=1 PP=1 EP=1        (single GPU; no SLURM, no DeepEP)
+#   - num_layers      4                     (vs production 43; MINIMUM slice
+#                                            that still exercises every V4
+#                                            attention layer kind)
+#   - compress_ratios [0,4,128,0]           layer 0 = dense+SWA+sink (cr=0)
+#                                            layer 1 = CSA           (cr=4)
+#                                            layer 2 = HCA           (cr=128)
+#                                            layer 3 = dense+SWA+sink (cr=0)
+#   - num_experts     32  topk 1            (production 256/topk6 div by 8 =
+#                                            the per-rank shape of the EP=8
+#                                            production run; same scaling the
+#                                            dsv3 proxy used. topk ceil(6/8)=1)
+#   - moe_ffn_hidden  2048                  (full V4-Flash MoE width; from yaml)
+#   - hidden_size     4096  heads 64  head_dim 512   (full V4-Flash; from yaml)
+#   - seq_length      1024                  (MINIMUM that keeps the HCA cr=128
+#                                            compressed pool non-trivial:
+#                                            1024/128 = 8 pooled tokens)
+#   - index_topk      128                   (CSA top-K; <= cr=4 pool 1024/4=256)
+#   - precision       BF16                  (V4-Flash default; also dodges the
+#                                            known tuned-hipBLASLt FP8 backward
+#                                            GSU split-K deadlock on this host)
+#
+# Correctness-first defaults (this is a "does V4 train at all on 1 gfx1250
+# GPU" bring-up, not a perf push). Everything below defaults to the robust
+# eager / stock path and is ${VAR:-DEFAULT}-guarded so you can flip any knob
+# from the command line without editing the script:
+#
+#   - V4 in-tree Triton attention kernels (dense / HCA / CSA) ........ OFF
+#       (USE_V4_TRITON_ATTENTION / USE_V4_TRITON_CSA_ATTENTION). They were
+#        tuned for MI355's 160 KiB SMEM at head_dim=512; eager is the safe
+#        path for gfx1250 first bring-up. Set =True to A/B them.
+#   - PrimusTurbo attention / DeepEP / grouped-MLP .................... OFF
+#       (DeepEP is an EP>1 multi-GPU dispatcher; irrelevant at EP=1.)
+#   - torch.compile Sinkhorn + plan-6 elementwise Triton fusions ...... OFF
+#       (PRIMUS_*_TRITON below; flip individually to =1 for perf A/B.)
+#   - tuned hipBLASLt .......................... OFF (hard-pinned, no opt-in)
+#       (stock container hipBLASLt only; the tuned feba897 bundle deadlocks
+#        this host on a backward-FP8 GSU split-K kernel -> node reboot.)
+#   - kineto / pytorch profiler ...................................... OFF
+#
+# REQUIRED gfx1250 workaround (kept ON, single-GPU-safe): RCCL
+# all_reduce(op=AVG) HANGS on this build even for single-rank process groups,
+# and Megatron's MoE aux-loss reduce uses AVG. sitecustomize on PYTHONPATH
+# rewrites AVG -> SUM/world_size (identity at world_size=1). See
+# rccl_avg_workaround/sitecustomize.py.
+#
+# Usage:
+#   ./run_deepseek_v4_flash_proxy_1gpu.sh                              # 10-iter smoke
+#   PRIMUS_SEQ_LENGTH=2048 ./run_deepseek_v4_flash_proxy_1gpu.sh       # longer ctx
+#   PRIMUS_NUM_EXPERTS=8 PRIMUS_MOE_TOPK=2 ./run_deepseek_v4_flash_proxy_1gpu.sh  # tiny MoE
+#   USE_V4_TRITON_ATTENTION=True USE_V4_TRITON_CSA_ATTENTION=True \
+#       ./run_deepseek_v4_flash_proxy_1gpu.sh                          # A/B Triton attn
+#   HIP_VISIBLE_DEVICES=3 ./run_deepseek_v4_flash_proxy_1gpu.sh        # pin a card
+###############################################################################
+set -eo pipefail
+
+export DOCKER_IMAGE=${DOCKER_IMAGE:-registry-sc-harbor.amd.com/framework/therock-npi@sha256:feba897e2a32a2465b8b296ed2662b2ad6136b5f1cf6f6c2716a3674aafc30f3}
+SCRIPT_DIR=$(realpath -m "$(dirname "$0")")
+# Prebuilt gfx1250 TransformerEngine wheel + source from the mi450 sibling tree
+# (same image pin feba897). Override TE_DIR / TE_WHEEL_DIR if they live elsewhere.
+export TE_DIR=${TE_DIR:-$(realpath -m "$SCRIPT_DIR/../../mi450/TransformerEngine")}
+export TE_WHEEL_DIR=${TE_WHEEL_DIR:-$(realpath -m "$SCRIPT_DIR/../../mi450/dist/feba897")}
+
+# ---------- Attention backend env (TE side) --------------------------------
+# V4 attention runs its own eager / Triton kernels, not the TE fused-attn path,
+# so these only matter for any non-V4 attention TE might still touch. Keep the
+# AOTriton fused default from the dsv3 recipe; harmless for the V4 path.
+export NVTE_FUSED_ATTN=1
+export NVTE_FUSED_ATTN_CK=0
+export NVTE_FUSED_ATTN_AOTRITON=1
+export NVTE_USE_CK_GEMM=0
+export NVTE_FLASH_ATTN=0
+
+# ---------- hipBLASLt: STOCK ONLY (container built-in gfx1250 catalog) ------
+# Hard-pinned to stock: no LD_PRELOAD, no tuned Tensile catalog, no env opt-in.
+# The tuned feba897 bundle DEADLOCKS on a backward-FP8 GSU split-K kernel on
+# this host (GPU wedge -> node reboot, debugged 2026-06-10), so this script
+# deliberately has no tuned path. Also do NOT export an empty
+# HIPBLASLT_TENSILE_LIBPATH into the container — a missing path breaks even
+# stock hipBLASLt ("Cannot read TensileLibrary...", HIPBLASLT Error: 3).
+unset HIPBLASLT_DIR HIPBLASLT_LD_PRELOAD HIPBLASLT_TENSILE_LIBPATH
+echo "[hipblaslt] STOCK (container built-in gfx1250 catalog); tuned path intentionally not supported here"
+
+# ---------- REQUIRED gfx1250 RCCL AVG->SUM workaround -----------------------
+# sitecustomize is auto-imported by every Python worker (dir on PYTHONPATH).
+export PYTHONPATH="$SCRIPT_DIR/rccl_avg_workaround:${PYTHONPATH:-}"
+
+# ---------- Distributed / NCCL: single GPU, loopback only -------------------
+export HSA_NO_SCRATCH_RECLAIM=1
+export NCCL_IB_DISABLE=1
+export NCCL_P2P_DISABLE=1
+export NCCL_IB_HCA=
+export NCCL_SOCKET_IFNAME=lo
+export GLOO_SOCKET_IFNAME=lo
+export RCCL_DISABLE_AMDSMI=1
+export NCCL_AMDSMI_DISABLE=1
+export USING_AINIC=0          # no AINIC / IB on this host; skip run_pretrain's IB tuning
+
+export GPUS_PER_NODE=1
+export NNODES=1
+export PYTHONUNBUFFERED=1
+
+# ---------- V4-Flash MINIMUM single-GPU proxy shape -------------------------
+export PRIMUS_TP=${PRIMUS_TP:-1}
+export PRIMUS_PP=${PRIMUS_PP:-1}
+export PRIMUS_EP=${PRIMUS_EP:-1}
+export PRIMUS_TOTAL_LAYERS=${PRIMUS_TOTAL_LAYERS:-4}
+export PRIMUS_COMPRESS_RATIOS=${PRIMUS_COMPRESS_RATIOS:-"[0,4,128,0]"}
+export PRIMUS_NUM_EXPERTS=${PRIMUS_NUM_EXPERTS:-32}
+export PRIMUS_MOE_TOPK=${PRIMUS_MOE_TOPK:-1}
+export PRIMUS_MOE_FFN_HIDDEN_SIZE=${PRIMUS_MOE_FFN_HIDDEN_SIZE:-2048}
+export PRIMUS_INDEX_TOPK=${PRIMUS_INDEX_TOPK:-128}
+export PRIMUS_SEQ_LENGTH=${PRIMUS_SEQ_LENGTH:-1024}
+export PRIMUS_MAX_POSITION_EMBEDDINGS=${PRIMUS_MAX_POSITION_EMBEDDINGS:-${PRIMUS_SEQ_LENGTH}}
+export MBS=${MBS:-1}
+export GBS=${GBS:-8}
+export TRAIN_ITERS=${TRAIN_ITERS:-10}
+
+# ---------- Perf knobs: OFF for a robust first bring-up ---------------------
+export USE_V4_TRITON_ATTENTION=${USE_V4_TRITON_ATTENTION:-False}
+export USE_V4_TRITON_CSA_ATTENTION=${USE_V4_TRITON_CSA_ATTENTION:-False}
+export USE_V4_TILELANG_ATTENTION=${USE_V4_TILELANG_ATTENTION:-False}
+export USE_V4_TILELANG_CSA_ATTENTION=${USE_V4_TILELANG_CSA_ATTENTION:-False}
+export USE_TURBO_ATTENTION=${USE_TURBO_ATTENTION:-False}
+export USE_TURBO_DEEPEP=${USE_TURBO_DEEPEP:-False}
+export TURBO_USE_GROUPED_MLP=${TURBO_USE_GROUPED_MLP:-False}
+export USE_V4_COMPILED_SINKHORN=${USE_V4_COMPILED_SINKHORN:-False}
+# plan-6 elementwise Triton fusions read straight from os.environ in-kernel;
+# default OFF here so the proxy runs the plain eager body. Flip any to 1 to A/B.
+export PRIMUS_STACK_GROUPED_WEIGHT_TRITON=${PRIMUS_STACK_GROUPED_WEIGHT_TRITON:-0}
+export PRIMUS_ROPE_TRITON=${PRIMUS_ROPE_TRITON:-0}
+export PRIMUS_SINKHORN_TRITON=${PRIMUS_SINKHORN_TRITON:-0}
+export PRIMUS_HC_TRITON=${PRIMUS_HC_TRITON:-0}
+export PRIMUS_INDEXER_TRITON=${PRIMUS_INDEXER_TRITON:-0}
+export PRIMUS_INDEXER_TRITON_FULL=${PRIMUS_INDEXER_TRITON_FULL:-0}
+export PRIMUS_V4_ROUTER_TRITON=${PRIMUS_V4_ROUTER_TRITON:-0}
+
+# enable_primus_turbo gates the turbo before_train patches; only on if a turbo
+# path is requested.
+export ENABLE_PRIMUS_TURBO=False
+if [ "$USE_TURBO_ATTENTION" = "True" ] || [ "$USE_TURBO_DEEPEP" = "True" ] || [ "$TURBO_USE_GROUPED_MLP" = "True" ]; then
+    ENABLE_PRIMUS_TURBO=True
+fi
+
+# MoE permute fusion (Triton permute_with_mask_map). VERIFIED working at
+# flash proxy shapes (32 experts / hidden 4096, 10/10 iters 2026-06-10), so
+# default ON here — but the SAME kernel's BWD autotune wedges the GPU at
+# V4-Pro shapes (48 experts / hidden 7168; MES unrecoverable -> node reboot).
+# If you grow this proxy's shapes and it hangs at iter-1 backward with GPU 0%,
+# flip MOE_PERMUTE_FUSION=False first.
+export MOE_PERMUTE_FUSION=${MOE_PERMUTE_FUSION:-True}
+
+export PROFILE=${PROFILE:-False}
+# PyTorch profiler writes the chrome trace via tensorboard_trace_handler(
+# args.tensorboard_dir), so tensorboard must be enabled to get a trace.
+# Auto-enable it when PROFILE=True. Profile window = [START,END); need
+# TRAIN_ITERS > PROFILE_STEP_END.
+export DISABLE_TENSORBOARD=${DISABLE_TENSORBOARD:-True}
+if [ "$PROFILE" = "True" ]; then export DISABLE_TENSORBOARD=False; fi
+export PROFILE_STEP_START=${PROFILE_STEP_START:-6}
+export PROFILE_STEP_END=${PROFILE_STEP_END:-7}
+export PRIMUS_TEAM=${PRIMUS_TEAM:-amd}
+export PRIMUS_USER=${PRIMUS_USER:-gfx1250-1gpu}
+export PRIMUS_EXP_NAME=${PRIMUS_EXP_NAME:-deepseek_v4_flash_1gpu_L${PRIMUS_TOTAL_LAYERS}_E${PRIMUS_NUM_EXPERTS}_seq${PRIMUS_SEQ_LENGTH}}
+
+PRIMUS_PATH="$SCRIPT_DIR"
+DATA_PATH="${PRIMUS_PATH}/data"
+mkdir -p "$DATA_PATH"
+
+EXP=${EXP:-examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml}
+LOG=${LOG:-deepseek-v4-flash-proxy-1gpu.log}
+
+# ---------- FP8 training (matches upstream commit fde4c0d2) ------------------
+# V4-Flash trains in FP8 by default now. PRECISION_TYPE=FP8 -> FP8=e4m3 +
+# FP8_RECIPE=mxfp8 (the paper's ue8m0 microscaling; TE MXFP8BlockScaling).
+# VERIFIED supported on this gfx1250 stock container (mxfp8_probe.py). Use the
+# OCP e4m3 format (e4m3fnuz is unsupported here). A/B back to BF16 with
+# PRECISION_TYPE=BF16 (or FP8=null).
+export PRECISION_TYPE=${PRECISION_TYPE:-FP8}
+if [ "$PRECISION_TYPE" = "FP8" ]; then
+    export FP8=${FP8:-e4m3}
+    export FP8_RECIPE=${FP8_RECIPE:-mxfp8}
+else
+    export FP8=${FP8:-null}
+    export FP8_RECIPE=${FP8_RECIPE:-null}
+    EXP=${EXP/deepseek_v4_flash-FP8/deepseek_v4_flash-BF16}
+fi
+
+if [ ! -d "$PRIMUS_PATH/third_party/Megatron-LM" ] || \
+   [ -z "$(ls -A "$PRIMUS_PATH/third_party/Megatron-LM" 2>/dev/null)" ]; then
+    echo "[ERROR] third_party/Megatron-LM missing/empty -> run: git submodule update --init --recursive" >&2
+    exit 1
+fi
+
+# V4 single-GPU overrides (trailing args -> run_pretrain.sh -> primus cli
+# train pretrain --config $EXP ...). Mirrors run_deepseek_v4.sh's CLI set,
+# minus the SLURM / DeepEP wiring, scaled down to one GPU / minimum layers.
+PROXY_OVERRIDES="\
+    --backend_path $PRIMUS_PATH/third_party/Megatron-LM \
+    --train_iters $TRAIN_ITERS \
+    --lr_warmup_iters 0 \
+    --lr_decay_iters $TRAIN_ITERS \
+    --num_layers $PRIMUS_TOTAL_LAYERS \
+    --compress_ratios $PRIMUS_COMPRESS_RATIOS \
+    --micro_batch_size $MBS \
+    --global_batch_size $GBS \
+    --seq_length $PRIMUS_SEQ_LENGTH \
+    --max_position_embeddings $PRIMUS_MAX_POSITION_EMBEDDINGS \
+    --rope_type rope \
+    --tensor_model_parallel_size $PRIMUS_TP \
+    --pipeline_model_parallel_size $PRIMUS_PP \
+    --expert_model_parallel_size $PRIMUS_EP \
+    --num_experts $PRIMUS_NUM_EXPERTS \
+    --moe_router_topk $PRIMUS_MOE_TOPK \
+    --moe_router_enable_expert_bias False \
+    --moe_ffn_hidden_size $PRIMUS_MOE_FFN_HIDDEN_SIZE \
+    --index_topk $PRIMUS_INDEX_TOPK \
+    --v4_grouped_experts_support_clamped_swiglu True \
+    --mtp_num_layers 0 \
+    --moe_permute_fusion $MOE_PERMUTE_FUSION \
+    --mock_data True \
+    --moe_router_force_load_balancing True \
+    --log_avg_skip_iterations 3 \
+    --enable_primus_turbo $ENABLE_PRIMUS_TURBO \
+    --use_turbo_attention $USE_TURBO_ATTENTION \
+    --use_turbo_deepep $USE_TURBO_DEEPEP \
+    --use_turbo_grouped_mlp $TURBO_USE_GROUPED_MLP \
+    --use_v4_triton_attention $USE_V4_TRITON_ATTENTION \
+    --use_v4_triton_csa_attention $USE_V4_TRITON_CSA_ATTENTION \
+    --use_v4_tilelang_attention $USE_V4_TILELANG_ATTENTION \
+    --use_v4_tilelang_csa_attention $USE_V4_TILELANG_CSA_ATTENTION \
+    --use_v4_compiled_sinkhorn $USE_V4_COMPILED_SINKHORN \
+    --fp8 $FP8 \
+    --fp8_recipe $FP8_RECIPE \
+    --recompute_num_layers 0 \
+    --recompute_granularity full \
+    --recompute_method block \
+    --gradient_accumulation_fusion False \
+    --overlap_grad_reduce False \
+    --overlap_param_gather False \
+    --disable_last_saving True \
+    --disable_wandb True \
+    --disable_tensorboard $DISABLE_TENSORBOARD \
+    --profile $PROFILE \
+    --use_pytorch_profiler $PROFILE \
+    --profile_step_start $PROFILE_STEP_START \
+    --profile_step_end $PROFILE_STEP_END"
+
+# Forward every env var the container needs (run_pretrain.sh / V4 builder /
+# in-kernel knobs read these from the environment).
+ENV_ARGS=()
+for v in DOCKER_IMAGE NVTE_FUSED_ATTN NVTE_FUSED_ATTN_CK NVTE_FUSED_ATTN_AOTRITON \
+         NVTE_FLASH_ATTN NVTE_USE_CK_GEMM PYTHONPATH HSA_NO_SCRATCH_RECLAIM \
+         NCCL_IB_DISABLE NCCL_P2P_DISABLE NCCL_IB_HCA NCCL_SOCKET_IFNAME \
+         GLOO_SOCKET_IFNAME RCCL_DISABLE_AMDSMI NCCL_AMDSMI_DISABLE USING_AINIC \
+         GPUS_PER_NODE NNODES PYTHONUNBUFFERED TE_DIR TE_WHEEL_DIR \
+         PRIMUS_SEQ_LENGTH PRIMUS_MAX_POSITION_EMBEDDINGS \
+         PRIMUS_TEAM PRIMUS_USER PRIMUS_EXP_NAME \
+         PRIMUS_STACK_GROUPED_WEIGHT_TRITON PRIMUS_ROPE_TRITON \
+         PRIMUS_SINKHORN_TRITON PRIMUS_HC_TRITON PRIMUS_INDEXER_TRITON \
+         PRIMUS_INDEXER_TRITON_FULL PRIMUS_V4_ROUTER_TRITON; do
+    ENV_ARGS+=("--env" "$v")
+done
+# Pin a physical card if the caller set HIP_VISIBLE_DEVICES (run_pretrain.sh
+# otherwise rewrites it to 0..GPUS_PER_NODE-1 = "0").
+[[ -n "${HIP_VISIBLE_DEVICES:-}" ]] && ENV_ARGS+=("--env" "HIP_VISIBLE_DEVICES")
+# Forward serialization knobs (for measuring AMD_SERIALIZE_COPY perf impact).
+for v in AMD_SERIALIZE_COPY AMD_SERIALIZE_KERNEL HIP_LAUNCH_BLOCKING; do
+    [[ -n "${!v:-}" ]] && ENV_ARGS+=("--env" "$v")
+done
+
+VOLUME_ARGS=(-v "$PRIMUS_PATH":"$PRIMUS_PATH" -v "$DATA_PATH":"$DATA_PATH")
+[[ -d "$TE_WHEEL_DIR" ]] && VOLUME_ARGS+=(-v "$TE_WHEEL_DIR":"$TE_WHEEL_DIR")
+[[ -d "$TE_DIR" ]] && VOLUME_ARGS+=(-v "$TE_DIR":"$TE_DIR")
+
+# Prebuilt gfx1250 TE wheel + Primus deps, installed before launch.
+TE_INSTALL_PREFIX="\
+    if ls ${TE_WHEEL_DIR}/transformer_engine-*.whl >/dev/null 2>&1; then \
+        echo '[TE] installing prebuilt wheel from ${TE_WHEEL_DIR}' && \
+        pip install --quiet --force-reinstall --no-deps ${TE_WHEEL_DIR}/transformer_engine-*.whl && \
+        pip install --quiet einops nvdlfw-inspect onnxscript onnx pydantic importlib-metadata packaging transformers pybind11; \
+    else \
+        echo '[TE] WARNING: no TE wheel found at ${TE_WHEEL_DIR}; run will likely fail'; \
+    fi && \
+    echo '[deps] installing Primus requirements' && \
+    pip install --quiet -r requirements.txt && "
+
+docker run --rm \
+    "${ENV_ARGS[@]}" \
+    --ipc=host --network=host \
+    --device=/dev/kfd --device=/dev/dri \
+    --cap-add=SYS_PTRACE --cap-add=CAP_SYS_ADMIN \
+    --security-opt seccomp=unconfined --group-add video \
+    --privileged \
+    --name primus-v4-flash-1gpu \
+    "${VOLUME_ARGS[@]}" \
+    "$DOCKER_IMAGE" /bin/bash -c "\
+        set -e && cd $PRIMUS_PATH && \
+        ${TE_INSTALL_PREFIX}\
+        echo '==================== V4-FLASH 1-GPU PROXY (gfx1250, BF16, eager, no profiler) ====================' && \
+        EXP=$EXP GPUS_PER_NODE=1 NNODES=1 bash examples/run_pretrain.sh \
+            ${PROXY_OVERRIDES}" \
+    2>&1 | tee "$LOG"

--- a/run_deepseek_v4_pro_fp8_paper.sh
+++ b/run_deepseek_v4_pro_fp8_paper.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+###############################################################################
+# DeepSeek-V4 Pro — PAPER-precision FP8 training (ue8m0 / mxfp8), CK-free.
+#
+# Goal: match the paper's FP8 precision map as closely as this gfx950 build
+# allows, using the **TransformerEngine** path (no Composable-Kernel grouped
+# GEMM), which is the only backend with mxfp8 (ue8m0 microscaling) support.
+#
+# Precision map (paper §4.x / techblog §9.6) — what runs in what:
+#   - MoE expert weight GEMMs       : FP8 (TEGroupedMLP -> TE general_grouped_gemm)
+#   - Attention QKV/O + dense proj  : FP8 (TELinear, under fp8 autocast)
+#   - Attention CORE (QK^T, softmax*V): BF16  (kept high-precision in training,
+#                                       same as V3 — fp8 attention is inference-only)
+#   - mHC Hyper-Connection params   : FP32  (Sinkhorn stability, §9.3)
+#   - Embedding / head / RMSNorm / router : BF16 (+ fp32 reductions / states)
+#   - Optimizer states (Muon / AdamW): FP32
+#   - Scale format                  : ue8m0  (E8M0 microscale) via fp8_recipe=mxfp8
+#
+# Backend = TE only, **no CK**:
+#   - TURBO_USE_GROUPED_MLP=False  -> experts route to TEGroupedMLP (hipBLASLt),
+#                                     NOT PrimusTurboGroupedMLP (ck_grouped_gemm).
+#   - USE_TURBO_DEEPEP=False       -> Megatron MoEFlexTokenDispatcher (no turbo).
+#   - projections via turbo linear (use_turbo_parallel_linear=true in the EXP
+#     yaml) OR TELinear -- both are Tensile/hipBLASLt F8, NOT CK. Only the turbo
+#     GROUPED-GEMM uses CK, and that is what TURBO_USE_GROUPED_MLP=False avoids.
+#   - NVTE_ROCM_ENABLE_MXFP8=1     -> unlock TE's MXFP8 path on gfx950 (required).
+#
+# KNOWN HARD BLOCKER on this build (verified, isolated 3-line TE GEMM test):
+#   TE's ROCm MXFP8 kernel asserts GEMM K % 128 == 0
+#   (transformer_engine/common/gemm/rocm_gemm.hip:1529). V4-Flash has MULTIPLE
+#   non-128-aligned GEMM dims (observed K=224 and K=32 so far), so ue8m0/mxfp8
+#   errors out and padding a single dim does NOT fix it -- V4's shapes are
+#   structurally incompatible with TE-ROCm MXFP8 here. => mxfp8 is currently
+#   NOT runnable; use FP8_RECIPE=tensorwise (default-overridable below) to get
+#   the SAME paper fp8 LAYOUT (all weight GEMMs fp8, no CK) with a per-tensor
+#   scale instead of the ue8m0 microscale. mxfp8 is kept as the default to
+#   document the paper target; flip to tensorwise to actually train.
+#
+# Usage:
+#   ./run_deepseek_v4_pro_fp8_paper.sh                       # paper mxfp8 (ue8m0)
+#   FP8_RECIPE=tensorwise ./run_deepseek_v4_pro_fp8_paper.sh # working fallback
+#   PRECISION_TYPE=BF16 ./run_deepseek_v4_pro_fp8_paper.sh   # A/B vs bf16
+###############################################################################
+set -euo pipefail
+
+# ---- TE mxfp8 (ue8m0) ------------------------------------------------------
+export NVTE_ROCM_ENABLE_MXFP8=${NVTE_ROCM_ENABLE_MXFP8:-1}
+export FP8=${FP8:-e4m3}
+export FP8_RECIPE=${FP8_RECIPE:-mxfp8}            # paper ue8m0; tensorwise to fall back
+
+# ---- CK-free: route experts/dispatcher/linear off PrimusTurbo onto TE -------
+export TURBO_USE_GROUPED_MLP=${TURBO_USE_GROUPED_MLP:-False}   # -> TEGroupedMLP (no ck_grouped_gemm)
+export USE_TURBO_DEEPEP=${USE_TURBO_DEEPEP:-False}             # -> Megatron dispatcher
+# Reuse the FP8 EXP yaml (use_turbo_parallel_linear=true -> turbo Tensile linear,
+# which is NOT CK). The only CK path (turbo grouped-GEMM) is disabled above.
+export EXP=${EXP:-examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml}
+
+# ---- Single-node TE distributed init needs a real NIC (not the cluster nic) -
+export GLOO_SOCKET_IFNAME=${GLOO_SOCKET_IFNAME:-lo}
+export NCCL_SOCKET_IFNAME=${NCCL_SOCKET_IFNAME:-lo}
+
+# Everything else (model widths, Muon, recompute, launch) comes from the Pro
+# Muon runner; we only override the precision/backend knobs above.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/run_deepseek_v4_pro_muon.sh"

--- a/run_deepseek_v4_pro_muon.sh
+++ b/run_deepseek_v4_pro_muon.sh
@@ -39,7 +39,13 @@
 #   PRIMUS_TOTAL_LAYERS=4 PRIMUS_SEQ_LENGTH=512 GBS=8 \
 #       ./run_deepseek_v4_pro_muon.sh                              # cheap validation
 #   OPTIMIZER=adam ./run_deepseek_v4_pro_muon.sh                   # A/B vs AdamW
+#   PRECISION_TYPE=BF16 ./run_deepseek_v4_pro_muon.sh             # A/B vs BF16 (fp8 is default-on)
 #   PROFILE=True DISABLE_TENSORBOARD=False ...                     # capture 1-step trace
+#
+# Precision: FP8 training is ON by default (FP8=e4m3, FP8_RECIPE=tensorwise).
+# Paper recipe is ue8m0/mxfp8 but it's not runnable on this gfx950 build (see the
+# "FP8 training" block below); tensorwise gives the paper's fp8 layout on the
+# weight GEMMs. PRECISION_TYPE=BF16 to A/B back to bf16.
 ###############################################################################
 set -euo pipefail
 set -x
@@ -52,7 +58,7 @@ export HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-1}
 
 # ---------- Model: DeepSeek-V4 Pro -----------------------------------------
 export PRIMUS_MODEL=${PRIMUS_MODEL:-deepseek_v4_pro}
-export EXP=${EXP:-examples/megatron/configs/MI355X/deepseek_v4_flash-BF16-pretrain.yaml}
+export EXP=${EXP:-examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml}
 
 # ---------- Pro production widths (paper §4.2.1) ----------------------------
 export PRIMUS_NUM_EXPERTS=${PRIMUS_NUM_EXPERTS:-384}
@@ -120,6 +126,13 @@ export MUON_MOMENTUM=${MUON_MOMENTUM:-0.95}            # paper momentum 0.95
 # extra_scale_factor (orth_grad RMS≈1/√max(m,n), times spectral scale √max(m,n)),
 # so 0.18 maps directly here.  Megatron default is 1.0 (≈5.5× too large vs paper).
 export MUON_EXTRA_SCALE_FACTOR=${MUON_EXTRA_SCALE_FACTOR:-0.18}
+# Newton-Schulz hardening knobs (matter for mxfp8, where NS can diverge on the
+# quant-noised gradient). num_ns_steps = NS iterations (more = better convergence
+# on ill-conditioned input); fp32_matmul_prec = precision of the NS matmuls
+# ("medium" = tf32-ish, "high" = full fp32 — full precision keeps a near-σ=1
+# input from being pushed past the quintic's stable region by rounding error).
+export MUON_NUM_NS_STEPS=${MUON_NUM_NS_STEPS:-5}
+export MUON_FP32_MATMUL_PREC=${MUON_FP32_MATMUL_PREC:-medium}
 # NOTE: muon_weight_decay is yaml-only (trainer_base.yaml=0.01); paper=0.1.
 # No CLI flag, so it stays 0.01 here unless overridden in an EXP yaml.
 # Muon hard requirements (Megatron arguments.py:1422):
@@ -141,12 +154,112 @@ export ENABLE_PRIMUS_TURBO=${ENABLE_PRIMUS_TURBO:-True}
 export USE_TURBO_ATTENTION=${USE_TURBO_ATTENTION:-False}
 export USE_TURBO_DEEPEP=${USE_TURBO_DEEPEP:-True}
 export TURBO_USE_GROUPED_MLP=${TURBO_USE_GROUPED_MLP:-True}
+# Primus Sync-Free MoE (eliminates the DeepEP host busy-wait on the variable
+# per-expert token counts): 0=off, 1=fused router/permute, 2=+no CPU busy-wait
+# (turbo deepep + grouped mlp), 3=fully sync-free (+fused act). Stage >=2 needs
+# use_turbo_grouped_mlp=True. Auto-enables the required sub-flags. Default 0.
+export TURBO_SYNC_FREE_MOE_STAGE=${TURBO_SYNC_FREE_MOE_STAGE:-0}
+# Phase 1b: route the dense/attention projections (q_down/kv/o_a etc.) through
+# Primus-Turbo linears so they pick up the mxfp8 (CK) path under the fp8 context.
+# Default OFF (attention stays bf16, the validated baseline). Set True to enable
+# fp8 attention/dense projections. Requires TP=1 and fp8_recipe in {tensorwise,
+# blockwise,mxfp8}; the MLA monkey-patch is auto-skipped for V4 (see mla_patches).
+export USE_TURBO_PARALLEL_LINEAR=${USE_TURBO_PARALLEL_LINEAR:-False}
+# Per-module recipe (paper): routed experts in MXFP4 while the rest of the layer
+# stays FP8. Works under the global FP8 recipe (no --fp4/--fp8 conflict): the
+# PrimusTurbo grouped MLP routes expert GEMMs through native FP4 (hipBLASLt).
+# Default OFF. When on, force the hipBLASLt FP4 backend (no AITER).
+export MOE_EXPERTS_FP4=${MOE_EXPERTS_FP4:-False}
+if [ "$MOE_EXPERTS_FP4" = "True" ]; then
+  export PRIMUS_TURBO_GEMM_BACKEND=${PRIMUS_TURBO_GEMM_BACKEND:-FP4:HIPBLASLT}
+fi
+# Phase 5 (paper): CSA-indexer QK score in FP4. Rounds q_i and K^{IComp} to
+# MXFP4 before the QK product (STE backward); w_i + ReLU/sum tail stay BF16.
+# Read directly by the Indexer via PRIMUS_INDEXER_FP4. Default OFF.
+export INDEXER_FP4=${INDEXER_FP4:-False}
+if [ "$INDEXER_FP4" = "True" ]; then
+  export PRIMUS_INDEXER_FP4=1
+  # The indexer QK now runs a REAL MXFP4 gemm (pt.ops.gemm_fp4) — force the
+  # hipBLASLt FP4 backend (no AITER), same as the MXFP4 expert path.
+  export PRIMUS_TURBO_GEMM_BACKEND=${PRIMUS_TURBO_GEMM_BACKEND:-FP4:HIPBLASLT}
+fi
+# MXFP8 expert-weight caching: expert weights are constant within an optimizer
+# step, so re-quantizing them every microbatch + recompute forward (the large
+# _mxfp8_quant_weight_fwd kernel) is redundant. When on, PrimusTurboGroupedMLP
+# prequantizes once per step and reuses the fp8 buffers (loss-neutral, faster).
+# Costs extra bytes/param resident — watch HBM at depth. Only affects the
+# mxfp8 (MX_BLOCKWISE) grouped path. Default OFF.
+export CACHE_MXFP8_WEIGHT=${CACHE_MXFP8_WEIGHT:-False}
+if [ "$CACHE_MXFP8_WEIGHT" = "True" ]; then
+  export PRIMUS_TURBO_CACHE_MXFP8_WEIGHT=1
+fi
+# FP8 attention projections (paper recipe): route q-up / o-proj through the fp8
+# turbo linear instead of the bf16 gather/scatter native path. Only valid at
+# TP=1 (gather/scatter are no-ops there); for TP>1 the turbo linear rejects
+# gather_output/scatter-input and it stays bf16. Default OFF.
+export V4_FP8_ATTN_PROJ=${V4_FP8_ATTN_PROJ:-False}
+if [ "$V4_FP8_ATTN_PROJ" = "True" ]; then
+  export PRIMUS_V4_FP8_ATTN_PROJ=1
+fi
 export USE_V4_TRITON_ATTENTION=${USE_V4_TRITON_ATTENTION:-True}
 export USE_V4_TRITON_CSA_ATTENTION=${USE_V4_TRITON_CSA_ATTENTION:-True}
 export USE_V4_TILELANG_ATTENTION=${USE_V4_TILELANG_ATTENTION:-False}
 export USE_V4_TILELANG_CSA_ATTENTION=${USE_V4_TILELANG_CSA_ATTENTION:-False}
 export USE_V4_COMPILED_SINKHORN=${USE_V4_COMPILED_SINKHORN:-False}
 export PRIMUS_V4_GROUPED_EXPERTS_SUPPORT_CLAMPED_SWIGLU=${PRIMUS_V4_GROUPED_EXPERTS_SUPPORT_CLAMPED_SWIGLU:-True}
+
+# ---------- FP8 training (paper §4.x quantization / techblog §9.6) ----------
+# Paper recipe: "FP4 + FP8 Mixed" — MoE experts + CSA-Indexer QK in FP4 (MXFP4),
+# EVERYTHING ELSE in FP8, all with the **ue8m0** microscaling scale format.
+# On this stack the ue8m0 path is `fp8_recipe=mxfp8` → TE MXFP8BlockScaling →
+# Primus-Turbo MX_BLOCKWISE granularity with scale_dtype=E8M0 (fp8_utils.py:148),
+# i.e. the paper's exact scaling format, native on MI355X/CDNA4.
+#
+# Integration gap vs the paper (NOT config — Primus V4 TODO, develop techblog
+# item 10 "Phase 2 FP4/FP8 Mixed"): the FP4 expert / FP4-Indexer path is not yet
+# wired in V4, so experts run at FP8 here (FP8 everywhere) rather than FP4. This
+# is the closest supported step toward the paper recipe. FP8 is highly outlier-
+# sensitive, which is why the paper pairs it with clamped SwiGLU (swiglu_limit,
+# already on above via PRIMUS_V4_GROUPED_EXPERTS_SUPPORT_CLAMPED_SWIGLU=True).
+# Precision toggle — shared interface with run_deepseek_v4.sh / the flash proxy:
+#   PRECISION_TYPE=FP8 (default) -> e4m3 + tensorwise; BF16 -> fp8 off.
+# FP8 / FP8_RECIPE still override directly (e.g. FP8_RECIPE=blockwise, or FP8=null).
+export PRECISION_TYPE=${PRECISION_TYPE:-FP8}
+if [ "$PRECISION_TYPE" = "FP8" ]; then
+  export FP8=${FP8:-e4m3}                      # forward fp8 format (paper E4M3); "hybrid" = E4M3 fwd / E5M2 bwd
+  # Paper recipe is ue8m0 microscaling (mxfp8), but mxfp8 is NOT runnable on this
+  # gfx950 build (turbo grouped-GEMM has no MX path; TE ROCm MXFP8 needs K%128==0,
+  # V4 has a K=224 proj). `tensorwise` is the working recipe — paper fp8 layout,
+  # non-ue8m0 scale. (other: blockwise [TE-ROCm unsupported] / delayed)
+  export FP8_RECIPE=${FP8_RECIPE:-tensorwise}
+  # mxfp8 (paper ue8m0) + Muon: TRAINS, but shows a transient early-training
+  # grad-norm spike. Earlier 8-iter runs only caught the spike and mislabelled it
+  # a divergence; a 40-iter run shows it SELF-HEALS and the loss descends cleanly.
+  #   What's happening: mxfp8 quant noise ill-conditions the gradient early (random
+  #   init), so Muon's Newton-Schulz update norm spikes for ~10-20 iters, then
+  #   settles as the model organizes. RAW grads stay ~0.99 throughout; only the
+  #   NS-orthogonalized UPDATE norm spikes (Muon-specific: Adam@same-config is flat).
+  #   It is NOT a kernel bug (both MX GEMMs ~4% correct on REAL E2E inputs via
+  #   capture-replay; error zero-mean).
+  #   FIX (verified, L4/64-expert/GBS512/seq128, 40 iters):
+  #     no warmup  -> loss 12->0.80, grad-norm peak ~2.4e5 (settles to ~35)
+  #     warmup=10  -> loss 12->0.44, grad-norm peak ~2.1e4 (12x lower), no NaN
+  #   So LR warmup tames the transient AND improves the loss — and it is what the
+  #   paper does. We therefore AUTO-ENABLE warmup for mxfp8 (default 10; override
+  #   LR_WARMUP_ITERS). Two more NS-hardening knobs are exposed if needed:
+  #   MUON_NUM_NS_STEPS (more iters) and MUON_FP32_MATMUL_PREC=high. tensorwise
+  #   stays the conservative default (smooth per-tensor scale, no transient).
+  #   NOTE: validated at reduced depth/width; full 61-layer/384-expert is a
+  #   separate multi-GPU confirmation.
+  if [ "$FP8_RECIPE" = "mxfp8" ]; then
+    export LR_WARMUP_ITERS=${LR_WARMUP_ITERS:-10}
+    echo "[INFO] FP8_RECIPE=mxfp8 + Muon: expect a transient early grad-norm spike" >&2
+    echo "       (self-heals; LR warmup auto-set to ${LR_WARMUP_ITERS} to damp it)." >&2
+  fi
+else
+  export FP8=${FP8:-null}                  # PRECISION_TYPE=BF16 -> disable fp8
+  export FP8_RECIPE=${FP8_RECIPE:-null}
+fi
 
 TURBO_DEEPEP_CLI_ARGS=()
 if [ "$USE_TURBO_DEEPEP" = "True" ]; then
@@ -187,7 +300,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --manual_gc_interval 100 \
   --num_layers "$PRIMUS_TOTAL_LAYERS" \
   --train_iters "$TRAIN_ITERS" \
-  --lr_warmup_iters 0 \
+  --lr_warmup_iters "${LR_WARMUP_ITERS:-0}" \
   --lr_decay_iters "$TRAIN_ITERS" \
   --micro_batch_size "$MBS" \
   --global_batch_size "$GBS" \
@@ -203,6 +316,7 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --expert_model_parallel_size "$PRIMUS_EP" \
   --num_experts "$PRIMUS_NUM_EXPERTS" \
   --moe_router_topk "$PRIMUS_MOE_TOPK" \
+  --moe_router_force_load_balancing "${MOE_FORCE_LOAD_BALANCE:-False}" \
   --moe_router_enable_expert_bias "$PRIMUS_MOE_ENABLE_EXPERT_BIAS" \
   --moe_ffn_hidden_size "$PRIMUS_MOE_FFN_HIDDEN_SIZE" \
   --index_topk "$PRIMUS_INDEX_TOPK" \
@@ -213,6 +327,8 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --optimizer "$OPTIMIZER" \
   --muon_momentum "$MUON_MOMENTUM" \
   --muon_extra_scale_factor "$MUON_EXTRA_SCALE_FACTOR" \
+  --muon_num_ns_steps "$MUON_NUM_NS_STEPS" \
+  --muon_fp32_matmul_prec "$MUON_FP32_MATMUL_PREC" \
   --use_distributed_optimizer "$USE_DISTRIBUTED_OPTIMIZER" \
   --use_precision_aware_optimizer "$USE_PRECISION_AWARE_OPTIMIZER" \
   --main_grads_dtype fp32 \
@@ -226,11 +342,14 @@ mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
   --use_v4_tilelang_csa_attention "$USE_V4_TILELANG_CSA_ATTENTION" \
   --use_v4_compiled_sinkhorn "$USE_V4_COMPILED_SINKHORN" \
   --use_turbo_deepep "$USE_TURBO_DEEPEP" \
+  --turbo_sync_free_moe_stage "$TURBO_SYNC_FREE_MOE_STAGE" \
   "${TURBO_DEEPEP_CLI_ARGS[@]}" \
   --use_turbo_grouped_mlp "$TURBO_USE_GROUPED_MLP" \
+  --use_turbo_parallel_linear "$USE_TURBO_PARALLEL_LINEAR" \
+  --moe_experts_fp4 "$MOE_EXPERTS_FP4" \
   --moe_use_legacy_grouped_gemm False \
-  --fp8 null \
-  --fp8_recipe null \
+  --fp8 "$FP8" \
+  --fp8_recipe "$FP8_RECIPE" \
   --recompute_num_layers 1 \
   --recompute_granularity full \
   --recompute_method uniform \

--- a/run_deepseek_v4_pro_muon_1gpu.sh
+++ b/run_deepseek_v4_pro_muon_1gpu.sh
@@ -1,0 +1,442 @@
+#!/bin/bash
+###############################################################################
+# DeepSeek-V4 *Pro* + Muon single-GPU bring-up on mi455 / gfx1250 (1 GPU).
+#
+# Single-GPU sibling of run_deepseek_v4_flash_proxy_1gpu.sh, for the Pro model.
+# The upstream run_deepseek_v4_pro_muon.sh uses `primus-cli direct`, which
+# assumes it is ALREADY inside the 8x288GB MI355X container at EP=8. This host
+# is one gfx1250 box with no SLURM and one GPU, so this script instead wraps
+# the SAME examples/run_pretrain.sh entrypoint in a local `docker run` (the
+# validated gfx1250 docker + TransformerEngine recipe from
+# ../../mi450/Primus/run_dsv3_proxy_4L.sh), selects the Pro model via
+# PRIMUS_MODEL, and scales it down to a MINIMUM single-GPU proxy:
+#
+#   - model           deepseek_v4_pro      hidden 7168 / 128 heads / head_dim
+#                                          512 / o_groups 16 (full Pro widths
+#                                          from deepseek_v4_pro.yaml)
+#   - parallel        TP=1 PP=1 EP=1       (single GPU; no SLURM, no DeepEP)
+#   - num_layers      4                    (vs production 61; MINIMUM slice
+#                                          that still exercises every V4
+#                                          attention layer kind)
+#   - compress_ratios [128,128,4,0]        Pro pattern (first two HCA, then
+#                                          CSA, last dense+SWA) -> covers
+#                                          HCA cr=128 / CSA cr=4 / dense cr=0
+#   - num_experts     48  topk 1           (production 384/topk6 div by 8 =
+#                                          the per-rank shape of the EP=8
+#                                          production run; topk ceil(6/8)=1.
+#                                          ~48 experts x 66M x 4L + Muon fp32
+#                                          states + seq-4096 activations -> 273
+#                                          GB peak (measured), fits the 432 GiB
+#                                          card; full 384 will NOT fit.)
+#   - moe_ffn_hidden  3072                 (full Pro MoE width; from yaml)
+#   - seq_length      4096                 (raised from 512: at GBS=8 the fixed
+#                                          Muon Newton-Schulz cost otherwise
+#                                          dominates GPU time; 4096
+#                                          tokens/microbatch amortizes it to a
+#                                          representative profile. CSA gather
+#                                          scales w/ seq. Set 512 for a fast smoke.)
+#   - index_topk      64                   (CSA top-K; <= cr=4 pool seq/4, i.e.
+#                                          4096/4=1024 at the default seq)
+#   - precision       FP8 e4m3 + tensorwise (paper fp8 LAYOUT, per-tensor scale;
+#                                          mxfp8/ue8m0 is GUARDED off — diverges
+#                                          on this build. CK-free TE path.
+#                                          PRECISION_TYPE=BF16 for a BF16 A/B.)
+#
+# Optimizer: Muon (paper §4.2.2), same recipe as the upstream pro_muon runner:
+#   momentum 0.95, update-RMS scale 0.18, AdamW eps 1e-20, LR 2.0e-4->2.0e-5,
+#   balance-loss 1e-4. Muon hard-requires use_distributed_optimizer=False +
+#   use_precision_aware_optimizer=False (so optimizer states stay fp32 — this
+#   is the binding memory cost, NOT activations). Set OPTIMIZER=adam to A/B.
+#   NOTE: at the tiny single-GPU GBS the Newton-Schulz cost looks huge as a %
+#   of GEMM (starved-batch artifact, not a Muon bug); raise GBS to amortize.
+#
+# Correctness-first defaults (this is a "does V4-Pro train at all on 1 gfx1250
+# GPU" bring-up, not a perf push). Eager attention; Turbo/DeepEP/tilelang/
+# compiled-Sinkhorn/plan-6 Triton fusions all OFF; stock hipBLASLt; profiler
+# OFF. Every knob is ${VAR:-DEFAULT}-guarded for command-line A/B.
+#
+# REQUIRED gfx1250 fix kept ON (single-GPU-safe): RCCL all_reduce(op=AVG) hangs
+# even at world_size=1 on this build and Megatron's MoE aux-loss reduce uses
+# AVG; sitecustomize on PYTHONPATH rewrites AVG -> SUM/world_size. See
+# rccl_avg_workaround/sitecustomize.py.
+#
+# Usage:
+#   ./run_deepseek_v4_pro_muon_1gpu.sh                                  # 10-iter smoke
+#   OPTIMIZER=adam ./run_deepseek_v4_pro_muon_1gpu.sh                   # A/B vs AdamW
+#   PRIMUS_TOTAL_LAYERS=6 ./run_deepseek_v4_pro_muon_1gpu.sh            # deeper slice (watch HBM)
+#   PRIMUS_NUM_EXPERTS=8 PRIMUS_MOE_TOPK=2 ./run_deepseek_v4_pro_muon_1gpu.sh  # tiny MoE
+#   HIP_VISIBLE_DEVICES=3 ./run_deepseek_v4_pro_muon_1gpu.sh            # pin a card
+###############################################################################
+set -eo pipefail
+
+export DOCKER_IMAGE=${DOCKER_IMAGE:-registry-sc-harbor.amd.com/framework/therock-npi@sha256:feba897e2a32a2465b8b296ed2662b2ad6136b5f1cf6f6c2716a3674aafc30f3}
+SCRIPT_DIR=$(realpath -m "$(dirname "$0")")
+export TE_DIR=${TE_DIR:-$(realpath -m "$SCRIPT_DIR/../../mi450/TransformerEngine")}
+export TE_WHEEL_DIR=${TE_WHEEL_DIR:-$(realpath -m "$SCRIPT_DIR/../../mi450/dist/feba897")}
+
+# ---------- Attention backend env (TE side) --------------------------------
+export NVTE_FUSED_ATTN=1
+export NVTE_FUSED_ATTN_CK=0
+export NVTE_FUSED_ATTN_AOTRITON=1
+export NVTE_USE_CK_GEMM=0
+export NVTE_FLASH_ATTN=0
+
+# ---------- hipBLASLt: STOCK by default; opt-in TUNED (PRIMUS_TUNED_HIPBLASLT=1) -
+# Stock is the safe default: the older feba897 tuned bundle DEADLOCKED on a
+# backward-FP8 GSU split-K kernel on this host (GPU wedge -> node reboot,
+# 2026-06-10). PRIMUS_TUNED_HIPBLASLT=1 opts into a freshly built GridBased
+# gfx1250 tuned library (qwen3/dsv3 tuned; swept clean on dsv4 fwd shapes) via
+# LD_PRELOAD + HIPBLASLT_TENSILE_LIBPATH. This is a GUARDED EXPERIMENT: run with
+# a watchdog and expect a possible node reboot if the backward path still wedges.
+# NOTE: never export an EMPTY HIPBLASLT_TENSILE_LIBPATH into the container — a
+# missing path breaks even stock hipBLASLt ("Cannot read TensileLibrary...").
+export PRIMUS_TUNED_HIPBLASLT=${PRIMUS_TUNED_HIPBLASLT:-0}
+export HBL_TUNED_RELEASE=${HBL_TUNED_RELEASE:-/home/yanyuqin/hipblaslt/rocm-libraries/projects/hipblaslt/build/release}
+if [ "$PRIMUS_TUNED_HIPBLASLT" = "1" ]; then
+    if [ ! -f "$HBL_TUNED_RELEASE/library/libhipblaslt.so.1" ]; then
+        echo "[hipblaslt] ERROR: tuned lib not found at $HBL_TUNED_RELEASE/library/libhipblaslt.so.1" >&2
+        exit 1
+    fi
+    # LD_PRELOAD / LD_LIBRARY_PATH are injected INSIDE the container (below) so the
+    # image's own rocm/torch lib paths are preserved (prepend, not override).
+    export HIPBLASLT_TENSILE_LIBPATH="$HBL_TUNED_RELEASE/Tensile/library/gfx1250"
+    echo "[hipblaslt] TUNED (opt-in): libpath=$HIPBLASLT_TENSILE_LIBPATH, LD_PRELOAD=libhipblaslt.so.1 (GUARDED: watch for wedge)"
+else
+    unset HIPBLASLT_DIR HIPBLASLT_LD_PRELOAD HIPBLASLT_TENSILE_LIBPATH
+    echo "[hipblaslt] STOCK (container built-in gfx1250 catalog)"
+fi
+
+# ---------- REQUIRED gfx1250 RCCL AVG->SUM workaround -----------------------
+export PYTHONPATH="$SCRIPT_DIR/rccl_avg_workaround:${PYTHONPATH:-}"
+
+# SDMA OFF on this host (run 3 debugging, 2026-06-10): an SDMA H2D copy
+# intermittently never signals completion — py-spy --native showed the trainer
+# pinned in rocr BusyWaitSignal under a trivial `torch.tensor(n, device=dev)`
+# in Megatron get_batch, GPU 0%, dmesg clean. Killing the stuck proc then
+# leaves MES unrecoverable (recovery disabled) -> node reboot. Blit-kernel
+# copies are slower but don't use the flaky SDMA queues. This may ALSO be the
+# true cause of the run-1 "permute autotune wedge" (same stuck-queue
+# signature; permute fusion possibly innocent).
+export HSA_ENABLE_SDMA=${HSA_ENABLE_SDMA:-0}
+
+# ---------- Distributed / NCCL: single GPU, loopback only -------------------
+export HSA_NO_SCRATCH_RECLAIM=1
+export NCCL_IB_DISABLE=1
+export NCCL_P2P_DISABLE=1
+export NCCL_IB_HCA=
+export NCCL_SOCKET_IFNAME=lo
+export GLOO_SOCKET_IFNAME=lo
+export RCCL_DISABLE_AMDSMI=1
+export NCCL_AMDSMI_DISABLE=1
+export USING_AINIC=0
+
+export GPUS_PER_NODE=1
+export NNODES=1
+export PYTHONUNBUFFERED=1
+
+# REQUIRED gfx1250 workaround for V4-Pro (default ON). The Pro model build
+# (hidden_size 7168, NOT a multiple of 4096) leaves a memory layout that wedges
+# the process's first high-priority MES queue creation at iter-1 get_batch
+# -> deadlock -> node reboot (debugged 2026-06-11; root cause = MES queue
+# creation vs non-4096-aligned allocation layout). AMD_SERIALIZE_COPY=3 alone
+# prevents it (kernels stay async; small iter-time cost on the eager
+# proxy). Bisected: KERNEL serialize + LAUNCH_BLOCKING are NOT needed, so they
+# default off. Set AMD_SERIALIZE_COPY=0 only to re-demonstrate the hang.
+export AMD_SERIALIZE_COPY=${AMD_SERIALIZE_COPY:-3}
+export AMD_SERIALIZE_KERNEL=${AMD_SERIALIZE_KERNEL:-0}
+export HIP_LAUNCH_BLOCKING=${HIP_LAUNCH_BLOCKING:-0}
+
+# ---------- Model: DeepSeek-V4 Pro (selected via the EXP yaml model: line) --
+export PRIMUS_MODEL=${PRIMUS_MODEL:-deepseek_v4_pro}
+
+# ---------- Pro MINIMUM single-GPU proxy shape ------------------------------
+export PRIMUS_TP=${PRIMUS_TP:-1}
+export PRIMUS_PP=${PRIMUS_PP:-1}
+export PRIMUS_EP=${PRIMUS_EP:-1}
+# 3 layers (down from 4): the 4-layer model sits near the 432GB gfx1250's
+# capacity and OOMs at iter 2 (Muon keeps fp32 optimizer states). Dropping
+# the last layer frees the headroom for a warm step.
+export PRIMUS_TOTAL_LAYERS=${PRIMUS_TOTAL_LAYERS:-3}
+export PRIMUS_NUM_EXPERTS=${PRIMUS_NUM_EXPERTS:-48}
+export PRIMUS_MOE_TOPK=${PRIMUS_MOE_TOPK:-1}
+export PRIMUS_MOE_FFN_HIDDEN_SIZE=${PRIMUS_MOE_FFN_HIDDEN_SIZE:-3072}
+export PRIMUS_INDEX_TOPK=${PRIMUS_INDEX_TOPK:-64}
+export PRIMUS_SEQ_LENGTH=${PRIMUS_SEQ_LENGTH:-4096}
+export PRIMUS_MAX_POSITION_EMBEDDINGS=${PRIMUS_MAX_POSITION_EMBEDDINGS:-${PRIMUS_SEQ_LENGTH}}
+export MBS=${MBS:-1}
+export GBS=${GBS:-8}
+export TRAIN_ITERS=${TRAIN_ITERS:-10}
+
+# Per-layer compression schedule, length == PRIMUS_TOTAL_LAYERS, mirroring the
+# Pro pattern (first two HCA(128), then CSA(4)/HCA(128) interleaved, last
+# dense+SWA(0)). Pure-bash generator (no host python needed).
+gen_pro_compress_ratios() {
+    local n=$1 i r=()
+    for ((i = 0; i < n; i++)); do
+        if   (( i < 2 ));     then r+=(128)
+        elif (( i == n-1 ));  then r+=(0)
+        elif (( i % 2 == 0)); then r+=(4)
+        else                       r+=(128)
+        fi
+    done
+    local IFS=,
+    echo "[${r[*]}]"
+}
+export PRIMUS_COMPRESS_RATIOS=${PRIMUS_COMPRESS_RATIOS:-$(gen_pro_compress_ratios "$PRIMUS_TOTAL_LAYERS")}
+
+# ---------- Optimizer: Muon (paper §4.2.2) ---------------------------------
+export OPTIMIZER=${OPTIMIZER:-muon}
+export MUON_MOMENTUM=${MUON_MOMENTUM:-0.95}
+export MUON_EXTRA_SCALE_FACTOR=${MUON_EXTRA_SCALE_FACTOR:-0.18}
+export USE_DISTRIBUTED_OPTIMIZER=${USE_DISTRIBUTED_OPTIMIZER:-False}
+export USE_PRECISION_AWARE_OPTIMIZER=${USE_PRECISION_AWARE_OPTIMIZER:-False}
+export LR=${LR:-2.0e-4}
+export MIN_LR=${MIN_LR:-2.0e-5}
+export ADAM_EPS=${ADAM_EPS:-1.0e-20}   # needs a decimal point — Primus parses "1e-20" as a string
+export MOE_AUX_LOSS_COEFF=${MOE_AUX_LOSS_COEFF:-0.0001}
+export MTP_NUM_LAYERS=${MTP_NUM_LAYERS:-0}   # V4 MTP layer not yet supported in-tree
+# Pro uses sqrtsoftplus; Megatron only supports aux-loss-free expert bias with
+# sigmoid, so disable expert bias (balancing falls back to seq_aux_loss).
+export PRIMUS_MOE_ENABLE_EXPERT_BIAS=${PRIMUS_MOE_ENABLE_EXPERT_BIAS:-False}
+
+# Muon needs fp32 optimizer states (precision-aware off forces this anyway).
+OPT_DTYPE_ARGS="--main_grads_dtype fp32 --exp_avg_dtype fp32 --exp_avg_sq_dtype fp32"
+
+# ---------- Perf knobs: OFF for a robust first bring-up ---------------------
+export USE_V4_TRITON_ATTENTION=${USE_V4_TRITON_ATTENTION:-False}
+export USE_V4_TRITON_CSA_ATTENTION=${USE_V4_TRITON_CSA_ATTENTION:-False}
+export USE_V4_TILELANG_ATTENTION=${USE_V4_TILELANG_ATTENTION:-False}
+export USE_V4_TILELANG_CSA_ATTENTION=${USE_V4_TILELANG_CSA_ATTENTION:-False}
+export USE_TURBO_ATTENTION=${USE_TURBO_ATTENTION:-False}
+export USE_TURBO_DEEPEP=${USE_TURBO_DEEPEP:-False}
+export TURBO_USE_GROUPED_MLP=${TURBO_USE_GROUPED_MLP:-False}
+# Projections: the FP8 yaml sets use_turbo_parallel_linear=true (PrimusTurboLinear);
+# turbo-free here -> TELinear. Override off so no turbo GEMM is invoked.
+export USE_TURBO_PARALLEL_LINEAR=${USE_TURBO_PARALLEL_LINEAR:-False}
+export USE_V4_COMPILED_SINKHORN=${USE_V4_COMPILED_SINKHORN:-False}
+export PRIMUS_STACK_GROUPED_WEIGHT_TRITON=${PRIMUS_STACK_GROUPED_WEIGHT_TRITON:-0}
+export PRIMUS_ROPE_TRITON=${PRIMUS_ROPE_TRITON:-0}
+export PRIMUS_SINKHORN_TRITON=${PRIMUS_SINKHORN_TRITON:-0}
+export PRIMUS_HC_TRITON=${PRIMUS_HC_TRITON:-0}
+export PRIMUS_INDEXER_TRITON=${PRIMUS_INDEXER_TRITON:-0}
+export PRIMUS_INDEXER_TRITON_FULL=${PRIMUS_INDEXER_TRITON_FULL:-0}
+export PRIMUS_V4_ROUTER_TRITON=${PRIMUS_V4_ROUTER_TRITON:-0}
+
+export ENABLE_PRIMUS_TURBO=False
+if [ "$USE_TURBO_ATTENTION" = "True" ] || [ "$USE_TURBO_DEEPEP" = "True" ] || [ "$TURBO_USE_GROUPED_MLP" = "True" ]; then
+    ENABLE_PRIMUS_TURBO=True
+fi
+
+# MoE permute fusion OFF for Pro on gfx1250: the Triton permute_with_mask_map
+# BACKWARD autotune wedges the GPU stream at Pro shapes (48 experts / hidden
+# 7168) — cuda.synchronize inside triton do_bench never returns (debugged
+# 2026-06-10 via py-spy; flash shapes 32 experts / hidden 4096 autotune fine).
+# Eager permute is the safe path; flip =True to retry after a triton fix.
+export MOE_PERMUTE_FUSION=${MOE_PERMUTE_FUSION:-False}
+
+export PROFILE=${PROFILE:-False}
+# PyTorch profiler writes the chrome trace via tensorboard_trace_handler(
+# args.tensorboard_dir), so the tensorboard dir MUST be enabled to get a trace.
+# Default tensorboard off, but auto-enable it whenever PROFILE=True so a
+# profiled run actually produces a trace. profile window = steps [START,END);
+# need TRAIN_ITERS > PROFILE_STEP_END.
+export DISABLE_TENSORBOARD=${DISABLE_TENSORBOARD:-True}
+if [ "$PROFILE" = "True" ]; then export DISABLE_TENSORBOARD=False; fi
+export PROFILE_STEP_START=${PROFILE_STEP_START:-6}
+export PROFILE_STEP_END=${PROFILE_STEP_END:-7}
+export PRIMUS_TEAM=${PRIMUS_TEAM:-amd}
+export PRIMUS_USER=${PRIMUS_USER:-gfx1250-1gpu}
+export PRIMUS_EXP_NAME=${PRIMUS_EXP_NAME:-deepseek_v4_pro_muon_1gpu_L${PRIMUS_TOTAL_LAYERS}_E${PRIMUS_NUM_EXPERTS}_seq${PRIMUS_SEQ_LENGTH}}
+
+PRIMUS_PATH="$SCRIPT_DIR"
+DATA_PATH="${PRIMUS_PATH}/data"
+mkdir -p "$DATA_PATH"
+
+EXP=${EXP:-examples/megatron/configs/MI355X/deepseek_v4_flash-FP8-pretrain.yaml}
+LOG=${LOG:-deepseek-v4-pro-muon-1gpu.log}
+
+# ---------- FP8 training (matches upstream run_deepseek_v4_pro_fp8_paper.sh) --
+# PRECISION_TYPE=FP8 (default) -> FP8=e4m3, FP8_RECIPE=tensorwise. This is the
+# paper's fp8 LAYOUT (all weight GEMMs in fp8: MoE expert GEMMs via TEGroupedMLP,
+# attention QKV/O + dense proj via TELinear; attention core QK^T/softmax*V stays
+# BF16; mHC/Sinkhorn fp32; embedding/head/RMSNorm/router BF16; optimizer fp32) —
+# but with a per-TENSOR scale instead of the paper's ue8m0 microscale.
+#
+# CK-free by construction: this 1gpu launcher already has TURBO_USE_GROUPED_MLP=
+# False + USE_TURBO_DEEPEP=False, so experts route to TEGroupedMLP (hipBLASLt),
+# not PrimusTurboGroupedMLP (ck_grouped_gemm). NVTE_ROCM_ENABLE_MXFP8=1 is set
+# by examples/run_pretrain.sh.
+#
+# WHY NOT mxfp8 (paper ue8m0): two blockers on this build, both upstream-
+# root-caused. (1) TE-ROCm MXFP8 asserts GEMM K % 128 == 0 (rocm_gemm.hip:1529)
+# and V4 has non-128 K dims (e.g. K=224, K=32) -> errors out. (2) Even if it ran,
+# mxfp8's e8m0 per-block quant noise AMPLIFIES MULTIPLICATIVELY through backward
+# depth -> divergence. tensorwise's smooth per-tensor fp32 scale is stable
+# (upstream: loss 12 -> 0.82 at full depth). So mxfp8 is GUARDED below.
+#
+# The earlier FP8 no-op (decoder skipped the fp8 context) is fixed upstream
+# (commit b662c40b) and lives in the mounted repo, so FP8 now actually engages.
+# A/B back to BF16 with PRECISION_TYPE=BF16 (or FP8=null).
+export NVTE_ROCM_ENABLE_MXFP8=${NVTE_ROCM_ENABLE_MXFP8:-1}
+# TURBO-FREE FP8: primus_turbo is only an import-shim in this gfx1250 container,
+# so the turbo FP8 path (PrimusTurboQuantConfig / primus_turbo_fp8_autocast)
+# can't run. Force the TE-native fp8_autocast branch (fp8_utils.py honors this).
+export PRIMUS_FP8_DISABLE_TURBO=${PRIMUS_FP8_DISABLE_TURBO:-1}
+export PRECISION_TYPE=${PRECISION_TYPE:-FP8}
+if [ "$PRECISION_TYPE" = "FP8" ]; then
+    export FP8=${FP8:-e4m3}
+    export FP8_RECIPE=${FP8_RECIPE:-tensorwise}
+    # GUARD: mxfp8 (paper ue8m0) diverges for V4 on this build. Refuse it unless
+    # explicitly forced, matching upstream run_deepseek_v4_pro_muon.sh.
+    if [ "$FP8_RECIPE" = "mxfp8" ] && [ "${MXFP8_I_KNOW_ITS_BROKEN:-0}" != "1" ]; then
+        echo "[FATAL] FP8_RECIPE=mxfp8 diverges for V4 on this build (TE K%128 assert +" >&2
+        echo "        e8m0 depth-amplified instability). Use FP8_RECIPE=tensorwise," >&2
+        echo "        or set MXFP8_I_KNOW_ITS_BROKEN=1 to force it anyway." >&2
+        exit 1
+    fi
+else
+    export FP8=${FP8:-null}
+    export FP8_RECIPE=${FP8_RECIPE:-null}
+fi
+
+if [ ! -d "$PRIMUS_PATH/third_party/Megatron-LM" ] || \
+   [ -z "$(ls -A "$PRIMUS_PATH/third_party/Megatron-LM" 2>/dev/null)" ]; then
+    echo "[ERROR] third_party/Megatron-LM missing/empty -> run: git submodule update --init --recursive" >&2
+    exit 1
+fi
+
+echo "[pro] model=$PRIMUS_MODEL layers=$PRIMUS_TOTAL_LAYERS experts=$PRIMUS_NUM_EXPERTS seq=$PRIMUS_SEQ_LENGTH optimizer=$OPTIMIZER compress_ratios=$PRIMUS_COMPRESS_RATIOS"
+
+# V4-Pro single-GPU overrides (trailing args -> run_pretrain.sh -> primus cli
+# train pretrain --config $EXP ...). Mirrors run_deepseek_v4_pro_muon.sh's CLI
+# set, minus the DeepEP wiring, scaled to one GPU / minimum layers.
+# overlap_grad_reduce/param_gather stay OFF: upstream enabled them for multi-
+# node DP scaling (needs the distributed optimizer + the indexer-param freeze),
+# but at single-GPU DP=1 they are no-ops, and Muon requires them off anyway.
+PROXY_OVERRIDES="\
+    --backend_path $PRIMUS_PATH/third_party/Megatron-LM \
+    --train_iters $TRAIN_ITERS \
+    --lr_warmup_iters 0 \
+    --lr_decay_iters $TRAIN_ITERS \
+    --num_layers $PRIMUS_TOTAL_LAYERS \
+    --compress_ratios $PRIMUS_COMPRESS_RATIOS \
+    --micro_batch_size $MBS \
+    --global_batch_size $GBS \
+    --lr $LR \
+    --min_lr $MIN_LR \
+    --adam_eps $ADAM_EPS \
+    --moe_aux_loss_coeff $MOE_AUX_LOSS_COEFF \
+    --seq_length $PRIMUS_SEQ_LENGTH \
+    --max_position_embeddings $PRIMUS_MAX_POSITION_EMBEDDINGS \
+    --rope_type rope \
+    --tensor_model_parallel_size $PRIMUS_TP \
+    --pipeline_model_parallel_size $PRIMUS_PP \
+    --expert_model_parallel_size $PRIMUS_EP \
+    --num_experts $PRIMUS_NUM_EXPERTS \
+    --moe_router_topk $PRIMUS_MOE_TOPK \
+    --moe_router_enable_expert_bias $PRIMUS_MOE_ENABLE_EXPERT_BIAS \
+    --moe_ffn_hidden_size $PRIMUS_MOE_FFN_HIDDEN_SIZE \
+    --index_topk $PRIMUS_INDEX_TOPK \
+    --v4_grouped_experts_support_clamped_swiglu True \
+    --mtp_num_layers $MTP_NUM_LAYERS \
+    --mock_data True \
+    --moe_router_force_load_balancing True \
+    --log_avg_skip_iterations 3 \
+    --optimizer $OPTIMIZER \
+    --muon_momentum $MUON_MOMENTUM \
+    --muon_extra_scale_factor $MUON_EXTRA_SCALE_FACTOR \
+    --use_distributed_optimizer $USE_DISTRIBUTED_OPTIMIZER \
+    --use_precision_aware_optimizer $USE_PRECISION_AWARE_OPTIMIZER \
+    $OPT_DTYPE_ARGS \
+    --enable_primus_turbo $ENABLE_PRIMUS_TURBO \
+    --use_turbo_attention $USE_TURBO_ATTENTION \
+    --use_turbo_deepep $USE_TURBO_DEEPEP \
+    --use_turbo_grouped_mlp $TURBO_USE_GROUPED_MLP \
+    --use_turbo_parallel_linear $USE_TURBO_PARALLEL_LINEAR \
+    --use_v4_triton_attention $USE_V4_TRITON_ATTENTION \
+    --use_v4_triton_csa_attention $USE_V4_TRITON_CSA_ATTENTION \
+    --use_v4_tilelang_attention $USE_V4_TILELANG_ATTENTION \
+    --use_v4_tilelang_csa_attention $USE_V4_TILELANG_CSA_ATTENTION \
+    --use_v4_compiled_sinkhorn $USE_V4_COMPILED_SINKHORN \
+    --moe_use_legacy_grouped_gemm False \
+    --moe_permute_fusion $MOE_PERMUTE_FUSION \
+    --fp8 $FP8 \
+    --fp8_recipe $FP8_RECIPE \
+    --recompute_num_layers 0 \
+    --recompute_granularity full \
+    --recompute_method block \
+    --gradient_accumulation_fusion False \
+    --overlap_grad_reduce False \
+    --overlap_param_gather False \
+    --disable_last_saving True \
+    --disable_wandb True \
+    --disable_tensorboard $DISABLE_TENSORBOARD \
+    --profile $PROFILE \
+    --use_pytorch_profiler $PROFILE \
+    --profile_step_start $PROFILE_STEP_START \
+    --profile_step_end $PROFILE_STEP_END"
+
+ENV_ARGS=()
+for v in DOCKER_IMAGE NVTE_FUSED_ATTN NVTE_FUSED_ATTN_CK NVTE_FUSED_ATTN_AOTRITON \
+         NVTE_FLASH_ATTN NVTE_USE_CK_GEMM NVTE_ROCM_ENABLE_MXFP8 PRIMUS_FP8_DISABLE_TURBO PYTHONPATH HSA_ENABLE_SDMA HSA_NO_SCRATCH_RECLAIM \
+         HIP_LAUNCH_BLOCKING AMD_SERIALIZE_KERNEL AMD_SERIALIZE_COPY \
+         AMD_LOG_LEVEL AMD_LOG_MASK MASTER_PORT TORCH_NCCL_HIGH_PRIORITY \
+         NCCL_IB_DISABLE NCCL_P2P_DISABLE NCCL_IB_HCA NCCL_SOCKET_IFNAME \
+         GLOO_SOCKET_IFNAME RCCL_DISABLE_AMDSMI NCCL_AMDSMI_DISABLE USING_AINIC \
+         GPUS_PER_NODE NNODES PYTHONUNBUFFERED TE_DIR TE_WHEEL_DIR PRIMUS_MODEL \
+         PRIMUS_SEQ_LENGTH PRIMUS_MAX_POSITION_EMBEDDINGS \
+         PRIMUS_TEAM PRIMUS_USER PRIMUS_EXP_NAME \
+         PRIMUS_STACK_GROUPED_WEIGHT_TRITON PRIMUS_ROPE_TRITON \
+         PRIMUS_SINKHORN_TRITON PRIMUS_HC_TRITON PRIMUS_INDEXER_TRITON \
+         PRIMUS_INDEXER_TRITON_FULL PRIMUS_V4_ROUTER_TRITON; do
+    ENV_ARGS+=("--env" "$v")
+done
+[[ -n "${HIP_VISIBLE_DEVICES:-}" ]] && ENV_ARGS+=("--env" "HIP_VISIBLE_DEVICES")
+# EXTRA_CLI: extra trailing --flag value overrides appended after PROXY_OVERRIDES
+# (argparse last-wins), for dimension bisects etc.
+[[ -n "${EXTRA_CLI:-}" ]] && ENV_ARGS+=("--env" "EXTRA_CLI")
+
+VOLUME_ARGS=(-v "$PRIMUS_PATH":"$PRIMUS_PATH" -v "$DATA_PATH":"$DATA_PATH")
+[[ -d "$TE_WHEEL_DIR" ]] && VOLUME_ARGS+=(-v "$TE_WHEEL_DIR":"$TE_WHEEL_DIR")
+[[ -d "$TE_DIR" ]] && VOLUME_ARGS+=(-v "$TE_DIR":"$TE_DIR")
+# Opt-in tuned hipBLASLt: mount the built library at the same path and pass the
+# loader env into the container (only when enabled, to keep stock runs untouched).
+if [ "$PRIMUS_TUNED_HIPBLASLT" = "1" ]; then
+    VOLUME_ARGS+=(-v "$HBL_TUNED_RELEASE":"$HBL_TUNED_RELEASE")
+    ENV_ARGS+=("--env" "PRIMUS_TUNED_HIPBLASLT" "--env" "HIPBLASLT_TENSILE_LIBPATH" \
+               "--env" "HBL_TUNED_RELEASE")
+fi
+# Container-side loader injection for the tuned lib (prepends to the image's paths).
+HBL_PRELOAD_PREFIX=""
+if [ "$PRIMUS_TUNED_HIPBLASLT" = "1" ]; then
+    HBL_PRELOAD_PREFIX="export LD_LIBRARY_PATH=\"\$HBL_TUNED_RELEASE/library:\${LD_LIBRARY_PATH:-}\" && export LD_PRELOAD=\"\$HBL_TUNED_RELEASE/library/libhipblaslt.so.1\${LD_PRELOAD:+:\$LD_PRELOAD}\" && echo \"[hipblaslt] container LD_PRELOAD=\$LD_PRELOAD\" && "
+fi
+
+TE_INSTALL_PREFIX="\
+    if ls ${TE_WHEEL_DIR}/transformer_engine-*.whl >/dev/null 2>&1; then \
+        echo '[TE] installing prebuilt wheel from ${TE_WHEEL_DIR}' && \
+        pip install --quiet --force-reinstall --no-deps ${TE_WHEEL_DIR}/transformer_engine-*.whl && \
+        pip install --quiet einops nvdlfw-inspect onnxscript onnx pydantic importlib-metadata packaging transformers pybind11; \
+    else \
+        echo '[TE] WARNING: no TE wheel found at ${TE_WHEEL_DIR}; run will likely fail'; \
+    fi && \
+    echo '[deps] installing Primus requirements' && \
+    pip install --quiet -r requirements.txt && "
+
+docker run --rm \
+    "${ENV_ARGS[@]}" \
+    --ipc=host --network=host \
+    --device=/dev/kfd --device=/dev/dri \
+    --cap-add=SYS_PTRACE --cap-add=CAP_SYS_ADMIN \
+    --security-opt seccomp=unconfined --group-add video \
+    --privileged \
+    --name primus-v4-pro-muon-1gpu \
+    "${VOLUME_ARGS[@]}" \
+    "$DOCKER_IMAGE" /bin/bash -c "\
+        set -e && cd $PRIMUS_PATH && \
+        ${HBL_PRELOAD_PREFIX}\
+        ${TE_INSTALL_PREFIX}\
+        echo '==================== V4-PRO + MUON 1-GPU PROXY (gfx1250, BF16, eager, no profiler) ====================' && \
+        EXP=$EXP PRIMUS_MODEL=$PRIMUS_MODEL GPUS_PER_NODE=1 NNODES=1 bash examples/run_pretrain.sh \
+            ${PROXY_OVERRIDES} ${EXTRA_CLI:-}" \
+    2>&1 | tee "$LOG"


### PR DESCRIPTION
Ports the DeepSeek-V4 low-precision training work from dev/john/dsv4 onto dev/tas/deepseek-v4. All precision paths default-OFF.

Quantization recipe (paper-aligned, flag-gated):
- FP8 tensorwise training for V4 Pro/Flash + single-GPU launchers.
- FP8 (mxfp8) attention/dense projections via Primus-Turbo (USE_TURBO_PARALLEL_LINEAR).
- MXFP4 grouped experts via per-group native FP4 (hipBLASLt).
- Per-module recipe: experts MXFP4 / rest FP8 (moe_experts_fp4).
- FP4 CSA-indexer QK + paper-recipe FP8/FP4 attention, real-FP4 indexer GEMM, MXFP8 expert-weight cache.
- Fused grouped-O into one grouped_gemm_fp8.

Indexer reconciliation (keep-both): preserves FP8-E4M3 indexer QK and adds FP4 QK as a selectable mode; mutually exclusive (both default-OFF -> BF16 QK), FP4 takes precedence as a dedicated real-GEMM branch.

Training + launchers:
- Muon mxfp8 fix: auto-enable LR warmup,  plumb NS knobs.
- Default seq_length 4096.
- gfx1250 launcher: opt-in tuned hipBLASLt (stock default), 3-layer default to fit the 432GB card. gfx1250-only.