### PR TITLE
DSv4: FlyDSL attention backend + MI355X Triton tuning

### DIFF
--- a/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
+++ b/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
@@ -149,6 +149,10 @@ class DeepSeekV4TransformerConfig(MLATransformerConfig):
     #                         > use_v4_triton_csa_attention > eager
     use_v4_tilelang_attention: bool = False
     use_v4_tilelang_csa_attention: bool = False
+    # FlyDSL backend (gfx950/MI355X). Forward-only, soft-dependency; falls back
+    # to Triton when the FlyDSL runtime is absent.
+    use_v4_flydsl_attention: bool = False
+    use_v4_flydsl_csa_attention: bool = False
 
     # ---- DeepSeek-V4 plan-5 P29: torch.compile-fused Sinkhorn ----
     # Plan-5 P29 (RESCOPED from "small-op fusion" — see plan-5 02-phase-

--- a/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
+++ b/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
@@ -651,6 +651,20 @@ class DeepseekV4Attention(MLASelfAttention):
         )
         if self._use_v4_tilelang_csa_attention and self.compress_ratio != 4:
             self._use_v4_tilelang_csa_attention = False
+        # FlyDSL backend flags (forward-only, soft-dep; same compress-ratio
+        # gating as the tilelang flags above).
+        self._use_v4_flydsl_attention: bool = _coerce_optional_bool_flag(
+            getattr(config, "use_v4_flydsl_attention", False),
+            field_name="use_v4_flydsl_attention",
+        )
+        if self._use_v4_flydsl_attention and self.compress_ratio not in (0, 128):
+            self._use_v4_flydsl_attention = False
+        self._use_v4_flydsl_csa_attention: bool = _coerce_optional_bool_flag(
+            getattr(config, "use_v4_flydsl_csa_attention", False),
+            field_name="use_v4_flydsl_csa_attention",
+        )
+        if self._use_v4_flydsl_csa_attention and self.compress_ratio != 4:
+            self._use_v4_flydsl_csa_attention = False
 
         self.core_attention: Optional[nn.Module] = None
         self._use_core_attention: bool = False
@@ -995,6 +1009,7 @@ class DeepseekV4Attention(MLASelfAttention):
                 scale=self._attention_scale(),
                 hca_local_seqlen=int(hca_local_seqlen),
                 use_tilelang=self._use_v4_tilelang_attention,
+                use_flydsl=self._use_v4_flydsl_attention,
             )
             ev_e.record()
             torch.cuda.synchronize()
@@ -1012,6 +1027,7 @@ class DeepseekV4Attention(MLASelfAttention):
             scale=self._attention_scale(),
             hca_local_seqlen=int(hca_local_seqlen),
             use_tilelang=self._use_v4_tilelang_attention,
+            use_flydsl=self._use_v4_flydsl_attention,
         )
 
     def _attention_forward_via_core(
@@ -1211,6 +1227,7 @@ class DeepseekV4Attention(MLASelfAttention):
                 training=self.training,
                 scale=self._attention_scale(),
                 use_tilelang=self._use_v4_tilelang_csa_attention,
+                use_flydsl=self._use_v4_flydsl_csa_attention,
             )
 
         # 3) Eager fallback gathers per-query pool slices: [B, S, K, Dh].

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/__init__.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/__init__.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FlyDSL attention-kernel backend for DeepSeek-V4 (gfx950 / MI355X).
+
+A *soft-dependency* alternate backend, structured exactly like the sibling
+``_tilelang`` package: the V4 attention layer calls :func:`should_dispatch`
+with the ``enabled`` flag from a config knob, and this module lazily imports
+the FlyDSL kernel wrappers. If the ``flydsl`` runtime (or a kernel submodule)
+is not importable, :func:`should_dispatch` returns ``False`` and the caller
+transparently falls back to the in-tree Triton path -- so a container without
+FlyDSL never breaks and never changes behaviour.
+
+Kernels live under ``_flydsl/kernels/``. Forward-only for now (inference/eval);
+training autograd is a follow-up.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Any, Optional, Set
+
+__all__ = [
+    "should_dispatch",
+    "is_flydsl_available",
+    "v4_attention_fwd_flydsl",
+    "v4_csa_attention_fwd_flydsl",
+]
+
+# Kernel names the layer may ask for, mirroring the _tilelang registry.
+_KNOWN_KERNEL_NAMES: Set[str] = {
+    "v4_attention_fwd",       # SWA / HCA forward (MQA launcher)
+    "v4_csa_attention_fwd",   # CSA forward
+    "v4_attention_bwd",       # present in-package; training-autograd hook TBD
+    "v4_csa_attention_bwd",   # present in-package; training-autograd hook TBD
+}
+
+# Forward kernels that are actually wired (have a working adapter below).
+_WIRED_FWD: Set[str] = {"v4_attention_fwd", "v4_csa_attention_fwd"}
+
+_PROBE_DONE: bool = False
+_FLYDSL_AVAILABLE: bool = False
+
+
+def _probe_flydsl() -> bool:
+    """Import the ``flydsl`` runtime once (cached); warn once on rank 0 if absent."""
+    global _PROBE_DONE, _FLYDSL_AVAILABLE
+    if _PROBE_DONE:
+        return _FLYDSL_AVAILABLE
+    _PROBE_DONE = True
+    try:
+        # The kernel wrappers add the FlyDSL build dir to sys.path at import;
+        # allow an override for non-default install locations.
+        src = os.environ.get("PRIMUS_V4_FLYDSL_SRC", "/workspace/FlyDSL-amd")
+        import sys
+
+        if src and src not in sys.path and os.path.isdir(src):
+            sys.path.insert(0, src)
+        import flydsl  # noqa: F401
+
+        _FLYDSL_AVAILABLE = True
+    except Exception as exc:  # ImportError, or a runtime/arch probe failure
+        if int(os.environ.get("RANK", "0")) == 0:
+            warnings.warn(
+                f"[v4-flydsl] FlyDSL runtime unavailable ({exc!r}); FlyDSL "
+                f"attention backend disabled, falling back to Triton.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        _FLYDSL_AVAILABLE = False
+    return _FLYDSL_AVAILABLE
+
+
+def is_flydsl_available() -> bool:
+    """True iff the FlyDSL runtime imported successfully (cached)."""
+    return _probe_flydsl()
+
+
+# --- lazy adapter cache -----------------------------------------------------
+_FWD_MQA = None      # _launch_v4_attention_fwd_flydsl_mqa
+_FWD_CSA = None      # _launch_v4_attention_fwd_csa
+
+
+def _load_fwd_mqa():
+    global _FWD_MQA
+    if _FWD_MQA is None:
+        from .kernels.v4_attention_fwd_flydsl_mqa import (
+            _launch_v4_attention_fwd_flydsl_mqa as fn,
+        )
+
+        _FWD_MQA = fn
+    return _FWD_MQA
+
+
+def _load_fwd_csa():
+    global _FWD_CSA
+    if _FWD_CSA is None:
+        from .kernels.v4_attention_fwd_flydsl_csa import _launch_v4_attention_fwd_csa as fn
+
+        _FWD_CSA = fn
+    return _FWD_CSA
+
+
+def should_dispatch(kernel_name: str, *, enabled: bool) -> bool:
+    """True iff FlyDSL should handle ``kernel_name`` (else Triton fallback).
+
+    Short-circuits when ``enabled`` is False so the off path never imports FlyDSL.
+    """
+    if not enabled:
+        return False
+    if kernel_name not in _KNOWN_KERNEL_NAMES:
+        raise ValueError(
+            f"Unknown FlyDSL kernel {kernel_name!r}; expected one of "
+            f"{sorted(_KNOWN_KERNEL_NAMES)}"
+        )
+    if kernel_name not in _WIRED_FWD:
+        # bwd kernels are present in-package but lack a training-autograd hook
+        return False
+    if not _probe_flydsl():
+        return False
+    try:
+        _load_fwd_csa() if kernel_name == "v4_csa_attention_fwd" else _load_fwd_mqa()
+    except Exception as exc:
+        if int(os.environ.get("RANK", "0")) == 0:
+            warnings.warn(
+                f"[v4-flydsl] kernel {kernel_name!r} import failed ({exc!r}); "
+                f"falling back to Triton.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        return False
+    return True
+
+
+# --- forward adapters (signatures match the dispatch sites) -----------------
+def v4_attention_fwd_flydsl(
+    q,
+    k,
+    v,
+    *,
+    sink: Optional[Any] = None,
+    swa_window: int = 0,
+    additive_mask: Optional[Any] = None,
+    scale: float,
+    hca_local_seqlen: int = 0,
+):
+    """SWA/HCA forward via FlyDSL. Returns the attention output tensor."""
+    out, _lse = _load_fwd_mqa()(
+        q, k, v, sink, int(swa_window), additive_mask, float(scale), int(hca_local_seqlen)
+    )
+    return out
+
+
+def v4_csa_attention_fwd_flydsl(
+    q,
+    k_local,
+    v_local,
+    gathered,
+    *,
+    sparse_mask,
+    sink: Optional[Any] = None,
+    swa_window: int = 0,
+    scale: float,
+    attn_dropout: float = 0.0,
+    training: bool = False,
+):
+    """CSA forward via FlyDSL (the 2.79x kernel). Returns the output tensor."""
+    out, _lse = _load_fwd_csa()(
+        q, k_local, v_local, gathered, sink, int(swa_window), sparse_mask, float(scale)
+    )
+    return out

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_attention_bwd_flydsl_mqa.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_attention_bwd_flydsl_mqa.py
@@ -1,0 +1,838 @@
+"""V4 SWA attention backward FlyDSL launcher (Phase B STEP 1b, cr=0, SWA-only).
+
+API contract (matches the Triton ``_launch_v4_attention_bwd`` signature; the
+bwd_modes harness calls this function):
+
+    flydsl_v4_attention_bwd(
+        q, k, v, out, dout, lse,
+        *,
+        sink, swa_window, additive_mask, scale, hca_local_seqlen,
+    ) -> (dq, dk, dv, dsink)
+
+STEP 1b SCOPE
+-------------
+Current state of each compute stage:
+  * preprocess (D scalar) -> FlyDSL kernel (``v4_swa_bwd_preprocess_kernel``)
+  * dq                    -> FlyDSL kernel (``v4_swa_bwd_dq_kernel``)
+                              forked from kernels/sla_bwd_dq.py
+  * dk / dv               -> Triton kernel (``_v4_attention_bwd_dkv_kernel``)
+  * dsink                 -> FlyDSL kernel writes it (via atomic_fadd in dq)
+
+Env knobs:
+  V4_FLYDSL_BWD_FLY_PREPROCESS  default 1 (1=FlyDSL, 0=Triton)
+  V4_FLYDSL_BWD_FLY_DQ          default 1 (1=FlyDSL, 0=Triton)
+  V4_FLYDSL_BWD_VERBOSE         default 0 (1=print provenance line)
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import threading
+from typing import Optional, Tuple
+
+import torch
+
+_FLYDSL_SRC = "/workspace/FlyDSL-amd"
+if _FLYDSL_SRC not in sys.path:
+    sys.path.insert(0, _FLYDSL_SRC)
+
+os.environ.setdefault("FLYDSL_WAVES_PER_EU", "2")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+if "/workspace/Primus" not in sys.path:
+    sys.path.insert(0, "/workspace/Primus")
+from primus.backends.megatron.core.transformer.v4_attention_kernels._triton.v4_attention_bwd import (  # noqa: E402
+    _v4_attention_bwd_preprocess_kernel,
+    _v4_attention_bwd_dq_kernel,
+    _v4_attention_bwd_dkv_kernel,
+    _v4_attention_bwd_dkv_pool_kernel,
+)
+import triton  # noqa: E402
+
+
+# Built lazily on first call; module-level kernel build is expensive.
+_PREPROCESS_KERNEL_CACHE = {}
+_PREPROCESS_KERNEL_LOCK = threading.Lock()
+
+_DQ_KERNEL_CACHE = {}
+_DQ_KERNEL_LOCK = threading.Lock()
+_DKV_KERNEL_CACHE = {}
+_DKV_KERNEL_LOCK = threading.Lock()
+_DQ_POOL_KERNEL_CACHE = {}
+_DQ_POOL_KERNEL_LOCK = threading.Lock()
+_DKV_POOL_KERNEL_CACHE = {}
+_DKV_POOL_KERNEL_LOCK = threading.Lock()
+
+
+def _get_fly_preprocess(head_dim: int, dtype_str: str, block_rows: int):
+    key = (head_dim, dtype_str, block_rows)
+    with _PREPROCESS_KERNEL_LOCK:
+        if key in _PREPROCESS_KERNEL_CACHE:
+            return _PREPROCESS_KERNEL_CACHE[key]
+        from v4_sla_bwd_kernel import build_v4_swa_bwd_preprocess_module
+        launch = build_v4_swa_bwd_preprocess_module(
+            head_dim=head_dim, dtype_str=dtype_str, block_rows=block_rows,
+        )
+        _PREPROCESS_KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _get_fly_dq(num_heads: int, head_dim: int, swa_window: int,
+                dtype_str: str, mqa_kv: bool, has_sink: bool):
+    key = (num_heads, head_dim, swa_window, dtype_str, mqa_kv, has_sink)
+    with _DQ_KERNEL_LOCK:
+        if key in _DQ_KERNEL_CACHE:
+            return _DQ_KERNEL_CACHE[key]
+        from v4_sla_bwd_kernel import build_v4_swa_bwd_dq_module
+        launch = build_v4_swa_bwd_dq_module(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            swa_window=swa_window,
+            dtype_str=dtype_str,
+            mqa_kv=mqa_kv,
+            has_sink=has_sink,
+        )
+        _DQ_KERNEL_CACHE[key] = launch
+        return launch
+
+
+
+
+def _get_fly_dq_pool(num_heads: int, head_dim: int, pool_size: int,
+                     hca_local_seqlen: int, dtype_str: str, mqa_kv: bool):
+    key = (num_heads, head_dim, pool_size, hca_local_seqlen, dtype_str, mqa_kv)
+    with _DQ_POOL_KERNEL_LOCK:
+        if key in _DQ_POOL_KERNEL_CACHE:
+            return _DQ_POOL_KERNEL_CACHE[key]
+        from v4_hca_bwd_dq_pool_kernel import build_v4_hca_bwd_dq_pool_module
+        launch = build_v4_hca_bwd_dq_pool_module(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            pool_size=pool_size,
+            hca_local_seqlen=hca_local_seqlen,
+            dtype_str=dtype_str,
+            mqa_kv=mqa_kv,
+        )
+        _DQ_POOL_KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _get_fly_dkv_pool(num_heads: int, head_dim: int, pool_size: int,
+                      hca_local_seqlen: int, dtype_str: str, mqa_kv: bool):
+    key = (num_heads, head_dim, pool_size, hca_local_seqlen, dtype_str, mqa_kv)
+    with _DKV_POOL_KERNEL_LOCK:
+        if key in _DKV_POOL_KERNEL_CACHE:
+            return _DKV_POOL_KERNEL_CACHE[key]
+        from v4_hca_bwd_dkv_pool_kernel import build_v4_hca_bwd_dkv_pool_module
+        launch = build_v4_hca_bwd_dkv_pool_module(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            pool_size=pool_size,
+            hca_local_seqlen=hca_local_seqlen,
+            dtype_str=dtype_str,
+            mqa_kv=mqa_kv,
+        )
+        _DKV_POOL_KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _get_fly_dkv(num_heads: int, head_dim: int, swa_window: int,
+                 dtype_str: str, mqa_kv: bool):
+    key = (num_heads, head_dim, swa_window, dtype_str, mqa_kv)
+    with _DKV_KERNEL_LOCK:
+        if key in _DKV_KERNEL_CACHE:
+            return _DKV_KERNEL_CACHE[key]
+        from v4_sla_bwd_dkv_kernel import build_v4_swa_bwd_dkv_module
+        launch = build_v4_swa_bwd_dkv_module(
+            num_heads=num_heads,
+            head_dim=head_dim,
+            swa_window=swa_window,
+            dtype_str=dtype_str,
+            mqa_kv=mqa_kv,
+        )
+        _DKV_KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _run_preprocess(
+    out: torch.Tensor,
+    dout: torch.Tensor,
+    *,
+    use_flydsl: bool,
+    block_m: int,
+    block_dmodel: int,
+) -> torch.Tensor:
+    """Compute D[b,h,m] = sum_d (out[b,h,m,d] * dout[b,h,m,d]) in fp32."""
+    B, HQ, Sq, D = out.shape
+    d_buf = torch.empty((B, HQ, Sq), device=out.device, dtype=torch.float32)
+    if use_flydsl:
+        out_f = out.contiguous().view(-1, D)
+        dout_f = dout.contiguous().view(-1, D)
+        delta_f = d_buf.view(-1)
+        n_rows = out_f.shape[0]
+        dtype_str = "bf16" if out.dtype == torch.bfloat16 else "f16"
+        max_block_threads = 256
+        threads_per_row = D // 8
+        for br in (8, 4, 2, 1):
+            if n_rows % br == 0 and br * threads_per_row <= max_block_threads:
+                block_rows = br
+                break
+        else:
+            block_rows = 1
+        launch = _get_fly_preprocess(D, dtype_str, block_rows)
+        launch(out_f, dout_f, delta_f, n_rows)
+        return d_buf
+    pre_grid = (triton.cdiv(Sq, block_m), B * HQ)
+    _v4_attention_bwd_preprocess_kernel[pre_grid](
+        out, dout, d_buf,
+        out.stride(0), out.stride(1), out.stride(2), out.stride(3),
+        dout.stride(0), dout.stride(1), dout.stride(2), dout.stride(3),
+        d_buf.stride(0), d_buf.stride(1), d_buf.stride(2),
+        Sq,
+        HEAD=HQ,
+        BLOCK_M=block_m,
+        BLOCK_DMODEL=block_dmodel,
+        num_warps=4, num_stages=1,
+    )
+    return d_buf
+
+
+def _run_dq_triton(
+    q, k, v, dout, lse, d_buf, dq_fp32, dsink_fp32, sink_arg, mask_arg,
+    *, scale, swa_window_constexpr, has_sink, has_add_mask,
+    hca_local_seqlen, use_causal,
+    block_m, block_n, block_dmodel,
+    stride_ms, stride_mn,
+    Sq, Sk, HQ, HK, B,
+    exact_tiles_m, exact_tiles_n,
+):
+    dq_grid = (triton.cdiv(Sq, block_m), B * HQ)
+    _v4_attention_bwd_dq_kernel[dq_grid](
+        q, k, v, dout, lse, d_buf, dq_fp32, dsink_fp32, sink_arg, mask_arg,
+        q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+        dout.stride(0), dout.stride(1), dout.stride(2), dout.stride(3),
+        lse.stride(0), lse.stride(1), lse.stride(2),
+        d_buf.stride(0), d_buf.stride(1), d_buf.stride(2),
+        dq_fp32.stride(0), dq_fp32.stride(1), dq_fp32.stride(2), dq_fp32.stride(3),
+        stride_ms, stride_mn,
+        Sq, Sk, float(scale),
+        HEAD_Q=HQ, HEAD_K=HK,
+        SWA_WINDOW=swa_window_constexpr,
+        HAS_SINK=has_sink, HAS_ADD_MASK=has_add_mask,
+        HCA_LOCAL_SEQLEN=hca_local_seqlen,
+        USE_CAUSAL=use_causal,
+        BLOCK_M=block_m, BLOCK_N=block_n, BLOCK_DMODEL=block_dmodel,
+        EXACT_TILES_M=exact_tiles_m, EXACT_TILES_N=exact_tiles_n,
+        num_warps=int(os.getenv("PRIMUS_V4_ATTN_BWD_DQ_NUM_WARPS", "2")),
+        num_stages=int(os.getenv("PRIMUS_V4_ATTN_BWD_DQ_NUM_STAGES", "1")),
+    )
+
+
+def _run_dq_flydsl(
+    q, k, v, dout, lse, d_buf, dq_fp32, dsink_fp32, sink_arg,
+    *, scale, swa_window, has_sink,
+    Sq, Sk, HQ, HK, B, D,
+):
+    """V4 SWA bwd dQ via FlyDSL. Writes dq_fp32 (fp32) and adds into
+    dsink_fp32 (fp32, atomic) when has_sink. Sink_arg is a fp32 dummy
+    buffer when has_sink=False.
+
+    Expects BHLD contiguous: q [B,HQ,Sq,D], k/v [B,HK,Sk,D], dout/lse/d_buf
+    same as Triton path. For MQA we ENFORCE HK==1 and pass k/v as-is
+    (the FlyDSL kernel uses stride_kh=0 via the mqa_kv codepath, which
+    expects K/V to be flat [B, Sk, D]-contiguous regardless of stride).
+    """
+    mqa_kv = (HK == 1)
+    # Sanity: V4 STEP 1 only supports MQA (HK==1). Keep this gate; if HK!=1
+    # we fall back to the Triton path upstream.
+    assert mqa_kv, f"FlyDSL dq STEP 1b only supports MQA (HK==1); got HK={HK}"
+    dtype_str = "bf16" if q.dtype == torch.bfloat16 else "f16"
+
+    launch = _get_fly_dq(
+        num_heads=HQ, head_dim=D, swa_window=int(swa_window),
+        dtype_str=dtype_str, mqa_kv=True, has_sink=has_sink,
+    )
+
+    # The FlyDSL kernel reads K/V via flat pointer ops, so they must be
+    # contiguous and rank-4 doesn't strictly matter. We pass the rank-4
+    # tensors directly; the BHLD path computes ((b*1 + 0)*Sk + n)*D + col
+    # for KV when mqa_kv=True. That matches the stride pattern of a
+    # [B, 1, Sk, D]-contiguous tensor.
+    # NOTE: K and V come in as [B, 1, Sk, D] from the harness MQA leaves
+    # (see bwd_modes _build_swa_inputs).
+    assert q.is_contiguous(), "q must be contiguous"
+    assert k.is_contiguous(), "k must be contiguous"
+    assert v.is_contiguous(), "v must be contiguous"
+    assert dout.is_contiguous(), "dout must be contiguous"
+    assert lse.is_contiguous(), "lse must be contiguous"
+    assert d_buf.is_contiguous(), "d_buf must be contiguous"
+    assert dq_fp32.is_contiguous(), "dq_fp32 must be contiguous"
+
+    launch(
+        q,                 # Q [B, HQ, Sq, D]
+        k,                 # K [B, 1, Sk, D] (MQA broadcast view)
+        v,                 # V [B, 1, Sk, D]
+        dout,              # DOS [B, HQ, Sq, D]
+        lse,               # LSE [B, HQ, Sq] fp32
+        d_buf,             # DELTAS [B, HQ, Sq] fp32
+        dq_fp32,           # DQ [B, HQ, Sq, D] fp32 (OUTPUT)
+        dsink_fp32,        # DSINK [HQ] fp32 (OUTPUT, atomic)
+        sink_arg,          # SINK [HQ] fp32 (INPUT, dummy if !has_sink)
+        int(B),
+        int(Sq),
+        int(Sk),
+    )
+
+
+
+def _run_dkv_flydsl(
+    q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32,
+    *, scale, swa_window, has_sink,
+    Sq, Sk, HQ, HK, B, D,
+):
+    """V4 SWA bwd dKdV via FlyDSL. Writes dk_fp32 / dv_fp32 (fp32 buffers).
+    MQA only (HK==1). One program per (b, n_block), head-loop accumulator,
+    no atomics."""
+    mqa_kv = (HK == 1)
+    assert mqa_kv, f"FlyDSL dkv STEP 1c only supports MQA (HK==1); got HK={HK}"
+    print(
+        f"[provenance] FlyDSL dkv launcher invoked, B={B} H={HQ} Sk={Sk} D={D}",
+        flush=True,
+    )
+    dtype_str = "bf16" if q.dtype == __import__("torch").bfloat16 else "f16"
+    launch = _get_fly_dkv(
+        num_heads=HQ, head_dim=D, swa_window=int(swa_window),
+        dtype_str=dtype_str, mqa_kv=True,
+    )
+    assert q.is_contiguous(), "q must be contiguous"
+    assert k.is_contiguous(), "k must be contiguous"
+    assert v.is_contiguous(), "v must be contiguous"
+    assert dout.is_contiguous(), "dout must be contiguous"
+    assert lse.is_contiguous(), "lse must be contiguous"
+    assert d_buf.is_contiguous(), "d_buf must be contiguous"
+    assert dk_fp32.is_contiguous(), "dk_fp32 must be contiguous"
+    assert dv_fp32.is_contiguous(), "dv_fp32 must be contiguous"
+    launch(
+        q,           # Q [B, HQ, Sq, D]
+        k,           # K [B, 1, Sk, D]
+        v,           # V [B, 1, Sk, D]
+        dout,        # DOS [B, HQ, Sq, D]
+        lse,         # LSE [B, HQ, Sq] fp32 (RAW domain)
+        d_buf,       # DELTAS [B, HQ, Sq] fp32
+        dk_fp32,     # DK [B, 1, Sk, D] fp32 (OUTPUT)
+        dv_fp32,     # DV [B, 1, Sk, D] fp32 (OUTPUT)
+        int(B),
+        int(Sq),
+        int(Sk),
+    )
+
+
+def _run_dq_pool_flydsl(
+    q, k, v, dout, lse, d_buf, dq_fp32, add_mask,
+    *, pool_size, hca_local_seqlen,
+    Sq, Sk, HQ, HK, B, D,
+):
+    """V4 HCA bwd dq POOL stream via FlyDSL. ACCUMULATES into dq_fp32.
+
+    Called AFTER ``_run_dq_flydsl`` has written the LOCAL stream dq into
+    dq_fp32. Race-free since each program owns a unique
+    (b, qhid, m_block) slice and the launch is sequenced after the local
+    dq launch.
+    """
+    mqa_kv = (HK == 1)
+    assert mqa_kv, f"FlyDSL dq_pool only supports MQA (HK==1); got HK={HK}"
+    assert pool_size <= 64, (
+        f"pool_size must fit in one BLOCK_N=64 block; got pool_size={pool_size}"
+    )
+    assert hca_local_seqlen % 64 == 0, (
+        f"hca_local_seqlen must be multiple of BLOCK_N=64; got {hca_local_seqlen}"
+    )
+    assert (hca_local_seqlen + pool_size) == Sk, (
+        f"expected hca_local_seqlen+pool_size == Sk; got {hca_local_seqlen}+{pool_size}!={Sk}"
+    )
+    assert add_mask is not None and add_mask.shape == (Sq, pool_size), (
+        f"add_mask shape mismatch: expected ({Sq},{pool_size}); got {tuple(add_mask.shape) if add_mask is not None else None}"
+    )
+    assert add_mask.dtype == q.dtype, (
+        f"add_mask dtype must match q.dtype; got {add_mask.dtype} vs {q.dtype}"
+    )
+    dtype_str = "bf16" if q.dtype == torch.bfloat16 else "f16"
+    launch = _get_fly_dq_pool(
+        num_heads=HQ, head_dim=D,
+        pool_size=int(pool_size),
+        hca_local_seqlen=int(hca_local_seqlen),
+        dtype_str=dtype_str, mqa_kv=True,
+    )
+    assert q.is_contiguous(), "q must be contiguous"
+    assert k.is_contiguous(), "k must be contiguous"
+    assert v.is_contiguous(), "v must be contiguous"
+    assert dout.is_contiguous(), "dout must be contiguous"
+    assert lse.is_contiguous(), "lse must be contiguous"
+    assert d_buf.is_contiguous(), "d_buf must be contiguous"
+    assert dq_fp32.is_contiguous(), "dq_fp32 must be contiguous"
+    assert add_mask.is_contiguous(), "add_mask must be contiguous"
+    launch(
+        q,
+        k,
+        v,
+        dout,
+        lse,
+        d_buf,
+        dq_fp32,
+        add_mask,
+        int(B),
+        int(Sq),
+        int(Sk),
+    )
+
+
+def _run_dkv_pool_flydsl(
+    q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32, add_mask,
+    *, pool_size, hca_local_seqlen,
+    Sq, Sk, HQ, HK, B, D,
+):
+    """V4 HCA bwd dKdV POOL stream via FlyDSL. WRITES into the POOL slice of
+    dk_fp32/dv_fp32 (which are zero-initialized by the wrapper and have the
+    LOCAL slice already populated by ``_run_dkv_flydsl``). Race-free:
+    LOCAL writes [..., :hca_local_seqlen, :] and POOL writes
+    [..., hca_local_seqlen:hca_local_seqlen+pool_size, :] -- disjoint.
+    """
+    mqa_kv = (HK == 1)
+    assert mqa_kv, f"FlyDSL dkv_pool only supports MQA (HK==1); got HK={HK}"
+    assert pool_size <= 32, (
+        f"pool_size must fit in one BLOCK_N=32 block; got pool_size={pool_size}"
+    )
+    assert hca_local_seqlen % 32 == 0, (
+        f"hca_local_seqlen must be multiple of BLOCK_N=32; got {hca_local_seqlen}"
+    )
+    assert (hca_local_seqlen + pool_size) == Sk, (
+        f"expected hca_local_seqlen+pool_size == Sk; got "
+        f"{hca_local_seqlen}+{pool_size}!={Sk}"
+    )
+    assert add_mask is not None and add_mask.shape == (Sq, pool_size), (
+        f"add_mask shape mismatch: expected ({Sq},{pool_size}); got "
+        f"{tuple(add_mask.shape) if add_mask is not None else None}"
+    )
+    assert add_mask.dtype == q.dtype, (
+        f"add_mask dtype must match q.dtype; got {add_mask.dtype} vs {q.dtype}"
+    )
+    dtype_str = "bf16" if q.dtype == torch.bfloat16 else "f16"
+    launch = _get_fly_dkv_pool(
+        num_heads=HQ, head_dim=D,
+        pool_size=int(pool_size),
+        hca_local_seqlen=int(hca_local_seqlen),
+        dtype_str=dtype_str, mqa_kv=True,
+    )
+    assert q.is_contiguous(), "q must be contiguous"
+    assert k.is_contiguous(), "k must be contiguous"
+    assert v.is_contiguous(), "v must be contiguous"
+    assert dout.is_contiguous(), "dout must be contiguous"
+    assert lse.is_contiguous(), "lse must be contiguous"
+    assert d_buf.is_contiguous(), "d_buf must be contiguous"
+    assert dk_fp32.is_contiguous(), "dk_fp32 must be contiguous"
+    assert dv_fp32.is_contiguous(), "dv_fp32 must be contiguous"
+    assert add_mask.is_contiguous(), "add_mask must be contiguous"
+    launch(
+        q,
+        k,
+        v,
+        dout,
+        lse,
+        d_buf,
+        dk_fp32,
+        dv_fp32,
+        add_mask,
+        int(B),
+        int(Sq),
+        int(Sk),
+    )
+
+
+def _run_dkv_triton(
+    q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32, mask_arg,
+    *, scale, swa_window_constexpr, has_add_mask,
+    hca_local_seqlen, use_causal,
+    block_m, block_n, block_dmodel,
+    stride_ms, stride_mn,
+    Sq, Sk, HQ, HK, B,
+    exact_tiles_m,
+):
+    dkv_block_n = block_n
+    dkv_n_blocks = triton.cdiv(Sk, dkv_block_n)
+    num_head_groups = 1
+    if HQ > HK:
+        # MQA/HQ>=128 (V4-Pro): HG=2 on gfx950 mirrors the prod
+        # _launch_v4_attention_bwd default. Overridable via env.
+        _hg_default = "2" if (HQ >= 64 and HK == 1) else "1"
+        target = int(os.getenv("PRIMUS_V4_ATTN_BWD_DKV_HEAD_GROUPS", _hg_default))
+        while target > 1 and HQ % target != 0:
+            target //= 2
+        num_head_groups = max(1, target)
+    dkv_grid = (dkv_n_blocks, B * HK, num_head_groups)
+    _v4_attention_bwd_dkv_kernel[dkv_grid](
+        q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32, mask_arg,
+        q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+        k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+        v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+        dout.stride(0), dout.stride(1), dout.stride(2), dout.stride(3),
+        lse.stride(0), lse.stride(1), lse.stride(2),
+        d_buf.stride(0), d_buf.stride(1), d_buf.stride(2),
+        dk_fp32.stride(0), dk_fp32.stride(1), dk_fp32.stride(2), dk_fp32.stride(3),
+        dv_fp32.stride(0), dv_fp32.stride(1), dv_fp32.stride(2), dv_fp32.stride(3),
+        stride_ms, stride_mn,
+        Sq, Sk, float(scale),
+        HEAD_Q=HQ, HEAD_K=HK,
+        SWA_WINDOW=swa_window_constexpr,
+        HAS_ADD_MASK=has_add_mask,
+        HCA_LOCAL_SEQLEN=hca_local_seqlen,
+        USE_CAUSAL=use_causal,
+        BLOCK_M=block_m, BLOCK_N=dkv_block_n, BLOCK_DMODEL=block_dmodel,
+        NUM_HEAD_GROUPS=num_head_groups,
+        EXACT_TILES_M=exact_tiles_m,
+        EXACT_TILES_N=(Sk % dkv_block_n) == 0,
+        num_warps=int(os.getenv("PRIMUS_V4_ATTN_BWD_DKV_NUM_WARPS", "2")),
+        num_stages=int(os.getenv("PRIMUS_V4_ATTN_BWD_DKV_NUM_STAGES", "1")),
+    )
+
+
+
+
+
+# ---------------------------------------------------------------------------
+# HCA pool-only dq accumulator (Triton, inline).
+#
+# This is a TEMPORARY Triton fallback for the POOL stream of HCA dq while
+# the FlyDSL pool kernel is being authored. It is structurally equivalent
+# to the pool branch of ``_v4_attention_bwd_dq_kernel`` (Triton ref) but
+# written as a standalone kernel so we can call it as a pure accumulator
+# (``DQ += pool_contrib``, no local loop). One program per (m_block, b*qhid).
+# ---------------------------------------------------------------------------
+
+
+import triton.language as tl  # noqa: E402
+
+
+@triton.jit
+def _hca_pool_dq_accumulator(
+    Q, K, V, DOUT, LSE, D, DQ, ADD_MASK,
+    stride_qb, stride_qh, stride_qm, stride_qd,
+    stride_kb, stride_kh, stride_kn, stride_kd,
+    stride_vb, stride_vh, stride_vn, stride_vd,
+    stride_dob, stride_doh, stride_dom, stride_dod,
+    stride_lb, stride_lh, stride_lm,
+    stride_db, stride_dh, stride_dm,
+    stride_dqb, stride_dqh, stride_dqm, stride_dqd,
+    stride_ms, stride_mn,
+    seqlen_q, seqlen_k, pool_size, sm_scale,
+    HEAD_Q: tl.constexpr,
+    HEAD_K: tl.constexpr,
+    HCA_LOCAL_SEQLEN: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_bh = tl.program_id(1)
+    bid = pid_bh // HEAD_Q
+    qhid = pid_bh % HEAD_Q
+    if HEAD_K == HEAD_Q:
+        khid = qhid
+    else:
+        khid = 0
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    pool_n = tl.arange(0, BLOCK_N)
+    offs_n = HCA_LOCAL_SEQLEN + pool_n
+    NEG_INF: tl.constexpr = -1.0e30
+    pool_n_mask = pool_n < pool_size
+
+    q_ptrs = Q + bid * stride_qb + qhid * stride_qh + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qd
+    dout_ptrs = DOUT + bid * stride_dob + qhid * stride_doh + offs_m[:, None] * stride_dom + offs_d[None, :] * stride_dod
+    lse_ptrs = LSE + bid * stride_lb + qhid * stride_lh + offs_m * stride_lm
+    dvec_ptrs = D + bid * stride_db + qhid * stride_dh + offs_m * stride_dm
+
+    q_load_mask = offs_m[:, None] < seqlen_q
+    q = tl.load(q_ptrs, mask=q_load_mask, other=0.0)
+    dout = tl.load(dout_ptrs, mask=q_load_mask, other=0.0)
+    lse = tl.load(lse_ptrs, mask=offs_m < seqlen_q, other=0.0)
+    dvec = tl.load(dvec_ptrs, mask=offs_m < seqlen_q, other=0.0)
+
+    k_ptrs = K + bid * stride_kb + khid * stride_kh + offs_n[:, None] * stride_kn + offs_d[None, :] * stride_kd
+    v_ptrs = V + bid * stride_vb + khid * stride_vh + offs_n[:, None] * stride_vn + offs_d[None, :] * stride_vd
+    kv_load_mask = pool_n_mask[:, None]
+    k = tl.load(k_ptrs, mask=kv_load_mask, other=0.0)
+    v = tl.load(v_ptrs, mask=kv_load_mask, other=0.0)
+
+    qk = tl.dot(q, tl.trans(k)) * sm_scale
+    mask_ptrs = ADD_MASK + offs_m[:, None] * stride_ms + pool_n[None, :] * stride_mn
+    mask_load_mask = (offs_m[:, None] < seqlen_q) & pool_n_mask[None, :]
+    add_bias = tl.load(mask_ptrs, mask=mask_load_mask, other=0.0).to(tl.float32)
+    qk = qk + add_bias
+    qk = tl.where(pool_n_mask[None, :], qk, NEG_INF)
+    qk = tl.where(offs_m[:, None] < seqlen_q, qk, NEG_INF)
+
+    p = tl.exp(qk - lse[:, None])
+    dp = tl.dot(dout, tl.trans(v))
+    ds = p * (dp - dvec[:, None])
+    dq_contrib = tl.dot(ds.to(k.dtype), k) * sm_scale
+
+    dq_ptrs = DQ + bid * stride_dqb + qhid * stride_dqh + offs_m[:, None] * stride_dqm + offs_d[None, :] * stride_dqd
+    dq_prev = tl.load(dq_ptrs, mask=offs_m[:, None] < seqlen_q, other=0.0)
+    tl.store(dq_ptrs, dq_prev + dq_contrib, mask=offs_m[:, None] < seqlen_q)
+
+
+def flydsl_v4_attention_bwd(
+    q: torch.Tensor,         # [B, HQ, Sq, D]
+    k: torch.Tensor,         # [B, HK, Sk, D]  (HK == 1 for MQA, HK == HQ for MHA)
+    v: torch.Tensor,         # [B, HK, Sk, D]
+    out: torch.Tensor,       # [B, HQ, Sq, D]
+    dout: torch.Tensor,      # [B, HQ, Sq, D]
+    lse: torch.Tensor,       # [B, HQ, Sq] fp32
+    *,
+    sink: Optional[torch.Tensor],
+    swa_window: int,
+    additive_mask: Optional[torch.Tensor],
+    scale: float,
+    hca_local_seqlen: int = 0,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """V4 SWA backward launcher (STEP 1b scope: SWA-only, no HCA)."""
+    if q.dim() != 4 or k.dim() != 4 or v.dim() != 4:
+        raise ValueError("rank-4 q/k/v required")
+    if dout.shape != out.shape or out.shape != q.shape:
+        raise ValueError(
+            f"shape mismatch: q={tuple(q.shape)} out={tuple(out.shape)} dout={tuple(dout.shape)}"
+        )
+    B, HQ, Sq, D = q.shape
+    HK = k.shape[1]
+    Sk = k.shape[2]
+    if k.shape != (B, HK, Sk, D) or v.shape != k.shape:
+        raise ValueError(f"k/v shape mismatch: k={tuple(k.shape)} v={tuple(v.shape)}")
+    if q.dtype != torch.bfloat16:
+        raise NotImplementedError(f"bf16 only; got q.dtype={q.dtype}")
+    if D % 16 != 0:
+        raise NotImplementedError(f"head_dim must be multiple of 16; got D={D}")
+    # STEP 2 HCA: accept SWA-only (additive_mask=None, hca_local_seqlen=0)
+    # AND HCA (additive_mask is [Sq, P], hca_local_seqlen=Sq, Sk=Sq+P).
+    is_hca = (additive_mask is not None) and (int(hca_local_seqlen) > 0)
+    if (additive_mask is not None) != (int(hca_local_seqlen) > 0):
+        raise NotImplementedError(
+            "additive_mask and hca_local_seqlen must both be set (HCA) or both unset (SWA)"
+        )
+    if is_hca:
+        if int(hca_local_seqlen) != Sq:
+            raise NotImplementedError(
+                f"HCA requires hca_local_seqlen == Sq; got {int(hca_local_seqlen)} vs Sq={Sq}"
+            )
+        if int(swa_window) <= 0:
+            raise NotImplementedError("HCA requires swa_window > 0 for the local stream")
+        if Sk <= Sq:
+            raise NotImplementedError(f"HCA requires Sk>Sq; got Sk={Sk} Sq={Sq}")
+        pool_size = Sk - Sq
+        if additive_mask.shape != (Sq, pool_size):
+            raise NotImplementedError(
+                f"HCA additive_mask must be [Sq={Sq}, P={pool_size}]; got {tuple(additive_mask.shape)}"
+            )
+        if B != 1:
+            raise NotImplementedError(
+                f"HCA path currently only supports B=1 (got B={B}); B>1 would mis-stride K/V."
+            )
+    else:
+        if int(swa_window) <= 0:
+            raise NotImplementedError("SWA requires swa_window > 0")
+        if Sq != Sk:
+            raise NotImplementedError("SWA requires Sq == Sk")
+
+    has_sink = sink is not None
+    has_add_mask = False
+    use_causal = False
+    swa_window_constexpr = int(swa_window)
+
+    BLOCK_M = int(os.getenv("PRIMUS_V4_ATTN_BWD_BLOCK_M", "32"))
+    BLOCK_N = int(os.getenv("PRIMUS_V4_ATTN_BWD_BLOCK_N", "16"))
+    BLOCK_DMODEL = D
+    exact_tiles_m = (Sq % BLOCK_M) == 0
+    exact_tiles_n = (Sk % BLOCK_N) == 0
+
+    dq_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+    dk_fp32 = torch.zeros((B, HK, Sk, D), device=q.device, dtype=torch.float32)
+    dv_fp32 = torch.zeros((B, HK, Sk, D), device=q.device, dtype=torch.float32)
+    if has_sink:
+        dsink_fp32 = torch.zeros((HQ,), device=q.device, dtype=torch.float32)
+        sink_arg = sink.to(torch.float32) if sink.dtype != torch.float32 else sink
+    else:
+        # Dummy buffers; FlyDSL kernel still takes them but doesn't touch
+        # them when has_sink=False at build time. For Triton path we mirror
+        # the original behavior of passing q-shape sentinels.
+        dsink_fp32 = torch.zeros((HQ,), device=q.device, dtype=torch.float32)
+        sink_arg = torch.zeros((HQ,), device=q.device, dtype=torch.float32)
+
+    use_fly_preprocess = (os.getenv("V4_FLYDSL_BWD_FLY_PREPROCESS", "1") == "1")
+    d_buf = _run_preprocess(
+        out, dout, use_flydsl=use_fly_preprocess,
+        block_m=BLOCK_M, block_dmodel=BLOCK_DMODEL,
+    )
+
+    mask_arg = q
+    stride_ms = 0
+    stride_mn = 0
+
+    use_fly_dq = (os.getenv("V4_FLYDSL_BWD_FLY_DQ", "1") == "1")
+    use_fly_dkv = (os.getenv("V4_FLYDSL_BWD_FLY_DKV", "1") == "1")
+    verbose = (os.getenv("V4_FLYDSL_BWD_VERBOSE", "0") == "1")
+
+    if verbose:
+        pp_tag = "flydsl" if use_fly_preprocess else "triton"
+        dq_tag = "flydsl" if use_fly_dq else "triton"
+        dkv_tag = "flydsl" if use_fly_dkv else "triton"
+        print(
+            f"[v4_bwd] preproc={pp_tag} dq={dq_tag} dkv={dkv_tag} "
+            f"has_sink={has_sink} Sq={Sq} Sk={Sk} HQ={HQ} HK={HK} D={D} swa={swa_window}",
+            flush=True,
+        )
+
+    if is_hca:
+        # ---- HCA mode (split-mask) ----
+        # 1. LOCAL stream (n < HCA_LOCAL_SEQLEN): existing FlyDSL dq + dkv,
+        #    with effective seq_len_k = HCA_LOCAL_SEQLEN. Kernel uses
+        #    seq_len_k for both n-loop bound and batch base; B=1 makes the
+        #    base zero so the reduced seq_len_k cleanly bounds the n-loop
+        #    without mis-striding K/V. (B=1-only; gated above.) The LOCAL
+        #    pass uses the JOINT lse (saved from fwd with both streams) and
+        #    JOINT delta (preprocess used full out, dout).
+        # 2. POOL stream (n in [HCA_LOCAL_SEQLEN, Sk)): Triton pool kernels
+        #    for this round; FlyDSL pool kernels are next-round work.
+        Sk_local = int(hca_local_seqlen)  # == Sq
+        pool_size = Sk - Sk_local
+        sink_dq_arg = sink_arg  # both fp32 [HQ]
+        use_fly_dq_pool = (os.getenv("V4_FLYDSL_BWD_FLY_DQ_POOL", "0") == "1")
+        use_fly_dkv_pool = (os.getenv("V4_FLYDSL_BWD_FLY_DKV_POOL", "0") == "1")
+        # Provenance: tag dq_pool / dkv_pool only based on knob (silent
+        # fallback would violate the strict-gate rule).
+        dq_pool_tag = "FlyDSL" if use_fly_dq_pool else "Triton"
+        dkv_pool_tag = "FlyDSL" if use_fly_dkv_pool else "Triton"
+        print(
+            f"[v4_bwd_hca] provenance: dq_local=FlyDSL dkv_local=FlyDSL "
+            f"dsink=FlyDSL dq_pool={dq_pool_tag} dkv_pool={dkv_pool_tag} "
+            f"B={B} HQ={HQ} HK={HK} Sq={Sq} Sk={Sk} pool={pool_size} D={D} "
+            f"swa={swa_window} hca_local_seqlen={Sk_local}",
+            flush=True,
+        )
+        # ---- LOCAL FlyDSL dq (computes dq_local + dsink) ----
+        _run_dq_flydsl(
+            q, k, v, dout, lse, d_buf, dq_fp32, dsink_fp32, sink_dq_arg,
+            scale=scale, swa_window=swa_window_constexpr, has_sink=has_sink,
+            Sq=Sq, Sk=Sk_local, HQ=HQ, HK=HK, B=B, D=D,
+        )
+        # ---- LOCAL FlyDSL dkv ----
+        _run_dkv_flydsl(
+            q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32,
+            scale=scale, swa_window=swa_window_constexpr, has_sink=has_sink,
+            Sq=Sq, Sk=Sk_local, HQ=HQ, HK=HK, B=B, D=D,
+        )
+        # ---- POOL dq accumulator: FlyDSL (knob ON) or Triton (default) ----
+        if use_fly_dq_pool:
+            _run_dq_pool_flydsl(
+                q, k, v, dout, lse, d_buf, dq_fp32, additive_mask,
+                pool_size=int(pool_size), hca_local_seqlen=Sk_local,
+                Sq=Sq, Sk=Sk, HQ=HQ, HK=HK, B=B, D=D,
+            )
+        else:
+            pool_block_n_dq = max(16, triton.next_power_of_2(pool_size))
+            _hca_pool_dq_accumulator[(triton.cdiv(Sq, BLOCK_M), B * HQ)](
+                q, k, v, dout, lse, d_buf, dq_fp32, additive_mask,
+                q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+                k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+                v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+                dout.stride(0), dout.stride(1), dout.stride(2), dout.stride(3),
+                lse.stride(0), lse.stride(1), lse.stride(2),
+                d_buf.stride(0), d_buf.stride(1), d_buf.stride(2),
+                dq_fp32.stride(0), dq_fp32.stride(1), dq_fp32.stride(2), dq_fp32.stride(3),
+                additive_mask.stride(0), additive_mask.stride(1),
+                Sq, Sk, pool_size, float(scale),
+                HEAD_Q=HQ, HEAD_K=HK,
+                HCA_LOCAL_SEQLEN=Sk_local,
+                BLOCK_M=BLOCK_M, BLOCK_N=pool_block_n_dq,
+                BLOCK_DMODEL=BLOCK_DMODEL,
+                num_warps=2, num_stages=1,
+            )
+        # ---- POOL dkv: FlyDSL (knob ON) or Triton (default) ----
+        if use_fly_dkv_pool:
+            _run_dkv_pool_flydsl(
+                q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32, additive_mask,
+                pool_size=int(pool_size), hca_local_seqlen=Sk_local,
+                Sq=Sq, Sk=Sk, HQ=HQ, HK=HK, B=B, D=D,
+            )
+        else:
+            pool_block_n_dkv = max(16, triton.next_power_of_2(pool_size))
+            pool_grid_m = triton.cdiv(Sq, BLOCK_M)
+            _v4_attention_bwd_dkv_pool_kernel[(pool_grid_m, B)](
+                q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32, additive_mask,
+                q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+                k.stride(0), k.stride(1), k.stride(2), k.stride(3),
+                v.stride(0), v.stride(1), v.stride(2), v.stride(3),
+                dout.stride(0), dout.stride(1), dout.stride(2), dout.stride(3),
+                lse.stride(0), lse.stride(1), lse.stride(2),
+                d_buf.stride(0), d_buf.stride(1), d_buf.stride(2),
+                dk_fp32.stride(0), dk_fp32.stride(1), dk_fp32.stride(2), dk_fp32.stride(3),
+                dv_fp32.stride(0), dv_fp32.stride(1), dv_fp32.stride(2), dv_fp32.stride(3),
+                additive_mask.stride(0), additive_mask.stride(1),
+                Sq, Sk, pool_size, float(scale),
+                HEAD_Q=HQ, HEAD_K=HK,
+                HCA_LOCAL_SEQLEN=Sk_local,
+                BLOCK_M=BLOCK_M, BLOCK_N=pool_block_n_dkv,
+                BLOCK_DMODEL=BLOCK_DMODEL,
+                num_warps=2, num_stages=1,
+            )
+    elif use_fly_dq:
+        # SWA-only path (STEP 1b unchanged).
+        sink_dq_arg = sink_arg  # both are fp32 [HQ]
+        _run_dq_flydsl(
+            q, k, v, dout, lse, d_buf, dq_fp32, dsink_fp32, sink_dq_arg,
+            scale=scale, swa_window=swa_window_constexpr, has_sink=has_sink,
+            Sq=Sq, Sk=Sk, HQ=HQ, HK=HK, B=B, D=D,
+        )
+    else:
+        _run_dq_triton(
+            q, k, v, dout, lse, d_buf, dq_fp32, dsink_fp32, sink_arg, mask_arg,
+            scale=scale, swa_window_constexpr=swa_window_constexpr,
+            has_sink=has_sink, has_add_mask=has_add_mask,
+            hca_local_seqlen=0, use_causal=use_causal,
+            block_m=BLOCK_M, block_n=BLOCK_N, block_dmodel=BLOCK_DMODEL,
+            stride_ms=stride_ms, stride_mn=stride_mn,
+            Sq=Sq, Sk=Sk, HQ=HQ, HK=HK, B=B,
+            exact_tiles_m=exact_tiles_m, exact_tiles_n=exact_tiles_n,
+        )
+
+    if not is_hca:
+        if use_fly_dkv:
+            _run_dkv_flydsl(
+                q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32,
+                scale=scale, swa_window=swa_window_constexpr, has_sink=has_sink,
+                Sq=Sq, Sk=Sk, HQ=HQ, HK=HK, B=B, D=D,
+            )
+        else:
+            _run_dkv_triton(
+                q, k, v, dout, lse, d_buf, dk_fp32, dv_fp32, mask_arg,
+                scale=scale, swa_window_constexpr=swa_window_constexpr,
+                has_add_mask=has_add_mask, hca_local_seqlen=0, use_causal=use_causal,
+                block_m=BLOCK_M, block_n=BLOCK_N, block_dmodel=BLOCK_DMODEL,
+                stride_ms=stride_ms, stride_mn=stride_mn,
+                Sq=Sq, Sk=Sk, HQ=HQ, HK=HK, B=B,
+                exact_tiles_m=exact_tiles_m,
+            )
+
+    dq_out = dq_fp32.to(q.dtype)
+    dk_out = dk_fp32.to(k.dtype)
+    dv_out = dv_fp32.to(v.dtype)
+    dsink_out = dsink_fp32.to(sink.dtype) if has_sink else None
+    return dq_out, dk_out, dv_out, dsink_out
+
+
+__all__ = ["flydsl_v4_attention_bwd"]

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_attention_fwd_flydsl_csa.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_attention_fwd_flydsl_csa.py
@@ -1,0 +1,180 @@
+"""V4 CSA attention forward FlyDSL launcher (Round 3 Step 2b).
+
+Stage A: correctness only. Per-row design forked from Triton monolithic CSA.
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import threading
+from typing import Optional, Tuple
+
+import torch
+
+_FLYDSL_SRC = "/workspace/FlyDSL-amd"
+if _FLYDSL_SRC not in sys.path:
+    sys.path.insert(0, _FLYDSL_SRC)
+
+os.environ.setdefault("FLYDSL_WAVES_PER_EU", "2")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+from v4_csa_fwd_kernel import build_v4_csa_fwd_module  # noqa: E402
+
+_KERNEL_CACHE = {}
+_KERNEL_CACHE_LOCK = threading.Lock()
+
+
+def _get_kernel(num_heads_q, head_dim, swa_window, dtype_str,
+                block_n, block_k, waves_per_eu, has_sink, has_sparse, mqa_kv,
+                head_group=1):
+    key = (num_heads_q, head_dim, swa_window, dtype_str,
+           block_n, block_k, waves_per_eu, has_sink, has_sparse, mqa_kv, head_group)
+    with _KERNEL_CACHE_LOCK:
+        if key in _KERNEL_CACHE:
+            return _KERNEL_CACHE[key]
+        launch = build_v4_csa_fwd_module(
+            num_heads=num_heads_q,
+            head_dim=head_dim,
+            swa_window=int(swa_window),
+            dtype_str=dtype_str,
+            waves_per_eu=waves_per_eu,
+            block_n=block_n,
+            block_k=block_k,
+            has_sink=has_sink,
+            has_sparse=has_sparse,
+            mqa_kv=mqa_kv,
+            head_group=head_group,
+        )
+        _KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _broadcast_kv_mqa(k: torch.Tensor, v: torch.Tensor, head_q: int):
+    if k.shape[1] == head_q:
+        return k, v
+    if k.shape[1] != 1:
+        raise ValueError(f"MQA expects K_H=1; got {k.shape[1]}")
+    k_full = k.expand(-1, head_q, -1, -1).clone(memory_format=torch.contiguous_format)
+    v_full = v.expand(-1, head_q, -1, -1).clone(memory_format=torch.contiguous_format)
+    return k_full, v_full
+
+
+def _launch_v4_attention_fwd_csa(
+    q: torch.Tensor,           # [B, H, Sq, D]
+    k_local: torch.Tensor,     # [B, H_KV, Sq, D]  (H_KV=1 for MQA)
+    v_local: torch.Tensor,     # [B, H_KV, Sq, D]
+    gathered: torch.Tensor,    # [B, Sq, K_topk, D]
+    *,
+    sink: Optional[torch.Tensor],  # [H] fp32 or None
+    swa_window: int,
+    sparse_mask: torch.Tensor,     # [B, Sq, K_topk] additive
+    scale: float,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """V4 CSA forward launcher.
+
+    Returns (out, lse) where out is bf16 [B, H, Sq, D] and lse is fp32 [B, H, Sq]
+    in raw-qk-scaled-domain (m + ln(l), where m absorbs sm_scale).
+    """
+    if q.dim() != 4 or k_local.dim() != 4 or v_local.dim() != 4:
+        raise ValueError("rank-4 q/k_local/v_local required")
+    if gathered.dim() != 4:
+        raise ValueError("rank-4 gathered [B,Sq,K_topk,D] required")
+    if sparse_mask.dim() != 3:
+        raise ValueError("rank-3 sparse_mask [B,Sq,K_topk] required")
+    B, HQ, Sq, D = q.shape
+    Bk, HK, Sk, Dk = k_local.shape
+    if (Bk, Sk, Dk) != (B, Sq, D) or v_local.shape != k_local.shape:
+        raise ValueError("k_local/v_local shape mismatch w.r.t. q")
+    if HK != 1 and HK != HQ:
+        raise ValueError(f"K_H must be 1 or {HQ}; got {HK}")
+    Bg, Sqg, K_topk, Dg = gathered.shape
+    if Bg != B or Sqg != Sq or Dg != D:
+        raise ValueError(f"gathered shape mismatch {tuple(gathered.shape)}")
+    Bm, Sqm, Km = sparse_mask.shape
+    if Bm != B or Sqm != Sq or Km != K_topk:
+        raise ValueError(f"sparse_mask shape mismatch {tuple(sparse_mask.shape)}")
+    if q.dtype != torch.bfloat16:
+        raise NotImplementedError(f"bf16 only; got {q.dtype}")
+    if D != 512:
+        raise NotImplementedError(f"head_dim=512 only; got {D}")
+    if int(swa_window) <= 0:
+        raise NotImplementedError("swa_window > 0 required")
+    expected_scale = 1.0 / math.sqrt(D)
+    if not math.isclose(float(scale), expected_scale, rel_tol=1e-4):
+        raise NotImplementedError(f"only scale=1/sqrt(D) supported; got {scale}")
+
+    has_sink = sink is not None
+    has_sparse = int(K_topk) > 0
+    mqa = (HK == 1) and (HQ > 1)
+
+    if has_sink:
+        sink_fp32 = sink.float().contiguous()
+        if sink_fp32.shape != (HQ,):
+            raise ValueError(f"sink shape must be ({HQ},); got {tuple(sink_fp32.shape)}")
+    else:
+        sink_fp32 = torch.zeros((max(HQ, 1),), dtype=torch.float32, device=q.device)
+
+    # MQA: avoid the .expand().clone() broadcast — pass [B,1,Sq,D] directly,
+    # kernel uses mqa_kv=True to drop head_idx from K/V indexing.
+    q_bhld = q.contiguous()
+    if mqa:
+        k_bhld = k_local.contiguous()
+        v_bhld = v_local.contiguous()
+    else:
+        k_bhld = k_local.contiguous()
+        v_bhld = v_local.contiguous()
+    o_bhld = torch.empty_like(q_bhld)
+    lse = torch.zeros((B, HQ, Sq), device=q.device, dtype=torch.float32)
+
+    # Sparse mask & gathered must be contiguous fp32 / bf16.
+    if K_topk > 0:
+        gathered_c = gathered.contiguous()
+        # sparse_mask is bf16 (typically) -> upcast to fp32 here so kernel can
+        # just add it as f32. (Triton path takes the dtype of input.)
+        if sparse_mask.dtype != torch.float32:
+            sparse_mask_fp32 = sparse_mask.float().contiguous()
+        else:
+            sparse_mask_fp32 = sparse_mask.contiguous()
+    else:
+        gathered_c = torch.empty((B, Sq, 1, D), dtype=q.dtype, device=q.device)
+        sparse_mask_fp32 = torch.zeros((B, Sq, 1), dtype=torch.float32, device=q.device)
+
+    block_n = int(os.environ.get("PRIMUS_V4_CSA_BLOCK_N", "8"))
+    block_k = int(os.environ.get("PRIMUS_V4_CSA_BLOCK_K", "16"))
+    waves_per_eu = int(os.environ.get("FLYDSL_WAVES_PER_EU", "2"))
+    # HG=2 is the banked default for the sparse path (same VGPR=250 / spill=0
+    # footprint as HG=1). K_topk==0 (dense fallback) still forces HG=1 below.
+    head_group = int(os.environ.get("PRIMUS_V4_CSA_HEAD_GROUP", "2"))
+    # Round 5 fix: dense-fallback path (K_topk==0) has no payoff from head-group
+    # fusion AND triggered a flyc closure-cache collision when has_sparse differed
+    # between HG=1 dense and HG>1 sparse compiles. Force HG=1 when dense.
+    if not has_sparse:
+        head_group = 1
+    if HQ % head_group != 0:
+        # Silently fall back to HG=1 if shape doesn't divide.
+        head_group = 1
+    launch = _get_kernel(HQ, D, int(swa_window), "bf16",
+                          block_n, block_k, waves_per_eu,
+                          has_sink, has_sparse, mqa,
+                          head_group=head_group)
+
+    launch(
+        q_bhld.view(-1),
+        k_bhld.view(-1),
+        v_bhld.view(-1),
+        gathered_c.view(-1),
+        sparse_mask_fp32.view(-1),
+        sink_fp32.view(-1),
+        o_bhld.view(-1),
+        lse.view(-1),
+        B,
+        Sq,
+        int(K_topk),
+    )
+    return o_bhld, lse
+
+
+__all__ = ["_launch_v4_attention_fwd_csa"]

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_attention_fwd_flydsl_mqa.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_attention_fwd_flydsl_mqa.py
@@ -1,0 +1,131 @@
+"""V4 SWA attention forward FlyDSL launcher with MQA stride-trick (Round 3 Stage C).
+
+Eliminates the K/V .expand().clone() broadcast that allocates H_Q copies of
+K and V. Passes the un-broadcast [B, 1, Sk, D] view directly; the kernel reads
+K/V with stride_kh=0 via the mqa_kv compile-time flag.
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import threading
+from typing import Optional, Tuple
+
+import torch
+
+_FLYDSL_SRC = "/workspace/FlyDSL-amd"
+if _FLYDSL_SRC not in sys.path:
+    sys.path.insert(0, _FLYDSL_SRC)
+
+os.environ.setdefault("FLYDSL_SLA_FWD_ENABLE_DMA", "1")
+os.environ.setdefault("FLYDSL_WAVES_PER_EU", "2")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+from v4_sla_fwd_kernel import build_v4_swa_fwd_module  # noqa: E402
+
+_KERNEL_CACHE = {}
+_KERNEL_CACHE_LOCK = threading.Lock()
+
+
+def _get_kernel(num_heads_q, head_dim, swa_window, dtype_str,
+                block_m, block_n, waves_per_eu, mqa_kv, flat_work_group_size):
+    key = (num_heads_q, head_dim, swa_window, dtype_str, block_m, block_n,
+           waves_per_eu, mqa_kv, flat_work_group_size)
+    with _KERNEL_CACHE_LOCK:
+        if key in _KERNEL_CACHE:
+            return _KERNEL_CACHE[key]
+        launch = build_v4_swa_fwd_module(
+            num_heads=num_heads_q,
+            head_dim=head_dim,
+            swa_window=int(swa_window),
+            dtype_str=dtype_str,
+            waves_per_eu=waves_per_eu,
+            block_m=block_m,
+            block_n=block_n,
+            flat_work_group_size=flat_work_group_size,
+            layout_bhld=True,
+            mqa_kv=mqa_kv,
+        )
+        _KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _launch_v4_attention_fwd_flydsl_mqa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    sink: Optional[torch.Tensor],
+    swa_window: int,
+    additive_mask: Optional[torch.Tensor],
+    scale: float,
+    hca_local_seqlen: int = 0,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """SWA-only launcher that AVOIDS the MQA broadcast.
+
+    For K_H=1 (MQA), passes the [B, 1, Sk, D] tensor directly and uses
+    the mqa_kv kernel variant. For K_H=HQ (non-MQA), falls back to the
+    standard kernel.
+    """
+    if q.dim() != 4 or k.dim() != 4 or v.dim() != 4:
+        raise ValueError("rank-4 q/k/v required")
+    B, HQ, Sq, D = q.shape
+    Bk, HK, Sk, Dk = k.shape
+    if (Bk, Sk, Dk) != (B, Sk, D) or v.shape != k.shape:
+        raise ValueError(f"shape mismatch")
+    if HK != 1 and HK != HQ:
+        raise ValueError(f"K_H must be 1 or {HQ}; got {HK}")
+    if q.dtype != torch.bfloat16:
+        raise NotImplementedError(f"bf16 only")
+    if D != 512:
+        raise NotImplementedError(f"head_dim=512 only")
+    if sink is not None:
+        raise NotImplementedError("sink not yet supported in MQA wrapper")
+    if additive_mask is not None or int(hca_local_seqlen) != 0:
+        raise NotImplementedError("HCA mode not in this wrapper")
+    if int(swa_window) <= 0:
+        raise NotImplementedError("swa_window > 0 required")
+    if Sq != Sk:
+        raise NotImplementedError("SWA: Sq==Sk required")
+    expected_scale = 1.0 / math.sqrt(D)
+    if not math.isclose(float(scale), expected_scale, rel_tol=1e-4):
+        raise NotImplementedError(f"scale=1/sqrt(D) only")
+
+    mqa = (HK == 1) and (HQ > 1)
+
+    q_bhld = q.contiguous()
+    if mqa:
+        # K/V are [B, 1, Sk, D]. We pass them flat-view but use mqa_kv kernel
+        # variant that drops head_idx from K/V indexing.
+        k_bhld = k.contiguous()
+        v_bhld = v.contiguous()
+    else:
+        k_bhld = k.contiguous()
+        v_bhld = v.contiguous()
+    o_bhld = torch.empty_like(q_bhld)
+    lse = torch.zeros((B, HQ, Sq), device=q.device, dtype=torch.float32)
+
+    block_m = int(os.environ.get("PRIMUS_V4_FLYDSL_BLOCK_M", "128"))
+    block_n = int(os.environ.get("PRIMUS_V4_FLYDSL_BLOCK_N", "32"))
+    waves_per_eu = int(os.environ.get("FLYDSL_WAVES_PER_EU", "2"))
+    fwgs_env = os.environ.get("PRIMUS_V4_FLYDSL_FWGS", "")
+    flat_work_group_size = int(fwgs_env) if fwgs_env else None
+    launch = _get_kernel(HQ, D, int(swa_window), "bf16", block_m, block_n,
+                          waves_per_eu, mqa, flat_work_group_size)
+
+    launch(
+        q_bhld.view(-1),
+        k_bhld.view(-1),
+        v_bhld.view(-1),
+        o_bhld.view(-1),
+        lse.view(-1),
+        B,
+        Sq,
+    )
+    return o_bhld, lse
+
+
+__all__ = ["_launch_v4_attention_fwd_flydsl_mqa"]

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_attention_bwd_flydsl_mqa.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_attention_bwd_flydsl_mqa.py
@@ -1,0 +1,306 @@
+"""V4 CSA attention backward FlyDSL launcher (Phase B STEP 3a + 3b).
+
+Env knobs:
+  V4_FLYDSL_CSA_BWD_FLY_DQ   default 0 (1 = FlyDSL dq, 0 = Triton dq)
+  V4_FLYDSL_CSA_BWD_FLY_DKV  default 0 (1 = FlyDSL dk_local/dv_local/
+                              dgathered/dsink, 0 = Triton)
+  V4_FLYDSL_BWD_VERBOSE      default 0
+
+Wiring:
+  knob_dq=0, knob_dkv=0   -> all Triton.
+  knob_dq=1, knob_dkv=0   -> FlyDSL dq-only; Triton emits all others.
+  knob_dq=0, knob_dkv=1   -> Triton dq; FlyDSL emits dk/dv/dgathered/dsink.
+                            (rare path; uses the FULL FlyDSL kernel and
+                            discards its dq.)
+  knob_dq=1, knob_dkv=1   -> ONE FlyDSL launch produces all 5 grads
+                            (no Triton call needed; the cheapest path
+                            when both are on).
+
+The launcher always emits a provenance line so the harness can prove the
+expected backend was used.
+"""
+from __future__ import annotations
+
+import math
+import os
+import sys
+import threading
+from typing import Optional, Tuple
+
+import torch
+
+_FLYDSL_SRC = "/workspace/FlyDSL-amd"
+if _FLYDSL_SRC not in sys.path:
+    sys.path.insert(0, _FLYDSL_SRC)
+
+os.environ.setdefault("FLYDSL_WAVES_PER_EU", "2")
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+if "/workspace/Primus" not in sys.path:
+    sys.path.insert(0, "/workspace/Primus")
+
+import triton  # noqa: E402
+
+from primus.backends.megatron.core.transformer.v4_attention_kernels._triton.v4_csa_attention_bwd import (  # noqa: E402
+    _launch_v4_csa_attention_bwd,
+)
+from primus.backends.megatron.core.transformer.v4_attention_kernels._triton.v4_attention_bwd import (  # noqa: E402
+    _v4_attention_bwd_preprocess_kernel,
+)
+
+
+_DQ_KERNEL_CACHE = {}
+_DQ_KERNEL_LOCK = threading.Lock()
+_FULL_KERNEL_CACHE = {}
+_FULL_KERNEL_LOCK = threading.Lock()
+
+
+def _get_fly_csa_dq(num_heads, head_dim, swa_window, dtype_str, has_sink, has_sparse,
+                    block_n, block_k):
+    key = (num_heads, head_dim, swa_window, dtype_str, has_sink, has_sparse, block_n, block_k)
+    with _DQ_KERNEL_LOCK:
+        if key in _DQ_KERNEL_CACHE:
+            return _DQ_KERNEL_CACHE[key]
+        from v4_csa_bwd_dq_kernel import build_v4_csa_bwd_dq_module
+        launch = build_v4_csa_bwd_dq_module(
+            num_heads=num_heads, head_dim=head_dim, swa_window=swa_window,
+            dtype_str=dtype_str, has_sink=has_sink, has_sparse=has_sparse,
+            block_n=block_n, block_k=block_k, mqa_kv=True,
+        )
+        _DQ_KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _get_fly_csa_full(num_heads, head_dim, swa_window, dtype_str, has_sink, has_sparse,
+                      block_n, block_k):
+    key = (num_heads, head_dim, swa_window, dtype_str, has_sink, has_sparse, block_n, block_k)
+    with _FULL_KERNEL_LOCK:
+        if key in _FULL_KERNEL_CACHE:
+            return _FULL_KERNEL_CACHE[key]
+        from v4_csa_bwd_full_kernel import build_v4_csa_bwd_full_module
+        launch = build_v4_csa_bwd_full_module(
+            num_heads=num_heads, head_dim=head_dim, swa_window=swa_window,
+            dtype_str=dtype_str, has_sink=has_sink, has_sparse=has_sparse,
+            block_n=block_n, block_k=block_k, mqa_kv=True,
+        )
+        _FULL_KERNEL_CACHE[key] = launch
+        return launch
+
+
+def _preprocess_deltas(out, dout, B, HQ, Sq, D):
+    BLOCK_M_PRE = 64
+    d_buf = torch.empty((B, HQ, Sq), device=out.device, dtype=torch.float32)
+    pre_grid = (triton.cdiv(Sq, BLOCK_M_PRE), B * HQ)
+    _v4_attention_bwd_preprocess_kernel[pre_grid](
+        out, dout, d_buf,
+        out.stride(0), out.stride(1), out.stride(2), out.stride(3),
+        dout.stride(0), dout.stride(1), dout.stride(2), dout.stride(3),
+        d_buf.stride(0), d_buf.stride(1), d_buf.stride(2),
+        Sq, HEAD=HQ,
+        BLOCK_M=BLOCK_M_PRE, BLOCK_DMODEL=D,
+        num_warps=4, num_stages=1,
+    )
+    return d_buf
+
+
+def flydsl_v4_csa_attention_bwd(
+    q: torch.Tensor,
+    k_local: torch.Tensor,
+    v_local: torch.Tensor,
+    gathered: torch.Tensor,
+    sparse_mask: torch.Tensor,
+    out: torch.Tensor,
+    dout: torch.Tensor,
+    lse: torch.Tensor,
+    *,
+    sink: Optional[torch.Tensor],
+    swa_window: int,
+    scale: float,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    if q.dim() != 4 or k_local.dim() != 4 or v_local.dim() != 4:
+        raise ValueError("rank-4 q / k_local / v_local required")
+    if dout.shape != out.shape or out.shape != q.shape:
+        raise ValueError(
+            f"shape mismatch: q={tuple(q.shape)} out={tuple(out.shape)} dout={tuple(dout.shape)}"
+        )
+    B, HQ, Sq, D = q.shape
+    K_topk = gathered.shape[2]
+    has_sink = sink is not None
+
+    use_fly_dq = (os.getenv("V4_FLYDSL_CSA_BWD_FLY_DQ", "0") == "1")
+    use_fly_dkv = (os.getenv("V4_FLYDSL_CSA_BWD_FLY_DKV", "0") == "1")
+    verbose = (os.getenv("V4_FLYDSL_BWD_VERBOSE", "0") == "1")
+
+    dq_tag = "FlyDSL" if use_fly_dq else "Triton"
+    dkv_tag = "FlyDSL" if use_fly_dkv else "Triton"
+    dsink_tag = "FlyDSL" if (use_fly_dkv and has_sink) else (
+        "FlyDSL" if (use_fly_dq and has_sink) else "Triton"
+    )
+    print(
+        f"[v4_csa_bwd] provenance: dq={dq_tag} dk_local={dkv_tag} dv_local={dkv_tag} "
+        f"dgathered={dkv_tag} dsink={dsink_tag} "
+        f"B={B} HQ={HQ} Sq={Sq} K_topk={K_topk} D={D} swa={swa_window} "
+        f"has_sink={has_sink}",
+        flush=True,
+    )
+
+    # ============================================================
+    # Path 1: nothing FlyDSL -> direct Triton pass-through.
+    # ============================================================
+    if not use_fly_dq and not use_fly_dkv:
+        return _launch_v4_csa_attention_bwd(
+            q, k_local, v_local, gathered, sparse_mask, out, dout, lse,
+            sink=sink, swa_window=int(swa_window), scale=float(scale),
+        )
+
+    # ============================================================
+    # Validate the FlyDSL kernel's preconditions.
+    # ============================================================
+    if q.dtype != torch.bfloat16:
+        raise NotImplementedError(f"FlyDSL CSA bwd supports bf16 only; got {q.dtype}")
+    if D % 64 != 0:
+        raise NotImplementedError(f"FlyDSL CSA bwd requires D % 64 == 0; got D={D}")
+
+    # MQA view -- the Triton wrapper expands MQA->MHA by .expand().contiguous(),
+    # so head 0 has the original values.
+    k_mqa = k_local[:, :1, :, :].contiguous()
+    v_mqa = v_local[:, :1, :, :].contiguous()
+
+    q_c = q.contiguous()
+    dout_c = dout.contiguous()
+    lse_c = lse.contiguous()
+    gathered_c = gathered.contiguous()
+    sparse_mask_c = sparse_mask.contiguous()
+
+    d_buf = _preprocess_deltas(out, dout_c, B, HQ, Sq, D)
+
+    if has_sink:
+        sink_arg = sink.to(torch.float32) if sink.dtype != torch.float32 else sink.contiguous()
+    else:
+        sink_arg = torch.zeros((HQ,), device=q.device, dtype=torch.float32)
+
+    block_n = 32
+    block_k = 32
+    dtype_str = "bf16"
+    has_sparse = (K_topk > 0)
+
+    # ============================================================
+    # Path 2: BOTH knobs on -- one FlyDSL full-kernel launch.
+    # ============================================================
+    if use_fly_dq and use_fly_dkv:
+        dq_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+        # dk_local / dv_local are stored at [B, HQ, Sq, D] (MHA-shape buffer
+        # matching Triton's atomic-add target). Caller is free to reduce.
+        dkl_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+        dvl_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+        dgathered_fp32 = torch.zeros((B, Sq, K_topk, D), device=q.device, dtype=torch.float32)
+        dsink_fp32 = torch.zeros((HQ,), device=q.device, dtype=torch.float32)
+
+        launch = _get_fly_csa_full(
+            num_heads=HQ, head_dim=D, swa_window=int(swa_window),
+            dtype_str=dtype_str, has_sink=has_sink, has_sparse=has_sparse,
+            block_n=block_n, block_k=block_k,
+        )
+
+        if verbose:
+            print(
+                f"[v4_csa_bwd] FlyDSL FULL launch: B={B} HQ={HQ} Sq={Sq} K_topk={K_topk} "
+                f"D={D} swa={swa_window} has_sink={has_sink} has_sparse={has_sparse}",
+                flush=True,
+            )
+
+        launch(
+            q_c, k_mqa, v_mqa, gathered_c, sparse_mask_c,
+            dout_c, lse_c, d_buf, sink_arg,
+            dq_fp32, dkl_fp32, dvl_fp32, dgathered_fp32, dsink_fp32,
+            int(B), int(Sq), int(K_topk),
+        )
+
+        dq_out = dq_fp32.to(q.dtype)
+        # dk_local / dv_local return shape [B, HQ, Sq, D] to match the Triton
+        # output (it returns the broadcast-MHA buffer; bwd_modes._run_csa_pair
+        # does the autograd reduction itself when the leaves were created
+        # via .expand().contiguous()).
+        dkl_out = dkl_fp32.to(k_local.dtype)
+        dvl_out = dvl_fp32.to(v_local.dtype)
+        dg_out = dgathered_fp32.to(gathered.dtype)
+        dsink_out = dsink_fp32.to(sink.dtype) if has_sink else None
+        return dq_out, dkl_out, dvl_out, dg_out, dsink_out
+
+    # ============================================================
+    # Path 3: partial overlap with Triton.
+    # ============================================================
+    # For partial paths we always run the Triton kernel and selectively
+    # override its outputs with FlyDSL values.
+    triton_out = _launch_v4_csa_attention_bwd(
+        q, k_local, v_local, gathered, sparse_mask, out, dout, lse,
+        sink=sink, swa_window=int(swa_window), scale=float(scale),
+    )
+    dq_t, dkl_t, dvl_t, dg_t, dsink_t = triton_out
+
+    if use_fly_dq:
+        # Override dq (+ dsink for sink case) with FlyDSL dq-only kernel.
+        dq_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+        dsink_fp32 = torch.zeros((HQ,), device=q.device, dtype=torch.float32)
+        launch = _get_fly_csa_dq(
+            num_heads=HQ, head_dim=D, swa_window=int(swa_window),
+            dtype_str=dtype_str, has_sink=has_sink, has_sparse=has_sparse,
+            block_n=block_n, block_k=block_k,
+        )
+        if verbose:
+            print(
+                f"[v4_csa_bwd] FlyDSL dq launch: B={B} HQ={HQ} Sq={Sq} K_topk={K_topk} "
+                f"D={D} swa={swa_window} has_sink={has_sink} has_sparse={has_sparse}",
+                flush=True,
+            )
+        launch(
+            q_c, k_mqa, v_mqa, gathered_c, sparse_mask_c,
+            dout_c, lse_c, d_buf, sink_arg,
+            dq_fp32, dsink_fp32,
+            int(B), int(Sq), int(K_topk),
+        )
+        dq_out = dq_fp32.to(q.dtype)
+        dsink_out = dsink_fp32.to(sink.dtype) if has_sink else None
+        return dq_out, dkl_t, dvl_t, dg_t, dsink_out
+
+    if use_fly_dkv:
+        # Run the FULL kernel; we keep dk/dv/dgathered/dsink from FlyDSL and
+        # discard its dq (Triton's dq is the reference here).
+        dq_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+        dkl_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+        dvl_fp32 = torch.zeros((B, HQ, Sq, D), device=q.device, dtype=torch.float32)
+        dgathered_fp32 = torch.zeros((B, Sq, K_topk, D), device=q.device, dtype=torch.float32)
+        dsink_fp32 = torch.zeros((HQ,), device=q.device, dtype=torch.float32)
+
+        launch = _get_fly_csa_full(
+            num_heads=HQ, head_dim=D, swa_window=int(swa_window),
+            dtype_str=dtype_str, has_sink=has_sink, has_sparse=has_sparse,
+            block_n=block_n, block_k=block_k,
+        )
+
+        if verbose:
+            print(
+                f"[v4_csa_bwd] FlyDSL DKV launch (dq discarded): B={B} HQ={HQ} Sq={Sq} K_topk={K_topk} "
+                f"D={D} swa={swa_window} has_sink={has_sink} has_sparse={has_sparse}",
+                flush=True,
+            )
+
+        launch(
+            q_c, k_mqa, v_mqa, gathered_c, sparse_mask_c,
+            dout_c, lse_c, d_buf, sink_arg,
+            dq_fp32, dkl_fp32, dvl_fp32, dgathered_fp32, dsink_fp32,
+            int(B), int(Sq), int(K_topk),
+        )
+
+        dkl_out = dkl_fp32.to(k_local.dtype)
+        dvl_out = dvl_fp32.to(v_local.dtype)
+        dg_out = dgathered_fp32.to(gathered.dtype)
+        dsink_out = dsink_fp32.to(sink.dtype) if has_sink else None
+        return dq_t, dkl_out, dvl_out, dg_out, dsink_out
+
+    raise RuntimeError("unreachable")
+
+
+__all__ = ["flydsl_v4_csa_attention_bwd"]

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_bwd_dq_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_bwd_dq_kernel.py
@@ -1,0 +1,564 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_csa_bwd_dq: V4 CSA-backward dq kernel for FlyDSL (STEP 3a).
+
+Per-row design (mirrors v4_csa_fwd_kernel.py):
+  grid       = (Sq, B * HQ)
+  BLOCK_SIZE = 64 (one wave). Each lane owns D_PER_LANE = HEAD_DIM // 64
+                 contiguous d values (=8 for D=512).
+
+Computes the FULL dq for one (b, qhid, q_row) by iterating BOTH
+  - LOCAL SWA stream (k_local / v_local, SWA-window-causal-mask)
+  - GATHERED stream  (gathered / sparse_mask, top-K=K_topk per row)
+The two streams share the saved JOINT LSE from CSA fwd.
+
+Inputs:
+  Q          [B, HQ, Sq, D]   bf16
+  K_LOCAL    [B,  1, Sk, D]   bf16  (MQA, HK=1)
+  V_LOCAL    [B,  1, Sk, D]   bf16
+  GATHERED   [B, Sq, K_topk, D]  bf16
+  SPARSE_MASK[B, Sq, K_topk]     bf16  (additive bias)
+  DOUT       [B, HQ, Sq, D]   bf16
+  LSE        [B, HQ, Sq]      fp32  (JOINT LSE, RAW domain)
+  DELTAS     [B, HQ, Sq]      fp32
+  SINK       [HQ]             fp32  (dummy if !has_sink)
+
+Outputs:
+  DQ         [B, HQ, Sq, D]   fp32  (overwritten -- one program owns the row)
+  DSINK      [HQ]             fp32  (atomic_add)
+"""
+
+from __future__ import annotations
+
+import math
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+
+KERNEL_NAME = "v4_csa_bwd_dq_kernel"
+_LOG2E = math.log2(math.e)
+_LLVM_GEP_DYNAMIC = -2147483648
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def build_v4_csa_bwd_dq_module(
+    num_heads,
+    head_dim,
+    swa_window,
+    dtype_str="bf16",
+    sm_scale=None,
+    waves_per_eu=2,
+    block_n=32,
+    block_k=32,
+    has_sink=True,
+    has_sparse=True,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    mqa_kv=True,
+):
+    """Build the V4 CSA backward dq launcher (one program per (b, h, q_row))."""
+    gpu_arch = get_hip_arch()
+    WARP_SIZE = 64
+    BLOCK_SIZE = WARP_SIZE
+    BLOCK_N = int(block_n)
+    BLOCK_K = int(block_k)
+    NUM_HEADS = int(num_heads)
+    HEAD_DIM = int(head_dim)
+    assert HEAD_DIM % WARP_SIZE == 0, f"head_dim must be divisible by {WARP_SIZE}"
+    D_PER_LANE = HEAD_DIM // WARP_SIZE
+    assert mqa_kv, "v4_csa_bwd_dq only supports MQA (HK=1)"
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    allocator = SmemAllocator(
+        None,
+        arch=gpu_arch,
+        global_sym_name=f"v4_csa_bwd_dq_smem_N{BLOCK_N}_K{BLOCK_K}_S{int(has_sink)}_HS{int(has_sparse)}",
+    )
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_csa_bwd_dq_kernel(
+        Q: fx.Tensor,
+        K_LOCAL: fx.Tensor,
+        V_LOCAL: fx.Tensor,
+        GATHERED: fx.Tensor,
+        SPARSE_MASK: fx.Tensor,
+        DOUT: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        SINK: fx.Tensor,
+        DQ: fx.Tensor,
+        DSINK: fx.Tensor,
+        seq_len: fx.Int32,
+        K_topk: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        f16_ty = elem_type
+        f32_ty = T.f32
+        fm_fast = arith.FastMathFlags.fast
+
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        kl_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K_LOCAL)
+        vl_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V_LOCAL)
+        g_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), GATHERED)
+        sm_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), SPARSE_MASK)
+        do_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DOUT)
+        dq_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DQ)
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+        deltas_rsrc = buffer_ops.create_buffer_resource(DELTAS, max_size=True)
+        if has_sink:
+            sink_rsrc = buffer_ops.create_buffer_resource(SINK, max_size=True)
+            dsink_rsrc = buffer_ops.create_buffer_resource(DSINK, max_size=True)
+
+        def _gep_load(base_ptr, elem_idx, vec_type, elem_t):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(
+                _llvm_ptr_ty(), base_ptr, [idx_i64],
+                rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                elem_type=elem_t,
+                noWrapFlags=0,
+            )
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def _gep_store_f32(val, base_ptr, elem_idx):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(
+                _llvm_ptr_ty(), base_ptr, [idx_i64],
+                rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                elem_type=T.f32,
+                noWrapFlags=0,
+            )
+            _llvm.StoreOp(val, gep.result)
+
+        def load_f16_v(base_ptr, elem_idx, n):
+            vt = T.vec(n, f16_ty)
+            return _gep_load(base_ptr, elem_idx, vt, f16_ty)
+
+        # ---- Thread / program IDs ----
+        pid_m = arith.index_cast(T.index, gpu.block_idx.x)
+        pid_bh = arith.index_cast(T.index, gpu.block_idx.y)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+        lane = tid
+
+        seq_len_v = arith.index_cast(T.index, seq_len)
+        K_topk_v = arith.index_cast(T.index, K_topk)
+
+        bid = pid_bh // arith.index(NUM_HEADS)
+        qhid = pid_bh % arith.index(NUM_HEADS)
+
+        q_active = arith.cmpi(arith.CmpIPredicate.slt, pid_m, seq_len_v)
+        pid_m_safe = arith.select(q_active, pid_m, arith.index(0))
+
+        NEG_INF_F = -1.0e30
+        c_neg_inf = arith.constant(NEG_INF_F, type=f32_ty)
+        c_zero_f = arith.constant(0.0, type=f32_ty)
+        c_sm_scale = arith.constant(float(sm_scale), type=f32_ty)
+        width_i32 = arith.constant(WARP_SIZE, type=T.i32)
+
+        zero_f32_vec = arith.constant_vector(0.0, T.vec(D_PER_LANE, f32_ty))
+        q_row_base = (
+            (bid * arith.index(NUM_HEADS) + qhid) * seq_len_v + pid_m_safe
+        ) * arith.index(HEAD_DIM)
+        q_lane_off = q_row_base + lane * arith.index(D_PER_LANE)
+        q_vec_raw = load_f16_v(q_ptr, q_lane_off, D_PER_LANE)
+        q_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), q_vec_raw)
+        q_f32 = arith.select(q_active, q_f32, zero_f32_vec)
+
+        do_lane_off = q_lane_off
+        do_vec_raw = load_f16_v(do_ptr, do_lane_off, D_PER_LANE)
+        do_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), do_vec_raw)
+        do_f32 = arith.select(q_active, do_f32, zero_f32_vec)
+
+        lse_delta_off = (bid * arith.index(NUM_HEADS) + qhid) * seq_len_v + pid_m_safe
+        lse_delta_off_i32 = arith.index_cast(T.i32, lse_delta_off)
+        lse_val = buffer_ops.buffer_load(
+            lse_rsrc, lse_delta_off_i32, vec_width=1, dtype=f32_ty,
+        )
+        delta_val = buffer_ops.buffer_load(
+            deltas_rsrc, lse_delta_off_i32, vec_width=1, dtype=f32_ty,
+        )
+
+        if has_sink:
+            qhid_i32 = arith.index_cast(T.i32, qhid)
+            sink_h = buffer_ops.buffer_load(
+                sink_rsrc, qhid_i32, vec_width=1, dtype=f32_ty,
+            )
+            sink_h = rocdl.readfirstlane(f32_ty, sink_h)
+            sub_sh = arith.SubFOp(sink_h, lse_val, fastmath=fm_fast).result
+            p_sink = math_dialect.exp(sub_sh, fastmath=fm_fast)
+            neg_p_sink = arith.SubFOp(c_zero_f, p_sink, fastmath=fm_fast).result
+            dsink_contrib = arith.MulFOp(
+                neg_p_sink, delta_val, fastmath=fm_fast,
+            ).result
+            is_lane0 = arith.cmpi(arith.CmpIPredicate.eq, lane, arith.index(0))
+            do_sink = arith.AndIOp(is_lane0, q_active).result
+            _if_sink = scf.IfOp(do_sink, [], has_else=False)
+            with ir.InsertionPoint(_if_sink.then_block):
+                _dsink_byte_off = arith.MulIOp(
+                    qhid_i32, arith.constant(4, type=T.i32),
+                ).result
+                _zero_i32_atom = arith.constant(0, type=T.i32)
+                rocdl.raw_ptr_buffer_atomic_fadd(
+                    dsink_contrib, dsink_rsrc, _dsink_byte_off,
+                    _zero_i32_atom, _zero_i32_atom,
+                )
+                scf.YieldOp([])
+
+        def warp_reduce_sum_f32(v):
+            cur = v
+            for off in [32, 16, 8, 4, 2, 1]:
+                xor_amt = arith.constant(off, type=T.i32)
+                peer = arith.ArithValue(cur).shuffle_xor(xor_amt, width_i32)
+                cur = arith.AddFOp(cur, peer, fastmath=fm_fast).result
+            return cur
+
+        def vec_dot_f32(a_vec, b_vec):
+            s = c_zero_f
+            for i in range_constexpr(D_PER_LANE):
+                av = vector.extract(a_vec, static_position=[i], dynamic_position=[])
+                bv = vector.extract(b_vec, static_position=[i], dynamic_position=[])
+                p = arith.MulFOp(av, bv, fastmath=fm_fast).result
+                s = arith.AddFOp(s, p, fastmath=fm_fast).result
+            return s
+
+        # ---- LOCAL SWA bounds ----
+        _pid_p1 = pid_m + arith.index(1)
+        _le_seq = arith.cmpi(arith.CmpIPredicate.sle, _pid_p1, seq_len_v)
+        n_loop_end_row = arith.select(_le_seq, _pid_p1, seq_len_v)
+        SWA = arith.index(int(swa_window))
+        _ge_w = arith.cmpi(arith.CmpIPredicate.sge, _pid_p1, SWA)
+        _n_lo_raw = arith.select(_ge_w, _pid_p1 - SWA, arith.index(0))
+        BN_idx = arith.index(BLOCK_N)
+        n_loop_start = (_n_lo_raw // BN_idx) * BN_idx
+        n_loop_end_blk = (
+            (n_loop_end_row + BN_idx - arith.index(1)) // BN_idx
+        ) * BN_idx
+
+        # Pad iter_args to >= 2 elements so scf.for_ always yields a tuple
+        # (the singleton path auto-unwraps to a scalar, breaking subscripting
+        # at D_PER_LANE==1 / D=64).
+        _PAD = 1 if D_PER_LANE == 1 else 0
+        init_local = []
+        for _ in range_constexpr(D_PER_LANE):
+            init_local.append(c_zero_f)
+        for _ in range_constexpr(_PAD):
+            init_local.append(c_zero_f)
+
+        pid_m_i32 = arith.index_cast(T.i32, pid_m)
+        seq_len_i32 = arith.index_cast(T.i32, seq_len_v)
+        w_i32 = arith.constant(int(swa_window), type=T.i32)
+        K_topk_i32 = arith.index_cast(T.i32, K_topk_v)
+
+        # ==== LOCAL SWA loop ====
+        for n_start, inner_args, loop_results_local in scf.for_(
+            n_loop_start,
+            n_loop_end_blk,
+            BN_idx,
+            iter_args=init_local,
+        ):
+            dq_accs = [inner_args[d] for d in range_constexpr(D_PER_LANE)]
+
+            n_start_i32 = arith.index_cast(T.i32, n_start)
+
+            kl_f32_cache = []
+            p_cache = []
+            dp_cache = []
+
+            for n_off in range_constexpr(BLOCK_N):
+                kv_col_i32 = arith.AddIOp(
+                    n_start_i32,
+                    arith.constant(n_off, type=T.i32),
+                ).result
+                _kv_plus_w = arith.AddIOp(kv_col_i32, w_i32).result
+                is_swa = arith.cmpi(
+                    arith.CmpIPredicate.sle, _kv_plus_w, pid_m_i32,
+                )
+                is_causal = arith.cmpi(
+                    arith.CmpIPredicate.sgt, kv_col_i32, pid_m_i32,
+                )
+                is_oob = arith.cmpi(
+                    arith.CmpIPredicate.sge, kv_col_i32, seq_len_i32,
+                )
+                bad = arith.OrIOp(
+                    arith.OrIOp(is_causal, is_swa).result,
+                    is_oob,
+                ).result
+
+                kv_col_idx = arith.index_cast(T.index, kv_col_i32)
+                kv_col_safe = arith.select(is_oob, arith.index(0), kv_col_idx)
+                kl_row_base = (
+                    bid * seq_len_v + kv_col_safe
+                ) * arith.index(HEAD_DIM)
+                kl_lane_off = kl_row_base + lane * arith.index(D_PER_LANE)
+                kl_vec = load_f16_v(kl_ptr, kl_lane_off, D_PER_LANE)
+                kl_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), kl_vec)
+                kl_f32_cache.append(kl_f32)
+
+                vl_vec = load_f16_v(vl_ptr, kl_lane_off, D_PER_LANE)
+                vl_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), vl_vec)
+
+                lane_dot_qk = vec_dot_f32(q_f32, kl_f32)
+                qk_full = warp_reduce_sum_f32(lane_dot_qk)
+                qk_scaled = arith.MulFOp(
+                    qk_full, c_sm_scale, fastmath=fm_fast,
+                ).result
+                qk_masked = arith.select(bad, c_neg_inf, qk_scaled)
+                diff_qk = arith.SubFOp(
+                    qk_masked, lse_val, fastmath=fm_fast,
+                ).result
+                p = math_dialect.exp(diff_qk, fastmath=fm_fast)
+                p_cache.append(p)
+
+                lane_dot_dp = vec_dot_f32(do_f32, vl_f32)
+                dp_full = warp_reduce_sum_f32(lane_dot_dp)
+                dp_cache.append(dp_full)
+
+            for n_off in range_constexpr(BLOCK_N):
+                p = p_cache[n_off]
+                dp = dp_cache[n_off]
+                diff = arith.SubFOp(dp, delta_val, fastmath=fm_fast).result
+                ds = arith.MulFOp(p, diff, fastmath=fm_fast).result
+                ds_scaled = arith.MulFOp(
+                    ds, c_sm_scale, fastmath=fm_fast,
+                ).result
+                kl_f32 = kl_f32_cache[n_off]
+                for d_off in range_constexpr(D_PER_LANE):
+                    klv = vector.extract(
+                        kl_f32, static_position=[d_off], dynamic_position=[],
+                    )
+                    contrib = arith.MulFOp(
+                        ds_scaled, klv, fastmath=fm_fast,
+                    ).result
+                    dq_accs[d_off] = arith.AddFOp(
+                        dq_accs[d_off], contrib, fastmath=fm_fast,
+                    ).result
+
+            _yield = list(dq_accs)
+            for _ in range_constexpr(_PAD):
+                _yield.append(c_zero_f)
+            yield _yield
+
+        dq_accs = [loop_results_local[d] for d in range_constexpr(D_PER_LANE)]
+
+        # ==== GATHERED branch ====
+        if has_sparse:
+            init_sparse = list(dq_accs)
+            for _ in range_constexpr(_PAD):
+                init_sparse.append(c_zero_f)
+            for k_start, inner_args_g, loop_results_g in scf.for_(
+                arith.index(0),
+                K_topk_v,
+                arith.index(BLOCK_K),
+                iter_args=init_sparse,
+            ):
+                dq_accs_g = [inner_args_g[d] for d in range_constexpr(D_PER_LANE)]
+
+                k_start_i32 = arith.index_cast(T.i32, k_start)
+
+                g_f32_cache = []
+                p_cache_g = []
+                dp_cache_g = []
+
+                for k_off in range_constexpr(BLOCK_K):
+                    k_pos_i32 = arith.AddIOp(
+                        k_start_i32,
+                        arith.constant(k_off, type=T.i32),
+                    ).result
+                    is_oob = arith.cmpi(
+                        arith.CmpIPredicate.sge, k_pos_i32, K_topk_i32,
+                    )
+                    k_pos_idx = arith.index_cast(T.index, k_pos_i32)
+                    k_pos_safe = arith.select(is_oob, arith.index(0), k_pos_idx)
+
+                    g_row_base = (
+                        (bid * seq_len_v + pid_m_safe) * K_topk_v + k_pos_safe
+                    ) * arith.index(HEAD_DIM)
+                    g_lane_off = g_row_base + lane * arith.index(D_PER_LANE)
+                    g_vec = load_f16_v(g_ptr, g_lane_off, D_PER_LANE)
+                    g_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), g_vec)
+                    g_f32_cache.append(g_f32)
+
+                    sm_off = (
+                        bid * seq_len_v + pid_m_safe
+                    ) * K_topk_v + k_pos_safe
+                    sm_raw_v1 = _gep_load(
+                        sm_ptr, sm_off, T.vec(1, elem_type), elem_type,
+                    )
+                    sm_raw = vector.extract(
+                        sm_raw_v1, static_position=[0], dynamic_position=[],
+                    )
+                    sm_val = arith.extf(f32_ty, sm_raw)
+                    sm_val = arith.select(is_oob, c_zero_f, sm_val)
+
+                    lane_dot_qk = vec_dot_f32(q_f32, g_f32)
+                    qk_full = warp_reduce_sum_f32(lane_dot_qk)
+                    qk_scaled = arith.MulFOp(
+                        qk_full, c_sm_scale, fastmath=fm_fast,
+                    ).result
+                    qk_biased = arith.AddFOp(
+                        qk_scaled, sm_val, fastmath=fm_fast,
+                    ).result
+                    bad = arith.OrIOp(
+                        is_oob,
+                        arith.cmpi(
+                            arith.CmpIPredicate.sge, pid_m_i32, seq_len_i32,
+                        ),
+                    ).result
+                    qk_masked = arith.select(bad, c_neg_inf, qk_biased)
+                    diff_qk = arith.SubFOp(
+                        qk_masked, lse_val, fastmath=fm_fast,
+                    ).result
+                    p = math_dialect.exp(diff_qk, fastmath=fm_fast)
+                    p_cache_g.append(p)
+
+                    lane_dot_dp = vec_dot_f32(do_f32, g_f32)
+                    dp_full = warp_reduce_sum_f32(lane_dot_dp)
+                    dp_cache_g.append(dp_full)
+
+                for k_off in range_constexpr(BLOCK_K):
+                    p = p_cache_g[k_off]
+                    dp = dp_cache_g[k_off]
+                    diff = arith.SubFOp(dp, delta_val, fastmath=fm_fast).result
+                    ds = arith.MulFOp(p, diff, fastmath=fm_fast).result
+                    ds_scaled = arith.MulFOp(
+                        ds, c_sm_scale, fastmath=fm_fast,
+                    ).result
+                    g_f32 = g_f32_cache[k_off]
+                    for d_off in range_constexpr(D_PER_LANE):
+                        gv = vector.extract(
+                            g_f32, static_position=[d_off], dynamic_position=[],
+                        )
+                        contrib = arith.MulFOp(
+                            ds_scaled, gv, fastmath=fm_fast,
+                        ).result
+                        dq_accs_g[d_off] = arith.AddFOp(
+                            dq_accs_g[d_off], contrib, fastmath=fm_fast,
+                        ).result
+
+                _yield_g = list(dq_accs_g)
+                for _ in range_constexpr(_PAD):
+                    _yield_g.append(c_zero_f)
+                yield _yield_g
+
+            dq_accs = [loop_results_g[d] for d in range_constexpr(D_PER_LANE)]
+
+        # ==== Store dq[d] into DQ buffer (fp32 direct store) ====
+        _o_guard = scf.IfOp(q_active, [], has_else=False)
+        with ir.InsertionPoint(_o_guard.then_block):
+            dq_row_base = (
+                (bid * arith.index(NUM_HEADS) + qhid) * seq_len_v + pid_m_safe
+            ) * arith.index(HEAD_DIM)
+            dq_lane_off = dq_row_base + lane * arith.index(D_PER_LANE)
+            for d_off in range_constexpr(D_PER_LANE):
+                elem_off = dq_lane_off + arith.index(d_off)
+                _gep_store_f32(dq_accs[d_off], dq_ptr, elem_off)
+            scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_csa_bwd_dq(
+        Q: fx.Tensor,
+        K_LOCAL: fx.Tensor,
+        V_LOCAL: fx.Tensor,
+        GATHERED: fx.Tensor,
+        SPARSE_MASK: fx.Tensor,
+        DOUT: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        SINK: fx.Tensor,
+        DQ: fx.Tensor,
+        DSINK: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len: fx.Int32,
+        K_topk: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        sl_idx = arith.index_cast(T.index, seq_len)
+        grid_x = sl_idx
+        grid_y = bs_idx * arith.index(NUM_HEADS)
+
+        launcher = v4_csa_bwd_dq_kernel(
+            Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK,
+            DOUT, LSE, DELTAS, SINK, DQ, DSINK,
+            seq_len, K_topk,
+        )
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                            T.i32, _wpe,
+                        )
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, grid_y, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(compile_hints):
+            return launch_v4_csa_bwd_dq(*args, **kwargs)
+
+    def _compile(
+        Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK,
+        DOUT, LSE, DELTAS, SINK, DQ, DSINK,
+        batch_size, seq_len, K_topk, stream=None,
+    ):
+        with CompilationContext.compile_hints(compile_hints):
+            return flyc.compile(
+                launch_v4_csa_bwd_dq,
+                Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK,
+                DOUT, LSE, DELTAS, SINK, DQ, DSINK,
+                batch_size, seq_len, K_topk, fx.Stream(stream),
+            )
+
+    _launch.compile = _compile
+    return _launch
+
+
+build_v4_csa_bwd_dq_module_primary = build_v4_csa_bwd_dq_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_bwd_full_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_bwd_full_kernel.py
@@ -1,0 +1,528 @@
+# SPDX-License-Identifier: Apache-2.0
+"""v4_csa_bwd_full: V4 CSA backward kernel, full output set (STEP 3b).
+
+Emits dq + dk_local + dv_local + dgathered + dsink in one launch.
+Mirrors `_v4_csa_attention_bwd_kernel` (Triton, _triton/v4_csa_attention_bwd.py)
+1:1: grid=(Sq, B*HQ); each program owns one query row. dq is direct-stored;
+dk_local, dv_local, dgathered, dsink are accumulated via atomic_fadd.
+"""
+from __future__ import annotations
+
+import math
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+
+KERNEL_NAME = "v4_csa_bwd_full_kernel"
+_LLVM_GEP_DYNAMIC = -2147483648
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def build_v4_csa_bwd_full_module(
+    num_heads, head_dim, swa_window,
+    dtype_str="bf16", sm_scale=None, waves_per_eu=2,
+    block_n=32, block_k=32,
+    has_sink=True, has_sparse=True,
+    unsafe_fp_math=True, fast_fp_math=True, daz=True,
+    mqa_kv=True,
+):
+    gpu_arch = get_hip_arch()
+    WARP_SIZE = 64
+    BLOCK_SIZE = WARP_SIZE
+    BLOCK_N = int(block_n)
+    BLOCK_K = int(block_k)
+    NUM_HEADS = int(num_heads)
+    HEAD_DIM = int(head_dim)
+    assert HEAD_DIM % WARP_SIZE == 0, f"head_dim must be divisible by {WARP_SIZE}"
+    D_PER_LANE = HEAD_DIM // WARP_SIZE
+    assert mqa_kv, "v4_csa_bwd_full only supports MQA (HK=1)"
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    allocator = SmemAllocator(
+        None, arch=gpu_arch,
+        global_sym_name=f"v4_csa_bwd_full_smem_N{BLOCK_N}_K{BLOCK_K}_S{int(has_sink)}_HS{int(has_sparse)}",
+    )
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_csa_bwd_full_kernel(
+        Q: fx.Tensor, K_LOCAL: fx.Tensor, V_LOCAL: fx.Tensor,
+        GATHERED: fx.Tensor, SPARSE_MASK: fx.Tensor,
+        DOUT: fx.Tensor, LSE: fx.Tensor, DELTAS: fx.Tensor, SINK: fx.Tensor,
+        DQ: fx.Tensor, DK_LOCAL: fx.Tensor, DV_LOCAL: fx.Tensor,
+        DGATHERED: fx.Tensor, DSINK: fx.Tensor,
+        seq_len: fx.Int32, K_topk: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        f16_ty = elem_type
+        f32_ty = T.f32
+        fm_fast = arith.FastMathFlags.fast
+
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        kl_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K_LOCAL)
+        vl_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V_LOCAL)
+        g_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), GATHERED)
+        sm_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), SPARSE_MASK)
+        do_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DOUT)
+        dq_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DQ)
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+        deltas_rsrc = buffer_ops.create_buffer_resource(DELTAS, max_size=True)
+        dkl_rsrc = buffer_ops.create_buffer_resource(DK_LOCAL, max_size=True)
+        dvl_rsrc = buffer_ops.create_buffer_resource(DV_LOCAL, max_size=True)
+        dg_rsrc = buffer_ops.create_buffer_resource(DGATHERED, max_size=True)
+        if has_sink:
+            sink_rsrc = buffer_ops.create_buffer_resource(SINK, max_size=True)
+            dsink_rsrc = buffer_ops.create_buffer_resource(DSINK, max_size=True)
+
+        def _gep_load(base_ptr, elem_idx, vec_type, elem_t):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(
+                _llvm_ptr_ty(), base_ptr, [idx_i64],
+                rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                elem_type=elem_t, noWrapFlags=0,
+            )
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def _gep_store_f32(val, base_ptr, elem_idx):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(
+                _llvm_ptr_ty(), base_ptr, [idx_i64],
+                rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                elem_type=T.f32, noWrapFlags=0,
+            )
+            _llvm.StoreOp(val, gep.result)
+
+        def load_f16_v(base_ptr, elem_idx, n):
+            vt = T.vec(n, f16_ty)
+            return _gep_load(base_ptr, elem_idx, vt, f16_ty)
+
+        pid_m = arith.index_cast(T.index, gpu.block_idx.x)
+        pid_bh = arith.index_cast(T.index, gpu.block_idx.y)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+        lane = tid
+
+        seq_len_v = arith.index_cast(T.index, seq_len)
+        K_topk_v = arith.index_cast(T.index, K_topk)
+
+        bid = pid_bh // arith.index(NUM_HEADS)
+        qhid = pid_bh % arith.index(NUM_HEADS)
+
+        q_active = arith.cmpi(arith.CmpIPredicate.slt, pid_m, seq_len_v)
+        pid_m_safe = arith.select(q_active, pid_m, arith.index(0))
+
+        NEG_INF_F = -1.0e30
+        c_neg_inf = arith.constant(NEG_INF_F, type=f32_ty)
+        c_zero_f = arith.constant(0.0, type=f32_ty)
+        c_sm_scale = arith.constant(float(sm_scale), type=f32_ty)
+        width_i32 = arith.constant(WARP_SIZE, type=T.i32)
+        c_four_i32 = arith.constant(4, type=T.i32)
+        c_zero_i32 = arith.constant(0, type=T.i32)
+
+        zero_f32_vec = arith.constant_vector(0.0, T.vec(D_PER_LANE, f32_ty))
+        q_row_base = (
+            (bid * arith.index(NUM_HEADS) + qhid) * seq_len_v + pid_m_safe
+        ) * arith.index(HEAD_DIM)
+        q_lane_off = q_row_base + lane * arith.index(D_PER_LANE)
+        q_vec_raw = load_f16_v(q_ptr, q_lane_off, D_PER_LANE)
+        q_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), q_vec_raw)
+        q_f32 = arith.select(q_active, q_f32, zero_f32_vec)
+
+        do_lane_off = q_lane_off
+        do_vec_raw = load_f16_v(do_ptr, do_lane_off, D_PER_LANE)
+        do_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), do_vec_raw)
+        do_f32 = arith.select(q_active, do_f32, zero_f32_vec)
+
+        lse_delta_off = (bid * arith.index(NUM_HEADS) + qhid) * seq_len_v + pid_m_safe
+        lse_delta_off_i32 = arith.index_cast(T.i32, lse_delta_off)
+        lse_val = buffer_ops.buffer_load(
+            lse_rsrc, lse_delta_off_i32, vec_width=1, dtype=f32_ty,
+        )
+        delta_val = buffer_ops.buffer_load(
+            deltas_rsrc, lse_delta_off_i32, vec_width=1, dtype=f32_ty,
+        )
+
+        qhid_i32 = arith.index_cast(T.i32, qhid)
+        bid_i32 = arith.index_cast(T.i32, bid)
+        lane_i32 = arith.index_cast(T.i32, lane)
+        pid_m_safe_i32 = arith.index_cast(T.i32, pid_m_safe)
+        head_dim_i32 = arith.constant(HEAD_DIM, type=T.i32)
+        d_per_lane_i32 = arith.constant(D_PER_LANE, type=T.i32)
+        num_heads_i32 = arith.constant(NUM_HEADS, type=T.i32)
+
+        if has_sink:
+            sink_h = buffer_ops.buffer_load(
+                sink_rsrc, qhid_i32, vec_width=1, dtype=f32_ty,
+            )
+            sink_h = rocdl.readfirstlane(f32_ty, sink_h)
+            sub_sh = arith.SubFOp(sink_h, lse_val, fastmath=fm_fast).result
+            p_sink = math_dialect.exp(sub_sh, fastmath=fm_fast)
+            neg_p_sink = arith.SubFOp(c_zero_f, p_sink, fastmath=fm_fast).result
+            dsink_contrib = arith.MulFOp(
+                neg_p_sink, delta_val, fastmath=fm_fast,
+            ).result
+            is_lane0 = arith.cmpi(arith.CmpIPredicate.eq, lane, arith.index(0))
+            do_sink = arith.AndIOp(is_lane0, q_active).result
+            _if_sink = scf.IfOp(do_sink, [], has_else=False)
+            with ir.InsertionPoint(_if_sink.then_block):
+                _dsink_byte_off = arith.MulIOp(qhid_i32, c_four_i32).result
+                rocdl.raw_ptr_buffer_atomic_fadd(
+                    dsink_contrib, dsink_rsrc, _dsink_byte_off,
+                    c_zero_i32, c_zero_i32,
+                )
+                scf.YieldOp([])
+
+        def warp_reduce_sum_f32(v):
+            cur = v
+            for off in [32, 16, 8, 4, 2, 1]:
+                xor_amt = arith.constant(off, type=T.i32)
+                peer = arith.ArithValue(cur).shuffle_xor(xor_amt, width_i32)
+                cur = arith.AddFOp(cur, peer, fastmath=fm_fast).result
+            return cur
+
+        def vec_dot_f32(a_vec, b_vec):
+            s = c_zero_f
+            for i in range_constexpr(D_PER_LANE):
+                av = vector.extract(a_vec, static_position=[i], dynamic_position=[])
+                bv = vector.extract(b_vec, static_position=[i], dynamic_position=[])
+                p = arith.MulFOp(av, bv, fastmath=fm_fast).result
+                s = arith.AddFOp(s, p, fastmath=fm_fast).result
+            return s
+
+        _pid_p1 = pid_m + arith.index(1)
+        _le_seq = arith.cmpi(arith.CmpIPredicate.sle, _pid_p1, seq_len_v)
+        n_loop_end_row = arith.select(_le_seq, _pid_p1, seq_len_v)
+        SWA = arith.index(int(swa_window))
+        _ge_w = arith.cmpi(arith.CmpIPredicate.sge, _pid_p1, SWA)
+        _n_lo_raw = arith.select(_ge_w, _pid_p1 - SWA, arith.index(0))
+        BN_idx = arith.index(BLOCK_N)
+        n_loop_start = (_n_lo_raw // BN_idx) * BN_idx
+        n_loop_end_blk = (
+            (n_loop_end_row + BN_idx - arith.index(1)) // BN_idx
+        ) * BN_idx
+
+        _PAD = 1 if D_PER_LANE == 1 else 0
+        init_local = []
+        for _ in range_constexpr(D_PER_LANE):
+            init_local.append(c_zero_f)
+        for _ in range_constexpr(_PAD):
+            init_local.append(c_zero_f)
+
+        pid_m_i32 = arith.index_cast(T.i32, pid_m)
+        seq_len_i32 = arith.index_cast(T.i32, seq_len_v)
+        w_i32 = arith.constant(int(swa_window), type=T.i32)
+        K_topk_i32 = arith.index_cast(T.i32, K_topk_v)
+
+        # ==== LOCAL SWA loop ====
+        for n_start, inner_args, loop_results_local in scf.for_(
+            n_loop_start, n_loop_end_blk, BN_idx, iter_args=init_local,
+        ):
+            dq_accs = [inner_args[d] for d in range_constexpr(D_PER_LANE)]
+            n_start_i32 = arith.index_cast(T.i32, n_start)
+
+            kl_f32_cache = []
+            p_cache = []
+            dp_cache = []
+            kv_col_i32_cache = []
+
+            for n_off in range_constexpr(BLOCK_N):
+                kv_col_i32 = arith.AddIOp(
+                    n_start_i32, arith.constant(n_off, type=T.i32),
+                ).result
+                kv_col_i32_cache.append(kv_col_i32)
+                _kv_plus_w = arith.AddIOp(kv_col_i32, w_i32).result
+                is_swa = arith.cmpi(arith.CmpIPredicate.sle, _kv_plus_w, pid_m_i32)
+                is_causal = arith.cmpi(arith.CmpIPredicate.sgt, kv_col_i32, pid_m_i32)
+                is_oob = arith.cmpi(arith.CmpIPredicate.sge, kv_col_i32, seq_len_i32)
+                bad = arith.OrIOp(
+                    arith.OrIOp(is_causal, is_swa).result,
+                    is_oob,
+                ).result
+
+                kv_col_idx = arith.index_cast(T.index, kv_col_i32)
+                kv_col_safe = arith.select(is_oob, arith.index(0), kv_col_idx)
+                kl_row_base = (bid * seq_len_v + kv_col_safe) * arith.index(HEAD_DIM)
+                kl_lane_off = kl_row_base + lane * arith.index(D_PER_LANE)
+                kl_vec = load_f16_v(kl_ptr, kl_lane_off, D_PER_LANE)
+                kl_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), kl_vec)
+                kl_f32_cache.append(kl_f32)
+
+                vl_vec = load_f16_v(vl_ptr, kl_lane_off, D_PER_LANE)
+                vl_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), vl_vec)
+
+                lane_dot_qk = vec_dot_f32(q_f32, kl_f32)
+                qk_full = warp_reduce_sum_f32(lane_dot_qk)
+                qk_scaled = arith.MulFOp(qk_full, c_sm_scale, fastmath=fm_fast).result
+                qk_masked = arith.select(bad, c_neg_inf, qk_scaled)
+                diff_qk = arith.SubFOp(qk_masked, lse_val, fastmath=fm_fast).result
+                p = math_dialect.exp(diff_qk, fastmath=fm_fast)
+                p_cache.append(p)
+
+                lane_dot_dp = vec_dot_f32(do_f32, vl_f32)
+                dp_full = warp_reduce_sum_f32(lane_dot_dp)
+                dp_cache.append(dp_full)
+
+            for n_off in range_constexpr(BLOCK_N):
+                p = p_cache[n_off]
+                dp = dp_cache[n_off]
+                diff = arith.SubFOp(dp, delta_val, fastmath=fm_fast).result
+                ds = arith.MulFOp(p, diff, fastmath=fm_fast).result
+                ds_scaled = arith.MulFOp(ds, c_sm_scale, fastmath=fm_fast).result
+                kl_f32 = kl_f32_cache[n_off]
+
+                # dq accumulator
+                for d_off in range_constexpr(D_PER_LANE):
+                    klv = vector.extract(kl_f32, static_position=[d_off], dynamic_position=[])
+                    contrib = arith.MulFOp(ds_scaled, klv, fastmath=fm_fast).result
+                    dq_accs[d_off] = arith.AddFOp(dq_accs[d_off], contrib, fastmath=fm_fast).result
+
+                # dk_local / dv_local atomic_add
+                kv_col_i32 = kv_col_i32_cache[n_off]
+                in_range = arith.cmpi(arith.CmpIPredicate.slt, kv_col_i32, seq_len_i32)
+                do_atom = arith.AndIOp(in_range, q_active).result
+                _if_dkv = scf.IfOp(do_atom, [], has_else=False)
+                with ir.InsertionPoint(_if_dkv.then_block):
+                    _bh = arith.AddIOp(
+                        arith.MulIOp(bid_i32, num_heads_i32).result, qhid_i32,
+                    ).result
+                    _bh_n = arith.AddIOp(
+                        arith.MulIOp(_bh, seq_len_i32).result, kv_col_i32,
+                    ).result
+                    _row_d = arith.AddIOp(
+                        arith.MulIOp(_bh_n, head_dim_i32).result,
+                        arith.MulIOp(lane_i32, d_per_lane_i32).result,
+                    ).result
+                    for d_off in range_constexpr(D_PER_LANE):
+                        elem_i32 = arith.AddIOp(_row_d, arith.constant(d_off, type=T.i32)).result
+                        byte_off = arith.MulIOp(elem_i32, c_four_i32).result
+                        qv = vector.extract(q_f32, static_position=[d_off], dynamic_position=[])
+                        dk_val = arith.MulFOp(ds_scaled, qv, fastmath=fm_fast).result
+                        rocdl.raw_ptr_buffer_atomic_fadd(
+                            dk_val, dkl_rsrc, byte_off, c_zero_i32, c_zero_i32,
+                        )
+                        dov = vector.extract(do_f32, static_position=[d_off], dynamic_position=[])
+                        dv_val = arith.MulFOp(p, dov, fastmath=fm_fast).result
+                        rocdl.raw_ptr_buffer_atomic_fadd(
+                            dv_val, dvl_rsrc, byte_off, c_zero_i32, c_zero_i32,
+                        )
+                    scf.YieldOp([])
+
+            _yield = list(dq_accs)
+            for _ in range_constexpr(_PAD):
+                _yield.append(c_zero_f)
+            yield _yield
+
+        dq_accs = [loop_results_local[d] for d in range_constexpr(D_PER_LANE)]
+
+        # ==== GATHERED branch ====
+        if has_sparse:
+            init_sparse = list(dq_accs)
+            for _ in range_constexpr(_PAD):
+                init_sparse.append(c_zero_f)
+            for k_start, inner_args_g, loop_results_g in scf.for_(
+                arith.index(0), K_topk_v, arith.index(BLOCK_K),
+                iter_args=init_sparse,
+            ):
+                dq_accs_g = [inner_args_g[d] for d in range_constexpr(D_PER_LANE)]
+                k_start_i32 = arith.index_cast(T.i32, k_start)
+
+                g_f32_cache = []
+                p_cache_g = []
+                dp_cache_g = []
+                k_pos_i32_cache = []
+
+                for k_off in range_constexpr(BLOCK_K):
+                    k_pos_i32 = arith.AddIOp(
+                        k_start_i32, arith.constant(k_off, type=T.i32),
+                    ).result
+                    k_pos_i32_cache.append(k_pos_i32)
+                    is_oob = arith.cmpi(arith.CmpIPredicate.sge, k_pos_i32, K_topk_i32)
+                    k_pos_idx = arith.index_cast(T.index, k_pos_i32)
+                    k_pos_safe = arith.select(is_oob, arith.index(0), k_pos_idx)
+
+                    g_row_base = (
+                        (bid * seq_len_v + pid_m_safe) * K_topk_v + k_pos_safe
+                    ) * arith.index(HEAD_DIM)
+                    g_lane_off = g_row_base + lane * arith.index(D_PER_LANE)
+                    g_vec = load_f16_v(g_ptr, g_lane_off, D_PER_LANE)
+                    g_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), g_vec)
+                    g_f32_cache.append(g_f32)
+
+                    sm_off = (bid * seq_len_v + pid_m_safe) * K_topk_v + k_pos_safe
+                    sm_raw_v1 = _gep_load(sm_ptr, sm_off, T.vec(1, elem_type), elem_type)
+                    sm_raw = vector.extract(sm_raw_v1, static_position=[0], dynamic_position=[])
+                    sm_val = arith.extf(f32_ty, sm_raw)
+                    sm_val = arith.select(is_oob, c_zero_f, sm_val)
+
+                    lane_dot_qk = vec_dot_f32(q_f32, g_f32)
+                    qk_full = warp_reduce_sum_f32(lane_dot_qk)
+                    qk_scaled = arith.MulFOp(qk_full, c_sm_scale, fastmath=fm_fast).result
+                    qk_biased = arith.AddFOp(qk_scaled, sm_val, fastmath=fm_fast).result
+                    bad = arith.OrIOp(
+                        is_oob,
+                        arith.cmpi(arith.CmpIPredicate.sge, pid_m_i32, seq_len_i32),
+                    ).result
+                    qk_masked = arith.select(bad, c_neg_inf, qk_biased)
+                    diff_qk = arith.SubFOp(qk_masked, lse_val, fastmath=fm_fast).result
+                    p = math_dialect.exp(diff_qk, fastmath=fm_fast)
+                    p_cache_g.append(p)
+
+                    lane_dot_dp = vec_dot_f32(do_f32, g_f32)
+                    dp_full = warp_reduce_sum_f32(lane_dot_dp)
+                    dp_cache_g.append(dp_full)
+
+                for k_off in range_constexpr(BLOCK_K):
+                    p = p_cache_g[k_off]
+                    dp = dp_cache_g[k_off]
+                    diff = arith.SubFOp(dp, delta_val, fastmath=fm_fast).result
+                    ds = arith.MulFOp(p, diff, fastmath=fm_fast).result
+                    ds_scaled = arith.MulFOp(ds, c_sm_scale, fastmath=fm_fast).result
+                    g_f32 = g_f32_cache[k_off]
+
+                    for d_off in range_constexpr(D_PER_LANE):
+                        gv = vector.extract(g_f32, static_position=[d_off], dynamic_position=[])
+                        contrib = arith.MulFOp(ds_scaled, gv, fastmath=fm_fast).result
+                        dq_accs_g[d_off] = arith.AddFOp(dq_accs_g[d_off], contrib, fastmath=fm_fast).result
+
+                    k_pos_i32 = k_pos_i32_cache[k_off]
+                    in_range_k = arith.cmpi(arith.CmpIPredicate.slt, k_pos_i32, K_topk_i32)
+                    do_atom_k = arith.AndIOp(in_range_k, q_active).result
+                    _if_dg = scf.IfOp(do_atom_k, [], has_else=False)
+                    with ir.InsertionPoint(_if_dg.then_block):
+                        _bm = arith.AddIOp(
+                            arith.MulIOp(bid_i32, seq_len_i32).result, pid_m_safe_i32,
+                        ).result
+                        _bm_k = arith.AddIOp(
+                            arith.MulIOp(_bm, K_topk_i32).result, k_pos_i32,
+                        ).result
+                        _row_d = arith.AddIOp(
+                            arith.MulIOp(_bm_k, head_dim_i32).result,
+                            arith.MulIOp(lane_i32, d_per_lane_i32).result,
+                        ).result
+                        for d_off in range_constexpr(D_PER_LANE):
+                            elem_i32 = arith.AddIOp(_row_d, arith.constant(d_off, type=T.i32)).result
+                            byte_off = arith.MulIOp(elem_i32, c_four_i32).result
+                            qv = vector.extract(q_f32, static_position=[d_off], dynamic_position=[])
+                            dov = vector.extract(do_f32, static_position=[d_off], dynamic_position=[])
+                            t1 = arith.MulFOp(ds_scaled, qv, fastmath=fm_fast).result
+                            t2 = arith.MulFOp(p, dov, fastmath=fm_fast).result
+                            dg_val = arith.AddFOp(t1, t2, fastmath=fm_fast).result
+                            rocdl.raw_ptr_buffer_atomic_fadd(
+                                dg_val, dg_rsrc, byte_off, c_zero_i32, c_zero_i32,
+                            )
+                        scf.YieldOp([])
+
+                _yield_g = list(dq_accs_g)
+                for _ in range_constexpr(_PAD):
+                    _yield_g.append(c_zero_f)
+                yield _yield_g
+
+            dq_accs = [loop_results_g[d] for d in range_constexpr(D_PER_LANE)]
+
+        # ==== Store dq direct ====
+        _o_guard = scf.IfOp(q_active, [], has_else=False)
+        with ir.InsertionPoint(_o_guard.then_block):
+            dq_row_base = (
+                (bid * arith.index(NUM_HEADS) + qhid) * seq_len_v + pid_m_safe
+            ) * arith.index(HEAD_DIM)
+            dq_lane_off = dq_row_base + lane * arith.index(D_PER_LANE)
+            for d_off in range_constexpr(D_PER_LANE):
+                elem_off = dq_lane_off + arith.index(d_off)
+                _gep_store_f32(dq_accs[d_off], dq_ptr, elem_off)
+            scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_csa_bwd_full(
+        Q: fx.Tensor, K_LOCAL: fx.Tensor, V_LOCAL: fx.Tensor,
+        GATHERED: fx.Tensor, SPARSE_MASK: fx.Tensor,
+        DOUT: fx.Tensor, LSE: fx.Tensor, DELTAS: fx.Tensor, SINK: fx.Tensor,
+        DQ: fx.Tensor, DK_LOCAL: fx.Tensor, DV_LOCAL: fx.Tensor,
+        DGATHERED: fx.Tensor, DSINK: fx.Tensor,
+        batch_size: fx.Int32, seq_len: fx.Int32, K_topk: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        sl_idx = arith.index_cast(T.index, seq_len)
+        grid_x = sl_idx
+        grid_y = bs_idx * arith.index(NUM_HEADS)
+
+        launcher = v4_csa_bwd_full_kernel(
+            Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK,
+            DOUT, LSE, DELTAS, SINK,
+            DQ, DK_LOCAL, DV_LOCAL, DGATHERED, DSINK,
+            seq_len, K_topk,
+        )
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(T.i32, _wpe)
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, grid_y, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    compile_hints = {"fast_fp_math": fast_fp_math, "unsafe_fp_math": unsafe_fp_math}
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(compile_hints):
+            return launch_v4_csa_bwd_full(*args, **kwargs)
+
+    def _compile(
+        Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK,
+        DOUT, LSE, DELTAS, SINK,
+        DQ, DK_LOCAL, DV_LOCAL, DGATHERED, DSINK,
+        batch_size, seq_len, K_topk, stream=None,
+    ):
+        with CompilationContext.compile_hints(compile_hints):
+            return flyc.compile(
+                launch_v4_csa_bwd_full,
+                Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK,
+                DOUT, LSE, DELTAS, SINK,
+                DQ, DK_LOCAL, DV_LOCAL, DGATHERED, DSINK,
+                batch_size, seq_len, K_topk, fx.Stream(stream),
+            )
+
+    _launch.compile = _compile
+    return _launch
+
+
+build_v4_csa_bwd_full_module_primary = build_v4_csa_bwd_full_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_fwd_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_csa_fwd_kernel.py
@@ -1,0 +1,675 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_csa_fwd: V4 CSA forward (FlyDSL per-row design).
+
+Round-3 Step 2b: ports the Triton monolithic CSA forward kernel to FlyDSL
+in a 1:1 per-row design. The Triton CSA monolithic kernel uses one program
+per (b, h, m), with per-key scalar dot-product. That structure ports cleanly:
+
+  grid = (Sq, B * HQ)
+  BLOCK_SIZE = 64 (one wave). Lane in 0..63 handles partial D=8.
+  Online softmax accumulator (m, l, acc) lives in fp32 in-register and is
+    distributed across lanes (each lane owns D/64 = 8 elements of the
+    accumulator's D dimension).
+
+This design does NOT use MFMA -- the per-row scalar dot-product matches
+Triton's monolithic kernel exactly (Triton CSA monolithic also uses
+``tl.sum(k * q, axis=1)`` not ``tl.dot``).
+
+Layout: BHLD (Q/K_local/V_local/O all [B, H, Sq, D]).
+  - Gathered: [B, Sq, K_topk, D] (no H dim -- shared across heads).
+  - sparse_mask: [B, Sq, K_topk] (no H dim -- broadcasts over H).
+  - sink: [H] fp32 or None.
+  - LSE: [B, H, Sq] fp32 (raw-domain: m_final + ln(l_final), since m_final
+    already includes sm_scale via the online softmax in raw-qk*sm_scale).
+
+Forward computes the joint online softmax over local_SWA (block-causal,
+window=swa_window, keys are k_local) + sparse (keys are gathered) + sink.
+
+K_topk == 0 supported (kernel skips the sparse loop).
+"""
+
+import math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import memref as _memref, scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+
+KERNEL_NAME = "v4_csa_fwd_kernel"
+
+_LOG2E = math.log2(math.e)
+
+_LLVM_GEP_DYNAMIC = -2147483648
+
+
+def _waitcnt_lgkm_0():
+    """s_waitcnt lgkmcnt(0): drain LDS/SMEM ops. vmcnt=63, expcnt=7."""
+    val = 0xF | (0x7 << 4) | (0 << 8) | (0x3 << 14)
+    rocdl.s_waitcnt(val)
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _llvm_lds_ptr_ty():
+    return ir.Type.parse("!llvm.ptr<3>")
+
+
+def build_v4_csa_fwd_module(
+    num_heads,
+    head_dim,
+    swa_window,
+    dtype_str="bf16",
+    sm_scale=None,
+    waves_per_eu=2,
+    block_n=32,
+    block_k=32,
+    has_sink=False,
+    has_sparse=True,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    mqa_kv=False,
+    head_group=1,
+):
+    """Build the V4 CSA forward per-row launcher.
+
+    Parameters:
+      num_heads: int  -- H_Q
+      head_dim: int   -- D (must be divisible by 64)
+      swa_window: int -- SWA window (> 0)
+      block_n: int    -- local-branch tile width (default 32)
+      block_k: int    -- sparse-branch tile width (default 32)
+      has_sink: bool  -- include sink epilogue
+      has_sparse: bool -- include sparse branch loop (K_topk > 0)
+    """
+    gpu_arch = get_hip_arch()
+    WARP_SIZE = 64
+    BLOCK_SIZE = WARP_SIZE  # one wave per program
+    BLOCK_N = int(block_n)
+    BLOCK_K = int(block_k)
+    NUM_HEADS = int(num_heads)
+    HEAD_DIM = int(head_dim)
+    assert HEAD_DIM % WARP_SIZE == 0, f"head_dim must be divisible by {WARP_SIZE}"
+    D_PER_LANE = HEAD_DIM // WARP_SIZE  # 8 for D=512
+    HEAD_GROUP = int(head_group)
+    assert NUM_HEADS % HEAD_GROUP == 0, f"num_heads {NUM_HEADS} must be divisible by head_group {HEAD_GROUP}"
+    NUM_HEAD_GROUPS = NUM_HEADS // HEAD_GROUP
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    # ---- LDS cache for sparse-branch gathered K-tile ----
+    ENABLE_LDS_CACHE = bool(has_sparse) and (os.environ.get("PRIMUS_V4_CSA_LDS_CACHE", "0") == "1")
+    LDS_GATHER_TILE_ELEMS = BLOCK_K * HEAD_DIM
+    LDS_GATHER_TILE_BYTES = LDS_GATHER_TILE_ELEMS * 2
+
+    allocator = SmemAllocator(
+        None,
+        arch=gpu_arch,
+        global_sym_name=f"v4_csa_fwd_smem_N{BLOCK_N}_K{BLOCK_K}_C{int(ENABLE_LDS_CACHE)}_HG{HEAD_GROUP}",
+    )
+    if ENABLE_LDS_CACHE:
+        lds_gather_offset = allocator._align(allocator.ptr, 16)
+        allocator.ptr = lds_gather_offset + LDS_GATHER_TILE_BYTES
+    else:
+        lds_gather_offset = 0
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_csa_fwd_kernel(
+        Q: fx.Tensor,
+        K_LOCAL: fx.Tensor,
+        V_LOCAL: fx.Tensor,
+        GATHERED: fx.Tensor,
+        SPARSE_MASK: fx.Tensor,
+        Sink: fx.Tensor,
+        O: fx.Tensor,
+        LSE: fx.Tensor,
+        seq_len: fx.Int32,
+        K_topk: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        compute_type = T.f32
+        fm_fast = arith.FastMathFlags.fast
+
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        kl_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K_LOCAL)
+        vl_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V_LOCAL)
+        g_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), GATHERED)
+        sm_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), SPARSE_MASK)
+        o_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), O)
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+        if has_sink:
+            sink_rsrc = buffer_ops.create_buffer_resource(Sink, max_size=True)
+
+        f16_ty = elem_type
+        f32_ty = T.f32
+
+        # ---- Helpers ----
+        def _gep_load_scalar(base_ptr, elem_idx, vec_type, elem_t):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=elem_t,
+                              noWrapFlags=0)
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def load_f16_v(base_ptr, elem_idx, n):
+            vt = T.vec(n, f16_ty)
+            return _gep_load_scalar(base_ptr, elem_idx, vt, f16_ty)
+
+        def load_f32_scalar(base_ptr, elem_idx):
+            return _gep_load_scalar(base_ptr, elem_idx, f32_ty, f32_ty)
+
+        # ---- Thread / program ----
+        pid_m = arith.index_cast(T.index, gpu.block_idx.x)
+        pid_bh = arith.index_cast(T.index, gpu.block_idx.y)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+        lane = tid
+
+        seq_len_v = arith.index_cast(T.index, seq_len)
+        K_topk_v = arith.index_cast(T.index, K_topk)
+
+        bid = pid_bh // arith.index(NUM_HEAD_GROUPS)
+        qhid_group = pid_bh % arith.index(NUM_HEAD_GROUPS)
+        # qhid_base is the head index of the first head in this program's head group.
+        qhid_base = qhid_group * arith.index(HEAD_GROUP)
+
+        # ---- LDS view for sparse-branch gathered cache ----
+        if ENABLE_LDS_CACHE:
+            base_ptr = allocator.get_base()
+            lds_gather = SmemPtr(
+                base_ptr,
+                lds_gather_offset,
+                elem_type,
+                shape=(LDS_GATHER_TILE_ELEMS,),
+            ).get()
+
+        # ---- Q row in-bounds guard ----
+        q_active = arith.cmpi(arith.CmpIPredicate.slt, pid_m, seq_len_v)
+        pid_m_safe = arith.select(q_active, pid_m, arith.index(0))
+
+        # ---- Load Q for all HEAD_GROUP heads in this program ----
+        zero_f32_vec = arith.constant_vector(0.0, T.vec(D_PER_LANE, f32_ty))
+        q_f32_vecs = []
+        for h_off in range_constexpr(HEAD_GROUP):
+            qhid_h = qhid_base + arith.index(h_off)
+            q_row_base = ((bid * arith.index(NUM_HEADS) + qhid_h) * seq_len_v + pid_m_safe) * arith.index(HEAD_DIM)
+            q_lane_off = q_row_base + lane * arith.index(D_PER_LANE)
+            q_vec = load_f16_v(q_ptr, q_lane_off, D_PER_LANE)
+            q_f32_vec = arith.extf(T.vec(D_PER_LANE, f32_ty), q_vec)
+            q_f32_vec = arith.select(q_active, q_f32_vec, zero_f32_vec)
+            q_f32_vecs.append(q_f32_vec)
+
+        # ---- Constants ----
+        NEG_INF_F = -1.0e30
+        c_neg_inf = arith.constant(NEG_INF_F, type=f32_ty)
+        c_zero_f = arith.constant(0.0, type=f32_ty)
+        c_one_f = arith.constant(1.0, type=f32_ty)
+        c_sm_scale_f = arith.constant(float(sm_scale), type=f32_ty)
+        c_log2e_f = arith.constant(_LOG2E, type=f32_ty)
+
+        lane_i32 = arith.index_cast(T.i32, lane)
+        width_i32 = arith.constant(WARP_SIZE, type=T.i32)
+
+        def warp_reduce_sum_f32(v):
+            cur = v
+            for off in [32, 16, 8, 4, 2, 1]:
+                xor_amt = arith.constant(off, type=T.i32)
+                peer = arith.ArithValue(cur).shuffle_xor(xor_amt, width_i32)
+                cur = arith.AddFOp(cur, peer, fastmath=fm_fast).result
+            return cur
+
+        def vec_dot_f32(a_vec, b_vec):
+            s = c_zero_f
+            for i in range_constexpr(D_PER_LANE):
+                av = vector.extract(a_vec, static_position=[i], dynamic_position=[])
+                bv = vector.extract(b_vec, static_position=[i], dynamic_position=[])
+                p = arith.MulFOp(av, bv, fastmath=fm_fast).result
+                s = arith.AddFOp(s, p, fastmath=fm_fast).result
+            return s
+
+        # ---- Local SWA loop bounds ----
+        _pid_p1 = pid_m + arith.index(1)
+        _le_seq = arith.cmpi(arith.CmpIPredicate.sle, _pid_p1, seq_len_v)
+        n_loop_end = arith.select(_le_seq, _pid_p1, seq_len_v)
+        SWA = arith.index(int(swa_window))
+        _ge_w = arith.cmpi(arith.CmpIPredicate.sge, _pid_p1, SWA)
+        _n_lo_raw = arith.select(_ge_w, _pid_p1 - SWA, arith.index(0))
+        BN_idx = arith.index(BLOCK_N)
+        n_loop_start = (_n_lo_raw // BN_idx) * BN_idx
+
+        # Init state: HEAD_GROUP copies of (m_i, l_i, acc[D_PER_LANE]).
+        # Layout: [m_0, l_0, acc_0_0..acc_0_{D-1}, m_1, l_1, acc_1_0..]
+        STATE_PER_HEAD = 2 + D_PER_LANE
+        init_args = []
+        for _h in range_constexpr(HEAD_GROUP):
+            init_args.append(c_neg_inf)  # m
+            init_args.append(c_zero_f)   # l
+            for _ in range_constexpr(D_PER_LANE):
+                init_args.append(c_zero_f)
+
+        # ==== LOCAL SWA loop ====
+        for n_start, inner_args, loop_results_local in scf.for_(
+            n_loop_start,
+            n_loop_end,
+            BN_idx,
+            iter_args=init_args,
+        ):
+            # Unpack HEAD_GROUP states from inner_args
+            m_is = [inner_args[h * STATE_PER_HEAD] for h in range_constexpr(HEAD_GROUP)]
+            l_is = [inner_args[h * STATE_PER_HEAD + 1] for h in range_constexpr(HEAD_GROUP)]
+            accs = [[inner_args[h * STATE_PER_HEAD + 2 + d] for d in range_constexpr(D_PER_LANE)] for h in range_constexpr(HEAD_GROUP)]
+
+            n_start_i32 = arith.index_cast(T.i32, n_start)
+            pid_m_i32 = arith.index_cast(T.i32, pid_m)
+            seq_len_i32 = seq_len
+            if hasattr(seq_len_i32, "ir_value"):
+                seq_len_i32 = seq_len_i32.ir_value()
+            w_i32 = arith.constant(int(swa_window), type=T.i32)
+
+            # Per-head QK values: [HEAD_GROUP][BLOCK_N]
+            qk_vals_per_head = [[] for _ in range_constexpr(HEAD_GROUP)]
+            kl_f32_cache = []
+            bad_lo_cache = []
+            for n_off in range_constexpr(BLOCK_N):
+                kv_col_i32 = arith.AddIOp(
+                    n_start_i32,
+                    arith.constant(n_off, type=T.i32),
+                ).result
+                _kv_plus_w_lo = arith.AddIOp(kv_col_i32, w_i32).result
+                is_swa_lo = arith.cmpi(
+                    arith.CmpIPredicate.sle, _kv_plus_w_lo, pid_m_i32)
+                is_causal_lo = arith.cmpi(
+                    arith.CmpIPredicate.sgt, kv_col_i32, pid_m_i32)
+                is_oob = arith.cmpi(
+                    arith.CmpIPredicate.sge, kv_col_i32, seq_len_i32)
+                bad_lo = arith.OrIOp(
+                    arith.OrIOp(is_causal_lo, is_swa_lo).result,
+                    is_oob).result
+                bad_lo_cache.append(bad_lo)
+
+                kv_col_idx = arith.index_cast(T.index, kv_col_i32)
+                kv_col_safe = arith.select(is_oob, arith.index(0), kv_col_idx)
+                # When mqa_kv, K is shared across heads -> load once.
+                # When mqa_kv=False, K differs per head, so we'd need per-head loads.
+                # For now this kernel requires mqa_kv when head_group > 1.
+                if mqa_kv:
+                    kl_row_base = (bid * seq_len_v + kv_col_safe) * arith.index(HEAD_DIM)
+                else:
+                    # head_group > 1 with non-MQA: would need per-head load. Disallowed at setup.
+                    kl_row_base = ((bid * arith.index(NUM_HEADS) + qhid_base) * seq_len_v + kv_col_safe) * arith.index(HEAD_DIM)
+                kl_lane_off = kl_row_base + lane * arith.index(D_PER_LANE)
+                kl_vec = load_f16_v(kl_ptr, kl_lane_off, D_PER_LANE)
+                kl_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), kl_vec)
+                kl_f32_cache.append(kl_f32)
+                # Compute qk for each head using the shared K.
+                for h_off in range_constexpr(HEAD_GROUP):
+                    lane_dot = vec_dot_f32(kl_f32, q_f32_vecs[h_off])
+                    qk_full = warp_reduce_sum_f32(lane_dot)
+                    qk_scaled = arith.MulFOp(qk_full, c_sm_scale_f, fastmath=fm_fast).result
+                    qk_masked = arith.select(bad_lo, c_neg_inf, qk_scaled)
+                    qk_vals_per_head[h_off].append(qk_masked)
+
+            # Per-head softmax update
+            new_m_is = []
+            new_l_is = []
+            new_accs = []
+            p_vals_per_head = []
+            for h_off in range_constexpr(HEAD_GROUP):
+                qk_vals_h = qk_vals_per_head[h_off]
+                m_tile = qk_vals_h[0]
+                for n_off in range_constexpr(BLOCK_N - 1):
+                    m_tile = arith.MaxNumFOp(m_tile, qk_vals_h[n_off + 1], fastmath=fm_fast).result
+                m_new = arith.MaxNumFOp(m_is[h_off], m_tile, fastmath=fm_fast).result
+
+                diff_m = arith.SubFOp(m_is[h_off], m_new, fastmath=fm_fast).result
+                diff_m_log2 = arith.MulFOp(diff_m, c_log2e_f, fastmath=fm_fast).result
+                alpha = arith.ArithValue(diff_m_log2).exp2(fastmath=fm_fast)
+
+                p_vals = []
+                tile_sum = c_zero_f
+                for n_off in range_constexpr(BLOCK_N):
+                    d = arith.SubFOp(qk_vals_h[n_off], m_new, fastmath=fm_fast).result
+                    dl = arith.MulFOp(d, c_log2e_f, fastmath=fm_fast).result
+                    p = arith.ArithValue(dl).exp2(fastmath=fm_fast)
+                    p_vals.append(p)
+                    tile_sum = arith.AddFOp(tile_sum, p, fastmath=fm_fast).result
+                p_vals_per_head.append(p_vals)
+
+                l_alpha = arith.MulFOp(l_is[h_off], alpha, fastmath=fm_fast).result
+                l_new = arith.AddFOp(l_alpha, tile_sum, fastmath=fm_fast).result
+
+                acc_h = accs[h_off]
+                new_acc_h = []
+                for d_off in range_constexpr(D_PER_LANE):
+                    new_acc_h.append(arith.MulFOp(acc_h[d_off], alpha, fastmath=fm_fast).result)
+                new_m_is.append(m_new)
+                new_l_is.append(l_new)
+                new_accs.append(new_acc_h)
+
+            # AV phase: load V once (MQA), reuse across HEAD_GROUP heads.
+            for n_off in range_constexpr(BLOCK_N):
+                kv_col_i32 = arith.AddIOp(
+                    n_start_i32,
+                    arith.constant(n_off, type=T.i32),
+                ).result
+                is_oob = arith.cmpi(
+                    arith.CmpIPredicate.sge, kv_col_i32, seq_len_i32)
+                kv_col_idx = arith.index_cast(T.index, kv_col_i32)
+                kv_col_safe = arith.select(is_oob, arith.index(0), kv_col_idx)
+                if mqa_kv:
+                    vl_row_base = (bid * seq_len_v + kv_col_safe) * arith.index(HEAD_DIM)
+                else:
+                    vl_row_base = ((bid * arith.index(NUM_HEADS) + qhid_base) * seq_len_v + kv_col_safe) * arith.index(HEAD_DIM)
+                vl_lane_off = vl_row_base + lane * arith.index(D_PER_LANE)
+                vl_vec = load_f16_v(vl_ptr, vl_lane_off, D_PER_LANE)
+                vl_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), vl_vec)
+                for h_off in range_constexpr(HEAD_GROUP):
+                    p_vals_h = p_vals_per_head[h_off]
+                    new_acc_h = new_accs[h_off]
+                    for d_off in range_constexpr(D_PER_LANE):
+                        vv = vector.extract(vl_f32, static_position=[d_off], dynamic_position=[])
+                        contrib = arith.MulFOp(p_vals_h[n_off], vv, fastmath=fm_fast).result
+                        new_acc_h[d_off] = arith.AddFOp(new_acc_h[d_off], contrib, fastmath=fm_fast).result
+
+            # Pack yield args
+            yield_args = []
+            for h_off in range_constexpr(HEAD_GROUP):
+                yield_args.append(new_m_is[h_off])
+                yield_args.append(new_l_is[h_off])
+                for d in range_constexpr(D_PER_LANE):
+                    yield_args.append(new_accs[h_off][d])
+            yield yield_args
+
+        # Unpack HEAD_GROUP states from local SWA results
+        m_is = [loop_results_local[h * STATE_PER_HEAD] for h in range_constexpr(HEAD_GROUP)]
+        l_is = [loop_results_local[h * STATE_PER_HEAD + 1] for h in range_constexpr(HEAD_GROUP)]
+        accs = [[loop_results_local[h * STATE_PER_HEAD + 2 + d] for d in range_constexpr(D_PER_LANE)] for h in range_constexpr(HEAD_GROUP)]
+
+        # ==== SPARSE branch ====
+        if has_sparse:
+            init_sparse = []
+            for h_off in range_constexpr(HEAD_GROUP):
+                init_sparse.append(m_is[h_off])
+                init_sparse.append(l_is[h_off])
+                for d in range_constexpr(D_PER_LANE):
+                    init_sparse.append(accs[h_off][d])
+            for k_start, inner_args, loop_results_sparse in scf.for_(
+                arith.index(0),
+                K_topk_v,
+                arith.index(BLOCK_K),
+                iter_args=init_sparse,
+            ):
+                m_is = [inner_args[h * STATE_PER_HEAD] for h in range_constexpr(HEAD_GROUP)]
+                l_is = [inner_args[h * STATE_PER_HEAD + 1] for h in range_constexpr(HEAD_GROUP)]
+                accs = [[inner_args[h * STATE_PER_HEAD + 2 + d] for d in range_constexpr(D_PER_LANE)] for h in range_constexpr(HEAD_GROUP)]
+
+                k_start_i32 = arith.index_cast(T.i32, k_start)
+                K_topk_i32 = K_topk
+                if hasattr(K_topk_i32, "ir_value"):
+                    K_topk_i32 = K_topk_i32.ir_value()
+
+                qk_vals_sparse_per_head = [[] for _ in range_constexpr(HEAD_GROUP)]
+                for k_off in range_constexpr(BLOCK_K):
+                    k_pos_i32 = arith.AddIOp(
+                        k_start_i32,
+                        arith.constant(k_off, type=T.i32),
+                    ).result
+                    is_oob = arith.cmpi(
+                        arith.CmpIPredicate.sge, k_pos_i32, K_topk_i32)
+                    k_pos_idx = arith.index_cast(T.index, k_pos_i32)
+                    k_pos_safe = arith.select(is_oob, arith.index(0), k_pos_idx)
+
+                    g_row_base = (
+                        (bid * seq_len_v + pid_m_safe) * K_topk_v + k_pos_safe
+                    ) * arith.index(HEAD_DIM)
+                    g_lane_off = g_row_base + lane * arith.index(D_PER_LANE)
+                    g_vec = load_f16_v(g_ptr, g_lane_off, D_PER_LANE)
+                    if ENABLE_LDS_CACHE:
+                        lds_idx = arith.index(k_off * HEAD_DIM) + lane * arith.index(D_PER_LANE)
+                        vector.store(g_vec, lds_gather, [lds_idx])
+                    g_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), g_vec)
+
+                    sm_off = (bid * seq_len_v + pid_m_safe) * K_topk_v + k_pos_safe
+                    sm_val = load_f32_scalar(sm_ptr, sm_off)
+                    # For each head, compute QK using shared g_f32.
+                    for h_off in range_constexpr(HEAD_GROUP):
+                        lane_dot = vec_dot_f32(g_f32, q_f32_vecs[h_off])
+                        qk_full = warp_reduce_sum_f32(lane_dot)
+                        qk_scaled = arith.MulFOp(qk_full, c_sm_scale_f, fastmath=fm_fast).result
+                        qk_biased = arith.AddFOp(qk_scaled, sm_val, fastmath=fm_fast).result
+                        qk_masked = arith.select(is_oob, c_neg_inf, qk_biased)
+                        qk_vals_sparse_per_head[h_off].append(qk_masked)
+
+                new_m_is = []
+                new_l_is = []
+                new_accs = []
+                p_vals_per_head = []
+                for h_off in range_constexpr(HEAD_GROUP):
+                    qk_vals_h = qk_vals_sparse_per_head[h_off]
+                    m_tile = qk_vals_h[0]
+                    for k_off in range_constexpr(BLOCK_K - 1):
+                        m_tile = arith.MaxNumFOp(m_tile, qk_vals_h[k_off + 1], fastmath=fm_fast).result
+                    m_new = arith.MaxNumFOp(m_is[h_off], m_tile, fastmath=fm_fast).result
+
+                    diff_m = arith.SubFOp(m_is[h_off], m_new, fastmath=fm_fast).result
+                    diff_m_log2 = arith.MulFOp(diff_m, c_log2e_f, fastmath=fm_fast).result
+                    alpha = arith.ArithValue(diff_m_log2).exp2(fastmath=fm_fast)
+
+                    p_vals = []
+                    tile_sum = c_zero_f
+                    for k_off in range_constexpr(BLOCK_K):
+                        d = arith.SubFOp(qk_vals_h[k_off], m_new, fastmath=fm_fast).result
+                        dl = arith.MulFOp(d, c_log2e_f, fastmath=fm_fast).result
+                        p = arith.ArithValue(dl).exp2(fastmath=fm_fast)
+                        p_vals.append(p)
+                        tile_sum = arith.AddFOp(tile_sum, p, fastmath=fm_fast).result
+                    p_vals_per_head.append(p_vals)
+
+                    l_alpha = arith.MulFOp(l_is[h_off], alpha, fastmath=fm_fast).result
+                    l_new = arith.AddFOp(l_alpha, tile_sum, fastmath=fm_fast).result
+
+                    acc_h = accs[h_off]
+                    new_acc_h = []
+                    for d_off in range_constexpr(D_PER_LANE):
+                        new_acc_h.append(arith.MulFOp(acc_h[d_off], alpha, fastmath=fm_fast).result)
+                    new_m_is.append(m_new)
+                    new_l_is.append(l_new)
+                    new_accs.append(new_acc_h)
+
+                # ---- AV phase: re-read gathered K-block once per k_off, reuse for all heads ----
+                if ENABLE_LDS_CACHE:
+                    _waitcnt_lgkm_0()
+                for k_off in range_constexpr(BLOCK_K):
+                    if ENABLE_LDS_CACHE:
+                        lds_idx = arith.index(k_off * HEAD_DIM) + lane * arith.index(D_PER_LANE)
+                        g_vec = vector.load(T.vec(D_PER_LANE, f16_ty), lds_gather, [lds_idx])
+                    else:
+                        k_pos_i32 = arith.AddIOp(
+                            k_start_i32,
+                            arith.constant(k_off, type=T.i32),
+                        ).result
+                        is_oob = arith.cmpi(
+                            arith.CmpIPredicate.sge, k_pos_i32, K_topk_i32)
+                        k_pos_idx = arith.index_cast(T.index, k_pos_i32)
+                        k_pos_safe = arith.select(is_oob, arith.index(0), k_pos_idx)
+                        g_row_base = (
+                            (bid * seq_len_v + pid_m_safe) * K_topk_v + k_pos_safe
+                        ) * arith.index(HEAD_DIM)
+                        g_lane_off = g_row_base + lane * arith.index(D_PER_LANE)
+                        g_vec = load_f16_v(g_ptr, g_lane_off, D_PER_LANE)
+                    g_f32 = arith.extf(T.vec(D_PER_LANE, f32_ty), g_vec)
+                    for h_off in range_constexpr(HEAD_GROUP):
+                        p_vals_h = p_vals_per_head[h_off]
+                        new_acc_h = new_accs[h_off]
+                        for d_off in range_constexpr(D_PER_LANE):
+                            vv = vector.extract(g_f32, static_position=[d_off], dynamic_position=[])
+                            contrib = arith.MulFOp(p_vals_h[k_off], vv, fastmath=fm_fast).result
+                            new_acc_h[d_off] = arith.AddFOp(new_acc_h[d_off], contrib, fastmath=fm_fast).result
+
+                # Pack yield args
+                yield_args = []
+                for h_off in range_constexpr(HEAD_GROUP):
+                    yield_args.append(new_m_is[h_off])
+                    yield_args.append(new_l_is[h_off])
+                    for d in range_constexpr(D_PER_LANE):
+                        yield_args.append(new_accs[h_off][d])
+                yield yield_args
+
+            m_is = [loop_results_sparse[h * STATE_PER_HEAD] for h in range_constexpr(HEAD_GROUP)]
+            l_is = [loop_results_sparse[h * STATE_PER_HEAD + 1] for h in range_constexpr(HEAD_GROUP)]
+            accs = [[loop_results_sparse[h * STATE_PER_HEAD + 2 + d] for d in range_constexpr(D_PER_LANE)] for h in range_constexpr(HEAD_GROUP)]
+
+        # ==== Sink epilogue (per-head) ====
+        if has_sink:
+            for h_off in range_constexpr(HEAD_GROUP):
+                qhid_h = qhid_base + arith.index(h_off)
+                qhid_i32 = arith.index_cast(T.i32, qhid_h)
+                sink_h_val = buffer_ops.buffer_load(
+                    sink_rsrc, qhid_i32, vec_width=1, dtype=f32_ty,
+                )
+                m_i_h = m_is[h_off]
+                l_i_h = l_is[h_off]
+                acc_h = accs[h_off]
+                m_new = arith.MaxNumFOp(m_i_h, sink_h_val, fastmath=fm_fast).result
+                d_alpha = arith.SubFOp(m_i_h, m_new, fastmath=fm_fast).result
+                d_alpha_log2 = arith.MulFOp(d_alpha, c_log2e_f, fastmath=fm_fast).result
+                alpha_sink = arith.ArithValue(d_alpha_log2).exp2(fastmath=fm_fast)
+                d_beta = arith.SubFOp(sink_h_val, m_new, fastmath=fm_fast).result
+                d_beta_log2 = arith.MulFOp(d_beta, c_log2e_f, fastmath=fm_fast).result
+                beta_sink = arith.ArithValue(d_beta_log2).exp2(fastmath=fm_fast)
+                l_alpha = arith.MulFOp(l_i_h, alpha_sink, fastmath=fm_fast).result
+                l_is[h_off] = arith.AddFOp(l_alpha, beta_sink, fastmath=fm_fast).result
+                new_acc_h = []
+                for d_off in range_constexpr(D_PER_LANE):
+                    new_acc_h.append(arith.MulFOp(acc_h[d_off], alpha_sink, fastmath=fm_fast).result)
+                accs[h_off] = new_acc_h
+                m_is[h_off] = m_new
+
+        # ==== Final divide and store (per-head) ====
+        _o_guard = scf.IfOp(q_active, [], has_else=False)
+        with ir.InsertionPoint(_o_guard.then_block):
+            for h_off in range_constexpr(HEAD_GROUP):
+                qhid_h = qhid_base + arith.index(h_off)
+                l_i_h = l_is[h_off]
+                m_i_h = m_is[h_off]
+                acc_h = accs[h_off]
+                inv_l = arith.DivFOp(c_one_f, l_i_h, fastmath=fm_fast).result
+                o_row_base = ((bid * arith.index(NUM_HEADS) + qhid_h) * seq_len_v + pid_m_safe) * arith.index(HEAD_DIM)
+                o_lane_off = o_row_base + lane * arith.index(D_PER_LANE)
+                for d_off in range_constexpr(D_PER_LANE):
+                    o_f32 = arith.MulFOp(acc_h[d_off], inv_l, fastmath=fm_fast).result
+                    o_f16 = arith.trunc_f(elem_type, o_f32)
+                    elem_off = o_lane_off + arith.index(d_off)
+                    idx_i64 = arith.index_cast(T.i64, elem_off)
+                    gep = _llvm.GEPOp(_llvm_ptr_ty(), o_ptr, [idx_i64],
+                                      rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                                      elem_type=elem_type,
+                                      noWrapFlags=0)
+                    _llvm.StoreOp(o_f16, gep.result)
+
+                is_lane0 = arith.cmpi(arith.CmpIPredicate.eq, lane, arith.index(0))
+                _lse_if = scf.IfOp(is_lane0, [], has_else=False)
+                with ir.InsertionPoint(_lse_if.then_block):
+                    ln_l = math_dialect.log(l_i_h, fastmath=fm_fast)
+                    lse_val = arith.AddFOp(m_i_h, ln_l, fastmath=fm_fast).result
+                    lse_off = (bid * arith.index(NUM_HEADS) + qhid_h) * seq_len_v + pid_m_safe
+                    lse_off_i32 = arith.index_cast(T.i32, lse_off)
+                    buffer_ops.buffer_store(lse_val, lse_rsrc, lse_off_i32)
+                    scf.YieldOp([])
+            scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_csa_fwd(
+        Q: fx.Tensor,
+        K_LOCAL: fx.Tensor,
+        V_LOCAL: fx.Tensor,
+        GATHERED: fx.Tensor,
+        SPARSE_MASK: fx.Tensor,
+        Sink: fx.Tensor,
+        O: fx.Tensor,
+        LSE: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len: fx.Int32,
+        K_topk: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        sl_idx = arith.index_cast(T.index, seq_len)
+        grid_x = sl_idx
+        grid_y = bs_idx * arith.index(NUM_HEAD_GROUPS)
+
+        launcher = v4_csa_fwd_kernel(
+            Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK, Sink, O, LSE,
+            seq_len, K_topk,
+        )
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                            T.i32, _wpe)
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, grid_y, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(compile_hints):
+            return launch_v4_csa_fwd(*args, **kwargs)
+
+    def _compile(Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK, Sink, O, LSE, batch_size, seq_len, K_topk, stream=None):
+        with CompilationContext.compile_hints(compile_hints):
+            return flyc.compile(
+                launch_v4_csa_fwd, Q, K_LOCAL, V_LOCAL, GATHERED, SPARSE_MASK, Sink, O, LSE,
+                batch_size, seq_len, K_topk, fx.Stream(stream))
+
+    _launch.compile = _compile
+
+    return _launch
+
+
+build_v4_csa_fwd_module_primary = build_v4_csa_fwd_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_hca_bwd_dkv_pool_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_hca_bwd_dkv_pool_kernel.py
@@ -1,0 +1,940 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_hca_bwd_dkv_pool: V4 HCA backward dK/dV POOL-stream kernel for FlyDSL.
+
+Forked from v4_sla_bwd_dkv_kernel.py (the SLA MQA dKdV head-loop accumulator
+template). Computes the POOL-stream contribution to dk/dv for an HCA
+(Hybrid-Causal-Additive) attention backward and stores into the POOL slice
+of dk_fp32 / dv_fp32 buffers (which are zero-initialised by the wrapper).
+
+Key differences vs the SWA kernel:
+  - KV range is fixed at [HCA_LOCAL_SEQLEN, HCA_LOCAL_SEQLEN+POOL_SIZE).
+    POOL_SIZE is a build-time constexpr. For HCA shapes POOL_SIZE <= BLOCK_N
+    (BLOCK_N=32 here, POOL_SIZE in {4,32}), so each program owns the entire
+    pool slice for one batch.
+  - No SWA-window mask, no causal mask. Two element-wise predicates only:
+      (a) pool_n < POOL_SIZE      -> NEG_INF outside the pool
+      (b) q_row < seq_len_q       -> NEG_INF for OOB q rows
+  - qk + add_bias from ADD_MASK[Sq, POOL_SIZE]. Each element loaded as bf16/f16
+    then cast to f32 inside the inner mask loop (matches dq_pool sibling).
+  - LSE / DELTAS are JOINT (saved from HCA fwd) so the same q_row LSE governs
+    both local and pool streams.
+  - Grid: (B,) -- one program per batch, owning the entire pool slice.
+  - Head loop is the SAME head-loop accumulator pattern: dynamic ``scf.for_``
+    over HQ (NOT range_constexpr; constexpr-unroll at HQ=128 hangs MLIR).
+  - sm_scale applied to dK once post head-loop (same as SWA dkv, P57 cr=0).
+  - No atomics. Single store per (b, pool_n) slice at the end.
+
+LDS budget at BLOCK_N=32, BLOCK_M2=32, D=512:
+    K = 32 KB, V = 32 KB, DO = 32 KB, Q = 32 KB, pT = 2 KB
+    Total = 130 KB <= 160 KB.
+Auto-fallback: if predicted > 160 KB, drop DO/Q LDS scratches and read
+Q/DO directly to register packs from HBM (mirrors SWA dkv).
+"""
+
+import math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import memref as _memref, scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+KERNEL_NAME = "v4_hca_bwd_dkv_pool_kernel"
+
+_LLVM_GEP_DYNAMIC = -2147483648
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _llvm_lds_ptr_ty():
+    return ir.Type.parse("!llvm.ptr<3>")
+
+
+def build_v4_hca_bwd_dkv_pool_module(
+    num_heads,
+    head_dim,
+    pool_size,
+    hca_local_seqlen,
+    dtype_str="bf16",
+    sm_scale=None,
+    waves_per_eu=2,
+    flat_work_group_size=None,
+    block_n=None,
+    block_m2=None,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    layout_bhld=True,
+    mqa_kv=True,
+):
+    """Build the V4 HCA backward dK/dV POOL-stream launcher (MQA only)."""
+    gpu_arch = get_hip_arch()
+
+    if block_n is None:
+        BLOCK_N = 32
+    else:
+        BLOCK_N = int(block_n)
+    if block_m2 is None:
+        BLOCK_M2 = 32
+    else:
+        BLOCK_M2 = int(block_m2)
+    WARP_SIZE = 64
+    # R6d-A: MFMA 16x16x32 -> each wave covers 16 KV rows.
+    NUM_WAVES = max(1, BLOCK_N // 16)
+    ROWS_PER_WAVE = BLOCK_N // NUM_WAVES
+    if flat_work_group_size is None:
+        flat_work_group_size = NUM_WAVES * WARP_SIZE
+    BLOCK_SIZE = flat_work_group_size
+
+    ENABLE_LDS_VEC16 = (os.getenv("FLYDSL_SLA_FWD_ENABLE_LDS_VEC16", "1") == "1")
+    USE_K16 = gpu_arch.startswith("gfx950")
+    # R6d-A: MFMA 16x16x32 K-step = 32; A/B-frag = 8 bf16 per lane.
+    assert USE_K16, "R6d-A dkv_pool requires gfx950 (MFMA 16x16x32 bf16)."
+    K_STEP_QK = 32
+    K_STEPS_QK = head_dim // K_STEP_QK
+    # R6d-A: each MFMA 16x16x32 tile produces a 16-wide N-chunk; D_CHUNK = 16 cols.
+    D_CHUNK = 16
+    D_CHUNKS = head_dim // D_CHUNK
+    K_STEPS_PT = BLOCK_M2 // K_STEP_QK
+    # R6d-A: GEMM1/GEMM3 cover m_col [0..BLOCK_M2) with multiple 16-col MFMA-N tiles per ks.
+    assert BLOCK_M2 % 16 == 0, f"BLOCK_M2 must be a multiple of 16 (MFMA-N), got {BLOCK_M2}"
+    M_TILES = BLOCK_M2 // 16
+
+    assert BLOCK_N % NUM_WAVES == 0
+    assert ROWS_PER_WAVE == 16, f"ROWS_PER_WAVE must equal 16 for MFMA 16x16x32, got {ROWS_PER_WAVE}"
+    assert head_dim % 32 == 0
+    assert head_dim >= 64
+    assert flat_work_group_size in (64, 128, 256, 512)
+    assert dtype_str == "bf16", "R6d-A dkv_pool currently only supports bf16."
+    assert BLOCK_N % 16 == 0
+    assert BLOCK_M2 % K_STEP_QK == 0, (
+        f"BLOCK_M2 ({BLOCK_M2}) must be a multiple of MFMA K-step "
+        f"({K_STEP_QK}) for the dV/dK GEMMs.")
+    assert mqa_kv, "v4_hca_bwd_dkv_pool currently only supports MQA (HK=1)."
+    assert isinstance(pool_size, int) and 0 < pool_size <= BLOCK_N, (
+        f"pool_size must be int in (0, {BLOCK_N}], got {pool_size!r}")
+    assert isinstance(hca_local_seqlen, int) and hca_local_seqlen >= 0
+    assert hca_local_seqlen % BLOCK_N == 0, (
+        f"hca_local_seqlen must be multiple of BLOCK_N={BLOCK_N}, got {hca_local_seqlen}")
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    POOL_SIZE = int(pool_size)
+    HCA_LOCAL = int(hca_local_seqlen)
+
+    K_STRIDE = HEAD_DIM
+    K_SWZ_ROW_MASK = (K_STRIDE // 16) - 1
+    assert K_SWZ_ROW_MASK >= 0
+    assert (K_SWZ_ROW_MASK & (K_SWZ_ROW_MASK + 1)) == 0
+    V_STRIDE = HEAD_DIM
+
+    VEC_WIDTH = 16 if ENABLE_LDS_VEC16 else 8
+    assert HEAD_DIM % VEC_WIDTH == 0
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    LDS_K_TILE_SIZE = BLOCK_N * K_STRIDE
+    LDS_V_TILE_SIZE = BLOCK_N * V_STRIDE
+    LDS_DO_STRIDE = HEAD_DIM
+    LDS_DO_ELEMS = BLOCK_M2 * LDS_DO_STRIDE
+    LDS_Q_STRIDE = HEAD_DIM
+    LDS_Q_ELEMS = BLOCK_M2 * LDS_Q_STRIDE
+    LDS_PT_STRIDE = BLOCK_M2
+    LDS_PT_ELEMS = BLOCK_N * LDS_PT_STRIDE
+
+    _LDS_LIMIT_BYTES = 160 * 1024
+
+    def _predict_lds_bytes(use_lds_for_q_do):
+        b = (LDS_K_TILE_SIZE + LDS_V_TILE_SIZE + LDS_PT_ELEMS) * 2
+        if use_lds_for_q_do:
+            b += (LDS_DO_ELEMS + LDS_Q_ELEMS) * 2
+        return b
+
+    USE_LDS_FOR_Q_DO = True
+    _pred_full = _predict_lds_bytes(True)
+    if _pred_full > _LDS_LIMIT_BYTES:
+        USE_LDS_FOR_Q_DO = False
+        _pred_min = _predict_lds_bytes(False)
+        if _pred_min > _LDS_LIMIT_BYTES:
+            raise RuntimeError(
+                f"v4_hca_bwd_dkv_pool: minimal LDS {_pred_min}B > limit "
+                f"{_LDS_LIMIT_BYTES}B at D={head_dim}, BLOCK_N={BLOCK_N}, "
+                f"BLOCK_M2={BLOCK_M2}."
+            )
+        import sys as _sys
+        print(f"[v4_hca_bwd_dkv_pool] auto-fallback: LDS {_pred_full}B > "
+              f"{_LDS_LIMIT_BYTES}B; disabling Q/DO LDS "
+              f"({_pred_full} -> {_pred_min})",
+              file=_sys.stderr, flush=True)
+    else:
+        import sys as _sys
+        print(f"[v4_hca_bwd_dkv_pool] LDS OK: predicted {_pred_full}B <= "
+              f"{_LDS_LIMIT_BYTES}B at D={head_dim}, BLOCK_N={BLOCK_N}, "
+              f"BLOCK_M2={BLOCK_M2}, USE_LDS_FOR_Q_DO=True",
+              file=_sys.stderr, flush=True)
+
+    allocator = SmemAllocator(
+        None, arch=gpu_arch,
+        global_sym_name=(
+            f"v4_hca_bwd_dkv_pool_smem_N{BLOCK_N}_M2_{BLOCK_M2}_P{POOL_SIZE}"
+            f"_L{HCA_LOCAL}_MQ{int(mqa_kv)}_QDO{int(USE_LDS_FOR_Q_DO)}"),
+    )
+    lds_kv_offset = allocator._align(allocator.ptr, 16)
+    LDS_V_BASE = LDS_K_TILE_SIZE
+    LDS_KV_TOTAL_SIZE = LDS_K_TILE_SIZE + LDS_V_TILE_SIZE
+    allocator.ptr = lds_kv_offset + LDS_KV_TOTAL_SIZE * 2
+
+    lds_pt_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_pt_offset + LDS_PT_ELEMS * 2
+
+    if USE_LDS_FOR_Q_DO:
+        lds_do_offset = allocator._align(allocator.ptr, 16)
+        allocator.ptr = lds_do_offset + LDS_DO_ELEMS * 2
+        lds_q_offset = allocator._align(allocator.ptr, 16)
+        allocator.ptr = lds_q_offset + LDS_Q_ELEMS * 2
+    else:
+        lds_do_offset = None
+        lds_q_offset = None
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_hca_bwd_dkv_pool_kernel(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        DK: fx.Tensor,
+        DV: fx.Tensor,
+        ADD_MASK: fx.Tensor,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        compute_type = T.f32
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        k_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K)
+        v_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V)
+        do_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DOS)
+        dk_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DK)
+        dv_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DV)
+        add_mask_ptr = _fly.extract_aligned_pointer_as_index(
+            _llvm_ptr_ty(), ADD_MASK)
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+        deltas_rsrc = buffer_ops.create_buffer_resource(DELTAS, max_size=True)
+        # R6e: dk/dv pool-slice writes are atomic_fadd (multi-program collisions).
+        dk_rsrc = buffer_ops.create_buffer_resource(DK, max_size=True)
+        dv_rsrc = buffer_ops.create_buffer_resource(DV, max_size=True)
+
+        fm_fast = arith.FastMathFlags.fast
+        vxf16_type = T.vec(VEC_WIDTH, elem_type)
+        v8f16_type = T.vec(8, elem_type)
+        # R6d-A: MFMA 16x16x32 C-frag = 4 fp32 per lane.
+        v4f32_type = T.vec(4, compute_type)
+        mfma_pack_type = v8f16_type
+        MFMA_LANE_K = 8
+        v1_elem_type = T.vec(1, elem_type)
+        _mfma_zero = ir.IntegerAttr.get(ir.IntegerType.get_signless(32), 0)
+
+        def mfma_acc(a, b, c):
+            # rocdl.mfma_f32_16x16x32_bf16 is the wrapped form: takes
+            # (result_type, [operands]) and returns the Value directly.
+            return rocdl.mfma_f32_16x16x32_bf16(
+                v4f32_type,
+                [a, b, c, _mfma_zero, _mfma_zero, _mfma_zero],
+            )
+
+        seq_len_q_v = arith.index_cast(T.index, seq_len_q)
+        seq_len_k_v = arith.index_cast(T.index, seq_len_k)
+
+        base_ptr = allocator.get_base()
+        lds_kv = SmemPtr(base_ptr, lds_kv_offset, elem_type,
+                         shape=(LDS_KV_TOTAL_SIZE,)).get()
+        lds_pt = SmemPtr(base_ptr, lds_pt_offset, elem_type,
+                         shape=(LDS_PT_ELEMS,)).get()
+        if USE_LDS_FOR_Q_DO:
+            lds_do = SmemPtr(base_ptr, lds_do_offset, elem_type,
+                             shape=(LDS_DO_ELEMS,)).get()
+            lds_q = SmemPtr(base_ptr, lds_q_offset, elem_type,
+                            shape=(LDS_Q_ELEMS,)).get()
+
+        block_id = arith.index_cast(T.index, gpu.block_idx.x)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+        wave_id = tid // WARP_SIZE
+        lane = tid % WARP_SIZE
+        # R6d-A MFMA 16x16x32 lane decomposition:
+        #   A-frag: A[lane_mod_16, ks*32 + lane_div_16*8 + 0..7]
+        #   B-frag: B[ks*32 + lane_div_16*8 + 0..7, lane_mod_16]
+        #   C-frag: C[lane_div_16*4 + ii, lane_mod_16]  for ii in 0..3
+        lane_mod_16 = lane % 16
+        lane_div_16 = lane // 16
+
+        wave_n_offset = wave_id * ROWS_PER_WAVE
+
+        # R6e: grid is (B * num_m_blocks,). Decompose into (batch_idx, m_tile_idx).
+        # Layout: m_tile fastest -> consecutive programs share Q/dO batch.
+        BM2_idx_grid = arith.index(BLOCK_M2)
+        _one_idx_grid = arith.index(1)
+        num_m_blocks = (seq_len_q_v + BM2_idx_grid - _one_idx_grid) // BM2_idx_grid
+        m_tile_idx = block_id % num_m_blocks
+        batch_idx = block_id // num_m_blocks
+        m_start = m_tile_idx * BM2_idx_grid
+        # Pool slice starts at HCA_LOCAL_SEQLEN and runs for POOL_SIZE keys.
+        kv_start = arith.index(HCA_LOCAL)
+
+        load_row_in_batch = tid // THREADS_PER_ROW_LOAD
+        load_lane_in_row = tid % THREADS_PER_ROW_LOAD
+        load_col_base = load_lane_in_row * VEC_WIDTH
+
+        bh_base_tokens_kv = batch_idx * seq_len_k_v
+
+        def bh_base_tokens_q_of(qhid_index):
+            return (batch_idx * NUM_HEADS + qhid_index) * seq_len_q_v
+
+        def global_idx_q(qhid_index, token_idx, col):
+            return ((bh_base_tokens_q_of(qhid_index) + token_idx)
+                    * arith.index(HEAD_DIM) + col)
+
+        def global_idx_kv(token_idx, col):
+            return (bh_base_tokens_kv + token_idx) * arith.index(HEAD_DIM) + col
+
+        def _gep_load(base_ptr_, elem_idx, vec_type, et=elem_type):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=et, noWrapFlags=0)
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def _gep_store_f32(val, base_ptr_, elem_idx):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=T.f32, noWrapFlags=0)
+            _llvm.StoreOp(val, gep.result)
+
+        def load_global_mfma_pack(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, mfma_pack_type)
+
+        def load_global_f16xN(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, vxf16_type)
+
+        def _k_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return col_idx ^ mask
+
+        if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+            NUM_BATCHES_KV = 1
+            KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+        else:
+            assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0
+            NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+            KV_NEEDS_GUARD = False
+
+        if ROWS_PER_BATCH_LOAD >= BLOCK_M2:
+            NUM_BATCHES_M = 1
+            M_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_M2
+        else:
+            assert BLOCK_M2 % ROWS_PER_BATCH_LOAD == 0
+            NUM_BATCHES_M = BLOCK_M2 // ROWS_PER_BATCH_LOAD
+            M_NEEDS_GUARD = False
+
+        c_zero_vxf16 = arith.constant_vector(0.0, vxf16_type)
+        c_zero_mfma_pack = arith.constant_vector(0.0, mfma_pack_type)
+        c_zero_elem = arith.constant(0.0, type=elem_type)
+        c_zero_f = arith.constant(0.0, type=compute_type)
+        c_neg_inf = arith.constant(-1.0e30, type=compute_type)
+        c_sm_scale = arith.constant(sm_scale, type=compute_type)
+        # R6d-A: 4-elem fp32 acc per MFMA 16x16x32 op.
+        v4f32_zero = arith.constant_vector(0.0, v4f32_type)
+
+        # ---- PROLOGUE: cooperative load K, V into LDS ----
+        pool_end = kv_start + arith.index(POOL_SIZE)
+
+        def coop_load_k():
+            k_base = arith.index(0)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = kv_start + load_row_in_batch + row_offset
+                in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, row_idx, pool_end)
+                row_safe = arith.select(in_bounds, row_idx, arith.index(0))
+                g_idx = global_idx_kv(row_safe, load_col_base)
+                vec = load_global_f16xN(k_ptr, g_idx)
+                vec_safe = arith.select(in_bounds, vec, c_zero_vxf16)
+                lds_row = load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch + row_offset,
+                        arith.index(BLOCK_N))
+                    _if_k = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_k.then_block):
+                        swz_col = _k_swizzle(lds_row, load_col_base)
+                        lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                        vector.store(vec_safe, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    vector.store(vec_safe, lds_kv, [lds_idx])
+
+        def coop_load_v():
+            v_base = arith.index(LDS_V_BASE)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = kv_start + load_row_in_batch + row_offset
+                in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, row_idx, pool_end)
+                row_safe = arith.select(in_bounds, row_idx, arith.index(0))
+                g_idx = global_idx_kv(row_safe, load_col_base)
+                vec = load_global_f16xN(v_ptr, g_idx)
+                vec_safe = arith.select(in_bounds, vec, c_zero_vxf16)
+                lds_row = load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch + row_offset,
+                        arith.index(BLOCK_N))
+                    _if_v = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_v.then_block):
+                        swz_col = _k_swizzle(lds_row, load_col_base)
+                        lds_idx = v_base + lds_row * V_STRIDE + swz_col
+                        vector.store(vec_safe, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = v_base + lds_row * V_STRIDE + swz_col
+                    vector.store(vec_safe, lds_kv, [lds_idx])
+
+        coop_load_k()
+        coop_load_v()
+        gpu.barrier()
+
+        # R6d-A: K/V LDS A-frag uses lane_mod_16 (16-row MFMA) and lane_div_16*8 for col.
+        # Per-call swizzle mask (folds wave_n_offset bits at D=512).
+        def _k_idx_wave(ks):
+            kv_row = wave_n_offset + lane_mod_16
+            col = arith.index(ks * K_STEP_QK) + lane_div_16 * MFMA_LANE_K
+            mask = (kv_row & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return (kv_row * arith.index(K_STRIDE) + (col ^ mask))
+
+        def _v_idx_wave(ks):
+            kv_row = wave_n_offset + lane_mod_16
+            col = arith.index(ks * K_STEP_QK) + lane_div_16 * MFMA_LANE_K
+            mask = (kv_row & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return (arith.index(LDS_V_BASE)
+                    + kv_row * arith.index(V_STRIDE) + (col ^ mask))
+
+        # R6e: m-loop replaced by per-program m-tile.
+        BN_idx = arith.index(BLOCK_N)
+        BM2_idx = arith.index(BLOCK_M2)
+        _one_idx = arith.index(1)
+
+        outer_carry = ([v4f32_zero for _ in range(D_CHUNKS)]
+                       + [v4f32_zero for _ in range(D_CHUNKS)])
+
+        seq_len_q_i32 = arith.index_cast(T.i32, seq_len_q_v)
+        wave_n_off_i32 = arith.index_cast(T.i32, wave_n_offset)
+        lane_div_16_i32 = arith.index_cast(T.i32, lane_div_16)
+        pool_size_i32 = arith.constant(POOL_SIZE, type=T.i32)
+
+        # ADD_MASK row stride in elements (= POOL_SIZE; bf16/f16 contiguous).
+        ADD_MASK_STRIDE_M = arith.index(POOL_SIZE)
+
+        NUM_HEADS_idx = arith.index(NUM_HEADS)
+        for qhid_constexpr_idx, h_carry, h_loop_results in scf.for_(
+            arith.index(0), NUM_HEADS_idx, arith.index(1), iter_args=outer_carry,
+        ):
+            qhid = qhid_constexpr_idx
+
+            # R6e: per-program m-tile (no inner m-loop). Accumulators are head-loop carry.
+            dv_accs = [h_carry[dc] for dc in range_constexpr(D_CHUNKS)]
+            dk_accs = [h_carry[D_CHUNKS + dc] for dc in range_constexpr(D_CHUNKS)]
+
+            # R6d-A: lane_mod_16 is the per-tile q-row coord; full per-tile loop builds row below.
+            q_row_abs = m_start + lane_mod_16
+            q_in_bounds = arith.cmpi(
+                arith.CmpIPredicate.slt, q_row_abs, seq_len_q_v)
+            q_row_safe = arith.select(q_in_bounds, q_row_abs, arith.index(0))
+
+            if USE_LDS_FOR_Q_DO:
+                for batch in range_constexpr(NUM_BATCHES_M):
+                    row_offset = batch * ROWS_PER_BATCH_LOAD
+                    row_idx = m_start + load_row_in_batch + row_offset
+                    in_bounds = arith.cmpi(
+                        arith.CmpIPredicate.slt, row_idx, seq_len_q_v)
+                    row_safe = arith.select(in_bounds, row_idx, arith.index(0))
+                    g_idx_do = global_idx_q(qhid, row_safe, load_col_base)
+                    g_idx_q = global_idx_q(qhid, row_safe, load_col_base)
+                    vec_do = load_global_f16xN(do_ptr, g_idx_do)
+                    vec_q = load_global_f16xN(q_ptr, g_idx_q)
+                    vec_do_safe = arith.select(in_bounds, vec_do, c_zero_vxf16)
+                    vec_q_safe = arith.select(in_bounds, vec_q, c_zero_vxf16)
+                    lds_row = load_row_in_batch + row_offset
+                    if M_NEEDS_GUARD:
+                        row_valid = arith.cmpi(
+                            arith.CmpIPredicate.ult,
+                            load_row_in_batch + row_offset,
+                            arith.index(BLOCK_M2))
+                        _if_qd = scf.IfOp(row_valid)
+                        with ir.InsertionPoint(_if_qd.then_block):
+                            lds_idx_do = (lds_row * arith.index(LDS_DO_STRIDE)
+                                          + load_col_base)
+                            lds_idx_q = (lds_row * arith.index(LDS_Q_STRIDE)
+                                         + load_col_base)
+                            vector.store(vec_do_safe, lds_do, [lds_idx_do])
+                            vector.store(vec_q_safe, lds_q, [lds_idx_q])
+                            scf.YieldOp([])
+                    else:
+                        lds_idx_do = (lds_row * arith.index(LDS_DO_STRIDE)
+                                      + load_col_base)
+                        lds_idx_q = (lds_row * arith.index(LDS_Q_STRIDE)
+                                     + load_col_base)
+                        vector.store(vec_do_safe, lds_do, [lds_idx_do])
+                        vector.store(vec_q_safe, lds_q, [lds_idx_q])
+                gpu.barrier()
+
+                # R6d-A: B-frag for GEMM1 (qkT = K @ Q^T) per m-tile mt in [0, M_TILES).
+                #   Q[mt*16 + lane_mod_16, ks*32 + lane_div_16*8 + 0..7]
+                q_b_packs = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                for mt in range_constexpr(M_TILES):
+                    for ks in range_constexpr(K_STEPS_QK):
+                        m_row = arith.index(mt * 16) + lane_mod_16
+                        d_col = (arith.index(ks * K_STEP_QK)
+                                 + lane_div_16 * MFMA_LANE_K)
+                        lds_idx = m_row * arith.index(LDS_Q_STRIDE) + d_col
+                        pack = vector.load_op(mfma_pack_type, lds_q, [lds_idx])
+                        q_b_packs[mt][ks] = pack
+
+                # R6d-A: B-frag for GEMM3 (dp = V @ DO^T) per m-tile mt.
+                do_b_packs_gemm3 = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                for mt in range_constexpr(M_TILES):
+                    for ks in range_constexpr(K_STEPS_QK):
+                        m_row = arith.index(mt * 16) + lane_mod_16
+                        d_col = (arith.index(ks * K_STEP_QK)
+                                 + lane_div_16 * MFMA_LANE_K)
+                        lds_idx = m_row * arith.index(LDS_DO_STRIDE) + d_col
+                        pack = vector.load_op(mfma_pack_type, lds_do, [lds_idx])
+                        do_b_packs_gemm3[mt][ks] = pack
+            else:
+                # R6d-A fallback: HBM-direct B-frag per m-tile. row = m_start + mt*16 + lane_mod_16.
+                q_b_packs = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                do_b_packs_gemm3 = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                for mt in range_constexpr(M_TILES):
+                    row_abs = m_start + arith.index(mt * 16) + lane_mod_16
+                    in_bnd = arith.cmpi(arith.CmpIPredicate.slt,
+                                        row_abs, seq_len_q_v)
+                    row_safe = arith.select(in_bnd, row_abs, arith.index(0))
+                    for ks in range_constexpr(K_STEPS_QK):
+                        col = (arith.index(ks * K_STEP_QK)
+                               + lane_div_16 * MFMA_LANE_K)
+                        g_idx = global_idx_q(qhid, row_safe, col)
+                        q_raw = load_global_mfma_pack(q_ptr, g_idx)
+                        q_b_packs[mt][ks] = arith.select(
+                            in_bnd, q_raw, c_zero_mfma_pack)
+                        do_raw = load_global_mfma_pack(do_ptr, g_idx)
+                        do_b_packs_gemm3[mt][ks] = arith.select(
+                            in_bnd, do_raw, c_zero_mfma_pack)
+
+            # ---- GEMM1: qkT = K @ Q^T (MFMA 16x16x32, one tile per m-tile mt) ----
+            s_accs = [v4f32_zero for _ in range(M_TILES)]
+            for ks in range_constexpr(K_STEPS_QK):
+                k_pack = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_wave(ks)])
+                for mt in range_constexpr(M_TILES):
+                    s_accs[mt] = mfma_acc(k_pack, q_b_packs[mt][ks], s_accs[mt])
+
+            # R6d-A: per m-tile lse/delta, pool-only mask, ADD_MASK bias, softmax.
+            # m_row for tile mt = m_start + mt*16 + lane_mod_16.
+            # Resulting pT_vals_per_tile[mt][ii] for ii in 0..3.
+            pT_vals_per_tile = []
+            lse_per_tile = []
+            delta_per_tile = []
+            for mt in range_constexpr(M_TILES):
+                m_row_for_lse = m_start + arith.index(mt * 16) + lane_mod_16
+                m_row_in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, m_row_for_lse, seq_len_q_v)
+                m_row_safe = arith.select(m_row_in_bounds, m_row_for_lse,
+                                          arith.index(0))
+                lse_off_i32 = arith.index_cast(
+                    T.i32, bh_base_tokens_q_of(qhid) + m_row_safe)
+                lse_v = buffer_ops.buffer_load(
+                    lse_rsrc, lse_off_i32, vec_width=1, dtype=T.f32)
+                delta_v = buffer_ops.buffer_load(
+                    deltas_rsrc, lse_off_i32, vec_width=1, dtype=T.f32)
+                lse_per_tile.append(lse_v)
+                delta_per_tile.append(delta_v)
+
+                m_row_abs_for_mask_i32 = arith.index_cast(T.i32, m_row_for_lse)
+                m_oob = arith.cmpi(
+                    arith.CmpIPredicate.sge,
+                    m_row_abs_for_mask_i32, seq_len_q_i32)
+                # ADD_MASK row base (clamp to row 0 if OOB; lane is masked).
+                add_mask_row_base = m_row_safe * ADD_MASK_STRIDE_M
+
+                pT_tile = []
+                for ii in range_constexpr(4):
+                    ii_i32 = arith.constant(ii, type=T.i32)
+                    # R6d-A: 16x16x32 C-frag lane stride is 4 (NOT 8 like 32x32x16).
+                    pool_n_rel_i32 = arith.AddIOp(
+                        arith.MulIOp(
+                            lane_div_16_i32,
+                            arith.constant(4, type=T.i32)).result,
+                        ii_i32).result
+                    pool_n_i32 = arith.AddIOp(
+                        wave_n_off_i32, pool_n_rel_i32).result
+                    pool_n_oob = arith.cmpi(
+                        arith.CmpIPredicate.sge, pool_n_i32, pool_size_i32)
+                    bad = arith.OrIOp(pool_n_oob, m_oob).result
+
+                    # Load add_bias from ADD_MASK[m_row, pool_n].
+                    pool_n_safe_i32 = arith.select(
+                        bad, arith.constant(0, type=T.i32), pool_n_i32)
+                    pool_n_idx = arith.index_cast(T.index, pool_n_safe_i32)
+                    add_elem_idx = add_mask_row_base + pool_n_idx
+                    bias_raw_v1 = _gep_load(
+                        add_mask_ptr, add_elem_idx, T.vec(1, elem_type))
+                    bias_raw = vector.extract(
+                        bias_raw_v1, static_position=[0], dynamic_position=[])
+                    bias_f32 = arith.extf(compute_type, bias_raw)
+                    bias_safe = arith.select(bad, c_zero_f, bias_f32)
+
+                    s_ii = vector.extract(s_accs[mt],
+                                          static_position=[ii],
+                                          dynamic_position=[])
+                    scaled = arith.MulFOp(
+                        s_ii, c_sm_scale, fastmath=fm_fast).result
+                    scaled_plus_bias = arith.AddFOp(
+                        scaled, bias_safe, fastmath=fm_fast).result
+                    scaled_m = arith.select(bad, c_neg_inf, scaled_plus_bias)
+                    diff = arith.SubFOp(
+                        scaled_m, lse_v, fastmath=fm_fast).result
+                    p = math_dialect.exp(diff, fastmath=fm_fast)
+                    pT_tile.append(p)
+                pT_vals_per_tile.append(pT_tile)
+
+            # ---- pT register -> LDS (per m-tile mt, write 4 C-frag elems/lane @ col mt*16 + lane_mod_16) ----
+            for mt in range_constexpr(M_TILES):
+                for ii in range_constexpr(4):
+                    kv_row_rel = (lane_div_16 * arith.index(4)
+                                  + arith.index(ii))
+                    kv_row = wave_n_offset + kv_row_rel
+                    pt_bf16 = arith.trunc_f(elem_type, pT_vals_per_tile[mt][ii])
+                    lds_pt_idx = (kv_row * arith.index(LDS_PT_STRIDE)
+                                  + arith.index(mt * 16) + lane_mod_16)
+                    v1 = vector.from_elements(v1_elem_type, [pt_bf16])
+                    vector.store(v1, lds_pt, [lds_pt_idx])
+
+            # ---- pT A-frag for GEMM2 (dV += pT @ DO):
+            #   A[kv_row=wave_n_offset+lane_mod_16, m_col=m_step*32+lane_div_16*8 + 0..7]
+            pt_a_packs = []
+            for m_step in range_constexpr(K_STEPS_PT):
+                kv_row_a = wave_n_offset + lane_mod_16
+                m_col_a = (arith.index(m_step * K_STEP_QK)
+                           + lane_div_16 * MFMA_LANE_K)
+                lds_idx = (kv_row_a * arith.index(LDS_PT_STRIDE) + m_col_a)
+                pack = vector.load_op(mfma_pack_type, lds_pt, [lds_idx])
+                pt_a_packs.append(pack)
+
+            # ---- GEMM2: dV += pT @ DO ----
+            # R6d-A GEMM2 (dV += pT @ DO): B-frag DO[m_step*32+lane_div_16*8+k, dc*16+lane_mod_16].
+            if USE_LDS_FOR_Q_DO:
+                def read_do_b_pack(m_step_idx, dc_idx):
+                    d_col = arith.index(dc_idx * D_CHUNK) + lane_mod_16
+                    m_base = (arith.index(m_step_idx * K_STEP_QK)
+                              + lane_div_16 * MFMA_LANE_K)
+                    vals = []
+                    for rk in range_constexpr(MFMA_LANE_K):
+                        m_row = m_base + arith.index(rk)
+                        lds_idx = (m_row * arith.index(LDS_DO_STRIDE)
+                                   + d_col)
+                        val = _memref.load(lds_do, [lds_idx])
+                        vals.append(val)
+                    return vector.from_elements(mfma_pack_type, vals)
+            else:
+                def read_do_b_pack(m_step_idx, dc_idx):
+                    d_col = arith.index(dc_idx * D_CHUNK) + lane_mod_16
+                    m_base = (arith.index(m_step_idx * K_STEP_QK)
+                              + lane_div_16 * MFMA_LANE_K)
+                    vals = []
+                    for rk in range_constexpr(MFMA_LANE_K):
+                        m_row_rel = m_base + arith.index(rk)
+                        m_row_abs = m_start + m_row_rel
+                        in_b = arith.cmpi(
+                            arith.CmpIPredicate.slt,
+                            m_row_abs, seq_len_q_v)
+                        m_row_safe2 = arith.select(
+                            in_b, m_row_abs, arith.index(0))
+                        g_idx = global_idx_q(qhid, m_row_safe2, d_col)
+                        v1 = _gep_load(do_ptr, g_idx, T.vec(1, elem_type))
+                        v_scalar = vector.extract(
+                            v1, static_position=[0], dynamic_position=[])
+                        v_safe = arith.select(in_b, v_scalar, c_zero_elem)
+                        vals.append(v_safe)
+                    return vector.from_elements(mfma_pack_type, vals)
+
+            new_dv_accs = list(dv_accs)
+            for dc in range_constexpr(D_CHUNKS):
+                for pks in range_constexpr(K_STEPS_PT):
+                    b_pack = read_do_b_pack(pks, dc)
+                    new_dv_accs[dc] = mfma_acc(
+                        pt_a_packs[pks], b_pack, new_dv_accs[dc])
+
+            # ---- GEMM3: dp = V @ DO^T (MFMA 16x16x32, one tile per m-tile mt) ----
+            dp_accs = [v4f32_zero for _ in range(M_TILES)]
+            for ks in range_constexpr(K_STEPS_QK):
+                v_pack = vector.load_op(
+                    mfma_pack_type, lds_kv, [_v_idx_wave(ks)])
+                for mt in range_constexpr(M_TILES):
+                    dp_accs[mt] = mfma_acc(
+                        v_pack, do_b_packs_gemm3[mt][ks], dp_accs[mt])
+
+            # ---- dsT = pT * (dp - delta) per m-tile ----
+            dsT_vals_per_tile = []
+            for mt in range_constexpr(M_TILES):
+                ds_tile = []
+                for ii in range_constexpr(4):
+                    dp_ii = vector.extract(
+                        dp_accs[mt], static_position=[ii],
+                        dynamic_position=[])
+                    diff = arith.SubFOp(
+                        dp_ii, delta_per_tile[mt],
+                        fastmath=fm_fast).result
+                    ds_ii = arith.MulFOp(
+                        pT_vals_per_tile[mt][ii], diff,
+                        fastmath=fm_fast).result
+                    ds_tile.append(ds_ii)
+                dsT_vals_per_tile.append(ds_tile)
+
+            # ---- dsT register -> LDS (per m-tile, col = mt*16 + lane_mod_16) ----
+            for mt in range_constexpr(M_TILES):
+                for ii in range_constexpr(4):
+                    kv_row_rel = (lane_div_16 * arith.index(4)
+                                  + arith.index(ii))
+                    kv_row = wave_n_offset + kv_row_rel
+                    ds_bf16 = arith.trunc_f(elem_type,
+                                            dsT_vals_per_tile[mt][ii])
+                    lds_pt_idx = (kv_row * arith.index(LDS_PT_STRIDE)
+                                  + arith.index(mt * 16) + lane_mod_16)
+                    v1_ds = vector.from_elements(v1_elem_type, [ds_bf16])
+                    vector.store(v1_ds, lds_pt, [lds_pt_idx])
+
+            # ---- dsT A-frag for GEMM4 (dK += dsT @ Q):
+            #   A[kv_row=wave_n_offset+lane_mod_16, m_col=m_step*32+lane_div_16*8 + 0..7]
+            ds_a_packs = []
+            for m_step in range_constexpr(K_STEPS_PT):
+                kv_row_a = wave_n_offset + lane_mod_16
+                m_col_a = (arith.index(m_step * K_STEP_QK)
+                           + lane_div_16 * MFMA_LANE_K)
+                lds_idx = (kv_row_a * arith.index(LDS_PT_STRIDE) + m_col_a)
+                pack = vector.load_op(mfma_pack_type, lds_pt, [lds_idx])
+                ds_a_packs.append(pack)
+
+            # ---- GEMM4: dK += dsT @ Q  (MFMA 16x16x32) ----
+            # B-frag: Q[m_step*32+lane_div_16*8+k, dc*16+lane_mod_16].
+            if USE_LDS_FOR_Q_DO:
+                def read_q_b_pack(m_step_idx, dc_idx):
+                    d_col = arith.index(dc_idx * D_CHUNK) + lane_mod_16
+                    m_base = (arith.index(m_step_idx * K_STEP_QK)
+                              + lane_div_16 * MFMA_LANE_K)
+                    vals = []
+                    for rk in range_constexpr(MFMA_LANE_K):
+                        m_row = m_base + arith.index(rk)
+                        lds_idx = (m_row * arith.index(LDS_Q_STRIDE)
+                                   + d_col)
+                        val = _memref.load(lds_q, [lds_idx])
+                        vals.append(val)
+                    return vector.from_elements(mfma_pack_type, vals)
+            else:
+                def read_q_b_pack(m_step_idx, dc_idx):
+                    d_col = arith.index(dc_idx * D_CHUNK) + lane_mod_16
+                    m_base = (arith.index(m_step_idx * K_STEP_QK)
+                              + lane_div_16 * MFMA_LANE_K)
+                    vals = []
+                    for rk in range_constexpr(MFMA_LANE_K):
+                        m_row_rel = m_base + arith.index(rk)
+                        m_row_abs = m_start + m_row_rel
+                        in_b = arith.cmpi(
+                            arith.CmpIPredicate.slt,
+                            m_row_abs, seq_len_q_v)
+                        m_row_safe2 = arith.select(
+                            in_b, m_row_abs, arith.index(0))
+                        g_idx = global_idx_q(qhid, m_row_safe2, d_col)
+                        v1 = _gep_load(q_ptr, g_idx, T.vec(1, elem_type))
+                        v_scalar = vector.extract(
+                            v1, static_position=[0], dynamic_position=[])
+                        v_safe = arith.select(in_b, v_scalar, c_zero_elem)
+                        vals.append(v_safe)
+                    return vector.from_elements(mfma_pack_type, vals)
+
+            new_dk_accs = list(dk_accs)
+            for dc in range_constexpr(D_CHUNKS):
+                for pks in range_constexpr(K_STEPS_PT):
+                    q_b_pack = read_q_b_pack(pks, dc)
+                    new_dk_accs[dc] = mfma_acc(
+                        ds_a_packs[pks], q_b_pack, new_dk_accs[dc])
+
+            gpu.barrier()
+
+            # R6e: yield (dv, dk) partial directly as head-loop carry; no inner m-loop.
+            yield list(new_dv_accs) + list(new_dk_accs)
+        outer_carry = list(h_loop_results)
+
+        # ---- Final: dK *= sm_scale, store ----
+        dv_finals = [outer_carry[dc] for dc in range(D_CHUNKS)]
+        dk_finals = [outer_carry[D_CHUNKS + dc] for dc in range(D_CHUNKS)]
+
+        # R6e: atomic_fadd into shared pool slice of dk/dv.
+        # Multiple m-tile programs collide on the same (b, pool_n, d) addresses.
+        # DK/DV are fp32 contiguous; byte_offset = global_idx_kv * 4.
+        _atom_zero_i32 = arith.constant(0, type=T.i32)
+        _four_i32 = arith.constant(4, type=T.i32)
+        for dc in range_constexpr(D_CHUNKS):
+            for ii in range_constexpr(4):
+                kv_row_rel = (lane_div_16 * arith.index(4)
+                              + arith.index(ii))
+                kv_row_abs = kv_start + wave_n_offset + kv_row_rel
+                d_col_abs = arith.index(dc * D_CHUNK) + lane_mod_16
+                kv_in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, kv_row_abs, pool_end)
+                _if_kv = scf.IfOp(kv_in_bounds)
+                with ir.InsertionPoint(_if_kv.then_block):
+                    dv_val = vector.extract(
+                        dv_finals[dc], static_position=[ii],
+                        dynamic_position=[])
+                    dk_val = vector.extract(
+                        dk_finals[dc], static_position=[ii],
+                        dynamic_position=[])
+                    dk_scaled = arith.MulFOp(
+                        dk_val, c_sm_scale, fastmath=fm_fast).result
+                    g_elem_idx = global_idx_kv(kv_row_abs, d_col_abs)
+                    g_elem_i32 = arith.index_cast(T.i32, g_elem_idx)
+                    byte_off_i32 = arith.MulIOp(
+                        g_elem_i32, _four_i32).result
+                    rocdl.raw_ptr_buffer_atomic_fadd(
+                        dv_val, dv_rsrc, byte_off_i32,
+                        _atom_zero_i32, _atom_zero_i32,
+                    )
+                    rocdl.raw_ptr_buffer_atomic_fadd(
+                        dk_scaled, dk_rsrc, byte_off_i32,
+                        _atom_zero_i32, _atom_zero_i32,
+                    )
+                    scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_hca_bwd_dkv_pool(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        DK: fx.Tensor,
+        DV: fx.Tensor,
+        ADD_MASK: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        # R6e: grid_x = B * num_m_blocks. Parallelize over m-tiles for B=1.
+        sq_idx_h = arith.index_cast(T.index, seq_len_q)
+        BM2_idx_h = arith.index(BLOCK_M2)
+        _one_idx_h = arith.index(1)
+        num_m_blocks_v = (sq_idx_h + BM2_idx_h - _one_idx_h) // BM2_idx_h
+        grid_x = bs_idx * num_m_blocks_v
+
+        launcher = v4_hca_bwd_dkv_pool_kernel(
+            Q, K, V, DOS, LSE, DELTAS, DK, DV, ADD_MASK,
+            seq_len_q, seq_len_k,
+        )
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = (
+                            ir.IntegerAttr.get(T.i32, _wpe))
+        if flat_work_group_size is not None:
+            _fwgs = int(flat_work_group_size)
+            if _fwgs >= 1:
+                flat_wg_attr = ir.StringAttr.get(f"{_fwgs},{_fwgs}")
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.flat_work_group_size"] = (
+                            flat_wg_attr)
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(
+                    passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, 1, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    _fmha_compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+        "llvm_options": {
+            "enable-post-misched": False,
+            "lsr-drop-solution": True,
+        },
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return launch_v4_hca_bwd_dkv_pool(*args, **kwargs)
+
+    def _compile(Q, K, V, DOS, LSE, DELTAS, DK, DV, ADD_MASK,
+                 batch_size, seq_len_q, seq_len_k, stream=None):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return flyc.compile(
+                launch_v4_hca_bwd_dkv_pool,
+                Q, K, V, DOS, LSE, DELTAS, DK, DV, ADD_MASK,
+                batch_size, seq_len_q, seq_len_k, fx.Stream(stream))
+
+    _launch.compile = _compile
+
+    return _launch
+
+
+# Convenience alias.
+build_v4_hca_bwd_dkv_pool_module_primary = build_v4_hca_bwd_dkv_pool_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_hca_bwd_dq_pool_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_hca_bwd_dq_pool_kernel.py
@@ -1,0 +1,1325 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_hca_bwd_dq_pool: V4 HCA backward dQ POOL-stream kernel for FlyDSL.
+
+Forked from v4_sla_bwd_dq_kernel.py. Computes the POOL stream contribution
+to dq for an HCA (Hybrid-Causal-Additive) attention backward, then
+ACCUMULATES into an existing dq_fp32 buffer (which already contains the
+LOCAL stream dq from the SWA dq kernel).
+
+Differences vs the SWA kernel:
+  - KV range is fixed at [HCA_LOCAL_SEQLEN, HCA_LOCAL_SEQLEN+POOL_SIZE).
+    POOL_SIZE is a build-time constexpr. For our shapes POOL_SIZE <= BLOCK_N
+    so there is exactly ONE n-block iteration.
+  - No SWA-window mask, no causal mask. Two element-wise predicates only:
+      (a) pool_n < POOL_SIZE     -> NEG_INF outside the pool
+      (b) q_row < seq_len_q      -> NEG_INF for OOB q rows
+  - qk + add_bias from the ADD_MASK tensor (shape [Sq, POOL_SIZE]).
+    Each element loaded as f32 (after cast from bf16/f16) and added to qk
+    before -lse and exp.
+  - No SINK / DSINK. Sink is handled by the LOCAL FlyDSL dq kernel; the
+    pool stream does not touch the sink.
+  - Final store ACCUMULATES into DQ (load + add + store). Race-free
+    because each program owns a unique (b, qhid, m_block) slice and the
+    pool kernel runs AFTER the SWA dq has finished writing dq for that
+    same slice (sequential launches from the wrapper).
+  - sm_scale is applied INSIDE the loop on qk (matches Triton ref); after
+    the n-loop (which has only one iter), sm_scale is applied ONCE MORE
+    on dq before accumulating into DQ (P57 cr=0 BWD).
+
+Layout: BHLD. Q/DOUT/DQ flat from (B, HQ, Sq, D). K/V flat from
+        (B, HK, Sk, D); MQA means HK=1, no head stride applied to KV.
+LSE/DELTAS: (B, HQ, Sq) flat, fp32, raw-domain (JOINT lse from fwd).
+ADD_MASK:   (Sq, POOL_SIZE) bf16/f16; loaded as f32 inside the kernel.
+DQ:         (B, HQ, Sq, D) fp32; ACCUMULATED.
+"""
+
+import math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import memref as _memref, scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+# ---- Module-level constants ----
+
+KERNEL_NAME = "v4_hca_bwd_dq_pool_kernel"
+
+_LOG2E = math.log2(math.e)  # 1.4426950408889634
+
+_LLVM_GEP_DYNAMIC = -2147483648  # LLVM kDynamicIndex sentinel (0x80000000 as signed i32)
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _llvm_lds_ptr_ty():
+    return ir.Type.parse("!llvm.ptr<3>")
+
+
+_VMCNT_LO_MASK = 0xF
+_LGKMCNT_EXPCNT_BASE = 0x3F70
+_VMCNT_HI_SHIFT = 14
+_VMCNT_HI_MASK = 0x3
+
+
+def _waitcnt_vm_n(n):
+    """Emit s_waitcnt vmcnt(n) only (lgkmcnt=63, expcnt=7)."""
+    val = (n & _VMCNT_LO_MASK) | _LGKMCNT_EXPCNT_BASE | (((n >> 4) & _VMCNT_HI_MASK) << _VMCNT_HI_SHIFT)
+    rocdl.s_waitcnt(val)
+
+
+def build_v4_hca_bwd_dq_pool_module(
+    num_heads,
+    head_dim,
+    pool_size,
+    hca_local_seqlen,
+    dtype_str="bf16",
+    sm_scale=None,
+    waves_per_eu=2,
+    flat_work_group_size=None,
+    block_m=None,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    layout_bhld=True,
+    mqa_kv=True,
+):
+    """Build the V4 HCA backward dQ POOL-stream launcher.
+
+    Args:
+        num_heads: HQ (number of Q heads).
+        head_dim: D (head dimension), must be % 32 == 0 and >= 64.
+        pool_size: int > 0; number of pool keys (<= BLOCK_N=64 in this
+            kernel; one n-block per program iter). Build-time constexpr.
+        hca_local_seqlen: int >= 0; offset into K/V at which the pool
+            keys start (== Sq for HCA split-mask). Build-time constexpr;
+            must be a multiple of BLOCK_N to keep the single-iter
+            n-block aligned.
+        sm_scale: defaults to 1/sqrt(head_dim).
+        mqa_kv: if True, K/V indexing drops head_idx (HK=1, stride_h=0).
+        layout_bhld: BHLD layout (True) or BLHD (False); V4 uses BHLD.
+
+    Returns: launch(Q, K, V, DOUT, LSE, DELTAS, DQ_FP32, ADD_MASK,
+                    batch_size, seq_len_q, seq_len_k, stream=None).
+            DQ_FP32 is ACCUMULATED into (load + add + store).
+    """
+    gpu_arch = get_hip_arch()
+
+    BLOCK_N = 64
+    K_SUB_N = 32
+    WARP_SIZE = 64
+
+    if block_m is not None:
+        BLOCK_M = block_m
+    else:
+        BLOCK_M = 128
+
+    if flat_work_group_size is None:
+        if BLOCK_M <= 128:
+            flat_work_group_size = 256
+        else:
+            flat_work_group_size = 512
+    NUM_WAVES = flat_work_group_size // WARP_SIZE
+    BLOCK_SIZE = flat_work_group_size
+    ROWS_PER_WAVE = BLOCK_M // NUM_WAVES
+    # V4 SWA: dense path. One outer iter = one BLOCK_N block.
+    BLOCK_N_OUT = BLOCK_N
+    N_SUBTILES = 1
+    ENABLE_PREFETCH_3BUF = (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_PREFETCH3", "0") == "1"
+    )
+    _has_lds_load_b128 = not gpu_arch.startswith("gfx942")
+    ENABLE_DMA = _has_lds_load_b128 and (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_DMA", "1") == "1"
+    )
+    ENABLE_LDS_VEC16 = (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_LDS_VEC16", "1") == "1"
+    )
+    REDUCE_MODE = os.getenv("FLYDSL_SLA_FWD_REDUCE_MODE", "xor").strip().lower()
+    if REDUCE_MODE not in ("xor", "ds_bpermute"):
+        REDUCE_MODE = "xor"
+    NUM_PREFETCH_K = 3 if ENABLE_PREFETCH_3BUF else (2 if ENABLE_DMA else 1)
+    NUM_PREFETCH_V = 3 if ENABLE_PREFETCH_3BUF else (2 if ENABLE_DMA else 1)
+    CK_LDS_SEQ = (1, 2, 0, 1, 0, 1, 2, 0) if ENABLE_PREFETCH_3BUF else (0,)
+
+    USE_HW_TR = gpu_arch.startswith("gfx950")
+    USE_K16 = gpu_arch.startswith("gfx950")
+
+    # Auto-fallback: gfx950 LDS limit is 160 KB. K+V double-buffering at D=512
+    # easily exceeds that. If predicted LDS exceeds budget, force DMA off
+    # (NUM_PREFETCH = 1) and warn. Keeps the kernel correct regardless of
+    # the env knob.
+    _LDS_LIMIT_BYTES = 160 * 1024
+    def _predicted_lds_bytes(nk, nv, dma):
+        # USE_HW_TR & DMA  -> V_STRIDE = head_dim
+        # USE_HW_TR & !DMA -> V_STRIDE = head_dim + 4
+        # !USE_HW_TR       -> V stored transposed: LDS V = head_dim * (BLOCK_N + 2)
+        if USE_HW_TR:
+            v_str = head_dim if dma else head_dim + 4
+            return (nk * BLOCK_N * head_dim + nv * BLOCK_N * v_str) * 2
+        vt = BLOCK_N + 2
+        return (nk * BLOCK_N * head_dim + nv * head_dim * vt) * 2
+    _pred = _predicted_lds_bytes(NUM_PREFETCH_K, NUM_PREFETCH_V, ENABLE_DMA)
+    if _pred > _LDS_LIMIT_BYTES and ENABLE_DMA:
+        # Try DMA off (single-buffered).
+        ENABLE_DMA = False
+        NUM_PREFETCH_K = 1
+        NUM_PREFETCH_V = 1
+        _pred2 = _predicted_lds_bytes(1, 1, False)
+        if _pred2 > _LDS_LIMIT_BYTES:
+            raise RuntimeError(
+                f"v4_hca_bwd_dq_pool: predicted LDS {_pred2}B > limit {_LDS_LIMIT_BYTES}B "
+                f"even single-buffered at D={head_dim}, BLOCK_N={BLOCK_N}"
+            )
+        import sys as _sys
+        print(
+            f"[v4_hca_bwd_dq_pool] LDS overflow at D={head_dim}, BLOCK_N={BLOCK_N}: "
+            f"auto-disabled DMA (predicted {_pred} -> {_pred2} bytes)",
+            file=_sys.stderr, flush=True,
+        )
+    K_STEP_QK = 16 if USE_K16 else 8
+    K_STEPS_QK = head_dim // K_STEP_QK
+    D_CHUNK = 32
+    D_CHUNKS = head_dim // D_CHUNK
+    PV_K_STEP = 16 if USE_K16 else 8
+    PV_K_STEPS = K_SUB_N // PV_K_STEP  # 2 steps per sub-tile (K=16) or 4 (K=8)
+
+    assert BLOCK_M % NUM_WAVES == 0
+    assert head_dim % 32 == 0, f"head_dim ({head_dim}) must be divisible by 32"
+    assert head_dim >= 64, f"head_dim ({head_dim}) must be >= 64"
+    assert flat_work_group_size in (128, 256, 512), (
+        f"flat_work_group_size must be 128, 256, or 512, got {flat_work_group_size}"
+    )
+    assert dtype_str in ("f16", "bf16"), "v4_hca_bwd_dq_pool only supports f16 and bf16"
+    assert BLOCK_N % 32 == 0
+    assert BLOCK_N_OUT == BLOCK_N
+    assert isinstance(pool_size, int) and 0 < pool_size <= BLOCK_N, (
+        f"pool_size must be int in (0, {BLOCK_N}], got {pool_size!r}")
+    assert isinstance(hca_local_seqlen, int) and hca_local_seqlen >= 0, (
+        f"hca_local_seqlen must be int >= 0, got {hca_local_seqlen!r}")
+    assert hca_local_seqlen % BLOCK_N == 0, (
+        f"hca_local_seqlen must be multiple of BLOCK_N={BLOCK_N}, got {hca_local_seqlen}")
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    STRIDE_TOKEN = NUM_HEADS * HEAD_DIM
+
+    K_STRIDE = HEAD_DIM
+    # XOR swizzle mask must fit within the row stride. The swizzle is
+    # applied at 16-element granularity, so the maximum mask is
+    # `(K_STRIDE // 16 - 1) << 4`. For D=128 that's 7 (=0x7), giving max
+    # mask 112 < 128. For D=64 it's 3 (=0x3), giving max mask 48 < 64.
+    # SLA test only covers D=128 (mask=7); using a hardcoded `& 7` for
+    # D=64 wraps writes into adjacent rows -> silent corruption.
+    K_SWZ_ROW_MASK = (K_STRIDE // 16) - 1
+    assert K_SWZ_ROW_MASK >= 0
+    assert (K_SWZ_ROW_MASK & (K_SWZ_ROW_MASK + 1)) == 0, (
+        f"K_SWZ_ROW_MASK must be 2^n-1, got {K_SWZ_ROW_MASK} (K_STRIDE={K_STRIDE})"
+    )
+    if USE_HW_TR:
+        V_STRIDE = HEAD_DIM if ENABLE_DMA else HEAD_DIM + 4
+    else:
+        VT_STRIDE = BLOCK_N + 2
+        V_STRIDE = VT_STRIDE
+    # V swizzle: similarly bounded by V_STRIDE / 16.
+    V_SWZ_ROW_MASK = min(3, (V_STRIDE // 16) - 1)
+    assert V_SWZ_ROW_MASK >= 0
+
+    VEC_WIDTH = 16 if ENABLE_LDS_VEC16 else 8
+    assert HEAD_DIM % VEC_WIDTH == 0
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+        NUM_BATCHES_KV = 1
+        KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+    else:
+        assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0
+        NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+        KV_NEEDS_GUARD = False
+
+    LDS_K_TILE_SIZE = BLOCK_N * K_STRIDE
+    if USE_HW_TR:
+        LDS_V_TILE_SIZE = BLOCK_N * V_STRIDE
+    else:
+        LDS_V_TILE_SIZE = HEAD_DIM * VT_STRIDE
+    LDS_K_TOTAL_SIZE = NUM_PREFETCH_K * LDS_K_TILE_SIZE
+    LDS_V_BASE = LDS_K_TOTAL_SIZE
+    LDS_V_TOTAL_SIZE = NUM_PREFETCH_V * LDS_V_TILE_SIZE
+    LDS_KV_TOTAL_SIZE = LDS_K_TOTAL_SIZE + LDS_V_TOTAL_SIZE
+
+    allocator = SmemAllocator(
+        None,
+        arch=gpu_arch,
+        global_sym_name=f"v4_hca_bwd_dq_pool_smem_M{BLOCK_M}_P{pool_size}_L{hca_local_seqlen}_MQ{int(mqa_kv)}",
+    )
+    lds_kv_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_kv_offset + LDS_KV_TOTAL_SIZE * 2
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_hca_bwd_dq_pool_kernel(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,      # grad of output (input)
+        LSE: fx.Tensor,      # log-sum-exp from fwd (input, f32, RAW domain, JOINT)
+        DELTAS: fx.Tensor,   # (o * do).sum(-1) preprocess (input, f32)
+        DQ: fx.Tensor,       # grad wrt Q (output, FP32, ACCUMULATED)
+        ADD_MASK: fx.Tensor, # additive pool mask (input, bf16/f16, [Sq, POOL_SIZE])
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        compute_type = T.f32
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        k_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K)
+        v_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V)
+        do_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DOS)
+        dq_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DQ)
+        add_mask_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), ADD_MASK)
+        # LSE / DELTAS: f32 scalar READS via buffer_load.
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+        deltas_rsrc = buffer_ops.create_buffer_resource(DELTAS, max_size=True)
+
+        # All FP operations use aggressive fast-math (no NaN/Inf checks, reassociation).
+        fm_fast = arith.FastMathFlags.fast
+        v4f16_type = T.vec(4, elem_type)
+        vxf16_type = T.vec(VEC_WIDTH, elem_type)
+        v8f16_type = T.vec(8, elem_type)
+        v16f32_type = T.vec(16, compute_type)
+        mfma_pack_type = v8f16_type if USE_K16 else v4f16_type
+        MFMA_LANE_K = 8 if USE_K16 else 4
+        _mfma_zero = ir.IntegerAttr.get(ir.IntegerType.get_signless(32), 0)
+
+        def _mfma(ods_fn, a, b, c):
+            return ods_fn(v16f32_type, a, b, c, _mfma_zero, _mfma_zero, _mfma_zero).result
+
+        def mfma_acc(a, b, c):
+            if dtype_str == "bf16":
+                if USE_K16:
+                    return _mfma(rocdl.mfma_f32_32x32x16_bf16, a, b, c)
+                a = vector.bitcast(T.i16x4, a)
+                b = vector.bitcast(T.i16x4, b)
+                return _mfma(rocdl.mfma_f32_32x32x8bf16_1k, a, b, c)
+            if USE_K16:
+                return _mfma(rocdl.mfma_f32_32x32x16_f16, a, b, c)
+            return _mfma(rocdl.mfma_f32_32x32x8f16, a, b, c)
+
+        seq_len_q_v = arith.index_cast(T.index, seq_len_q)
+        seq_len_k_v = arith.index_cast(T.index, seq_len_k)
+
+        # ---- LDS view ----
+        base_ptr = allocator.get_base()
+        lds_kv = SmemPtr(
+            base_ptr,
+            lds_kv_offset,
+            elem_type,
+            shape=(LDS_KV_TOTAL_SIZE,),
+        ).get()
+
+        # ---- Thread / block indices ----
+        block_id = arith.index_cast(T.index, gpu.block_idx.x)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+
+        wave_id = tid // WARP_SIZE
+        lane = tid % WARP_SIZE
+        lane_mod_32 = lane % 32
+        lane_div_32 = lane // 32  # 0/1
+
+        # ds_read_b64_tr_b16 lane decomposition
+        tr_k_group = (lane % 16) // 4
+        tr_col_sub = lane % 4
+        tr_col_half = (lane % 32) // 16
+
+        def ds_read_tr_v4f16(lds_elem_idx):
+            byte_offset = lds_elem_idx * 2 + lds_kv_offset
+            byte_i64 = arith.index_cast(T.i64, byte_offset)
+            ptr = _llvm.IntToPtrOp(_llvm_lds_ptr_ty(), byte_i64).result
+            return rocdl.ds_read_tr16_b64(v4f16_type, ptr).result
+
+        wave_q_offset = wave_id * ROWS_PER_WAVE
+
+        # ---- Decompose block_id: (batch, q_tile, head) ----
+        head_idx = block_id % NUM_HEADS
+        batch_q_tile_id = block_id // NUM_HEADS
+        num_q_tiles = (seq_len_q_v + BLOCK_M - 1) // BLOCK_M
+        q_tile_idx = batch_q_tile_id % num_q_tiles
+        batch_idx = batch_q_tile_id // num_q_tiles
+        q_start = q_tile_idx * BLOCK_M
+
+        # ---- V4 HCA POOL: fixed K-block range [HCA_LOCAL_SEQLEN, HCA_LOCAL_SEQLEN+POOL_SIZE) ----
+        # POOL_SIZE <= BLOCK_N and HCA_LOCAL_SEQLEN % BLOCK_N == 0 (asserted
+        # at build time), so this is exactly ONE n-block per program.
+        BN = arith.index(BLOCK_N)
+        BM = arith.index(BLOCK_M)
+        _zero_idx = arith.index(0)
+        _one_idx = arith.index(1)
+        n_block_start = arith.index(hca_local_seqlen // BLOCK_N)
+        n_block_end = n_block_start + _one_idx
+
+        # ---- Cooperative load decomposition ----
+        load_row_in_batch = tid // THREADS_PER_ROW_LOAD
+        load_lane_in_row = tid % THREADS_PER_ROW_LOAD
+        load_col_base = load_lane_in_row * VEC_WIDTH
+
+        # ---- Helper: global flat index ----
+        if layout_bhld:
+            bh_base_tokens_q = (batch_idx * NUM_HEADS + head_idx) * seq_len_q_v
+            if mqa_kv:
+                bh_base_tokens_kv = batch_idx * seq_len_k_v
+            else:
+                bh_base_tokens_kv = (batch_idx * NUM_HEADS + head_idx) * seq_len_k_v
+
+            def global_idx_q(token_idx, col):
+                return (bh_base_tokens_q + token_idx) * arith.index(HEAD_DIM) + col
+
+            def global_idx_kv(token_idx, col):
+                return (bh_base_tokens_kv + token_idx) * arith.index(HEAD_DIM) + col
+        else:
+            # BLHD path: kept for symmetry but V4 uses BHLD.
+            def global_idx_q(token_idx, col):
+                token = batch_idx * seq_len_q_v + token_idx
+                return token * STRIDE_TOKEN + head_idx * HEAD_DIM + col
+
+            if mqa_kv:
+                def global_idx_kv(token_idx, col):
+                    token = batch_idx * seq_len_k_v + token_idx
+                    return token * HEAD_DIM + col
+            else:
+                def global_idx_kv(token_idx, col):
+                    token = batch_idx * seq_len_k_v + token_idx
+                    return token * STRIDE_TOKEN + head_idx * HEAD_DIM + col
+
+        def _gep_load(base_ptr_, elem_idx, vec_type, et=elem_type):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=et,
+                              noWrapFlags=0)
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def _gep_store_f32(val, base_ptr_, elem_idx):
+            """Store a single f32 value via GEP into an fp32 buffer."""
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=T.f32,
+                              noWrapFlags=0)
+            _llvm.StoreOp(val, gep.result)
+
+        def load_global_mfma_pack(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, mfma_pack_type)
+
+        def load_global_f16xN(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, vxf16_type)
+
+        def bf16_trunc_pack_v4(f32_vals):
+            _v2i32 = T.vec(2, T.i32)
+            _c16 = arith.constant(16, type=T.i32)
+            _cmask = arith.constant(0xFFFF0000, type=T.i32)
+            a0 = arith.ArithValue(f32_vals[0]).bitcast(T.i32)
+            b0 = arith.ArithValue(f32_vals[1]).bitcast(T.i32)
+            p0 = arith.OrIOp(arith.AndIOp(b0, _cmask).result,
+                             arith.ShRUIOp(a0, _c16).result).result
+            a1 = arith.ArithValue(f32_vals[2]).bitcast(T.i32)
+            b1 = arith.ArithValue(f32_vals[3]).bitcast(T.i32)
+            p1 = arith.OrIOp(arith.AndIOp(b1, _cmask).result,
+                             arith.ShRUIOp(a1, _c16).result).result
+            return vector.bitcast(v4f16_type, vector.from_elements(_v2i32, [p0, p1]))
+
+        def bf16_trunc_pack_v8(f32_vals):
+            _v4i32 = T.vec(4, T.i32)
+            _c16 = arith.constant(16, type=T.i32)
+            _cmask = arith.constant(0xFFFF0000, type=T.i32)
+            pairs = []
+            for j in range_constexpr(4):
+                a = arith.ArithValue(f32_vals[j * 2]).bitcast(T.i32)
+                b = arith.ArithValue(f32_vals[j * 2 + 1]).bitcast(T.i32)
+                p = arith.OrIOp(arith.AndIOp(b, _cmask).result,
+                                arith.ShRUIOp(a, _c16).result).result
+                pairs.append(p)
+            return vector.bitcast(v8f16_type, vector.from_elements(_v4i32, pairs))
+
+        def k_buf_base(buf_id):
+            if isinstance(buf_id, int):
+                return arith.index(buf_id * LDS_K_TILE_SIZE)
+            return buf_id * arith.index(LDS_K_TILE_SIZE)
+
+        def v_buf_base(buf_id):
+            if isinstance(buf_id, int):
+                return arith.index(LDS_V_BASE + buf_id * LDS_V_TILE_SIZE)
+            return arith.index(LDS_V_BASE) + buf_id * arith.index(LDS_V_TILE_SIZE)
+
+        # ---- K XOR swizzle: col ^ ((row & K_SWZ_ROW_MASK) << 4) at 16-element granularity ----
+        # K_SWZ_ROW_MASK derived from K_STRIDE to stay within the row.
+        def _k_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return col_idx ^ mask
+
+        # ---- Cooperative K load (row-major, XOR-swizzled) ----
+        def coop_load_k(tile_start, buf_id=0):
+            """K row-bounds-aware cooperative load.
+
+            Pool kernel reads BLOCK_N rows starting at kv_start; for pool
+            sizes < BLOCK_N the top rows are past seq_len_k and would read
+            garbage. Gate each load with row_idx < seq_len_k_v and store
+            zero into the LDS slot for OOB rows.
+            """
+            k_base = k_buf_base(buf_id)
+            c_zero_vxf16 = arith.constant_vector(0.0, vxf16_type)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid_blk = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    row_valid = arith.AndIOp(row_valid_blk, row_valid_seq).result
+                    lds_row = load_row_in_batch + row_offset
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(k_ptr, g_idx)
+                    vec = arith.select(row_valid, raw_vec, c_zero_vxf16)
+                    _if_k = scf.IfOp(arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch, arith.index(BLOCK_N),
+                    ))
+                    with ir.InsertionPoint(_if_k.then_block):
+                        vector.store(vec, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    lds_row = load_row_in_batch + row_offset
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(k_ptr, g_idx)
+                    vec = arith.select(row_valid_seq, raw_vec, c_zero_vxf16)
+                    vector.store(vec, lds_kv, [lds_idx])
+
+        # ---- Cooperative V-into-K-LDS-slot load (K-style XOR swizzle) ----
+        def coop_load_v_as_k(tile_start, buf_id=0):
+            """V-into-K-slot with row bounds check (zero OOB rows)."""
+            k_base = k_buf_base(buf_id)
+            c_zero_vxf16 = arith.constant_vector(0.0, vxf16_type)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid_blk = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    row_valid = arith.AndIOp(row_valid_blk, row_valid_seq).result
+                    lds_row = load_row_in_batch + row_offset
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(v_ptr, g_idx)
+                    vec = arith.select(row_valid, raw_vec, c_zero_vxf16)
+                    _if_v = scf.IfOp(arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch, arith.index(BLOCK_N),
+                    ))
+                    with ir.InsertionPoint(_if_v.then_block):
+                        vector.store(vec, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    lds_row = load_row_in_batch + row_offset
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(v_ptr, g_idx)
+                    vec = arith.select(row_valid_seq, raw_vec, c_zero_vxf16)
+                    vector.store(vec, lds_kv, [lds_idx])
+
+        # ---- Cooperative V load (V LDS layout) ----
+        def _v_store_row_major(v_base, lds_row, vec):
+            lds_idx = v_base + lds_row * V_STRIDE + load_col_base
+            vector.store(vec, lds_kv, [lds_idx])
+
+        _v1_type = T.vec(1, elem_type) if not USE_HW_TR else None
+
+        def _v_store_transposed(v_base, lds_row, vec):
+            for _e in range_constexpr(VEC_WIDTH):
+                elem = vector.extract(vec, static_position=[_e], dynamic_position=[])
+                vt_d = load_col_base + _e
+                vt_idx = v_base + vt_d * VT_STRIDE + lds_row
+                v1 = vector.from_elements(_v1_type, [elem])
+                vector.store(v1, lds_kv, [vt_idx])
+
+        _v_store_to_lds = _v_store_row_major if USE_HW_TR else _v_store_transposed
+
+        def coop_load_v(tile_start, buf_id=0):
+            v_base = v_buf_base(buf_id)
+            c_zero_vxf16 = arith.constant_vector(0.0, vxf16_type)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid_blk = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    row_valid = arith.AndIOp(row_valid_blk, row_valid_seq).result
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(v_ptr, g_idx)
+                    vec = arith.select(row_valid, raw_vec, c_zero_vxf16)
+                    _if_v = scf.IfOp(arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch, arith.index(BLOCK_N),
+                    ))
+                    with ir.InsertionPoint(_if_v.then_block):
+                        lds_row = load_row_in_batch + row_offset
+                        _v_store_to_lds(v_base, lds_row, vec)
+                        scf.YieldOp([])
+                else:
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(v_ptr, g_idx)
+                    vec = arith.select(row_valid_seq, raw_vec, c_zero_vxf16)
+                    lds_row = load_row_in_batch + row_offset
+                    _v_store_to_lds(v_base, lds_row, vec)
+
+        # ---- Cooperative K-into-V-LDS-slot load ----
+        def coop_load_k_as_v(tile_start, buf_id=0):
+            """K-into-V-slot with row bounds check (zero OOB rows)."""
+            v_base = v_buf_base(buf_id)
+            c_zero_vxf16 = arith.constant_vector(0.0, vxf16_type)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid_blk = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    row_valid = arith.AndIOp(row_valid_blk, row_valid_seq).result
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(k_ptr, g_idx)
+                    vec = arith.select(row_valid, raw_vec, c_zero_vxf16)
+                    _if_v = scf.IfOp(arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch, arith.index(BLOCK_N),
+                    ))
+                    with ir.InsertionPoint(_if_v.then_block):
+                        lds_row = load_row_in_batch + row_offset
+                        _v_store_to_lds(v_base, lds_row, vec)
+                        scf.YieldOp([])
+                else:
+                    row_valid_seq = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        row_idx, seq_len_k_v,
+                    )
+                    g_idx_safe_row = arith.select(row_valid_seq, row_idx, arith.index(0))
+                    g_idx = global_idx_kv(g_idx_safe_row, load_col_base)
+                    raw_vec = load_global_f16xN(k_ptr, g_idx)
+                    vec = arith.select(row_valid_seq, raw_vec, c_zero_vxf16)
+                    lds_row = load_row_in_batch + row_offset
+                    _v_store_to_lds(v_base, lds_row, vec)
+
+        # ---- DMA loading for K (buffer_load_dwordx4 ... lds) ----
+        if ENABLE_DMA:
+            from flydsl._mlir.dialects import llvm
+            k_rsrc = buffer_ops.create_buffer_resource(K, max_size=True)
+            _lds_ptr_ty = _llvm_lds_ptr_ty()
+            DMA_BYTES = 16
+            DMA_BATCH_BYTES = BLOCK_SIZE * DMA_BYTES
+            K_TILE_BYTES = BLOCK_N * K_STRIDE * 2
+            NUM_DMA_K = K_TILE_BYTES // DMA_BATCH_BYTES
+            LANES_PER_K_ROW = HEAD_DIM * 2 // DMA_BYTES
+            ROWS_PER_DMA_BATCH = DMA_BATCH_BYTES // (HEAD_DIM * 2)
+            lds_kv_base_idx = _memref.extract_aligned_pointer_as_index(lds_kv)
+            _dma_size = arith.constant(DMA_BYTES, type=T.i32)
+            _dma_soff = arith.constant(0, type=T.i32)
+            _dma_off = arith.constant(0, type=T.i32)
+            _dma_aux = arith.constant(1, type=T.i32)
+
+            def _kv_global_byte(tile_start, row_in_tile, col_byte):
+                if layout_bhld:
+                    row_within = tile_start + row_in_tile
+                    return ((bh_base_tokens_kv + row_within)
+                            * arith.index(HEAD_DIM * 2) + col_byte)
+                else:
+                    global_row = (batch_idx * seq_len_k_v + tile_start + row_in_tile)
+                    if mqa_kv:
+                        return (global_row * arith.index(HEAD_DIM * 2) + col_byte)
+                    else:
+                        return (global_row * arith.index(STRIDE_TOKEN * 2)
+                                + head_idx * arith.index(HEAD_DIM * 2)
+                                + col_byte)
+
+            def coop_dma_k(tile_start, buf_id=0):
+                if isinstance(buf_id, int):
+                    k_lds_byte_base = lds_kv_base_idx + arith.index(buf_id * LDS_K_TILE_SIZE * 2)
+                else:
+                    k_lds_byte_base = lds_kv_base_idx + buf_id * arith.index(LDS_K_TILE_SIZE * 2)
+                for d in range_constexpr(NUM_DMA_K):
+                    lds_addr = (k_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_K_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH))
+                    swiz_col_f16 = (tid % LANES_PER_K_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        k_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+        def _v_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(V_SWZ_ROW_MASK)) << arith.index(4)
+            return col_idx ^ mask
+
+        if ENABLE_DMA:
+            v_rsrc = buffer_ops.create_buffer_resource(V, max_size=True)
+            V_TILE_BYTES = BLOCK_N * V_STRIDE * 2
+            NUM_DMA_V = V_TILE_BYTES // DMA_BATCH_BYTES
+            LANES_PER_V_ROW = HEAD_DIM * 2 // DMA_BYTES
+            ROWS_PER_DMA_BATCH_V = DMA_BATCH_BYTES // (HEAD_DIM * 2)
+
+            def coop_dma_v(tile_start, buf_id=0):
+                v_lds_byte_base = (lds_kv_base_idx
+                                   + arith.index((LDS_V_BASE + buf_id * LDS_V_TILE_SIZE) * 2))
+                for d in range_constexpr(NUM_DMA_V):
+                    lds_addr = (v_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_V_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH_V))
+                    swiz_col_f16 = (tid % LANES_PER_V_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(V_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        v_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+            # ---- Bwd dQ DMA variants (cross-pointer, matching swizzle) ----
+            def coop_dma_v_as_k(tile_start, buf_id=0):
+                if isinstance(buf_id, int):
+                    k_lds_byte_base = lds_kv_base_idx + arith.index(buf_id * LDS_K_TILE_SIZE * 2)
+                else:
+                    k_lds_byte_base = lds_kv_base_idx + buf_id * arith.index(LDS_K_TILE_SIZE * 2)
+                for d in range_constexpr(NUM_DMA_K):
+                    lds_addr = (k_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_K_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH))
+                    swiz_col_f16 = (tid % LANES_PER_K_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        v_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+            def coop_dma_k_as_v(tile_start, buf_id=0):
+                if isinstance(buf_id, int):
+                    v_lds_byte_base = (lds_kv_base_idx
+                                       + arith.index((LDS_V_BASE + buf_id * LDS_V_TILE_SIZE) * 2))
+                else:
+                    v_lds_byte_base = (lds_kv_base_idx
+                                       + arith.index(LDS_V_BASE * 2)
+                                       + buf_id * arith.index(LDS_V_TILE_SIZE * 2))
+                for d in range_constexpr(NUM_DMA_V):
+                    lds_addr = (v_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_V_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH_V))
+                    swiz_col_f16 = (tid % LANES_PER_V_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(V_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        k_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+        # ---- Preload Q^T B-operand and DO^T B-operand packs ----
+        q_row = q_start + wave_q_offset + lane_mod_32
+        q_in_bounds = arith.cmpi(arith.CmpIPredicate.slt, q_row, seq_len_q_v)
+        q_row_safe = arith.select(q_in_bounds, q_row, arith.index(0))
+        c_zero_mfma_pack = arith.constant_vector(0.0, mfma_pack_type)
+        q_b_packs = []
+        do_b_packs = []
+        for ks in range_constexpr(K_STEPS_QK):
+            col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+            g_idx = global_idx_q(q_row_safe, col)
+            q_raw = load_global_mfma_pack(q_ptr, g_idx)
+            q_b_packs.append(arith.select(q_in_bounds, q_raw, c_zero_mfma_pack))
+            do_raw = load_global_mfma_pack(do_ptr, g_idx)
+            do_b_packs.append(arith.select(q_in_bounds, do_raw, c_zero_mfma_pack))
+
+        # ---- Constants ----
+        c_zero_f = arith.constant(0.0, type=compute_type)
+        c_neg_inf = arith.constant(-1.0e30, type=compute_type)  # finite NEG_INF (matches Triton)
+        c_zero_v16f32 = arith.constant_vector(0.0, v16f32_type)
+        # V4 LSE is RAW-domain (qk*sm_scale + ln(l)). So use sm_scale, not sm_scale*log2e.
+        c_sm_scale = arith.constant(sm_scale, type=compute_type)
+
+        # ---- Per-q-row scalars (LSE, delta) ----
+        # bh_base_tokens_q is the Q LSE/DELTAS base too (LSE shape [B,HQ,Sq]).
+        lse_delta_off_i32 = arith.index_cast(
+            T.i32, bh_base_tokens_q + q_row_safe)
+        lse_val = buffer_ops.buffer_load(
+            lse_rsrc, lse_delta_off_i32, vec_width=1, dtype=T.f32,
+        )
+        delta_val = buffer_ops.buffer_load(
+            deltas_rsrc, lse_delta_off_i32, vec_width=1, dtype=T.f32,
+        )
+
+        # ---- (No SINK contribution: pool kernel does not touch sink.) ----
+
+        # ---- POOL: single n-block; double-buffered LDS optional ----
+        _use_dbuf = ENABLE_DMA
+
+        init_args = []
+        for _ in range_constexpr(D_CHUNKS):
+            init_args.append(c_zero_v16f32)
+        if _use_dbuf:
+            init_args.append(arith.index(0))  # cur_buf_id
+
+            # PROLOGUE: prefetch iter 0's K into BOTH slots of buf 0.
+            _init_kv_start = n_block_start * BN
+            coop_dma_k(_init_kv_start, buf_id=0)
+            coop_dma_k_as_v(_init_kv_start, buf_id=0)
+
+        for block_idx, inner_iter_args, loop_results in scf.for_(
+            n_block_start,
+            n_block_end,
+            arith.index(1),
+            iter_args=init_args,
+        ):
+            dq_accs = [
+                inner_iter_args[i] for i in range_constexpr(D_CHUNKS)
+            ]
+            if _use_dbuf:
+                cur_buf = inner_iter_args[D_CHUNKS]
+                next_buf = arith.index(1) - cur_buf
+
+            # V4 SWA: block_idx is directly the K-block index.
+            kv_block_start = block_idx * BN
+            kv_start = kv_block_start
+
+            if _use_dbuf:
+                rocdl.s_waitcnt(0)
+                gpu.barrier()
+                k_base = k_buf_base(cur_buf)
+            else:
+                coop_load_k(kv_start, buf_id=0)
+                coop_load_k_as_v(kv_start, buf_id=0)
+                gpu.barrier()
+                k_base = k_buf_base(0)
+
+            # ==== GEMM1: s = Q @ K^T ====
+            k_hi_offset = K_SUB_N * K_STRIDE
+            k_swz_mask = (lane_mod_32 & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+
+            def _k_idx_lo(ks):
+                col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+                return k_base + lane_mod_32 * K_STRIDE + (col ^ k_swz_mask)
+
+            def _k_idx_hi(ks):
+                col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+                return (k_base + k_hi_offset
+                        + lane_mod_32 * K_STRIDE + (col ^ k_swz_mask))
+
+            s_acc_lo = c_zero_v16f32
+            s_acc_hi = c_zero_v16f32
+            for ks in range_constexpr(K_STEPS_QK):
+                k_pack_lo = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_lo(ks)])
+                k_pack_hi = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_hi(ks)])
+                s_acc_lo = mfma_acc(k_pack_lo, q_b_packs[ks], s_acc_lo)
+                s_acc_hi = mfma_acc(k_pack_hi, q_b_packs[ks], s_acc_hi)
+
+            # ==== Compute p[r] = exp((qk + add_bias) * sm_scale_inline - LSE) ====
+            #
+            # POOL-only mask. The s_acc registers map (per lane, per reg r) to
+            # the S = Q @ K^T cell at row = q_row (= lane_mod_32 + wave_q_offset
+            # + q_start) and column = kv_start + lane_div_32*4 + (r//4)*8 + r%4
+            # (lo half), or +K_SUB_N (hi half). Translate to pool_n by
+            # subtracting HCA_LOCAL_SEQLEN; gate with pool_n < POOL_SIZE and
+            # q_row < seq_len_q.
+            seq_len_q_i32 = arith.index_cast(T.i32, seq_len_q_v)
+            q_row_i32_mask = arith.index_cast(T.i32, q_row)
+            lane_div_32_i32 = arith.index_cast(T.i32, lane_div_32)
+            lane_off_i32 = arith.MulIOp(
+                lane_div_32_i32, arith.constant(4, type=T.i32)).result
+            hca_local_i32 = arith.constant(hca_local_seqlen, type=T.i32)
+            pool_size_i32 = arith.constant(pool_size, type=T.i32)
+            kv_start_i32 = arith.index_cast(T.i32, kv_start)
+            # pool_n base for this lane = kv_start + lane_off - hca_local_seqlen
+            # (kv_start = hca_local_seqlen + 0 for the single pool block).
+            pool_n_base_i32 = arith.SubIOp(
+                arith.AddIOp(kv_start_i32, lane_off_i32).result,
+                hca_local_i32,
+            ).result
+
+            # Is this q_row out of bounds? -> entire row masked.
+            q_oob = arith.cmpi(
+                arith.CmpIPredicate.sge, q_row_i32_mask, seq_len_q_i32,
+            )
+
+            # --- Load add_bias from ADD_MASK[q_row, pool_n] via GEP ---
+            # ADD_MASK shape [Sq, POOL_SIZE] contiguous; element bytes = 2
+            # (bf16 / f16). For each (lane, r), compute pool_n (lo or hi) and
+            # load a single bf16/f16, then cast to f32.
+            ADD_MASK_STRIDE_M = arith.index(pool_size)  # row stride in elements
+            q_row_idx_for_mask = arith.select(q_oob, arith.index(0), q_row)
+            # Precompute add-mask row base offset in elements.
+            add_mask_row_base = q_row_idx_for_mask * ADD_MASK_STRIDE_M
+
+            def _load_add_bias(pool_n_i32, bad_pred):
+                """Load ADD_MASK[q_row, pool_n] as f32; return 0.0 if bad."""
+                # Convert pool_n to index for GEP.
+                pool_n_i32_safe = arith.select(
+                    bad_pred, arith.constant(0, type=T.i32), pool_n_i32,
+                )
+                pool_n_idx = arith.index_cast(T.index, pool_n_i32_safe)
+                elem_idx = add_mask_row_base + pool_n_idx
+                bias_raw_v1 = _gep_load(
+                    add_mask_ptr, elem_idx, T.vec(1, elem_type),
+                )
+                bias_raw = vector.extract(
+                    bias_raw_v1, static_position=[0], dynamic_position=[],
+                )
+                bias_f32 = arith.extf(compute_type, bias_raw)
+                # If bad (OOB pool_n or q_oob), zero out the bias (mask wins
+                # anyway via NEG_INF, but keep numerics tidy).
+                return arith.select(bad_pred, c_zero_f, bias_f32)
+
+            p_vals_lo = []
+            p_vals_hi = []
+            for r in range_constexpr(16):
+                r_off_i32 = arith.constant(
+                    (r % 4) + (r // 4) * 8, type=T.i32)
+
+                # --- lo half ---
+                pool_n_lo_i32 = arith.AddIOp(
+                    pool_n_base_i32, r_off_i32,
+                ).result
+                is_pool_oob_lo = arith.cmpi(
+                    arith.CmpIPredicate.sge, pool_n_lo_i32, pool_size_i32,
+                )
+                bad_lo = arith.OrIOp(is_pool_oob_lo, q_oob).result
+
+                s_lo_f32 = vector.extract(
+                    s_acc_lo, static_position=[r], dynamic_position=[])
+                bias_lo = _load_add_bias(pool_n_lo_i32, bad_lo)
+                qk_plus_bias_lo = arith.AddFOp(
+                    s_lo_f32, bias_lo, fastmath=fm_fast).result
+                # Triton: qk = qk * sm_scale; qk = qk + add_bias.
+                # We deferred sm_scale to here: (qk + bias) is wrong; need
+                # qk*scale + bias. Re-do as: s_scaled + bias.
+                scaled_lo = arith.MulFOp(
+                    s_lo_f32, c_sm_scale, fastmath=fm_fast).result
+                scaled_plus_bias_lo = arith.AddFOp(
+                    scaled_lo, bias_lo, fastmath=fm_fast).result
+                scaled_lo_masked = arith.select(
+                    bad_lo, c_neg_inf, scaled_plus_bias_lo,
+                )
+                diff_lo = arith.SubFOp(
+                    scaled_lo_masked, lse_val, fastmath=fm_fast).result
+                p_lo = math_dialect.exp(diff_lo, fastmath=fm_fast)
+                p_vals_lo.append(p_lo)
+
+                # --- hi half: pool_n_hi = pool_n_lo + K_SUB_N ---
+                pool_n_hi_i32 = arith.AddIOp(
+                    pool_n_lo_i32,
+                    arith.constant(K_SUB_N, type=T.i32),
+                ).result
+                is_pool_oob_hi = arith.cmpi(
+                    arith.CmpIPredicate.sge, pool_n_hi_i32, pool_size_i32,
+                )
+                bad_hi = arith.OrIOp(is_pool_oob_hi, q_oob).result
+
+                s_hi_f32 = vector.extract(
+                    s_acc_hi, static_position=[r], dynamic_position=[])
+                bias_hi = _load_add_bias(pool_n_hi_i32, bad_hi)
+                scaled_hi = arith.MulFOp(
+                    s_hi_f32, c_sm_scale, fastmath=fm_fast).result
+                scaled_plus_bias_hi = arith.AddFOp(
+                    scaled_hi, bias_hi, fastmath=fm_fast).result
+                scaled_hi_masked = arith.select(
+                    bad_hi, c_neg_inf, scaled_plus_bias_hi,
+                )
+                diff_hi = arith.SubFOp(
+                    scaled_hi_masked, lse_val, fastmath=fm_fast).result
+                p_hi = math_dialect.exp(diff_hi, fastmath=fm_fast)
+                p_vals_hi.append(p_hi)
+
+            # ==== Overwrite K LDS slot with V for GEMM2 ====
+            gpu.barrier()
+            if _use_dbuf:
+                coop_dma_v_as_k(kv_start, buf_id=cur_buf)
+                rocdl.s_waitcnt(0)
+                gpu.barrier()
+            elif ENABLE_DMA:
+                coop_dma_v_as_k(kv_start, buf_id=0)
+                rocdl.s_waitcnt(0)
+                gpu.barrier()
+            else:
+                coop_load_v_as_k(kv_start, buf_id=0)
+                gpu.barrier()
+
+            # ==== GEMM2: dP = DO @ V^T ====
+            dp_acc_lo = c_zero_v16f32
+            dp_acc_hi = c_zero_v16f32
+            for ks in range_constexpr(K_STEPS_QK):
+                v_pack_lo = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_lo(ks)])
+                v_pack_hi = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_hi(ks)])
+                dp_acc_lo = mfma_acc(v_pack_lo, do_b_packs[ks], dp_acc_lo)
+                dp_acc_hi = mfma_acc(v_pack_hi, do_b_packs[ks], dp_acc_hi)
+
+            # ==== Prefetch iter+1's K DMAs (async) ====
+            if _use_dbuf:
+                _next_block_idx = block_idx + arith.index(1)
+                _has_next = arith.cmpi(
+                    arith.CmpIPredicate.slt,
+                    _next_block_idx, n_block_end)
+                _pre_if = scf.IfOp(_has_next)
+                with ir.InsertionPoint(_pre_if.then_block):
+                    _next_kv_start = _next_block_idx * BN
+                    coop_dma_k(_next_kv_start, next_buf)
+                    coop_dma_k_as_v(_next_kv_start, next_buf)
+                    scf.YieldOp([])
+
+            # ==== Compute dS[r] = p[r] * (dp[r] - delta) ====
+            ds_vals_lo = []
+            ds_vals_hi = []
+            for r in range_constexpr(16):
+                dp_lo = vector.extract(
+                    dp_acc_lo, static_position=[r], dynamic_position=[])
+                dp_hi = vector.extract(
+                    dp_acc_hi, static_position=[r], dynamic_position=[])
+                diff_lo = arith.SubFOp(
+                    dp_lo, delta_val, fastmath=fm_fast).result
+                diff_hi = arith.SubFOp(
+                    dp_hi, delta_val, fastmath=fm_fast).result
+                ds_lo = arith.MulFOp(
+                    p_vals_lo[r], diff_lo, fastmath=fm_fast).result
+                ds_hi = arith.MulFOp(
+                    p_vals_hi[r], diff_hi, fastmath=fm_fast).result
+                ds_vals_lo.append(ds_lo)
+                ds_vals_hi.append(ds_hi)
+
+            # ==== Pack dS f32 -> mfma_pack_type (bf16/f16) ====
+            if dtype_str == "bf16" and USE_K16:
+                ds_packs_lo = []
+                ds_packs_hi = []
+                for pks in range_constexpr(PV_K_STEPS):
+                    base = pks * 8
+                    ds_packs_lo.append(bf16_trunc_pack_v8(
+                        ds_vals_lo[base:base+8]))
+                    ds_packs_hi.append(bf16_trunc_pack_v8(
+                        ds_vals_hi[base:base+8]))
+            elif dtype_str == "bf16":
+                ds_packs_lo = []
+                ds_packs_hi = []
+                for pks in range_constexpr(PV_K_STEPS):
+                    base = pks * 4
+                    ds_packs_lo.append(bf16_trunc_pack_v4(
+                        ds_vals_lo[base:base+4]))
+                    ds_packs_hi.append(bf16_trunc_pack_v4(
+                        ds_vals_hi[base:base+4]))
+            else:
+                ds_f16_lo = [arith.trunc_f(elem_type, ds_vals_lo[r])
+                             for r in range_constexpr(16)]
+                ds_f16_hi = [arith.trunc_f(elem_type, ds_vals_hi[r])
+                             for r in range_constexpr(16)]
+                _pack_ty = v8f16_type if USE_K16 else v4f16_type
+                _pw = 8 if USE_K16 else 4
+                ds_packs_lo = []
+                ds_packs_hi = []
+                for pks in range_constexpr(PV_K_STEPS):
+                    b = pks * _pw
+                    ds_packs_lo.append(vector.from_elements(
+                        _pack_ty, [ds_f16_lo[b + i] for i in range(_pw)]))
+                    ds_packs_hi.append(vector.from_elements(
+                        _pack_ty, [ds_f16_hi[b + i] for i in range(_pw)]))
+
+            # ==== GEMM3: dQ += K @ dS  (uses fwd's V-read schedule with K substituted) ====
+            _steps = [(dc, pks)
+                      for dc in range(D_CHUNKS)
+                      for pks in range(PV_K_STEPS)]
+            TOTAL_PV = len(_steps)
+            v_base = v_buf_base(cur_buf) if _use_dbuf else v_buf_base(0)
+
+            def _read_k_as_v_pack(step_idx):
+                dc, pks = _steps[step_idx]
+                if USE_HW_TR:
+                    d_col = (arith.index(dc * D_CHUNK)
+                             + tr_col_half * 16 + tr_col_sub * 4)
+                    k_row = (arith.index(pks * PV_K_STEP)
+                             + lane_div_32 * 4 + tr_k_group)
+                    _d_col_eff = _v_swizzle(k_row, d_col) if ENABLE_DMA else d_col
+                    lds_lo = v_base + k_row * V_STRIDE + _d_col_eff
+                    lds_hi = lds_lo + arith.index(K_SUB_N * V_STRIDE)
+                    if USE_K16:
+                        vl_a = ds_read_tr_v4f16(lds_lo)
+                        vl_b = ds_read_tr_v4f16(
+                            lds_lo + arith.index(8 * V_STRIDE))
+                        vl = vector.shuffle(
+                            vl_a, vl_b, [0, 1, 2, 3, 4, 5, 6, 7])
+                        vh_a = ds_read_tr_v4f16(lds_hi)
+                        vh_b = ds_read_tr_v4f16(
+                            lds_hi + arith.index(8 * V_STRIDE))
+                        vh = vector.shuffle(
+                            vh_a, vh_b, [0, 1, 2, 3, 4, 5, 6, 7])
+                    else:
+                        vl = ds_read_tr_v4f16(lds_lo)
+                        vh = ds_read_tr_v4f16(lds_hi)
+                else:
+                    d_pos = arith.index(dc * D_CHUNK) + lane_mod_32
+                    kb = arith.index(pks * PV_K_STEP) + lane_div_32 * 4
+                    v_lo_idx = v_base + d_pos * VT_STRIDE + kb
+                    v_hi_idx = v_lo_idx + arith.index(K_SUB_N)
+                    vl = vector.load(v4f16_type, lds_kv, [v_lo_idx])
+                    vh = vector.load(v4f16_type, lds_kv, [v_hi_idx])
+                return vl, vh
+
+            k_lo_cur, k_hi_cur = _read_k_as_v_pack(0)
+            for si in range_constexpr(TOTAL_PV):
+                dc, pks = _steps[si]
+                if si + 1 < TOTAL_PV:
+                    k_lo_nxt, k_hi_nxt = _read_k_as_v_pack(si + 1)
+                dq_accs[dc] = mfma_acc(
+                    k_lo_cur, ds_packs_lo[pks], dq_accs[dc])
+                dq_accs[dc] = mfma_acc(
+                    k_hi_cur, ds_packs_hi[pks], dq_accs[dc])
+                if si + 1 < TOTAL_PV:
+                    k_lo_cur = k_lo_nxt
+                    k_hi_cur = k_hi_nxt
+
+            # End of iter: yield dq_accs and swapped cur_buf.
+            gpu.barrier()
+            _yield = list(dq_accs)
+            if _use_dbuf:
+                _yield.append(next_buf)
+            yield _yield
+
+        # ---- Final store: dQ_fp32 += dq_acc * sm_scale (load + add + store) ----
+        # Pool kernel ACCUMULATES into the existing LOCAL-stream dq buffer.
+        # Race-free because each program owns a unique (b, qhid, m_block)
+        # slice, and the launcher runs this kernel sequentially AFTER the
+        # SWA dq kernel has finished writing the LOCAL contribution.
+        dq_finals = [
+            loop_results[dc] for dc in range_constexpr(D_CHUNKS)
+        ]
+        sm_scale_vec = vector.broadcast(v16f32_type, c_sm_scale)
+
+        def _gep_load_f32(base_ptr_, elem_idx):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=T.f32,
+                              noWrapFlags=0)
+            return _llvm.LoadOp(T.f32, gep.result).result
+
+        _o_guard = scf.IfOp(q_in_bounds, [], has_else=False)
+        with ir.InsertionPoint(_o_guard.then_block):
+            for dc in range_constexpr(D_CHUNKS):
+                dq_scaled = arith.MulFOp(
+                    dq_finals[dc], sm_scale_vec, fastmath=fm_fast,
+                ).result
+                for r in range_constexpr(16):
+                    dq_val = vector.extract(
+                        dq_scaled,
+                        static_position=[r],
+                        dynamic_position=[],
+                    )
+                    d_row_rel = lane_div_32 * 4 + (r // 4) * 8 + (r % 4)
+                    d_col = arith.index(dc * D_CHUNK) + d_row_rel
+                    dq_global = global_idx_q(q_row, d_col)
+                    dq_prev = _gep_load_f32(dq_ptr, dq_global)
+                    dq_sum = arith.AddFOp(
+                        dq_val, dq_prev, fastmath=fm_fast,
+                    ).result
+                    _gep_store_f32(dq_sum, dq_ptr, dq_global)
+            scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_hca_bwd_dq_pool(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        DQ: fx.Tensor,
+        ADD_MASK: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        sl_idx = arith.index_cast(T.index, seq_len_q)
+        num_q_tiles = (sl_idx + BLOCK_M - 1) // BLOCK_M
+        grid_x = bs_idx * num_q_tiles * NUM_HEADS
+
+        launcher = v4_hca_bwd_dq_pool_kernel(
+            Q, K, V, DOS, LSE, DELTAS, DQ, ADD_MASK, seq_len_q, seq_len_k,
+        )
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                            T.i32,
+                            _wpe,
+                        )
+        if flat_work_group_size is not None:
+            _fwgs = int(flat_work_group_size)
+            if _fwgs >= 1:
+                flat_wg_attr = ir.StringAttr.get(f"{_fwgs},{_fwgs}")
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.flat_work_group_size"] = flat_wg_attr
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, 1, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    _fmha_compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+        "llvm_options": {
+            "enable-post-misched": False,
+            "lsr-drop-solution": True,
+        },
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return launch_v4_hca_bwd_dq_pool(*args, **kwargs)
+
+    def _compile(Q, K, V, DOS, LSE, DELTAS, DQ, ADD_MASK,
+                 batch_size, seq_len_q, seq_len_k, stream=None):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return flyc.compile(
+                launch_v4_hca_bwd_dq_pool, Q, K, V, DOS, LSE, DELTAS, DQ, ADD_MASK,
+                batch_size, seq_len_q, seq_len_k, fx.Stream(stream))
+
+    _launch.compile = _compile
+
+    return _launch
+
+
+# Convenience alias.
+build_v4_hca_bwd_dq_pool_module_primary = build_v4_hca_bwd_dq_pool_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_bwd_dkv_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_bwd_dkv_kernel.py
@@ -1,0 +1,1170 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_swa_bwd_dkv: V4 SWA-causal attention backward dK/dV kernel for FlyDSL.
+
+Strategy:
+  * One workgroup per (batch, n_block). K and V loaded once into LDS
+    and stay resident for the program's lifetime (no LUT, no atomics).
+  * Inner loop iterates qhid in [0, HQ); for each head, iterates m-blocks
+    bounded by the SWA window. dK and dV f32 accumulators live in VGPRs.
+  * MQA head-loop accumulator: one dk/dv slice per (b, n_block) gets
+    all HQ heads accumulated -- deterministic, no atomics.
+  * SWA + causal mask per element. LSE is RAW-domain
+    (qk*sm_scale + ln(l)); p = exp(qk*sm_scale - lse).
+  * sm_scale applied to dK exactly once post-loop (Triton P57 cr=0).
+  * dK / dV written as f32 (matches launcher's dk_fp32 / dv_fp32 buffers).
+
+LDS budget at BLOCK_N=32, BLOCK_M2=32, D=512:
+    K = 32 KB, V = 32 KB, DO = 32 KB, Q = 32 KB, pT = 2 KB
+    Total = 130 KB <= 160 KB.
+Auto-fallback: if predicted > 160 KB, drop DO/Q LDS scratches and
+read Q/DO directly to register packs from HBM (mirrors STEP-1b dq).
+"""
+
+import math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import memref as _memref, scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+KERNEL_NAME = "v4_swa_bwd_dkv_kernel"
+
+_LLVM_GEP_DYNAMIC = -2147483648
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _llvm_lds_ptr_ty():
+    return ir.Type.parse("!llvm.ptr<3>")
+
+
+def build_v4_swa_bwd_dkv_module(
+    num_heads,
+    head_dim,
+    swa_window,
+    dtype_str="bf16",
+    sm_scale=None,
+    waves_per_eu=2,
+    flat_work_group_size=None,
+    block_n=None,
+    block_m2=None,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    layout_bhld=True,
+    mqa_kv=True,
+):
+    """Build the V4 SWA backward dK/dV launcher (MQA only)."""
+    gpu_arch = get_hip_arch()
+
+    if block_n is None:
+        # R6k-1: D-split wave remap default. BLOCK_N=16 halves per-lane
+        # fp32 accumulator footprint (256 -> 128 fp32) by partitioning D
+        # across waves instead of N. Both waves cover the same 16 KV
+        # rows; each wave owns half of the D-chunks of dk/dv.
+        BLOCK_N = 16
+    else:
+        BLOCK_N = int(block_n)
+    if block_m2 is None:
+        BLOCK_M2 = 32
+    else:
+        BLOCK_M2 = int(block_m2)
+    WARP_SIZE = 64
+    # R6k-1: D-split mode. When BLOCK_N == 16 (matches MFMA-N tile),
+    # force NUM_WAVES=2 and partition D between the two waves instead
+    # of partitioning N. Each wave then carries only half the dk/dv
+    # accumulator footprint. For BLOCK_N > 16 we keep the legacy N-split.
+    D_SPLIT_WAVES = (BLOCK_N == 16)
+    if D_SPLIT_WAVES:
+        NUM_WAVES = 2
+        ROWS_PER_WAVE = 16  # both waves work on the same 16 rows
+    else:
+        # Legacy N-split: each wave gets BLOCK_N/NUM_WAVES rows.
+        NUM_WAVES = max(1, BLOCK_N // 16)
+        ROWS_PER_WAVE = BLOCK_N // NUM_WAVES
+    if flat_work_group_size is None:
+        flat_work_group_size = NUM_WAVES * WARP_SIZE
+    BLOCK_SIZE = flat_work_group_size
+
+    ENABLE_LDS_VEC16 = (os.getenv("FLYDSL_SLA_FWD_ENABLE_LDS_VEC16", "1") == "1")
+    USE_K16 = gpu_arch.startswith("gfx950")
+    # R6b: MFMA 16x16x32 K-step = 32; A/B-frag = 8 bf16 per lane.
+    assert USE_K16, "R6b dkv requires gfx950 (MFMA 16x16x32 bf16)."
+    K_STEP_QK = 32
+    K_STEPS_QK = head_dim // K_STEP_QK
+    # R6b: each MFMA 16x16x32 tile produces a 16-wide N-chunk; D_CHUNK = 16 cols.
+    D_CHUNK = 16
+    D_CHUNKS = head_dim // D_CHUNK
+    # R6k-1: per-wave D-chunk count. In D-split mode each wave owns half.
+    if D_SPLIT_WAVES:
+        assert D_CHUNKS % NUM_WAVES == 0, (
+            f"D_CHUNKS ({D_CHUNKS}) must be divisible by NUM_WAVES "
+            f"({NUM_WAVES}) for D-split mode.")
+        D_CHUNKS_LOCAL = D_CHUNKS // NUM_WAVES
+    else:
+        D_CHUNKS_LOCAL = D_CHUNKS
+    K_STEPS_PT = BLOCK_M2 // K_STEP_QK
+    # R6b: GEMM1/GEMM3 cover m_col [0..BLOCK_M2) with multiple 16-col MFMA-N tiles per ks.
+    assert BLOCK_M2 % 16 == 0, f"BLOCK_M2 must be a multiple of 16 (MFMA-N), got {BLOCK_M2}"
+    M_TILES = BLOCK_M2 // 16
+
+    assert BLOCK_N % NUM_WAVES == 0
+    assert ROWS_PER_WAVE == 16, f"ROWS_PER_WAVE must equal 16 for MFMA 16x16x32, got {ROWS_PER_WAVE}"
+    assert head_dim % 32 == 0
+    assert head_dim >= 64
+    assert flat_work_group_size in (64, 128, 256, 512)
+    assert dtype_str == "bf16", "R6b dkv currently only supports bf16."
+    assert BLOCK_N % 16 == 0
+    assert BLOCK_M2 % K_STEP_QK == 0, (
+        f"BLOCK_M2 ({BLOCK_M2}) must be a multiple of MFMA K-step "
+        f"({K_STEP_QK}) for the dV/dK GEMMs.")
+    assert isinstance(swa_window, int) and swa_window > 0
+    assert mqa_kv, "v4_swa_bwd_dkv currently only supports MQA (HK=1)."
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+
+    K_STRIDE = HEAD_DIM
+    K_SWZ_ROW_MASK = (K_STRIDE // 16) - 1
+    assert K_SWZ_ROW_MASK >= 0
+    assert (K_SWZ_ROW_MASK & (K_SWZ_ROW_MASK + 1)) == 0
+    V_STRIDE = HEAD_DIM
+
+    VEC_WIDTH = 16 if ENABLE_LDS_VEC16 else 8
+    assert HEAD_DIM % VEC_WIDTH == 0
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    LDS_K_TILE_SIZE = BLOCK_N * K_STRIDE
+    LDS_V_TILE_SIZE = BLOCK_N * V_STRIDE
+    LDS_DO_STRIDE = HEAD_DIM
+    LDS_DO_ELEMS = BLOCK_M2 * LDS_DO_STRIDE
+    LDS_Q_STRIDE = HEAD_DIM
+    LDS_Q_ELEMS = BLOCK_M2 * LDS_Q_STRIDE
+    LDS_PT_STRIDE = BLOCK_M2
+    LDS_PT_ELEMS = BLOCK_N * LDS_PT_STRIDE
+
+    _LDS_LIMIT_BYTES = 160 * 1024
+
+    def _predict_lds_bytes(use_lds_for_q_do):
+        b = (LDS_K_TILE_SIZE + LDS_V_TILE_SIZE + LDS_PT_ELEMS) * 2
+        if use_lds_for_q_do:
+            b += (LDS_DO_ELEMS + LDS_Q_ELEMS) * 2
+        return b
+
+    USE_LDS_FOR_Q_DO = True
+    _pred_full = _predict_lds_bytes(True)
+    if _pred_full > _LDS_LIMIT_BYTES:
+        USE_LDS_FOR_Q_DO = False
+        _pred_min = _predict_lds_bytes(False)
+        if _pred_min > _LDS_LIMIT_BYTES:
+            raise RuntimeError(
+                f"v4_swa_bwd_dkv: minimal LDS {_pred_min}B > limit "
+                f"{_LDS_LIMIT_BYTES}B at D={head_dim}, BLOCK_N={BLOCK_N}, "
+                f"BLOCK_M2={BLOCK_M2}."
+            )
+        import sys as _sys
+        print(f"[v4_swa_bwd_dkv] auto-fallback: LDS {_pred_full}B > "
+              f"{_LDS_LIMIT_BYTES}B; disabling Q/DO LDS "
+              f"({_pred_full} -> {_pred_min})",
+              file=_sys.stderr, flush=True)
+    else:
+        import sys as _sys
+        print(f"[v4_swa_bwd_dkv] LDS OK: predicted {_pred_full}B <= "
+              f"{_LDS_LIMIT_BYTES}B at D={head_dim}, BLOCK_N={BLOCK_N}, "
+              f"BLOCK_M2={BLOCK_M2}, USE_LDS_FOR_Q_DO=True",
+              file=_sys.stderr, flush=True)
+
+    allocator = SmemAllocator(
+        None, arch=gpu_arch,
+        global_sym_name=(
+            f"v4_swa_bwd_dkv_smem_N{BLOCK_N}_M2_{BLOCK_M2}_W{swa_window}"
+            f"_MQ{int(mqa_kv)}_QDO{int(USE_LDS_FOR_Q_DO)}"
+            f"_DS{int(D_SPLIT_WAVES)}"),
+    )
+    lds_kv_offset = allocator._align(allocator.ptr, 16)
+    LDS_V_BASE = LDS_K_TILE_SIZE
+    LDS_KV_TOTAL_SIZE = LDS_K_TILE_SIZE + LDS_V_TILE_SIZE
+    allocator.ptr = lds_kv_offset + LDS_KV_TOTAL_SIZE * 2
+
+    lds_pt_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_pt_offset + LDS_PT_ELEMS * 2
+
+    if USE_LDS_FOR_Q_DO:
+        lds_do_offset = allocator._align(allocator.ptr, 16)
+        allocator.ptr = lds_do_offset + LDS_DO_ELEMS * 2
+        lds_q_offset = allocator._align(allocator.ptr, 16)
+        allocator.ptr = lds_q_offset + LDS_Q_ELEMS * 2
+    else:
+        lds_do_offset = None
+        lds_q_offset = None
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_swa_bwd_dkv_kernel(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        DK: fx.Tensor,
+        DV: fx.Tensor,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        compute_type = T.f32
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        k_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K)
+        v_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V)
+        do_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DOS)
+        dk_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DK)
+        dv_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DV)
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+        deltas_rsrc = buffer_ops.create_buffer_resource(DELTAS, max_size=True)
+
+        fm_fast = arith.FastMathFlags.fast
+        vxf16_type = T.vec(VEC_WIDTH, elem_type)
+        v8f16_type = T.vec(8, elem_type)
+        # R6M: tr16 returns 4 bf16 per lane (v4f16-typed). Two calls + shuffle
+        # form the MFMA 16x16x32 B-frag (8 bf16) via HW transpose.
+        v4f16_type = T.vec(4, elem_type)
+        # R6b: MFMA 16x16x32 C-frag = 4 fp32 per lane.
+        v4f32_type = T.vec(4, compute_type)
+        mfma_pack_type = v8f16_type
+        MFMA_LANE_K = 8
+        v1_elem_type = T.vec(1, elem_type)
+        _mfma_zero = ir.IntegerAttr.get(ir.IntegerType.get_signless(32), 0)
+
+        def mfma_acc(a, b, c):
+            # rocdl.mfma_f32_16x16x32_bf16 is the wrapped form: takes
+            # (result_type, [operands]) and returns the Value directly.
+            return rocdl.mfma_f32_16x16x32_bf16(
+                v4f32_type,
+                [a, b, c, _mfma_zero, _mfma_zero, _mfma_zero],
+            )
+
+        seq_len_q_v = arith.index_cast(T.index, seq_len_q)
+        seq_len_k_v = arith.index_cast(T.index, seq_len_k)
+
+        base_ptr = allocator.get_base()
+        lds_kv = SmemPtr(base_ptr, lds_kv_offset, elem_type,
+                         shape=(LDS_KV_TOTAL_SIZE,)).get()
+        lds_pt = SmemPtr(base_ptr, lds_pt_offset, elem_type,
+                         shape=(LDS_PT_ELEMS,)).get()
+        if USE_LDS_FOR_Q_DO:
+            lds_do = SmemPtr(base_ptr, lds_do_offset, elem_type,
+                             shape=(LDS_DO_ELEMS,)).get()
+            lds_q = SmemPtr(base_ptr, lds_q_offset, elem_type,
+                            shape=(LDS_Q_ELEMS,)).get()
+
+        block_id = arith.index_cast(T.index, gpu.block_idx.x)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+        wave_id = tid // WARP_SIZE
+        lane = tid % WARP_SIZE
+        # R6b MFMA 16x16x32 lane decomposition:
+        #   A-frag: A[lane_mod_16, ks*32 + lane_div_16*8 + 0..7]
+        #   B-frag: B[ks*32 + lane_div_16*8 + 0..7, lane_mod_16]
+        #   C-frag: C[lane_div_16*4 + ii, lane_mod_16]  for ii in 0..3
+        lane_mod_16 = lane % 16
+        lane_div_16 = lane // 16
+        # R6M: ds_read_tr16_b64 per-lane decomposition (matches proto).
+        tr_k_group = lane_mod_16 // arith.index(4)
+        tr_col_sub = lane_mod_16 % arith.index(4)
+
+        # R6k-1: in D-split mode both waves cover the same 16 KV rows
+        # (wave_n_offset == 0) and instead carry disjoint D-chunks of
+        # dk/dv. wave_d_col_offset is the wave's D-column base offset
+        # (0 for wave 0, D_CHUNKS_LOCAL*D_CHUNK for wave 1).
+        if D_SPLIT_WAVES:
+            wave_n_offset = arith.index(0)
+            wave_d_col_offset = wave_id * arith.index(D_CHUNKS_LOCAL * D_CHUNK)
+        else:
+            wave_n_offset = wave_id * ROWS_PER_WAVE
+            wave_d_col_offset = arith.index(0)
+
+        # R6S: Hoist a SINGLE per-lane base byte-pointer for DO/Q LDS
+        # tr16 reads. Each ds_read_tr16_b64 then uses
+        # `base + constexpr byte imm` so LLVM ISel folds the
+        # (m_step, dc, addr_0/1) deltas into the `offset:` immediate
+        # of the LDS instruction. Removes the per-call IntToPtrOp ->
+        # 32 AGPR spill chain that was throttling GEMM2/4 to 28.6%
+        # MFMA duty (vs Triton's 53.7%).
+        if USE_LDS_FOR_Q_DO:
+            assert LDS_DO_STRIDE == LDS_Q_STRIDE, (
+                'R6S tr16 base+imm assumes DO and Q share STRIDE')
+            tr_lane_base_elem = (
+                lane_div_16 * arith.index(MFMA_LANE_K * LDS_DO_STRIDE)
+                + tr_k_group * arith.index(LDS_DO_STRIDE)
+                + wave_d_col_offset
+                + tr_col_sub * arith.index(4)
+            )
+            tr_lane_base_byte = tr_lane_base_elem * arith.index(2)
+            tr_lane_base_i64 = arith.index_cast(T.i64, tr_lane_base_byte)
+            tr_lane_base_do_byte_i64 = arith.AddIOp(
+                tr_lane_base_i64,
+                arith.constant(lds_do_offset, type=T.i64),
+            ).result
+            tr_lane_base_q_byte_i64 = arith.AddIOp(
+                tr_lane_base_i64,
+                arith.constant(lds_q_offset, type=T.i64),
+            ).result
+            tr_lane_base_do_ptr = _llvm.IntToPtrOp(
+                _llvm_lds_ptr_ty(), tr_lane_base_do_byte_i64
+            ).result
+            tr_lane_base_q_ptr = _llvm.IntToPtrOp(
+                _llvm_lds_ptr_ty(), tr_lane_base_q_byte_i64
+            ).result
+
+        # 6N-2 iter2: de-dup helper (Q/DO B-frag loads also gated). Each m-tile mt is owned by wave (mt % NUM_WAVES).
+        # In D-split mode the owning wave runs GEMM1/softmax/pT-write/GEMM3/dsT
+        # for that mt; the other wave skips. GEMM2/4 use the SHARED pT/dsT LDS.
+        if D_SPLIT_WAVES:
+            owns_mt_preds = [
+                arith.cmpi(arith.CmpIPredicate.eq, wave_id,
+                           arith.index(mt % NUM_WAVES))
+                for mt in range(M_TILES)
+            ]
+        else:
+            owns_mt_preds = None
+
+        num_n_blocks = (seq_len_k_v + BLOCK_N - 1) // BLOCK_N
+        n_block_idx = block_id % num_n_blocks
+        batch_idx = block_id // num_n_blocks
+        kv_start = n_block_idx * arith.index(BLOCK_N)
+
+        load_row_in_batch = tid // THREADS_PER_ROW_LOAD
+        load_lane_in_row = tid % THREADS_PER_ROW_LOAD
+        load_col_base = load_lane_in_row * VEC_WIDTH
+
+        # MQA: KV stride drops head.
+        bh_base_tokens_kv = batch_idx * seq_len_k_v
+
+        def bh_base_tokens_q_of(qhid_index):
+            return (batch_idx * NUM_HEADS + qhid_index) * seq_len_q_v
+
+        def global_idx_q(qhid_index, token_idx, col):
+            return ((bh_base_tokens_q_of(qhid_index) + token_idx)
+                    * arith.index(HEAD_DIM) + col)
+
+        def global_idx_kv(token_idx, col):
+            return (bh_base_tokens_kv + token_idx) * arith.index(HEAD_DIM) + col
+
+        def _gep_load(base_ptr_, elem_idx, vec_type, et=elem_type):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=et, noWrapFlags=0)
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def _gep_store_f32(val, base_ptr_, elem_idx):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=T.f32, noWrapFlags=0)
+            _llvm.StoreOp(val, gep.result)
+
+        def load_global_mfma_pack(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, mfma_pack_type)
+
+        def load_global_f16xN(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, vxf16_type)
+
+        def _k_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return col_idx ^ mask
+
+        if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+            NUM_BATCHES_KV = 1
+            KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+        else:
+            assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0
+            NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+            KV_NEEDS_GUARD = False
+
+        if ROWS_PER_BATCH_LOAD >= BLOCK_M2:
+            NUM_BATCHES_M = 1
+            M_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_M2
+        else:
+            assert BLOCK_M2 % ROWS_PER_BATCH_LOAD == 0
+            NUM_BATCHES_M = BLOCK_M2 // ROWS_PER_BATCH_LOAD
+            M_NEEDS_GUARD = False
+
+        c_zero_vxf16 = arith.constant_vector(0.0, vxf16_type)
+        c_zero_mfma_pack = arith.constant_vector(0.0, mfma_pack_type)
+        c_zero_elem = arith.constant(0.0, type=elem_type)
+        c_neg_inf = arith.constant(-1.0e30, type=compute_type)
+        c_sm_scale = arith.constant(sm_scale, type=compute_type)
+        # R6b: 4-elem fp32 acc per MFMA 16x16x32 op.
+        v4f32_zero = arith.constant_vector(0.0, v4f32_type)
+
+        def coop_load_k(tile_start):
+            k_base = arith.index(0)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, row_idx, seq_len_k_v)
+                row_safe = arith.select(in_bounds, row_idx, arith.index(0))
+                g_idx = global_idx_kv(row_safe, load_col_base)
+                vec = load_global_f16xN(k_ptr, g_idx)
+                vec_safe = arith.select(in_bounds, vec, c_zero_vxf16)
+                lds_row = load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch + row_offset,
+                        arith.index(BLOCK_N))
+                    _if_k = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_k.then_block):
+                        swz_col = _k_swizzle(lds_row, load_col_base)
+                        lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                        vector.store(vec_safe, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    vector.store(vec_safe, lds_kv, [lds_idx])
+
+        def coop_load_v(tile_start):
+            v_base = arith.index(LDS_V_BASE)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, row_idx, seq_len_k_v)
+                row_safe = arith.select(in_bounds, row_idx, arith.index(0))
+                g_idx = global_idx_kv(row_safe, load_col_base)
+                vec = load_global_f16xN(v_ptr, g_idx)
+                vec_safe = arith.select(in_bounds, vec, c_zero_vxf16)
+                lds_row = load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch + row_offset,
+                        arith.index(BLOCK_N))
+                    _if_v = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_v.then_block):
+                        swz_col = _k_swizzle(lds_row, load_col_base)
+                        lds_idx = v_base + lds_row * V_STRIDE + swz_col
+                        vector.store(vec_safe, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = v_base + lds_row * V_STRIDE + swz_col
+                    vector.store(vec_safe, lds_kv, [lds_idx])
+
+        # ---- PROLOGUE: K, V into LDS (persistent for program lifetime) ----
+        coop_load_k(kv_start)
+        coop_load_v(kv_start)
+        gpu.barrier()
+
+        # R6b: K/V LDS A-frag load uses lane_mod_16 (16-row MFMA) and lane_div_16*8 for col.
+        # Swizzle mask key is the per-wave KV row (wave_n_offset + lane_mod_16), but since
+        # NUM_WAVES <= 2 and (wave_n_offset & K_SWZ_ROW_MASK) is 0 at D=64 (and bit-aligned
+        # at D=512 once wave_n_offset is folded in below), we recompute the mask per call.
+        def _k_idx_wave(ks):
+            kv_row = wave_n_offset + lane_mod_16
+            col = arith.index(ks * K_STEP_QK) + lane_div_16 * MFMA_LANE_K
+            mask = (kv_row & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return (kv_row * arith.index(K_STRIDE) + (col ^ mask))
+
+        def _v_idx_wave(ks):
+            kv_row = wave_n_offset + lane_mod_16
+            col = arith.index(ks * K_STEP_QK) + lane_div_16 * MFMA_LANE_K
+            mask = (kv_row & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return (arith.index(LDS_V_BASE)
+                    + kv_row * arith.index(V_STRIDE) + (col ^ mask))
+
+        # ---- SWA + m-loop bounds (constant across head loop) ----
+        SWA = arith.index(swa_window)
+        BN_idx = arith.index(BLOCK_N)
+        BM2_idx = arith.index(BLOCK_M2)
+        _one_idx = arith.index(1)
+        n_block_lo = kv_start
+        n_block_hi = kv_start + BN_idx
+        m_loop_start = (n_block_lo // BM2_idx) * BM2_idx
+        _m_end_raw = n_block_hi + SWA - _one_idx
+        _le_seq = arith.cmpi(arith.CmpIPredicate.sle, _m_end_raw, seq_len_q_v)
+        _m_end_cl = arith.select(_le_seq, _m_end_raw, seq_len_q_v)
+        m_loop_end = ((_m_end_cl + BM2_idx - _one_idx) // BM2_idx) * BM2_idx
+
+        # R6k-1: each wave only carries D_CHUNKS_LOCAL chunks of dv and dk.
+        outer_carry = ([v4f32_zero for _ in range(D_CHUNKS_LOCAL)]
+                       + [v4f32_zero for _ in range(D_CHUNKS_LOCAL)])
+
+        seq_len_k_i32 = arith.index_cast(T.i32, seq_len_k_v)
+        seq_len_q_i32 = arith.index_cast(T.i32, seq_len_q_v)
+        w_i32 = arith.constant(swa_window, type=T.i32)
+        wave_n_off_i32 = arith.index_cast(T.i32, wave_n_offset)
+        kv_start_i32 = arith.index_cast(T.i32, kv_start)
+        lane_div_16_i32 = arith.index_cast(T.i32, lane_div_16)
+
+        NUM_HEADS_idx = arith.index(NUM_HEADS)
+        for qhid_constexpr_idx, h_carry, h_loop_results in scf.for_(
+            arith.index(0), NUM_HEADS_idx, arith.index(1), iter_args=outer_carry,
+        ):
+            qhid = qhid_constexpr_idx
+
+            m_init_args = [h_carry[i] for i in range(2 * D_CHUNKS_LOCAL)]
+            for m_start, m_carry, m_loop_results in scf.for_(
+                m_loop_start, m_loop_end, BM2_idx, iter_args=m_init_args,
+            ):
+                # R6k-1: each wave's dv/dk slice has D_CHUNKS_LOCAL chunks.
+                dv_accs = [m_carry[dc] for dc in range_constexpr(D_CHUNKS_LOCAL)]
+                dk_accs = [m_carry[D_CHUNKS_LOCAL + dc] for dc in range_constexpr(D_CHUNKS_LOCAL)]
+
+                q_row_abs = m_start + lane_mod_16
+                q_in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, q_row_abs, seq_len_q_v)
+                q_row_safe = arith.select(q_in_bounds, q_row_abs, arith.index(0))
+
+                # ---- Q + DO loads ----
+                if USE_LDS_FOR_Q_DO:
+                    for batch in range_constexpr(NUM_BATCHES_M):
+                        row_offset = batch * ROWS_PER_BATCH_LOAD
+                        row_idx = m_start + load_row_in_batch + row_offset
+                        in_bounds = arith.cmpi(
+                            arith.CmpIPredicate.slt, row_idx, seq_len_q_v)
+                        row_safe = arith.select(in_bounds, row_idx, arith.index(0))
+                        g_idx_do = global_idx_q(qhid, row_safe, load_col_base)
+                        g_idx_q = global_idx_q(qhid, row_safe, load_col_base)
+                        vec_do = load_global_f16xN(do_ptr, g_idx_do)
+                        vec_q = load_global_f16xN(q_ptr, g_idx_q)
+                        vec_do_safe = arith.select(in_bounds, vec_do, c_zero_vxf16)
+                        vec_q_safe = arith.select(in_bounds, vec_q, c_zero_vxf16)
+                        lds_row = load_row_in_batch + row_offset
+                        if M_NEEDS_GUARD:
+                            row_valid = arith.cmpi(
+                                arith.CmpIPredicate.ult,
+                                load_row_in_batch + row_offset,
+                                arith.index(BLOCK_M2))
+                            _if_qd = scf.IfOp(row_valid)
+                            with ir.InsertionPoint(_if_qd.then_block):
+                                lds_idx_do = (lds_row * arith.index(LDS_DO_STRIDE)
+                                              + load_col_base)
+                                lds_idx_q = (lds_row * arith.index(LDS_Q_STRIDE)
+                                             + load_col_base)
+                                vector.store(vec_do_safe, lds_do, [lds_idx_do])
+                                vector.store(vec_q_safe, lds_q, [lds_idx_q])
+                                scf.YieldOp([])
+                        else:
+                            lds_idx_do = (lds_row * arith.index(LDS_DO_STRIDE)
+                                          + load_col_base)
+                            lds_idx_q = (lds_row * arith.index(LDS_Q_STRIDE)
+                                         + load_col_base)
+                            vector.store(vec_do_safe, lds_do, [lds_idx_do])
+                            vector.store(vec_q_safe, lds_q, [lds_idx_q])
+                    gpu.barrier()
+
+                    # 6N-2 iter2: when D-split, q_b_packs / do_b_packs_gemm3
+                    # are loaded INSIDE the per-mt scf.IfOp gates (see
+                    # GEMM1 / GEMM3 below) so un-owned waves do not waste
+                    # LDS read instructions. Build trivial sentinels.
+                    if D_SPLIT_WAVES:
+                        q_b_packs = None  # gated path: loads done in GEMM1 if-block
+                        do_b_packs_gemm3 = None  # gated path: loads done in GEMM3 if-block
+                    else:
+                        q_b_packs = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                        for mt in range_constexpr(M_TILES):
+                            for ks in range_constexpr(K_STEPS_QK):
+                                m_row = arith.index(mt * 16) + lane_mod_16
+                                d_col = (arith.index(ks * K_STEP_QK)
+                                         + lane_div_16 * MFMA_LANE_K)
+                                lds_idx = m_row * arith.index(LDS_Q_STRIDE) + d_col
+                                pack = vector.load_op(mfma_pack_type, lds_q, [lds_idx])
+                                q_b_packs[mt][ks] = pack
+
+                        do_b_packs_gemm3 = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                        for mt in range_constexpr(M_TILES):
+                            for ks in range_constexpr(K_STEPS_QK):
+                                m_row = arith.index(mt * 16) + lane_mod_16
+                                d_col = (arith.index(ks * K_STEP_QK)
+                                         + lane_div_16 * MFMA_LANE_K)
+                                lds_idx = m_row * arith.index(LDS_DO_STRIDE) + d_col
+                                pack = vector.load_op(mfma_pack_type, lds_do, [lds_idx])
+                                do_b_packs_gemm3[mt][ks] = pack
+                else:
+                    # R6b fallback: HBM-direct B-frag per m-tile. row = m_start + mt*16 + lane_mod_16.
+                    q_b_packs = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                    do_b_packs_gemm3 = [[None] * K_STEPS_QK for _ in range(M_TILES)]
+                    for mt in range_constexpr(M_TILES):
+                        row_abs = m_start + arith.index(mt * 16) + lane_mod_16
+                        in_bnd = arith.cmpi(arith.CmpIPredicate.slt,
+                                            row_abs, seq_len_q_v)
+                        row_safe = arith.select(in_bnd, row_abs, arith.index(0))
+                        for ks in range_constexpr(K_STEPS_QK):
+                            col = (arith.index(ks * K_STEP_QK)
+                                   + lane_div_16 * MFMA_LANE_K)
+                            g_idx = global_idx_q(qhid, row_safe, col)
+                            q_raw = load_global_mfma_pack(q_ptr, g_idx)
+                            q_b_packs[mt][ks] = arith.select(
+                                in_bnd, q_raw, c_zero_mfma_pack)
+                            do_raw = load_global_mfma_pack(do_ptr, g_idx)
+                            do_b_packs_gemm3[mt][ks] = arith.select(
+                                in_bnd, do_raw, c_zero_mfma_pack)
+
+                # 6N-2: de-dup GEMM1 + softmax + pT_write per mt-tile.
+                # Each mt is owned by one wave (wave_id == mt % NUM_WAVES).
+                # The owning wave runs everything; the other yields zeros.
+                # delta_per_tile must be valid in BOTH waves (used after barrier
+                # for the dsT compute), so we read it unconditionally.
+                s_accs = [None for _ in range(M_TILES)]
+                pT_vals_per_tile = [None for _ in range(M_TILES)]
+                delta_per_tile = []
+                for mt in range_constexpr(M_TILES):
+                    # delta is needed by every wave (dsT compute happens after
+                    # GEMM3 dp_accs[mt] is restored from LDS-broadcast / read).
+                    # In de-dup mode dsT is owned by mt-owner only, so delta
+                    # also only needs to be live in the owning wave. But the
+                    # buffer_load is a cheap SMEM op; we leave it unconditional
+                    # for simplicity. Same for lse below.
+                    m_row_for_lse = m_start + arith.index(mt * 16) + lane_mod_16
+                    m_row_in_bounds = arith.cmpi(
+                        arith.CmpIPredicate.slt, m_row_for_lse, seq_len_q_v)
+                    m_row_safe = arith.select(m_row_in_bounds, m_row_for_lse,
+                                              arith.index(0))
+                    lse_off_i32 = arith.index_cast(
+                        T.i32, bh_base_tokens_q_of(qhid) + m_row_safe)
+                    lse_v = buffer_ops.buffer_load(
+                        lse_rsrc, lse_off_i32, vec_width=1, dtype=T.f32)
+                    delta_v = buffer_ops.buffer_load(
+                        deltas_rsrc, lse_off_i32, vec_width=1, dtype=T.f32)
+                    delta_per_tile.append(delta_v)
+
+                    if D_SPLIT_WAVES:
+                        owns = owns_mt_preds[mt]
+                        # ---- GATED block: GEMM1[mt] + softmax + pT LDS write ----
+                        # Yields (s_acc, pT0, pT1, pT2, pT3).
+                        if_g1sm = scf.IfOp(
+                            owns,
+                            results_=[v4f32_type, T.f32, T.f32, T.f32, T.f32],
+                            has_else=True)
+                        with ir.InsertionPoint(if_g1sm.then_block):
+                            # GEMM1[mt]: accumulate over K_STEPS_QK.
+                            # 6N-2 iter2: load Q B-frag inside the gate when LDS Q/DO.
+                            acc = v4f32_zero
+                            for ks in range_constexpr(K_STEPS_QK):
+                                k_pack = vector.load_op(
+                                    mfma_pack_type, lds_kv, [_k_idx_wave(ks)])
+                                if USE_LDS_FOR_Q_DO:
+                                    _m_row_b = arith.index(mt * 16) + lane_mod_16
+                                    _d_col_b = (arith.index(ks * K_STEP_QK)
+                                                + lane_div_16 * MFMA_LANE_K)
+                                    _lds_idx_b = (_m_row_b * arith.index(LDS_Q_STRIDE)
+                                                  + _d_col_b)
+                                    q_pack = vector.load_op(
+                                        mfma_pack_type, lds_q, [_lds_idx_b])
+                                else:
+                                    q_pack = q_b_packs[mt][ks]
+                                acc = mfma_acc(k_pack, q_pack, acc)
+
+                            m_row_abs_for_mask_i32 = arith.index_cast(
+                                T.i32, m_row_for_lse)
+                            m_oob = arith.cmpi(
+                                arith.CmpIPredicate.sge,
+                                m_row_abs_for_mask_i32, seq_len_q_i32)
+                            pT_pieces = []
+                            for ii in range_constexpr(4):
+                                ii_i32 = arith.constant(ii, type=T.i32)
+                                kv_row_rel_i32 = arith.AddIOp(
+                                    arith.MulIOp(
+                                        lane_div_16_i32,
+                                        arith.constant(4, type=T.i32)).result,
+                                    ii_i32).result
+                                kv_abs_i32 = arith.AddIOp(
+                                    arith.AddIOp(
+                                        kv_start_i32, wave_n_off_i32).result,
+                                    kv_row_rel_i32).result
+                                kv_oob = arith.cmpi(
+                                    arith.CmpIPredicate.sge,
+                                    kv_abs_i32, seq_len_k_i32)
+                                is_causal = arith.cmpi(
+                                    arith.CmpIPredicate.sgt,
+                                    kv_abs_i32, m_row_abs_for_mask_i32)
+                                kv_plus_w = arith.AddIOp(
+                                    kv_abs_i32, w_i32).result
+                                is_swa = arith.cmpi(
+                                    arith.CmpIPredicate.sle,
+                                    kv_plus_w, m_row_abs_for_mask_i32)
+                                bad = arith.OrIOp(
+                                    arith.OrIOp(
+                                        arith.OrIOp(is_causal, is_swa).result,
+                                        kv_oob).result,
+                                    m_oob).result
+                                s_ii = vector.extract(
+                                    acc, static_position=[ii],
+                                    dynamic_position=[])
+                                scaled = arith.MulFOp(
+                                    s_ii, c_sm_scale,
+                                    fastmath=fm_fast).result
+                                scaled_m = arith.select(bad, c_neg_inf, scaled)
+                                diff = arith.SubFOp(
+                                    scaled_m, lse_v,
+                                    fastmath=fm_fast).result
+                                p = math_dialect.exp(diff, fastmath=fm_fast)
+                                pT_pieces.append(p)
+                                # Write pT to LDS for this mt.
+                                kv_row_rel = (lane_div_16 * arith.index(4)
+                                              + arith.index(ii))
+                                kv_row = wave_n_offset + kv_row_rel
+                                pt_bf16 = arith.trunc_f(elem_type, p)
+                                lds_pt_idx = (
+                                    kv_row * arith.index(LDS_PT_STRIDE)
+                                    + arith.index(mt * 16) + lane_mod_16)
+                                v1_pt = vector.from_elements(
+                                    v1_elem_type, [pt_bf16])
+                                vector.store(v1_pt, lds_pt, [lds_pt_idx])
+                            scf.YieldOp([acc] + pT_pieces)
+                        with ir.InsertionPoint(if_g1sm.else_block):
+                            _zero_f32 = arith.constant(0.0, type=T.f32)
+                            scf.YieldOp([v4f32_zero, _zero_f32, _zero_f32,
+                                          _zero_f32, _zero_f32])
+                        s_accs[mt] = if_g1sm.results[0]
+                        pT_vals_per_tile[mt] = [
+                            if_g1sm.results[1], if_g1sm.results[2],
+                            if_g1sm.results[3], if_g1sm.results[4],
+                        ]
+                    else:
+                        # Legacy path: every wave does GEMM1[mt] + softmax + pT_write.
+                        acc = v4f32_zero
+                        for ks in range_constexpr(K_STEPS_QK):
+                            k_pack = vector.load_op(
+                                mfma_pack_type, lds_kv, [_k_idx_wave(ks)])
+                            acc = mfma_acc(k_pack, q_b_packs[mt][ks], acc)
+                        s_accs[mt] = acc
+
+                        m_row_abs_for_mask_i32 = arith.index_cast(
+                            T.i32, m_row_for_lse)
+                        m_oob = arith.cmpi(
+                            arith.CmpIPredicate.sge,
+                            m_row_abs_for_mask_i32, seq_len_q_i32)
+                        pT_tile = []
+                        for ii in range_constexpr(4):
+                            ii_i32 = arith.constant(ii, type=T.i32)
+                            kv_row_rel_i32 = arith.AddIOp(
+                                arith.MulIOp(
+                                    lane_div_16_i32,
+                                    arith.constant(4, type=T.i32)).result,
+                                ii_i32).result
+                            kv_abs_i32 = arith.AddIOp(
+                                arith.AddIOp(
+                                    kv_start_i32, wave_n_off_i32).result,
+                                kv_row_rel_i32).result
+                            kv_oob = arith.cmpi(
+                                arith.CmpIPredicate.sge,
+                                kv_abs_i32, seq_len_k_i32)
+                            is_causal = arith.cmpi(
+                                arith.CmpIPredicate.sgt,
+                                kv_abs_i32, m_row_abs_for_mask_i32)
+                            kv_plus_w = arith.AddIOp(
+                                kv_abs_i32, w_i32).result
+                            is_swa = arith.cmpi(
+                                arith.CmpIPredicate.sle,
+                                kv_plus_w, m_row_abs_for_mask_i32)
+                            bad = arith.OrIOp(
+                                arith.OrIOp(
+                                    arith.OrIOp(is_causal, is_swa).result,
+                                    kv_oob).result,
+                                m_oob).result
+                            s_ii = vector.extract(
+                                acc, static_position=[ii],
+                                dynamic_position=[])
+                            scaled = arith.MulFOp(
+                                s_ii, c_sm_scale,
+                                fastmath=fm_fast).result
+                            scaled_m = arith.select(bad, c_neg_inf, scaled)
+                            diff = arith.SubFOp(
+                                scaled_m, lse_v, fastmath=fm_fast).result
+                            p = math_dialect.exp(diff, fastmath=fm_fast)
+                            pT_tile.append(p)
+                            kv_row_rel = (lane_div_16 * arith.index(4)
+                                          + arith.index(ii))
+                            kv_row = wave_n_offset + kv_row_rel
+                            pt_bf16 = arith.trunc_f(elem_type, p)
+                            lds_pt_idx = (kv_row * arith.index(LDS_PT_STRIDE)
+                                          + arith.index(mt * 16) + lane_mod_16)
+                            v1_pt = vector.from_elements(v1_elem_type, [pt_bf16])
+                            vector.store(v1_pt, lds_pt, [lds_pt_idx])
+                        pT_vals_per_tile[mt] = pT_tile
+
+                # R6k-1: D-split barrier. Both waves write the SAME pT
+                # values (identical s_accs derived from full-D GEMM1) to
+                # the SAME LDS rows (wave_n_offset=0 for both waves), but
+                # the writer-lane != reader-lane mapping crosses wave
+                # boundaries: lane L in wave 0 reads cells written by
+                # lanes from wave 1 (and vice versa). Without a barrier
+                # wave 1 could observe wave 0's stale prior-iteration pT.
+                if D_SPLIT_WAVES:
+                    gpu.barrier()
+
+                # ---- pT A-frag for GEMM2 (dV += pT @ DO):
+                #   A[kv_row=wave_n_offset+lane_mod_16, m_col=m_step*32+lane_div_16*8 + 0..7]
+                pt_a_packs = []
+                for m_step in range_constexpr(K_STEPS_PT):
+                    kv_row_a = wave_n_offset + lane_mod_16
+                    m_col_a = (arith.index(m_step * K_STEP_QK)
+                               + lane_div_16 * MFMA_LANE_K)
+                    lds_idx = (kv_row_a * arith.index(LDS_PT_STRIDE) + m_col_a)
+                    pack = vector.load_op(mfma_pack_type, lds_pt, [lds_idx])
+                    pt_a_packs.append(pack)
+
+                # ---- GEMM2: dV += pT @ DO ----
+                # R6b GEMM2: B-frag DO[m_step*32+lane_div_16*8+k, d_col_global+lane_mod_16].
+                # R6k-1: dc_idx is wave-local; d_col_global = wave_d_col_offset + dc_idx*D_CHUNK.
+                if USE_LDS_FOR_Q_DO:
+                    # R6S: tr16 LDS reads via `base + constexpr byte imm`
+                    # so LLVM ISel folds the per-call delta into the LDS
+                    # instruction's `offset:` immediate. Replaces the
+                    # per-call IntToPtrOp pattern that was spilling 32
+                    # absolute addresses across AGPRs/scratch.
+                    def _ds_read_tr_do_imm(byte_imm):
+                        gep = _llvm.GEPOp(
+                            _llvm_lds_ptr_ty(), tr_lane_base_do_ptr, [],
+                            rawConstantIndices=[byte_imm],
+                            elem_type=T.i8, noWrapFlags=0)
+                        return rocdl.ds_read_tr16_b64(
+                            v4f16_type, gep.result).result
+
+                    def read_do_b_pack(m_step_idx, dc_idx):
+                        # All offsets are Python ints (constexpr unrolled).
+                        base_elem = (m_step_idx * K_STEP_QK * LDS_DO_STRIDE
+                                     + dc_idx * D_CHUNK)
+                        byte_imm_0 = base_elem * 2
+                        byte_imm_1 = byte_imm_0 + 4 * LDS_DO_STRIDE * 2
+                        v_lo = _ds_read_tr_do_imm(byte_imm_0)
+                        v_hi = _ds_read_tr_do_imm(byte_imm_1)
+                        v_full = vector.shuffle(
+                            v_lo, v_hi, [0, 1, 2, 3, 4, 5, 6, 7])
+                        return vector.bitcast(mfma_pack_type, v_full)
+                else:
+                    def read_do_b_pack(m_step_idx, dc_idx):
+                        d_col = (wave_d_col_offset
+                                 + arith.index(dc_idx * D_CHUNK)
+                                 + lane_mod_16)
+                        m_base = (arith.index(m_step_idx * K_STEP_QK)
+                                  + lane_div_16 * MFMA_LANE_K)
+                        vals = []
+                        for rk in range_constexpr(MFMA_LANE_K):
+                            m_row_rel = m_base + arith.index(rk)
+                            m_row_abs = m_start + m_row_rel
+                            in_b = arith.cmpi(
+                                arith.CmpIPredicate.slt,
+                                m_row_abs, seq_len_q_v)
+                            m_row_safe2 = arith.select(
+                                in_b, m_row_abs, arith.index(0))
+                            g_idx = global_idx_q(qhid, m_row_safe2, d_col)
+                            v1 = _gep_load(do_ptr, g_idx, T.vec(1, elem_type))
+                            v_scalar = vector.extract(
+                                v1, static_position=[0], dynamic_position=[])
+                            v_safe = arith.select(in_b, v_scalar, c_zero_elem)
+                            vals.append(v_safe)
+                        return vector.from_elements(mfma_pack_type, vals)
+
+                # R6k-1: dc loops wave-local (D_CHUNKS_LOCAL); reader adds
+                # wave_d_col_offset internally.
+                new_dv_accs = list(dv_accs)
+                for dc in range_constexpr(D_CHUNKS_LOCAL):
+                    for pks in range_constexpr(K_STEPS_PT):
+                        b_pack = read_do_b_pack(pks, dc)
+                        new_dv_accs[dc] = mfma_acc(
+                            pt_a_packs[pks], b_pack, new_dv_accs[dc])
+
+                # 6N-2: de-dup GEMM3 + dsT + dsT_write per mt-tile.
+                # The owning wave for mt does GEMM3 MFMA, dsT compute, and LDS write.
+                # The other wave skips entirely. GEMM4 readers see the full
+                # dsT via LDS broadcast after the trailing barrier.
+                if D_SPLIT_WAVES:
+                    for mt in range_constexpr(M_TILES):
+                        owns = owns_mt_preds[mt]
+                        if_g3 = scf.IfOp(owns, results_=[], has_else=False)
+                        with ir.InsertionPoint(if_g3.then_block):
+                            # GEMM3[mt]
+                            # 6N-2 iter2: load DO B-frag inside the gate when LDS Q/DO.
+                            acc = v4f32_zero
+                            for ks in range_constexpr(K_STEPS_QK):
+                                v_pack = vector.load_op(
+                                    mfma_pack_type, lds_kv, [_v_idx_wave(ks)])
+                                if USE_LDS_FOR_Q_DO:
+                                    _m_row_b = arith.index(mt * 16) + lane_mod_16
+                                    _d_col_b = (arith.index(ks * K_STEP_QK)
+                                                + lane_div_16 * MFMA_LANE_K)
+                                    _lds_idx_b = (_m_row_b * arith.index(LDS_DO_STRIDE)
+                                                  + _d_col_b)
+                                    do_pack = vector.load_op(
+                                        mfma_pack_type, lds_do, [_lds_idx_b])
+                                else:
+                                    do_pack = do_b_packs_gemm3[mt][ks]
+                                acc = mfma_acc(v_pack, do_pack, acc)
+                            # dsT + LDS write per ii.
+                            for ii in range_constexpr(4):
+                                dp_ii = vector.extract(
+                                    acc, static_position=[ii],
+                                    dynamic_position=[])
+                                diff = arith.SubFOp(
+                                    dp_ii, delta_per_tile[mt],
+                                    fastmath=fm_fast).result
+                                ds_ii = arith.MulFOp(
+                                    pT_vals_per_tile[mt][ii], diff,
+                                    fastmath=fm_fast).result
+                                kv_row_rel = (lane_div_16 * arith.index(4)
+                                              + arith.index(ii))
+                                kv_row = wave_n_offset + kv_row_rel
+                                ds_bf16 = arith.trunc_f(elem_type, ds_ii)
+                                lds_pt_idx = (
+                                    kv_row * arith.index(LDS_PT_STRIDE)
+                                    + arith.index(mt * 16) + lane_mod_16)
+                                v1_ds = vector.from_elements(
+                                    v1_elem_type, [ds_bf16])
+                                vector.store(v1_ds, lds_pt, [lds_pt_idx])
+                            scf.YieldOp([])
+                else:
+                    # Legacy path
+                    dp_accs = [v4f32_zero for _ in range(M_TILES)]
+                    for ks in range_constexpr(K_STEPS_QK):
+                        v_pack = vector.load_op(
+                            mfma_pack_type, lds_kv, [_v_idx_wave(ks)])
+                        for mt in range_constexpr(M_TILES):
+                            dp_accs[mt] = mfma_acc(
+                                v_pack, do_b_packs_gemm3[mt][ks], dp_accs[mt])
+                    for mt in range_constexpr(M_TILES):
+                        for ii in range_constexpr(4):
+                            dp_ii = vector.extract(
+                                dp_accs[mt], static_position=[ii],
+                                dynamic_position=[])
+                            diff = arith.SubFOp(
+                                dp_ii, delta_per_tile[mt],
+                                fastmath=fm_fast).result
+                            ds_ii = arith.MulFOp(
+                                pT_vals_per_tile[mt][ii], diff,
+                                fastmath=fm_fast).result
+                            kv_row_rel = (lane_div_16 * arith.index(4)
+                                          + arith.index(ii))
+                            kv_row = wave_n_offset + kv_row_rel
+                            ds_bf16 = arith.trunc_f(elem_type, ds_ii)
+                            lds_pt_idx = (kv_row * arith.index(LDS_PT_STRIDE)
+                                          + arith.index(mt * 16) + lane_mod_16)
+                            v1_ds = vector.from_elements(v1_elem_type, [ds_bf16])
+                            vector.store(v1_ds, lds_pt, [lds_pt_idx])
+
+                # R6k-1: D-split barrier (see GEMM2 pT barrier comment).
+                if D_SPLIT_WAVES:
+                    gpu.barrier()
+
+                # ---- dsT A-frag for GEMM4 (dK += dsT @ Q):
+                #   A[kv_row=wave_n_offset+lane_mod_16, m_col=m_step*32+lane_div_16*8 + 0..7]
+                ds_a_packs = []
+                for m_step in range_constexpr(K_STEPS_PT):
+                    kv_row_a = wave_n_offset + lane_mod_16
+                    m_col_a = (arith.index(m_step * K_STEP_QK)
+                               + lane_div_16 * MFMA_LANE_K)
+                    lds_idx = (kv_row_a * arith.index(LDS_PT_STRIDE) + m_col_a)
+                    pack = vector.load_op(mfma_pack_type, lds_pt, [lds_idx])
+                    ds_a_packs.append(pack)
+
+                # ---- GEMM4: dK += dsT @ Q  (MFMA 16x16x32) ----
+                # R6k-1: Q B-frag d_col = wave_d_col_offset + dc_idx*D_CHUNK + lane_mod_16.
+                if USE_LDS_FOR_Q_DO:
+                    # R6S: tr16 LDS reads via `base + constexpr byte imm`
+                    # (same recipe as GEMM2). Uses tr_lane_base_q_ptr.
+                    def _ds_read_tr_q_imm(byte_imm):
+                        gep = _llvm.GEPOp(
+                            _llvm_lds_ptr_ty(), tr_lane_base_q_ptr, [],
+                            rawConstantIndices=[byte_imm],
+                            elem_type=T.i8, noWrapFlags=0)
+                        return rocdl.ds_read_tr16_b64(
+                            v4f16_type, gep.result).result
+
+                    def read_q_b_pack(m_step_idx, dc_idx):
+                        base_elem = (m_step_idx * K_STEP_QK * LDS_Q_STRIDE
+                                     + dc_idx * D_CHUNK)
+                        byte_imm_0 = base_elem * 2
+                        byte_imm_1 = byte_imm_0 + 4 * LDS_Q_STRIDE * 2
+                        v_lo = _ds_read_tr_q_imm(byte_imm_0)
+                        v_hi = _ds_read_tr_q_imm(byte_imm_1)
+                        v_full = vector.shuffle(
+                            v_lo, v_hi, [0, 1, 2, 3, 4, 5, 6, 7])
+                        return vector.bitcast(mfma_pack_type, v_full)
+                else:
+                    def read_q_b_pack(m_step_idx, dc_idx):
+                        d_col = (wave_d_col_offset
+                                 + arith.index(dc_idx * D_CHUNK)
+                                 + lane_mod_16)
+                        m_base = (arith.index(m_step_idx * K_STEP_QK)
+                                  + lane_div_16 * MFMA_LANE_K)
+                        vals = []
+                        for rk in range_constexpr(MFMA_LANE_K):
+                            m_row_rel = m_base + arith.index(rk)
+                            m_row_abs = m_start + m_row_rel
+                            in_b = arith.cmpi(
+                                arith.CmpIPredicate.slt,
+                                m_row_abs, seq_len_q_v)
+                            m_row_safe2 = arith.select(
+                                in_b, m_row_abs, arith.index(0))
+                            g_idx = global_idx_q(qhid, m_row_safe2, d_col)
+                            v1 = _gep_load(q_ptr, g_idx, T.vec(1, elem_type))
+                            v_scalar = vector.extract(
+                                v1, static_position=[0], dynamic_position=[])
+                            v_safe = arith.select(in_b, v_scalar, c_zero_elem)
+                            vals.append(v_safe)
+                        return vector.from_elements(mfma_pack_type, vals)
+
+                # R6k-1: dc loops wave-local; reader adds wave_d_col_offset.
+                new_dk_accs = list(dk_accs)
+                for dc in range_constexpr(D_CHUNKS_LOCAL):
+                    for pks in range_constexpr(K_STEPS_PT):
+                        q_b_pack = read_q_b_pack(pks, dc)
+                        new_dk_accs[dc] = mfma_acc(
+                            ds_a_packs[pks], q_b_pack, new_dk_accs[dc])
+
+                gpu.barrier()
+
+                yield list(new_dv_accs) + list(new_dk_accs)
+
+            yield list(m_loop_results)
+        outer_carry = list(h_loop_results)
+
+        # ---- Final: dK *= sm_scale, store ----
+        # R6k-1: D-split mode -> each wave only owns D_CHUNKS_LOCAL chunks
+        # and writes its own slice of dK/dV (no inter-wave reduction needed:
+        # the D-axis is disjoint per wave, and the N-axis is shared so the
+        # accumulators ARE complete for each wave's D-slice).
+        dv_finals = [outer_carry[dc] for dc in range(D_CHUNKS_LOCAL)]
+        dk_finals = [outer_carry[D_CHUNKS_LOCAL + dc] for dc in range(D_CHUNKS_LOCAL)]
+
+        for dc in range_constexpr(D_CHUNKS_LOCAL):
+            for ii in range_constexpr(4):
+                kv_row_rel = (lane_div_16 * arith.index(4)
+                              + arith.index(ii))
+                kv_row_abs = kv_start + wave_n_offset + kv_row_rel
+                d_col_abs = (wave_d_col_offset
+                             + arith.index(dc * D_CHUNK)
+                             + lane_mod_16)
+                kv_in_bounds = arith.cmpi(
+                    arith.CmpIPredicate.slt, kv_row_abs, seq_len_k_v)
+                _if_kv = scf.IfOp(kv_in_bounds)
+                with ir.InsertionPoint(_if_kv.then_block):
+                    dv_val = vector.extract(
+                        dv_finals[dc], static_position=[ii],
+                        dynamic_position=[])
+                    dk_val = vector.extract(
+                        dk_finals[dc], static_position=[ii],
+                        dynamic_position=[])
+                    dk_scaled = arith.MulFOp(
+                        dk_val, c_sm_scale, fastmath=fm_fast).result
+                    g_idx = global_idx_kv(kv_row_abs, d_col_abs)
+                    _gep_store_f32(dv_val, dv_ptr, g_idx)
+                    _gep_store_f32(dk_scaled, dk_ptr, g_idx)
+                    scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_swa_bwd_dkv(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        DK: fx.Tensor,
+        DV: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        sk_idx = arith.index_cast(T.index, seq_len_k)
+        num_n_blocks = (sk_idx + BLOCK_N - 1) // BLOCK_N
+        grid_x = bs_idx * num_n_blocks
+
+        launcher = v4_swa_bwd_dkv_kernel(
+            Q, K, V, DOS, LSE, DELTAS, DK, DV, seq_len_q, seq_len_k,
+        )
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = (
+                            ir.IntegerAttr.get(T.i32, _wpe))
+        if flat_work_group_size is not None:
+            _fwgs = int(flat_work_group_size)
+            if _fwgs >= 1:
+                flat_wg_attr = ir.StringAttr.get(f"{_fwgs},{_fwgs}")
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.flat_work_group_size"] = (
+                            flat_wg_attr)
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(
+                    passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, 1, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    _fmha_compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+        "llvm_options": {
+            "enable-post-misched": True,  # R6L iter5
+            "lsr-drop-solution": True,
+        },
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return launch_v4_swa_bwd_dkv(*args, **kwargs)
+
+    def _compile(Q, K, V, DOS, LSE, DELTAS, DK, DV,
+                 batch_size, seq_len_q, seq_len_k, stream=None):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return flyc.compile(
+                launch_v4_swa_bwd_dkv, Q, K, V, DOS, LSE, DELTAS, DK, DV,
+                batch_size, seq_len_q, seq_len_k, fx.Stream(stream))
+
+    _launch.compile = _compile
+
+    return _launch
+
+
+build_v4_swa_bwd_dkv_module_primary = build_v4_swa_bwd_dkv_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_bwd_dq_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_bwd_dq_kernel.py
@@ -1,0 +1,1238 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_swa_bwd_dq: V4 SWA-causal attention backward dQ kernel for FlyDSL.
+
+Forked from kernels/sla_bwd_dq.py (FlyDSL SLA backward dQ). Differences:
+  - Outer KV loop iterates a contiguous block range bounded by the SWA
+    window for the current Q tile (no LUT).
+  - Per-element SWA + causal mask + boundary mask (mirrors Triton ref).
+  - LSE is RAW-domain (Triton: lse = m + ln(l), in domain qk*sm_scale),
+    so p = exp(qk*sm_scale - lse) (NOT exp2).
+  - sm_scale is applied TWICE: once inside the loop on qk (matches
+    Triton: qk = qk * sm_scale), and once after the n-loop on dq
+    (matches Triton: dq = dq * sm_scale). The two multiplies are NOT
+    redundant: ds = p*(dp - dvec) carries the in-loop scale via P;
+    the post-loop multiply is the outer chain-rule scale on dq.
+  - MQA: K/V are [B, 1, Sk, D] - stride_kh = 0 - drop head_idx from
+    KV indexing when mqa_kv=True.
+  - Sink: optional SINK[HQ] fp32; dsink = -sum(p_sink * dvec) via
+    atomic_fadd one scalar per row-owner-lane into DSINK[qhid]. Sink
+    does NOT change dq (fwd already folded p_sink into lse).
+  - dq written as fp32 (matches the launcher's fp32 dq_fp32 buffer).
+
+Layout: BHLD. Q/DOUT/DQ flat from (B, HQ, Sq, D). K/V flat from
+        (B, HK, Sk, D); MQA means HK=1, no head stride applied to KV.
+LSE/DELTAS: (B, HQ, Sq) flat, fp32, raw-domain.
+SINK:   (HQ,) fp32 - dummy buffer when has_sink=False.
+DSINK:  (HQ,) fp32 - atomic accumulator - caller must zero-init.
+"""
+
+import math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import memref as _memref, scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+# ---- Module-level constants ----
+
+KERNEL_NAME = "v4_swa_bwd_dq_kernel"
+
+_LOG2E = math.log2(math.e)  # 1.4426950408889634
+
+_LLVM_GEP_DYNAMIC = -2147483648  # LLVM kDynamicIndex sentinel (0x80000000 as signed i32)
+
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _llvm_lds_ptr_ty():
+    return ir.Type.parse("!llvm.ptr<3>")
+
+
+_VMCNT_LO_MASK = 0xF
+_LGKMCNT_EXPCNT_BASE = 0x3F70
+_VMCNT_HI_SHIFT = 14
+_VMCNT_HI_MASK = 0x3
+
+
+def _waitcnt_vm_n(n):
+    """Emit s_waitcnt vmcnt(n) only (lgkmcnt=63, expcnt=7)."""
+    val = (n & _VMCNT_LO_MASK) | _LGKMCNT_EXPCNT_BASE | (((n >> 4) & _VMCNT_HI_MASK) << _VMCNT_HI_SHIFT)
+    rocdl.s_waitcnt(val)
+
+
+def build_v4_swa_bwd_dq_module(
+    num_heads,
+    head_dim,
+    swa_window,
+    dtype_str="bf16",
+    sm_scale=None,
+    waves_per_eu=2,
+    flat_work_group_size=None,
+    block_m=None,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    layout_bhld=True,
+    mqa_kv=True,
+    has_sink=True,
+):
+    """Build the V4 SWA backward dQ launcher.
+
+    Args:
+        num_heads: HQ (number of Q heads).
+        head_dim: D (head dimension), must be % 32 == 0 and >= 64.
+        swa_window: int > 0; SWA window length.
+        sm_scale: defaults to 1/sqrt(head_dim).
+        mqa_kv: if True, K/V indexing drops head_idx (HK=1, stride_h=0).
+        has_sink: if True, SINK/DSINK tensors are used. If False, both
+            are dummy buffers (the kernel still takes them but doesn't
+            touch them).
+        layout_bhld: BHLD layout (True) or BLHD (False); V4 uses BHLD.
+
+    Returns: launch(Q, K, V, DOUT, LSE, DELTAS, DQ_FP32, DSINK, SINK,
+                    batch_size, seq_len_q, seq_len_k, stream=None).
+    """
+    gpu_arch = get_hip_arch()
+
+    BLOCK_N = 64
+    K_SUB_N = 32
+    WARP_SIZE = 64
+
+    if block_m is not None:
+        BLOCK_M = block_m
+    else:
+        BLOCK_M = 128
+
+    if flat_work_group_size is None:
+        if BLOCK_M <= 128:
+            flat_work_group_size = 256
+        else:
+            flat_work_group_size = 512
+    NUM_WAVES = flat_work_group_size // WARP_SIZE
+    BLOCK_SIZE = flat_work_group_size
+    ROWS_PER_WAVE = BLOCK_M // NUM_WAVES
+    # V4 SWA: dense path. One outer iter = one BLOCK_N block.
+    BLOCK_N_OUT = BLOCK_N
+    N_SUBTILES = 1
+    ENABLE_PREFETCH_3BUF = (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_PREFETCH3", "0") == "1"
+    )
+    _has_lds_load_b128 = not gpu_arch.startswith("gfx942")
+    ENABLE_DMA = _has_lds_load_b128 and (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_DMA", "1") == "1"
+    )
+    ENABLE_LDS_VEC16 = (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_LDS_VEC16", "1") == "1"
+    )
+    REDUCE_MODE = os.getenv("FLYDSL_SLA_FWD_REDUCE_MODE", "xor").strip().lower()
+    if REDUCE_MODE not in ("xor", "ds_bpermute"):
+        REDUCE_MODE = "xor"
+    NUM_PREFETCH_K = 3 if ENABLE_PREFETCH_3BUF else (2 if ENABLE_DMA else 1)
+    NUM_PREFETCH_V = 3 if ENABLE_PREFETCH_3BUF else (2 if ENABLE_DMA else 1)
+    CK_LDS_SEQ = (1, 2, 0, 1, 0, 1, 2, 0) if ENABLE_PREFETCH_3BUF else (0,)
+
+    USE_HW_TR = gpu_arch.startswith("gfx950")
+    USE_K16 = gpu_arch.startswith("gfx950")
+
+    # Auto-fallback: gfx950 LDS limit is 160 KB. K+V double-buffering at D=512
+    # easily exceeds that. If predicted LDS exceeds budget, force DMA off
+    # (NUM_PREFETCH = 1) and warn. Keeps the kernel correct regardless of
+    # the env knob.
+    _LDS_LIMIT_BYTES = 160 * 1024
+    def _predicted_lds_bytes(nk, nv, dma):
+        # USE_HW_TR & DMA  -> V_STRIDE = head_dim
+        # USE_HW_TR & !DMA -> V_STRIDE = head_dim + 4
+        # !USE_HW_TR       -> V stored transposed: LDS V = head_dim * (BLOCK_N + 2)
+        if USE_HW_TR:
+            v_str = head_dim if dma else head_dim + 4
+            return (nk * BLOCK_N * head_dim + nv * BLOCK_N * v_str) * 2
+        vt = BLOCK_N + 2
+        return (nk * BLOCK_N * head_dim + nv * head_dim * vt) * 2
+    _pred = _predicted_lds_bytes(NUM_PREFETCH_K, NUM_PREFETCH_V, ENABLE_DMA)
+    if _pred > _LDS_LIMIT_BYTES and ENABLE_DMA:
+        # Try DMA off (single-buffered).
+        ENABLE_DMA = False
+        NUM_PREFETCH_K = 1
+        NUM_PREFETCH_V = 1
+        _pred2 = _predicted_lds_bytes(1, 1, False)
+        if _pred2 > _LDS_LIMIT_BYTES:
+            raise RuntimeError(
+                f"v4_swa_bwd_dq: predicted LDS {_pred2}B > limit {_LDS_LIMIT_BYTES}B "
+                f"even single-buffered at D={head_dim}, BLOCK_N={BLOCK_N}"
+            )
+        import sys as _sys
+        print(
+            f"[v4_swa_bwd_dq] LDS overflow at D={head_dim}, BLOCK_N={BLOCK_N}: "
+            f"auto-disabled DMA (predicted {_pred} -> {_pred2} bytes)",
+            file=_sys.stderr, flush=True,
+        )
+    K_STEP_QK = 16 if USE_K16 else 8
+    K_STEPS_QK = head_dim // K_STEP_QK
+    D_CHUNK = 32
+    D_CHUNKS = head_dim // D_CHUNK
+    PV_K_STEP = 16 if USE_K16 else 8
+    PV_K_STEPS = K_SUB_N // PV_K_STEP  # 2 steps per sub-tile (K=16) or 4 (K=8)
+
+    assert BLOCK_M % NUM_WAVES == 0
+    assert head_dim % 32 == 0, f"head_dim ({head_dim}) must be divisible by 32"
+    assert head_dim >= 64, f"head_dim ({head_dim}) must be >= 64"
+    assert flat_work_group_size in (128, 256, 512), (
+        f"flat_work_group_size must be 128, 256, or 512, got {flat_work_group_size}"
+    )
+    assert dtype_str in ("f16", "bf16"), "v4_swa_bwd_dq only supports f16 and bf16"
+    assert BLOCK_N % 32 == 0
+    assert BLOCK_N_OUT == BLOCK_N
+    assert isinstance(swa_window, int) and swa_window > 0, (
+        f"swa_window must be int > 0, got {swa_window!r}")
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    STRIDE_TOKEN = NUM_HEADS * HEAD_DIM
+
+    K_STRIDE = HEAD_DIM
+    # XOR swizzle mask must fit within the row stride. The swizzle is
+    # applied at 16-element granularity, so the maximum mask is
+    # `(K_STRIDE // 16 - 1) << 4`. For D=128 that's 7 (=0x7), giving max
+    # mask 112 < 128. For D=64 it's 3 (=0x3), giving max mask 48 < 64.
+    # SLA test only covers D=128 (mask=7); using a hardcoded `& 7` for
+    # D=64 wraps writes into adjacent rows -> silent corruption.
+    K_SWZ_ROW_MASK = (K_STRIDE // 16) - 1
+    assert K_SWZ_ROW_MASK >= 0
+    assert (K_SWZ_ROW_MASK & (K_SWZ_ROW_MASK + 1)) == 0, (
+        f"K_SWZ_ROW_MASK must be 2^n-1, got {K_SWZ_ROW_MASK} (K_STRIDE={K_STRIDE})"
+    )
+    if USE_HW_TR:
+        V_STRIDE = HEAD_DIM if ENABLE_DMA else HEAD_DIM + 4
+    else:
+        VT_STRIDE = BLOCK_N + 2
+        V_STRIDE = VT_STRIDE
+    # V swizzle: similarly bounded by V_STRIDE / 16.
+    V_SWZ_ROW_MASK = min(3, (V_STRIDE // 16) - 1)
+    assert V_SWZ_ROW_MASK >= 0
+
+    VEC_WIDTH = 16 if ENABLE_LDS_VEC16 else 8
+    assert HEAD_DIM % VEC_WIDTH == 0
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+        NUM_BATCHES_KV = 1
+        KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+    else:
+        assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0
+        NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+        KV_NEEDS_GUARD = False
+
+    LDS_K_TILE_SIZE = BLOCK_N * K_STRIDE
+    if USE_HW_TR:
+        LDS_V_TILE_SIZE = BLOCK_N * V_STRIDE
+    else:
+        LDS_V_TILE_SIZE = HEAD_DIM * VT_STRIDE
+    LDS_K_TOTAL_SIZE = NUM_PREFETCH_K * LDS_K_TILE_SIZE
+    LDS_V_BASE = LDS_K_TOTAL_SIZE
+    LDS_V_TOTAL_SIZE = NUM_PREFETCH_V * LDS_V_TILE_SIZE
+    LDS_KV_TOTAL_SIZE = LDS_K_TOTAL_SIZE + LDS_V_TOTAL_SIZE
+
+    allocator = SmemAllocator(
+        None,
+        arch=gpu_arch,
+        global_sym_name=f"v4_swa_bwd_dq_smem_M{BLOCK_M}_W{swa_window}_S{int(has_sink)}_MQ{int(mqa_kv)}",
+    )
+    lds_kv_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_kv_offset + LDS_KV_TOTAL_SIZE * 2
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_swa_bwd_dq_kernel(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,      # grad of output (input)
+        LSE: fx.Tensor,      # log-sum-exp from fwd (input, f32, RAW domain)
+        DELTAS: fx.Tensor,   # (o * do).sum(-1) preprocess (input, f32)
+        DQ: fx.Tensor,       # grad wrt Q (output, FP32)
+        DSINK: fx.Tensor,    # grad wrt sink (output, FP32, [HQ])
+        SINK: fx.Tensor,     # sink param (input, FP32, [HQ]); dummy if !has_sink
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        compute_type = T.f32
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        k_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K)
+        v_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V)
+        do_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DOS)
+        dq_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), DQ)
+        # LSE / DELTAS: f32 scalar READS via buffer_load.
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+        deltas_rsrc = buffer_ops.create_buffer_resource(DELTAS, max_size=True)
+        sink_rsrc = buffer_ops.create_buffer_resource(SINK, max_size=True)
+        # DSINK: f32 atomic_fadd via buffer_atomic_fadd.
+        dsink_rsrc = buffer_ops.create_buffer_resource(DSINK, max_size=True)
+
+        # All FP operations use aggressive fast-math (no NaN/Inf checks, reassociation).
+        fm_fast = arith.FastMathFlags.fast
+        v4f16_type = T.vec(4, elem_type)
+        vxf16_type = T.vec(VEC_WIDTH, elem_type)
+        v8f16_type = T.vec(8, elem_type)
+        v16f32_type = T.vec(16, compute_type)
+        mfma_pack_type = v8f16_type if USE_K16 else v4f16_type
+        MFMA_LANE_K = 8 if USE_K16 else 4
+        _mfma_zero = ir.IntegerAttr.get(ir.IntegerType.get_signless(32), 0)
+
+        def _mfma(ods_fn, a, b, c):
+            return ods_fn(v16f32_type, a, b, c, _mfma_zero, _mfma_zero, _mfma_zero).result
+
+        def mfma_acc(a, b, c):
+            if dtype_str == "bf16":
+                if USE_K16:
+                    return _mfma(rocdl.mfma_f32_32x32x16_bf16, a, b, c)
+                a = vector.bitcast(T.i16x4, a)
+                b = vector.bitcast(T.i16x4, b)
+                return _mfma(rocdl.mfma_f32_32x32x8bf16_1k, a, b, c)
+            if USE_K16:
+                return _mfma(rocdl.mfma_f32_32x32x16_f16, a, b, c)
+            return _mfma(rocdl.mfma_f32_32x32x8f16, a, b, c)
+
+        seq_len_q_v = arith.index_cast(T.index, seq_len_q)
+        seq_len_k_v = arith.index_cast(T.index, seq_len_k)
+
+        # ---- LDS view ----
+        base_ptr = allocator.get_base()
+        lds_kv = SmemPtr(
+            base_ptr,
+            lds_kv_offset,
+            elem_type,
+            shape=(LDS_KV_TOTAL_SIZE,),
+        ).get()
+
+        # ---- Thread / block indices ----
+        block_id = arith.index_cast(T.index, gpu.block_idx.x)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+
+        wave_id = tid // WARP_SIZE
+        lane = tid % WARP_SIZE
+        lane_mod_32 = lane % 32
+        lane_div_32 = lane // 32  # 0/1
+
+        # ds_read_b64_tr_b16 lane decomposition
+        tr_k_group = (lane % 16) // 4
+        tr_col_sub = lane % 4
+        tr_col_half = (lane % 32) // 16
+
+        def ds_read_tr_v4f16(lds_elem_idx):
+            byte_offset = lds_elem_idx * 2 + lds_kv_offset
+            byte_i64 = arith.index_cast(T.i64, byte_offset)
+            ptr = _llvm.IntToPtrOp(_llvm_lds_ptr_ty(), byte_i64).result
+            return rocdl.ds_read_tr16_b64(v4f16_type, ptr).result
+
+        wave_q_offset = wave_id * ROWS_PER_WAVE
+
+        # ---- Decompose block_id: (batch, q_tile, head) ----
+        head_idx = block_id % NUM_HEADS
+        batch_q_tile_id = block_id // NUM_HEADS
+        num_q_tiles = (seq_len_q_v + BLOCK_M - 1) // BLOCK_M
+        q_tile_idx = batch_q_tile_id % num_q_tiles
+        batch_idx = batch_q_tile_id // num_q_tiles
+        q_start = q_tile_idx * BLOCK_M
+
+        # ---- V4 SWA: per-tile contiguous K-block range (wave-uniform) ----
+        SWA = arith.index(swa_window)
+        BN = arith.index(BLOCK_N)
+        BM = arith.index(BLOCK_M)
+        _zero_idx = arith.index(0)
+        _one_idx = arith.index(1)
+        # n_block_start = max(0, q_start - W + 1) // BLOCK_N
+        # n_block_end   = ceil(min(q_start + BLOCK_M, seq_len_k), BLOCK_N)
+        _q_plus_one = q_start + _one_idx
+        _ge_w = arith.cmpi(arith.CmpIPredicate.sge, _q_plus_one, SWA)
+        _n_start_row = arith.select(_ge_w, _q_plus_one - SWA, _zero_idx)
+        n_block_start = _n_start_row // BN
+        _n_end_row_uncl = q_start + BM
+        _le_seq = arith.cmpi(arith.CmpIPredicate.sle, _n_end_row_uncl, seq_len_k_v)
+        n_end_row_cl = arith.select(_le_seq, _n_end_row_uncl, seq_len_k_v)
+        n_block_end = (n_end_row_cl + BN - _one_idx) // BN
+
+        # ---- Cooperative load decomposition ----
+        load_row_in_batch = tid // THREADS_PER_ROW_LOAD
+        load_lane_in_row = tid % THREADS_PER_ROW_LOAD
+        load_col_base = load_lane_in_row * VEC_WIDTH
+
+        # ---- Helper: global flat index ----
+        if layout_bhld:
+            bh_base_tokens_q = (batch_idx * NUM_HEADS + head_idx) * seq_len_q_v
+            if mqa_kv:
+                bh_base_tokens_kv = batch_idx * seq_len_k_v
+            else:
+                bh_base_tokens_kv = (batch_idx * NUM_HEADS + head_idx) * seq_len_k_v
+
+            def global_idx_q(token_idx, col):
+                return (bh_base_tokens_q + token_idx) * arith.index(HEAD_DIM) + col
+
+            def global_idx_kv(token_idx, col):
+                return (bh_base_tokens_kv + token_idx) * arith.index(HEAD_DIM) + col
+        else:
+            # BLHD path: kept for symmetry but V4 uses BHLD.
+            def global_idx_q(token_idx, col):
+                token = batch_idx * seq_len_q_v + token_idx
+                return token * STRIDE_TOKEN + head_idx * HEAD_DIM + col
+
+            if mqa_kv:
+                def global_idx_kv(token_idx, col):
+                    token = batch_idx * seq_len_k_v + token_idx
+                    return token * HEAD_DIM + col
+            else:
+                def global_idx_kv(token_idx, col):
+                    token = batch_idx * seq_len_k_v + token_idx
+                    return token * STRIDE_TOKEN + head_idx * HEAD_DIM + col
+
+        def _gep_load(base_ptr_, elem_idx, vec_type, et=elem_type):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=et,
+                              noWrapFlags=0)
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def _gep_store_f32(val, base_ptr_, elem_idx):
+            """Store a single f32 value via GEP into an fp32 buffer."""
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr_, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=T.f32,
+                              noWrapFlags=0)
+            _llvm.StoreOp(val, gep.result)
+
+        def load_global_mfma_pack(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, mfma_pack_type)
+
+        def load_global_f16xN(base_ptr_, base_idx):
+            return _gep_load(base_ptr_, base_idx, vxf16_type)
+
+        def bf16_trunc_pack_v4(f32_vals):
+            _v2i32 = T.vec(2, T.i32)
+            _c16 = arith.constant(16, type=T.i32)
+            _cmask = arith.constant(0xFFFF0000, type=T.i32)
+            a0 = arith.ArithValue(f32_vals[0]).bitcast(T.i32)
+            b0 = arith.ArithValue(f32_vals[1]).bitcast(T.i32)
+            p0 = arith.OrIOp(arith.AndIOp(b0, _cmask).result,
+                             arith.ShRUIOp(a0, _c16).result).result
+            a1 = arith.ArithValue(f32_vals[2]).bitcast(T.i32)
+            b1 = arith.ArithValue(f32_vals[3]).bitcast(T.i32)
+            p1 = arith.OrIOp(arith.AndIOp(b1, _cmask).result,
+                             arith.ShRUIOp(a1, _c16).result).result
+            return vector.bitcast(v4f16_type, vector.from_elements(_v2i32, [p0, p1]))
+
+        def bf16_trunc_pack_v8(f32_vals):
+            _v4i32 = T.vec(4, T.i32)
+            _c16 = arith.constant(16, type=T.i32)
+            _cmask = arith.constant(0xFFFF0000, type=T.i32)
+            pairs = []
+            for j in range_constexpr(4):
+                a = arith.ArithValue(f32_vals[j * 2]).bitcast(T.i32)
+                b = arith.ArithValue(f32_vals[j * 2 + 1]).bitcast(T.i32)
+                p = arith.OrIOp(arith.AndIOp(b, _cmask).result,
+                                arith.ShRUIOp(a, _c16).result).result
+                pairs.append(p)
+            return vector.bitcast(v8f16_type, vector.from_elements(_v4i32, pairs))
+
+        def k_buf_base(buf_id):
+            if isinstance(buf_id, int):
+                return arith.index(buf_id * LDS_K_TILE_SIZE)
+            return buf_id * arith.index(LDS_K_TILE_SIZE)
+
+        def v_buf_base(buf_id):
+            if isinstance(buf_id, int):
+                return arith.index(LDS_V_BASE + buf_id * LDS_V_TILE_SIZE)
+            return arith.index(LDS_V_BASE) + buf_id * arith.index(LDS_V_TILE_SIZE)
+
+        # ---- K XOR swizzle: col ^ ((row & K_SWZ_ROW_MASK) << 4) at 16-element granularity ----
+        # K_SWZ_ROW_MASK derived from K_STRIDE to stay within the row.
+        def _k_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+            return col_idx ^ mask
+
+        # ---- Cooperative K load (row-major, XOR-swizzled) ----
+        def coop_load_k(tile_start, buf_id=0):
+            k_base = k_buf_base(buf_id)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    _if_k = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_k.then_block):
+                        g_idx = global_idx_kv(row_idx, load_col_base)
+                        lds_row = load_row_in_batch + row_offset
+                        swz_col = _k_swizzle(lds_row, load_col_base)
+                        lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                        vec = load_global_f16xN(k_ptr, g_idx)
+                        vector.store(vec, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    g_idx = global_idx_kv(row_idx, load_col_base)
+                    lds_row = load_row_in_batch + row_offset
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    vec = load_global_f16xN(k_ptr, g_idx)
+                    vector.store(vec, lds_kv, [lds_idx])
+
+        # ---- Cooperative V-into-K-LDS-slot load (K-style XOR swizzle) ----
+        def coop_load_v_as_k(tile_start, buf_id=0):
+            k_base = k_buf_base(buf_id)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    _if_v = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_v.then_block):
+                        g_idx = global_idx_kv(row_idx, load_col_base)
+                        lds_row = load_row_in_batch + row_offset
+                        swz_col = _k_swizzle(lds_row, load_col_base)
+                        lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                        vec = load_global_f16xN(v_ptr, g_idx)
+                        vector.store(vec, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    g_idx = global_idx_kv(row_idx, load_col_base)
+                    lds_row = load_row_in_batch + row_offset
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    vec = load_global_f16xN(v_ptr, g_idx)
+                    vector.store(vec, lds_kv, [lds_idx])
+
+        # ---- Cooperative V load (V LDS layout) ----
+        def _v_store_row_major(v_base, lds_row, vec):
+            lds_idx = v_base + lds_row * V_STRIDE + load_col_base
+            vector.store(vec, lds_kv, [lds_idx])
+
+        _v1_type = T.vec(1, elem_type) if not USE_HW_TR else None
+
+        def _v_store_transposed(v_base, lds_row, vec):
+            for _e in range_constexpr(VEC_WIDTH):
+                elem = vector.extract(vec, static_position=[_e], dynamic_position=[])
+                vt_d = load_col_base + _e
+                vt_idx = v_base + vt_d * VT_STRIDE + lds_row
+                v1 = vector.from_elements(_v1_type, [elem])
+                vector.store(v1, lds_kv, [vt_idx])
+
+        _v_store_to_lds = _v_store_row_major if USE_HW_TR else _v_store_transposed
+
+        def coop_load_v(tile_start, buf_id=0):
+            v_base = v_buf_base(buf_id)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    _if_v = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_v.then_block):
+                        g_idx = global_idx_kv(row_idx, load_col_base)
+                        lds_row = load_row_in_batch + row_offset
+                        vec = load_global_f16xN(v_ptr, g_idx)
+                        _v_store_to_lds(v_base, lds_row, vec)
+                        scf.YieldOp([])
+                else:
+                    g_idx = global_idx_kv(row_idx, load_col_base)
+                    lds_row = load_row_in_batch + row_offset
+                    vec = load_global_f16xN(v_ptr, g_idx)
+                    _v_store_to_lds(v_base, lds_row, vec)
+
+        # ---- Cooperative K-into-V-LDS-slot load ----
+        def coop_load_k_as_v(tile_start, buf_id=0):
+            v_base = v_buf_base(buf_id)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    _if_v = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_v.then_block):
+                        g_idx = global_idx_kv(row_idx, load_col_base)
+                        lds_row = load_row_in_batch + row_offset
+                        vec = load_global_f16xN(k_ptr, g_idx)
+                        _v_store_to_lds(v_base, lds_row, vec)
+                        scf.YieldOp([])
+                else:
+                    g_idx = global_idx_kv(row_idx, load_col_base)
+                    lds_row = load_row_in_batch + row_offset
+                    vec = load_global_f16xN(k_ptr, g_idx)
+                    _v_store_to_lds(v_base, lds_row, vec)
+
+        # ---- DMA loading for K (buffer_load_dwordx4 ... lds) ----
+        if ENABLE_DMA:
+            from flydsl._mlir.dialects import llvm
+            k_rsrc = buffer_ops.create_buffer_resource(K, max_size=True)
+            _lds_ptr_ty = _llvm_lds_ptr_ty()
+            DMA_BYTES = 16
+            DMA_BATCH_BYTES = BLOCK_SIZE * DMA_BYTES
+            K_TILE_BYTES = BLOCK_N * K_STRIDE * 2
+            NUM_DMA_K = K_TILE_BYTES // DMA_BATCH_BYTES
+            LANES_PER_K_ROW = HEAD_DIM * 2 // DMA_BYTES
+            ROWS_PER_DMA_BATCH = DMA_BATCH_BYTES // (HEAD_DIM * 2)
+            lds_kv_base_idx = _memref.extract_aligned_pointer_as_index(lds_kv)
+            _dma_size = arith.constant(DMA_BYTES, type=T.i32)
+            _dma_soff = arith.constant(0, type=T.i32)
+            _dma_off = arith.constant(0, type=T.i32)
+            _dma_aux = arith.constant(1, type=T.i32)
+
+            def _kv_global_byte(tile_start, row_in_tile, col_byte):
+                if layout_bhld:
+                    row_within = tile_start + row_in_tile
+                    return ((bh_base_tokens_kv + row_within)
+                            * arith.index(HEAD_DIM * 2) + col_byte)
+                else:
+                    global_row = (batch_idx * seq_len_k_v + tile_start + row_in_tile)
+                    if mqa_kv:
+                        return (global_row * arith.index(HEAD_DIM * 2) + col_byte)
+                    else:
+                        return (global_row * arith.index(STRIDE_TOKEN * 2)
+                                + head_idx * arith.index(HEAD_DIM * 2)
+                                + col_byte)
+
+            def coop_dma_k(tile_start, buf_id=0):
+                if isinstance(buf_id, int):
+                    k_lds_byte_base = lds_kv_base_idx + arith.index(buf_id * LDS_K_TILE_SIZE * 2)
+                else:
+                    k_lds_byte_base = lds_kv_base_idx + buf_id * arith.index(LDS_K_TILE_SIZE * 2)
+                for d in range_constexpr(NUM_DMA_K):
+                    lds_addr = (k_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_K_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH))
+                    swiz_col_f16 = (tid % LANES_PER_K_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        k_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+        def _v_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(V_SWZ_ROW_MASK)) << arith.index(4)
+            return col_idx ^ mask
+
+        if ENABLE_DMA:
+            v_rsrc = buffer_ops.create_buffer_resource(V, max_size=True)
+            V_TILE_BYTES = BLOCK_N * V_STRIDE * 2
+            NUM_DMA_V = V_TILE_BYTES // DMA_BATCH_BYTES
+            LANES_PER_V_ROW = HEAD_DIM * 2 // DMA_BYTES
+            ROWS_PER_DMA_BATCH_V = DMA_BATCH_BYTES // (HEAD_DIM * 2)
+
+            def coop_dma_v(tile_start, buf_id=0):
+                v_lds_byte_base = (lds_kv_base_idx
+                                   + arith.index((LDS_V_BASE + buf_id * LDS_V_TILE_SIZE) * 2))
+                for d in range_constexpr(NUM_DMA_V):
+                    lds_addr = (v_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_V_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH_V))
+                    swiz_col_f16 = (tid % LANES_PER_V_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(V_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        v_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+            # ---- Bwd dQ DMA variants (cross-pointer, matching swizzle) ----
+            def coop_dma_v_as_k(tile_start, buf_id=0):
+                if isinstance(buf_id, int):
+                    k_lds_byte_base = lds_kv_base_idx + arith.index(buf_id * LDS_K_TILE_SIZE * 2)
+                else:
+                    k_lds_byte_base = lds_kv_base_idx + buf_id * arith.index(LDS_K_TILE_SIZE * 2)
+                for d in range_constexpr(NUM_DMA_K):
+                    lds_addr = (k_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_K_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH))
+                    swiz_col_f16 = (tid % LANES_PER_K_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        v_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+            def coop_dma_k_as_v(tile_start, buf_id=0):
+                if isinstance(buf_id, int):
+                    v_lds_byte_base = (lds_kv_base_idx
+                                       + arith.index((LDS_V_BASE + buf_id * LDS_V_TILE_SIZE) * 2))
+                else:
+                    v_lds_byte_base = (lds_kv_base_idx
+                                       + arith.index(LDS_V_BASE * 2)
+                                       + buf_id * arith.index(LDS_V_TILE_SIZE * 2))
+                for d in range_constexpr(NUM_DMA_V):
+                    lds_addr = (v_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_V_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH_V))
+                    swiz_col_f16 = (tid % LANES_PER_V_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(V_SWZ_ROW_MASK)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    global_byte = _kv_global_byte(tile_start, row_in_tile, col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+                    rocdl.raw_ptr_buffer_load_lds(
+                        k_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+        # ---- Preload Q^T B-operand and DO^T B-operand packs ----
+        q_row = q_start + wave_q_offset + lane_mod_32
+        q_in_bounds = arith.cmpi(arith.CmpIPredicate.slt, q_row, seq_len_q_v)
+        q_row_safe = arith.select(q_in_bounds, q_row, arith.index(0))
+        c_zero_mfma_pack = arith.constant_vector(0.0, mfma_pack_type)
+        q_b_packs = []
+        do_b_packs = []
+        for ks in range_constexpr(K_STEPS_QK):
+            col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+            g_idx = global_idx_q(q_row_safe, col)
+            q_raw = load_global_mfma_pack(q_ptr, g_idx)
+            q_b_packs.append(arith.select(q_in_bounds, q_raw, c_zero_mfma_pack))
+            do_raw = load_global_mfma_pack(do_ptr, g_idx)
+            do_b_packs.append(arith.select(q_in_bounds, do_raw, c_zero_mfma_pack))
+
+        # ---- Constants ----
+        c_zero_f = arith.constant(0.0, type=compute_type)
+        c_neg_inf = arith.constant(-1.0e30, type=compute_type)  # finite NEG_INF (matches Triton)
+        c_zero_v16f32 = arith.constant_vector(0.0, v16f32_type)
+        # V4 LSE is RAW-domain (qk*sm_scale + ln(l)). So use sm_scale, not sm_scale*log2e.
+        c_sm_scale = arith.constant(sm_scale, type=compute_type)
+
+        # ---- Per-q-row scalars (LSE, delta) ----
+        # bh_base_tokens_q is the Q LSE/DELTAS base too (LSE shape [B,HQ,Sq]).
+        lse_delta_off_i32 = arith.index_cast(
+            T.i32, bh_base_tokens_q + q_row_safe)
+        lse_val = buffer_ops.buffer_load(
+            lse_rsrc, lse_delta_off_i32, vec_width=1, dtype=T.f32,
+        )
+        delta_val = buffer_ops.buffer_load(
+            deltas_rsrc, lse_delta_off_i32, vec_width=1, dtype=T.f32,
+        )
+
+        # ---- SINK contribution to DSINK ----
+        # Per Triton ref:
+        #   sink_h = SINK[qhid]   (uniform across lanes of this program)
+        #   p_sink = exp(sink_h - lse)
+        #   dsink_contrib = sum_m -p_sink_masked * dvec_masked  (over BLOCK_M rows)
+        #   atomic_fadd(DSINK + qhid, dsink_contrib)
+        # We do the atomic per row-owner lane (lane_div_32==0 lane) to avoid
+        # the cross-wave reduction. That gives BLOCK_M atomics per program -
+        # slow but bulletproof. Each lane contributes -p_sink * dvec for its
+        # owned row only when q_in_bounds.
+        if has_sink:
+            head_idx_i32 = arith.index_cast(T.i32, head_idx)
+            sink_h_scalar = buffer_ops.buffer_load(
+                sink_rsrc, head_idx_i32, vec_width=1, dtype=T.f32,
+            )
+            sink_h_uniform = rocdl.readfirstlane(T.f32, sink_h_scalar)
+            sub_val = arith.SubFOp(
+                sink_h_uniform, lse_val, fastmath=fm_fast,
+            ).result
+            p_sink = math_dialect.exp(sub_val, fastmath=fm_fast)
+            neg_p_sink = arith.SubFOp(
+                c_zero_f, p_sink, fastmath=fm_fast,
+            ).result
+            contrib = arith.MulFOp(
+                neg_p_sink, delta_val, fastmath=fm_fast,
+            ).result
+            # Gate: only the row-owner lane (lane_div_32==0) and only when
+            # q_row < seq_len_q, atomically adds.
+            is_row_owner = arith.cmpi(
+                arith.CmpIPredicate.eq, lane_div_32, arith.index(0),
+            )
+            do_sink_atomic = arith.AndIOp(is_row_owner, q_in_bounds).result
+            _if_sink = scf.IfOp(do_sink_atomic, [], has_else=False)
+            with ir.InsertionPoint(_if_sink.then_block):
+                # DSINK byte offset = head_idx * 4 (fp32).
+                _dsink_byte_off = arith.MulIOp(
+                    head_idx_i32, arith.constant(4, type=T.i32),
+                ).result
+                _zero_i32_atom = arith.constant(0, type=T.i32)
+                rocdl.raw_ptr_buffer_atomic_fadd(
+                    contrib, dsink_rsrc, _dsink_byte_off,
+                    _zero_i32_atom, _zero_i32_atom,
+                )
+                scf.YieldOp([])
+
+        # ---- MILESTONE: dense SWA bwd dQ with double-buffered LDS ----
+        _use_dbuf = ENABLE_DMA
+
+        init_args = []
+        for _ in range_constexpr(D_CHUNKS):
+            init_args.append(c_zero_v16f32)
+        if _use_dbuf:
+            init_args.append(arith.index(0))  # cur_buf_id
+
+            # PROLOGUE: prefetch iter 0's K into BOTH slots of buf 0.
+            _init_kv_start = n_block_start * BN
+            coop_dma_k(_init_kv_start, buf_id=0)
+            coop_dma_k_as_v(_init_kv_start, buf_id=0)
+
+        for block_idx, inner_iter_args, loop_results in scf.for_(
+            n_block_start,
+            n_block_end,
+            arith.index(1),
+            iter_args=init_args,
+        ):
+            dq_accs = [
+                inner_iter_args[i] for i in range_constexpr(D_CHUNKS)
+            ]
+            if _use_dbuf:
+                cur_buf = inner_iter_args[D_CHUNKS]
+                next_buf = arith.index(1) - cur_buf
+
+            # V4 SWA: block_idx is directly the K-block index.
+            kv_block_start = block_idx * BN
+            kv_start = kv_block_start
+
+            if _use_dbuf:
+                rocdl.s_waitcnt(0)
+                gpu.barrier()
+                k_base = k_buf_base(cur_buf)
+            else:
+                coop_load_k(kv_start, buf_id=0)
+                coop_load_k_as_v(kv_start, buf_id=0)
+                gpu.barrier()
+                k_base = k_buf_base(0)
+
+            # ==== GEMM1: s = Q @ K^T ====
+            k_hi_offset = K_SUB_N * K_STRIDE
+            k_swz_mask = (lane_mod_32 & arith.index(K_SWZ_ROW_MASK)) << arith.index(4)
+
+            def _k_idx_lo(ks):
+                col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+                return k_base + lane_mod_32 * K_STRIDE + (col ^ k_swz_mask)
+
+            def _k_idx_hi(ks):
+                col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+                return (k_base + k_hi_offset
+                        + lane_mod_32 * K_STRIDE + (col ^ k_swz_mask))
+
+            s_acc_lo = c_zero_v16f32
+            s_acc_hi = c_zero_v16f32
+            for ks in range_constexpr(K_STEPS_QK):
+                k_pack_lo = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_lo(ks)])
+                k_pack_hi = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_hi(ks)])
+                s_acc_lo = mfma_acc(k_pack_lo, q_b_packs[ks], s_acc_lo)
+                s_acc_hi = mfma_acc(k_pack_hi, q_b_packs[ks], s_acc_hi)
+
+            # ==== Compute p[r] = exp(qk * sm_scale - LSE) with SWA + causal + boundary mask ====
+            kv_start_i32 = arith.index_cast(T.i32, kv_start)
+            seq_len_k_i32 = arith.index_cast(T.i32, seq_len_k_v)
+            seq_len_q_i32 = arith.index_cast(T.i32, seq_len_q_v)
+            q_row_i32_mask = arith.index_cast(T.i32, q_row)
+            w_i32 = arith.constant(swa_window, type=T.i32)
+            lane_div_32_i32 = arith.index_cast(T.i32, lane_div_32)
+            lane_off_i32 = arith.MulIOp(
+                lane_div_32_i32, arith.constant(4, type=T.i32)).result
+
+            # Is this q_row out of bounds? In that case all mask elements = NEG_INF.
+            q_oob = arith.cmpi(
+                arith.CmpIPredicate.sge, q_row_i32_mask, seq_len_q_i32,
+            )
+
+            p_vals_lo = []
+            p_vals_hi = []
+            for r in range_constexpr(16):
+                r_off_i32 = arith.constant(
+                    (r % 4) + (r // 4) * 8, type=T.i32)
+
+                # lo half: col = kv_start + lane_off + r_off
+                kv_col_lo_i32 = arith.AddIOp(
+                    arith.AddIOp(kv_start_i32, lane_off_i32).result,
+                    r_off_i32).result
+                # boundary
+                is_oob_lo = arith.cmpi(
+                    arith.CmpIPredicate.sge, kv_col_lo_i32, seq_len_k_i32)
+                # causal: kv_col > q_row
+                is_causal_lo = arith.cmpi(
+                    arith.CmpIPredicate.sgt, kv_col_lo_i32, q_row_i32_mask)
+                # SWA: kv_col + W <= q_row
+                kv_plus_w_lo = arith.AddIOp(kv_col_lo_i32, w_i32).result
+                is_swa_lo = arith.cmpi(
+                    arith.CmpIPredicate.sle, kv_plus_w_lo, q_row_i32_mask)
+                bad_lo = arith.OrIOp(
+                    arith.OrIOp(
+                        arith.OrIOp(is_causal_lo, is_swa_lo).result,
+                        is_oob_lo,
+                    ).result,
+                    q_oob,
+                ).result
+
+                s_lo_f32 = vector.extract(
+                    s_acc_lo, static_position=[r], dynamic_position=[])
+                scaled_lo = arith.MulFOp(
+                    s_lo_f32, c_sm_scale, fastmath=fm_fast).result
+                scaled_lo_masked = arith.select(bad_lo, c_neg_inf, scaled_lo)
+                diff_lo = arith.SubFOp(
+                    scaled_lo_masked, lse_val, fastmath=fm_fast).result
+                p_lo = math_dialect.exp(diff_lo, fastmath=fm_fast)
+                p_vals_lo.append(p_lo)
+
+                # hi half: col = lo_col + K_SUB_N
+                kv_col_hi_i32 = arith.AddIOp(
+                    kv_col_lo_i32,
+                    arith.constant(K_SUB_N, type=T.i32)).result
+                is_oob_hi = arith.cmpi(
+                    arith.CmpIPredicate.sge, kv_col_hi_i32, seq_len_k_i32)
+                is_causal_hi = arith.cmpi(
+                    arith.CmpIPredicate.sgt, kv_col_hi_i32, q_row_i32_mask)
+                kv_plus_w_hi = arith.AddIOp(kv_col_hi_i32, w_i32).result
+                is_swa_hi = arith.cmpi(
+                    arith.CmpIPredicate.sle, kv_plus_w_hi, q_row_i32_mask)
+                bad_hi = arith.OrIOp(
+                    arith.OrIOp(
+                        arith.OrIOp(is_causal_hi, is_swa_hi).result,
+                        is_oob_hi,
+                    ).result,
+                    q_oob,
+                ).result
+
+                s_hi_f32 = vector.extract(
+                    s_acc_hi, static_position=[r], dynamic_position=[])
+                scaled_hi = arith.MulFOp(
+                    s_hi_f32, c_sm_scale, fastmath=fm_fast).result
+                scaled_hi_masked = arith.select(bad_hi, c_neg_inf, scaled_hi)
+                diff_hi = arith.SubFOp(
+                    scaled_hi_masked, lse_val, fastmath=fm_fast).result
+                p_hi = math_dialect.exp(diff_hi, fastmath=fm_fast)
+                p_vals_hi.append(p_hi)
+
+            # ==== Overwrite K LDS slot with V for GEMM2 ====
+            gpu.barrier()
+            if _use_dbuf:
+                coop_dma_v_as_k(kv_start, buf_id=cur_buf)
+                rocdl.s_waitcnt(0)
+                gpu.barrier()
+            elif ENABLE_DMA:
+                coop_dma_v_as_k(kv_start, buf_id=0)
+                rocdl.s_waitcnt(0)
+                gpu.barrier()
+            else:
+                coop_load_v_as_k(kv_start, buf_id=0)
+                gpu.barrier()
+
+            # ==== GEMM2: dP = DO @ V^T ====
+            dp_acc_lo = c_zero_v16f32
+            dp_acc_hi = c_zero_v16f32
+            for ks in range_constexpr(K_STEPS_QK):
+                v_pack_lo = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_lo(ks)])
+                v_pack_hi = vector.load_op(
+                    mfma_pack_type, lds_kv, [_k_idx_hi(ks)])
+                dp_acc_lo = mfma_acc(v_pack_lo, do_b_packs[ks], dp_acc_lo)
+                dp_acc_hi = mfma_acc(v_pack_hi, do_b_packs[ks], dp_acc_hi)
+
+            # ==== Prefetch iter+1's K DMAs (async) ====
+            if _use_dbuf:
+                _next_block_idx = block_idx + arith.index(1)
+                _has_next = arith.cmpi(
+                    arith.CmpIPredicate.slt,
+                    _next_block_idx, n_block_end)
+                _pre_if = scf.IfOp(_has_next)
+                with ir.InsertionPoint(_pre_if.then_block):
+                    _next_kv_start = _next_block_idx * BN
+                    coop_dma_k(_next_kv_start, next_buf)
+                    coop_dma_k_as_v(_next_kv_start, next_buf)
+                    scf.YieldOp([])
+
+            # ==== Compute dS[r] = p[r] * (dp[r] - delta) ====
+            ds_vals_lo = []
+            ds_vals_hi = []
+            for r in range_constexpr(16):
+                dp_lo = vector.extract(
+                    dp_acc_lo, static_position=[r], dynamic_position=[])
+                dp_hi = vector.extract(
+                    dp_acc_hi, static_position=[r], dynamic_position=[])
+                diff_lo = arith.SubFOp(
+                    dp_lo, delta_val, fastmath=fm_fast).result
+                diff_hi = arith.SubFOp(
+                    dp_hi, delta_val, fastmath=fm_fast).result
+                ds_lo = arith.MulFOp(
+                    p_vals_lo[r], diff_lo, fastmath=fm_fast).result
+                ds_hi = arith.MulFOp(
+                    p_vals_hi[r], diff_hi, fastmath=fm_fast).result
+                ds_vals_lo.append(ds_lo)
+                ds_vals_hi.append(ds_hi)
+
+            # ==== Pack dS f32 -> mfma_pack_type (bf16/f16) ====
+            if dtype_str == "bf16" and USE_K16:
+                ds_packs_lo = []
+                ds_packs_hi = []
+                for pks in range_constexpr(PV_K_STEPS):
+                    base = pks * 8
+                    ds_packs_lo.append(bf16_trunc_pack_v8(
+                        ds_vals_lo[base:base+8]))
+                    ds_packs_hi.append(bf16_trunc_pack_v8(
+                        ds_vals_hi[base:base+8]))
+            elif dtype_str == "bf16":
+                ds_packs_lo = []
+                ds_packs_hi = []
+                for pks in range_constexpr(PV_K_STEPS):
+                    base = pks * 4
+                    ds_packs_lo.append(bf16_trunc_pack_v4(
+                        ds_vals_lo[base:base+4]))
+                    ds_packs_hi.append(bf16_trunc_pack_v4(
+                        ds_vals_hi[base:base+4]))
+            else:
+                ds_f16_lo = [arith.trunc_f(elem_type, ds_vals_lo[r])
+                             for r in range_constexpr(16)]
+                ds_f16_hi = [arith.trunc_f(elem_type, ds_vals_hi[r])
+                             for r in range_constexpr(16)]
+                _pack_ty = v8f16_type if USE_K16 else v4f16_type
+                _pw = 8 if USE_K16 else 4
+                ds_packs_lo = []
+                ds_packs_hi = []
+                for pks in range_constexpr(PV_K_STEPS):
+                    b = pks * _pw
+                    ds_packs_lo.append(vector.from_elements(
+                        _pack_ty, [ds_f16_lo[b + i] for i in range(_pw)]))
+                    ds_packs_hi.append(vector.from_elements(
+                        _pack_ty, [ds_f16_hi[b + i] for i in range(_pw)]))
+
+            # ==== GEMM3: dQ += K @ dS  (uses fwd's V-read schedule with K substituted) ====
+            _steps = [(dc, pks)
+                      for dc in range(D_CHUNKS)
+                      for pks in range(PV_K_STEPS)]
+            TOTAL_PV = len(_steps)
+            v_base = v_buf_base(cur_buf) if _use_dbuf else v_buf_base(0)
+
+            def _read_k_as_v_pack(step_idx):
+                dc, pks = _steps[step_idx]
+                if USE_HW_TR:
+                    d_col = (arith.index(dc * D_CHUNK)
+                             + tr_col_half * 16 + tr_col_sub * 4)
+                    k_row = (arith.index(pks * PV_K_STEP)
+                             + lane_div_32 * 4 + tr_k_group)
+                    _d_col_eff = _v_swizzle(k_row, d_col) if ENABLE_DMA else d_col
+                    lds_lo = v_base + k_row * V_STRIDE + _d_col_eff
+                    lds_hi = lds_lo + arith.index(K_SUB_N * V_STRIDE)
+                    if USE_K16:
+                        vl_a = ds_read_tr_v4f16(lds_lo)
+                        vl_b = ds_read_tr_v4f16(
+                            lds_lo + arith.index(8 * V_STRIDE))
+                        vl = vector.shuffle(
+                            vl_a, vl_b, [0, 1, 2, 3, 4, 5, 6, 7])
+                        vh_a = ds_read_tr_v4f16(lds_hi)
+                        vh_b = ds_read_tr_v4f16(
+                            lds_hi + arith.index(8 * V_STRIDE))
+                        vh = vector.shuffle(
+                            vh_a, vh_b, [0, 1, 2, 3, 4, 5, 6, 7])
+                    else:
+                        vl = ds_read_tr_v4f16(lds_lo)
+                        vh = ds_read_tr_v4f16(lds_hi)
+                else:
+                    d_pos = arith.index(dc * D_CHUNK) + lane_mod_32
+                    kb = arith.index(pks * PV_K_STEP) + lane_div_32 * 4
+                    v_lo_idx = v_base + d_pos * VT_STRIDE + kb
+                    v_hi_idx = v_lo_idx + arith.index(K_SUB_N)
+                    vl = vector.load(v4f16_type, lds_kv, [v_lo_idx])
+                    vh = vector.load(v4f16_type, lds_kv, [v_hi_idx])
+                return vl, vh
+
+            k_lo_cur, k_hi_cur = _read_k_as_v_pack(0)
+            for si in range_constexpr(TOTAL_PV):
+                dc, pks = _steps[si]
+                if si + 1 < TOTAL_PV:
+                    k_lo_nxt, k_hi_nxt = _read_k_as_v_pack(si + 1)
+                dq_accs[dc] = mfma_acc(
+                    k_lo_cur, ds_packs_lo[pks], dq_accs[dc])
+                dq_accs[dc] = mfma_acc(
+                    k_hi_cur, ds_packs_hi[pks], dq_accs[dc])
+                if si + 1 < TOTAL_PV:
+                    k_lo_cur = k_lo_nxt
+                    k_hi_cur = k_hi_nxt
+
+            # End of iter: yield dq_accs and swapped cur_buf.
+            gpu.barrier()
+            _yield = list(dq_accs)
+            if _use_dbuf:
+                _yield.append(next_buf)
+            yield _yield
+
+        # ---- Final store: dQ_fp32 = dq_acc * sm_scale (NO trunc; fp32) ----
+        dq_finals = [
+            loop_results[dc] for dc in range_constexpr(D_CHUNKS)
+        ]
+        sm_scale_vec = vector.broadcast(v16f32_type, c_sm_scale)
+
+        _o_guard = scf.IfOp(q_in_bounds, [], has_else=False)
+        with ir.InsertionPoint(_o_guard.then_block):
+            for dc in range_constexpr(D_CHUNKS):
+                dq_scaled = arith.MulFOp(
+                    dq_finals[dc], sm_scale_vec, fastmath=fm_fast,
+                ).result
+                for r in range_constexpr(16):
+                    dq_val = vector.extract(
+                        dq_scaled,
+                        static_position=[r],
+                        dynamic_position=[],
+                    )
+                    d_row_rel = lane_div_32 * 4 + (r // 4) * 8 + (r % 4)
+                    d_col = arith.index(dc * D_CHUNK) + d_row_rel
+                    dq_global = global_idx_q(q_row, d_col)
+                    _gep_store_f32(dq_val, dq_ptr, dq_global)
+            scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_swa_bwd_dq(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        DOS: fx.Tensor,
+        LSE: fx.Tensor,
+        DELTAS: fx.Tensor,
+        DQ: fx.Tensor,
+        DSINK: fx.Tensor,
+        SINK: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len_q: fx.Int32,
+        seq_len_k: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        sl_idx = arith.index_cast(T.index, seq_len_q)
+        num_q_tiles = (sl_idx + BLOCK_M - 1) // BLOCK_M
+        grid_x = bs_idx * num_q_tiles * NUM_HEADS
+
+        launcher = v4_swa_bwd_dq_kernel(
+            Q, K, V, DOS, LSE, DELTAS, DQ, DSINK, SINK, seq_len_q, seq_len_k,
+        )
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                            T.i32,
+                            _wpe,
+                        )
+        if flat_work_group_size is not None:
+            _fwgs = int(flat_work_group_size)
+            if _fwgs >= 1:
+                flat_wg_attr = ir.StringAttr.get(f"{_fwgs},{_fwgs}")
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.flat_work_group_size"] = flat_wg_attr
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, 1, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    _fmha_compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+        "llvm_options": {
+            "enable-post-misched": False,
+            "lsr-drop-solution": True,
+        },
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return launch_v4_swa_bwd_dq(*args, **kwargs)
+
+    def _compile(Q, K, V, DOS, LSE, DELTAS, DQ, DSINK, SINK,
+                 batch_size, seq_len_q, seq_len_k, stream=None):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return flyc.compile(
+                launch_v4_swa_bwd_dq, Q, K, V, DOS, LSE, DELTAS, DQ, DSINK, SINK,
+                batch_size, seq_len_q, seq_len_k, fx.Stream(stream))
+
+    _launch.compile = _compile
+
+    return _launch
+
+
+# Convenience alias.
+build_v4_swa_bwd_dq_module_primary = build_v4_swa_bwd_dq_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_bwd_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_bwd_kernel.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_sla_bwd_kernel: V4 SWA attention backward kernels (FlyDSL, STEP 1).
+
+Forked from /workspace/FlyDSL-amd/kernels/sla_bwd_preprocess.py.
+
+STEP 1 SCOPE
+============
+Only the preprocess kernel is implemented in this file. dq / dkv are still
+handled by Triton in the v4_attention_bwd_flydsl_mqa wrapper (see that file
+for the rationale). The hooks defined here will be the landing spots for
+the dq / dkv kernels in STEP 1b / STEP 1c.
+
+PREPROCESS KERNEL (D scalar)
+---------------------------
+Computes ``delta[b, h, m] = sum_d (out[b, h, m, d] * dout[b, h, m, d])`` in
+fp32 for every query row. This is the standard FA-2 pre-pass and is dense
+(no SWA / sink dependency) so it is the simplest piece to lift to FlyDSL
+first.
+
+Inputs (flat views):
+    OS, DOS  shape (N_ROWS, D) where N_ROWS = B*HQ*Sq
+    DELTAS   shape (N_ROWS,)    fp32
+
+Grid: (N_ROWS / BLOCK_ROWS, 1, 1).
+Block: BLOCK_ROWS * THREADS_PER_ROW threads.
+
+Each row uses THREADS_PER_ROW = D // VEC_WIDTH threads. Cross-thread row
+reduction uses ``shuffle_xor`` at offsets THREADS_PER_ROW/2, /4, ..., 1
+which stays inside a THREADS_PER_ROW-lane subgroup (XOR never carries out
+of a power-of-2 subgroup).
+
+Requires: head_dim % VEC_WIDTH == 0, N_ROWS % BLOCK_ROWS == 0.
+"""
+
+import math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import arith, buffer_ops, range_constexpr
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T, Int32
+from flydsl.expr.numeric import Float32
+from flydsl.expr.vector import ReductionOp
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from kernels.kernels_common import dtype_to_elem_type
+
+KERNEL_NAME_PRE = "v4_swa_bwd_preprocess_kernel"
+
+# Wider VEC_WIDTH than the SLA kernel (D=512 vs D=128). At D=512 with
+# VEC_WIDTH=8 we would need 64 threads per row (== a full warp), which is
+# fine but uses one wave per BLOCK_ROWS rows. We use VEC_WIDTH=16 so
+# THREADS_PER_ROW=32 and a 256-thread block processes 8 rows = 2 waves
+# (more parallel tile generators per CU at the cost of slightly wider
+# loads). Either is correct.
+VEC_WIDTH = 8
+WARP_SIZE = 64
+
+
+def build_v4_swa_bwd_preprocess_module(
+    head_dim,
+    dtype_str="bf16",
+    block_rows=None,
+):
+    """Build the V4 SWA backward preprocess launcher.
+
+    Inputs (flattened to 2D by the launcher):
+        OS, DOS  shape (N_ROWS, D) where N_ROWS = B*H*L
+        DELTAS   shape (N_ROWS,)    f32
+
+    Args:
+        head_dim: head dimension (must be divisible by VEC_WIDTH).
+        dtype_str: "bf16" or "f16" for O_S / DO_S; DELTAS is always f32.
+        block_rows: rows processed per block. Default 8.
+    """
+    gpu_arch = get_hip_arch()
+
+    if block_rows is None:
+        BLOCK_ROWS = 8
+    else:
+        BLOCK_ROWS = block_rows
+
+    assert head_dim % VEC_WIDTH == 0, f"head_dim {head_dim} must be % {VEC_WIDTH}"
+    assert head_dim >= VEC_WIDTH, f"head_dim {head_dim} < VEC_WIDTH {VEC_WIDTH}"
+    assert dtype_str in ("bf16", "f16"), f"unsupported dtype {dtype_str}"
+
+    D = head_dim
+    THREADS_PER_ROW = D // VEC_WIDTH  # 32 for D=512, VEC_WIDTH=16
+    BLOCK_THREADS = BLOCK_ROWS * THREADS_PER_ROW
+    assert BLOCK_THREADS <= 1024, f"BLOCK_THREADS {BLOCK_THREADS} > 1024"
+    assert THREADS_PER_ROW & (THREADS_PER_ROW - 1) == 0, \
+        "THREADS_PER_ROW must be power of 2 for shfl_xor reduction"
+
+    elem_bits = 16  # bf16 / f16
+
+    @flyc.kernel
+    def v4_swa_bwd_preprocess_kernel(
+        OS: fx.Tensor,   # (N_ROWS, D)
+        DOS: fx.Tensor,  # (N_ROWS, D)
+        DELTAS: fx.Tensor,  # (N_ROWS,)
+    ):
+        bid = fx.block_idx.x
+        tid = fx.thread_idx.x
+
+        elem_type = dtype_to_elem_type(dtype_str)
+        compute_type = T.f32
+        fm_fast = arith.FastMathFlags.fast
+
+        # ---- Thread decomposition ----
+        row_in_block_i32 = tid // Int32(THREADS_PER_ROW)
+        col_in_row_i32 = tid % Int32(THREADS_PER_ROW)
+
+        global_row_i32 = bid * Int32(BLOCK_ROWS) + row_in_block_i32
+        global_row_idx = ArithValue(global_row_i32).index_cast(T.index)
+
+        # ---- Buffer-backed 2D tensors for loads ----
+        OS_buf = fx.rocdl.make_buffer_tensor(OS)
+        DOS_buf = fx.rocdl.make_buffer_tensor(DOS)
+        delta_rsrc = buffer_ops.create_buffer_resource(DELTAS, max_size=True)
+
+        row_os = fx.slice(OS_buf, (global_row_i32, None))
+        row_dos = fx.slice(DOS_buf, (global_row_i32, None))
+
+        in_div_os = fx.logical_divide(row_os, fx.make_layout(VEC_WIDTH, 1))
+        in_div_dos = fx.logical_divide(row_dos, fx.make_layout(VEC_WIDTH, 1))
+
+        copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_bits)
+        vec_reg_ty = fx.MemRefType.get(
+            elem_type, fx.LayoutType.get(VEC_WIDTH, 1), fx.AddressSpace.Register
+        )
+        vec_reg_lay = fx.make_layout(VEC_WIDTH, 1)
+
+        def _load_vec(div_tensor, col_idx):
+            r = fx.memref_alloca(vec_reg_ty, vec_reg_lay)
+            fx.copy_atom_call(copy_atom, fx.slice(div_tensor, (None, col_idx)), r)
+            return fx.memref_load_vec(r)
+
+        os_vec = _load_vec(in_div_os, col_in_row_i32)
+        dos_vec = _load_vec(in_div_dos, col_in_row_i32)
+
+        os_f32 = os_vec.to(Float32)
+        dos_f32 = dos_vec.to(Float32)
+        prod_f32 = os_f32 * dos_f32
+        local_sum = prod_f32.reduce(ReductionOp.ADD, fastmath=fm_fast)
+
+        width_i32 = Int32(WARP_SIZE)
+        val = local_sum
+        num_rounds = int(math.log2(THREADS_PER_ROW))
+        for _sh_exp in range_constexpr(num_rounds):
+            off = Int32(THREADS_PER_ROW // (2 << _sh_exp))
+            peer = val.shuffle_xor(off, width_i32)
+            val = val.addf(peer, fastmath=fm_fast)
+
+        if col_in_row_i32 == Int32(0):
+            delta_off_i32 = arith.index_cast(T.i32, global_row_idx)
+            val_ir = val.ir_value() if hasattr(val, "ir_value") else val
+            buffer_ops.buffer_store(val_ir, delta_rsrc, delta_off_i32)
+
+    @flyc.jit
+    def launch_v4_swa_bwd_preprocess(
+        OS: fx.Tensor,
+        DOS: fx.Tensor,
+        DELTAS: fx.Tensor,
+        n_rows: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        """Launch grid: (n_rows / BLOCK_ROWS, 1, 1).
+
+        Expects OS, DOS to be views of shape (n_rows, D). DELTAS is (n_rows,).
+        """
+        blocks_i32 = n_rows // Int32(BLOCK_ROWS)
+        blocks_idx = ArithValue(blocks_i32).index_cast(T.index)
+        launcher = v4_swa_bwd_preprocess_kernel(OS, DOS, DELTAS)
+        launcher.launch(
+            grid=(blocks_idx, arith.index(1), arith.index(1)),
+            block=(BLOCK_THREADS, 1, 1),
+            stream=stream,
+        )
+
+    return launch_v4_swa_bwd_preprocess
+
+
+# Convenience alias used by the wrapper.
+def build_v4_swa_bwd_preprocess(*args, **kwargs):
+    return build_v4_swa_bwd_preprocess_module(*args, **kwargs)
+
+
+
+# ---------------------------------------------------------------------------
+# STEP 1b: dq kernel re-export (forked from kernels/sla_bwd_dq.py).
+# Lives in v4_sla_bwd_dq_kernel.py for file-size reasons; re-exported here
+# so the wrapper can import a single module.
+# ---------------------------------------------------------------------------
+import os as _os
+import sys as _sys
+_HERE = _os.path.dirname(_os.path.abspath(__file__))
+if _HERE not in _sys.path:
+    _sys.path.insert(0, _HERE)
+from v4_sla_bwd_dq_kernel import (  # noqa: E402,F401
+    build_v4_swa_bwd_dq_module,
+    build_v4_swa_bwd_dq_module_primary,
+)

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_fwd_kernel.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_flydsl/kernels/v4_sla_fwd_kernel.py
@@ -1,0 +1,1367 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""v4_swa_fwd: V4 dense sliding-window-causal attention forward (FlyDSL).
+
+Forked from kernels/sla_fwd.py. Differences:
+  - No LUT: outer KV loop iterates a contiguous block range bounded by
+    the SWA window for the current Q tile (depends on q_tile_idx, but
+    wave-uniform).
+  - Per-element SWA mask: kv_col > q_row OR kv_col + swa_window <= q_row
+    OR kv_col >= seq_len -> NEG_INF, applied before softmax max-reduce.
+  - LSE is fp32 raw-domain `lse = m_final*scale + ln(l_final)` to match
+    V4 Triton reference (m_i + tl.log(l_i)).
+  - A-1 scope: no sink, no additive mask, no HCA. MQA broadcast at the
+    Python launcher (kernel sees full MHA K/V).
+
+Layout: BHLD. Q/K/V/O flattened from (B, H, L, D).
+LSE: (B, H, L) flat, fp32.
+Grid: (B * num_q_tiles * H,), num_q_tiles = L / BLOCK_M.
+"""
+
+import math
+import os
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.compiler.kernel_function import CompilationContext
+from flydsl.expr import arith, buffer_ops, gpu, range_constexpr, rocdl, vector
+from flydsl.expr.typing import T
+from kernels.kernels_common import dtype_to_elem_type
+from flydsl.runtime.device import get_rocm_arch as get_hip_arch
+from flydsl.utils.smem_allocator import SmemAllocator, SmemPtr
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import memref as _memref, scf, fly as _fly, llvm as _llvm, math as math_dialect
+
+# ---- Module-level constants ----
+
+KERNEL_NAME = "v4_swa_fwd_kernel"
+
+_LOG2E = math.log2(math.e)  # 1.4426950408889634
+
+_LLVM_GEP_DYNAMIC = -2147483648  # LLVM kDynamicIndex sentinel (0x80000000 as signed i32)
+
+def _llvm_ptr_ty():
+    return ir.Type.parse("!llvm.ptr")
+
+
+def _llvm_lds_ptr_ty():
+    return ir.Type.parse("!llvm.ptr<3>")
+
+_VMCNT_LO_MASK = 0xF
+_LGKMCNT_EXPCNT_BASE = 0x3F70
+_VMCNT_HI_SHIFT = 14
+_VMCNT_HI_MASK = 0x3
+
+
+def _waitcnt_vm_n(n):
+    """Emit s_waitcnt vmcnt(n) only (lgkmcnt=63, expcnt=7)."""
+    val = (n & _VMCNT_LO_MASK) | _LGKMCNT_EXPCNT_BASE | (((n >> 4) & _VMCNT_HI_MASK) << _VMCNT_HI_SHIFT)
+    rocdl.s_waitcnt(val)
+
+
+def build_v4_swa_fwd_module(
+    num_heads,
+    head_dim,
+    swa_window,
+    dtype_str="bf16",
+    sm_scale=None,
+    waves_per_eu=2,
+    flat_work_group_size=None,
+    block_m=None,
+    block_n=None,
+    unsafe_fp_math=True,
+    fast_fp_math=True,
+    daz=True,
+    layout_bhld=True,
+    mqa_kv=False,
+):
+    """Build the SLA sparse-fwd launcher. Single-variant only (no auto-dispatch).
+
+    mqa_kv: if True, K and V are MQA-shape [B, 1, Sk, D] (stride_kh=0) and
+    indexing into them drops head_idx. The kernel still sees Q at [B, H, Sq, D].
+
+    layout_bhld:
+      False → Q/K/V/O in (B, L, H, D) layout (inherited from flash_attn_func,
+              matches torch `(batch, seq, num_heads, head_dim)` natural form).
+      True  → Q/K/V/O in (B, H, L, D) layout (SLA's native form; avoids a
+              transpose at the integration boundary in `SparseLinearAttention`).
+      LUT and LSE layouts are unchanged either way:
+        LUT (B, H, M_BLOCKS, topk) flattened, dtype i32.
+        LSE (B, H, L) flattened, dtype f32.
+    """
+    gpu_arch = get_hip_arch()
+
+    if block_n is None:
+        BLOCK_N = 64
+    else:
+        BLOCK_N = int(block_n)
+    K_SUB_N = min(BLOCK_N, 32)
+    N_HALVES = BLOCK_N // 32  # 1 or 2; how many K_SUB_N halves per BLOCK_N
+    WARP_SIZE = 64
+    # SLA is always non-causal; the sparse map decides which blocks attend.
+    causal = False
+
+    if block_m is not None:
+        BLOCK_M = block_m
+    else:
+        BLOCK_M = 128
+
+    if flat_work_group_size is None:
+        if BLOCK_M <= 128:
+            flat_work_group_size = 256
+        else:
+            flat_work_group_size = 512
+    NUM_WAVES = flat_work_group_size // WARP_SIZE
+    BLOCK_SIZE = flat_work_group_size
+    ROWS_PER_WAVE = BLOCK_M // NUM_WAVES
+    # V4 SWA: always N32 path. One outer iter = one BLOCK_N block.
+    PATH_TAG = "N32"
+    BLOCK_N_OUT = BLOCK_N
+    N_SUBTILES = 1
+    ENABLE_PREFETCH_3BUF = (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_PREFETCH3", "0") == "1"
+    )
+    # buffer_load_dwordx4_lds (16B DMA-to-LDS) requires gfx950+; gfx94x only has dword (4B).
+    # For SLA we default-on DMA when hardware supports it — this is the whole point.
+    _has_lds_load_b128 = not gpu_arch.startswith("gfx942")
+    ENABLE_DMA = _has_lds_load_b128 and (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_DMA", "1") == "1"
+    )
+    ENABLE_LDS_VEC16 = (
+        os.getenv("FLYDSL_SLA_FWD_ENABLE_LDS_VEC16", "1") == "1"
+    )
+    REDUCE_MODE = os.getenv("FLYDSL_SLA_FWD_REDUCE_MODE", "xor").strip().lower()
+    if REDUCE_MODE not in ("xor", "ds_bpermute"):
+        REDUCE_MODE = "xor"
+    FORCE_SINGLE_BUF_DMA = (
+        os.getenv("FLYDSL_V4_SWA_SINGLE_BUF_DMA", "0") == "1"
+    )
+    if ENABLE_PREFETCH_3BUF:
+        NUM_PREFETCH_K = 3
+    elif ENABLE_DMA and not FORCE_SINGLE_BUF_DMA:
+        NUM_PREFETCH_K = 2
+    else:
+        NUM_PREFETCH_K = 1
+    # Lever A: double-buffer V in DMA-dbuf mode so V HBM latency overlaps
+    # with the QK MFMA of the next iteration (mirrors K-dbuf behavior).
+    if ENABLE_PREFETCH_3BUF:
+        NUM_PREFETCH_V = 3
+    elif ENABLE_DMA and not FORCE_SINGLE_BUF_DMA:
+        NUM_PREFETCH_V = 2
+    else:
+        NUM_PREFETCH_V = 1
+    CK_LDS_SEQ = (1, 2, 0, 1, 0, 1, 2, 0) if ENABLE_PREFETCH_3BUF else (0,)
+
+    # gfx950+ has ds_read_tr16_b64 (HW transpose LDS read); gfx942 needs V^T stored in LDS.
+    USE_HW_TR = gpu_arch.startswith("gfx950")
+
+    # MFMA32 K-dimension: 16 on gfx950+ (CDNA4) for both GEMMs.
+    USE_K16 = gpu_arch.startswith("gfx950")
+    K_STEP_QK = 16 if USE_K16 else 8
+    K_STEPS_QK = head_dim // K_STEP_QK
+    D_CHUNK = 32
+    D_CHUNKS = head_dim // D_CHUNK
+    PV_K_STEP = 16 if USE_K16 else 8
+    PV_K_STEPS = K_SUB_N // PV_K_STEP  # 2 steps per sub-tile (K=16) or 4 (K=8)
+
+    assert BLOCK_M % NUM_WAVES == 0
+    assert head_dim % 32 == 0, f"head_dim ({head_dim}) must be divisible by 32"
+    assert head_dim >= 64, f"head_dim ({head_dim}) must be >= 64"
+    assert flat_work_group_size in (128, 256, 512), (
+        f"flat_work_group_size must be 128, 256, or 512, got {flat_work_group_size}"
+    )
+    assert dtype_str in ("f16", "bf16"), "sla_fwd only supports f16 and bf16"
+    assert BLOCK_N % 32 == 0 or BLOCK_N == 32
+    assert BLOCK_N_OUT == BLOCK_N
+    assert N_HALVES in (1, 2)
+    assert isinstance(swa_window, int) and swa_window > 0, (
+        f"swa_window must be int > 0, got {swa_window!r}")
+
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+    NUM_HEADS = num_heads
+    HEAD_DIM = head_dim
+    CAUSAL = causal
+    STRIDE_TOKEN = NUM_HEADS * HEAD_DIM
+
+    # Bank-conflict-free LDS strides.
+    # K uses XOR swizzle (col ^ ((row & 7) << 4)) at 16-element granularity
+    # instead of padding. This enables ds_read_b128 (stride is 256B-aligned).
+    K_STRIDE = HEAD_DIM
+    if USE_HW_TR:
+        V_STRIDE = HEAD_DIM if ENABLE_DMA else HEAD_DIM + 4
+    else:
+        VT_STRIDE = BLOCK_N + 2
+        V_STRIDE = VT_STRIDE
+
+    # Vectorized cooperative load constants.
+    VEC_WIDTH = 16 if ENABLE_LDS_VEC16 else 8
+    assert HEAD_DIM % VEC_WIDTH == 0
+    THREADS_PER_ROW_LOAD = HEAD_DIM // VEC_WIDTH
+    assert BLOCK_SIZE % THREADS_PER_ROW_LOAD == 0
+    ROWS_PER_BATCH_LOAD = BLOCK_SIZE // THREADS_PER_ROW_LOAD
+
+    if ROWS_PER_BATCH_LOAD >= BLOCK_N:
+        NUM_BATCHES_KV = 1
+        KV_NEEDS_GUARD = ROWS_PER_BATCH_LOAD > BLOCK_N
+    else:
+        assert BLOCK_N % ROWS_PER_BATCH_LOAD == 0
+        NUM_BATCHES_KV = BLOCK_N // ROWS_PER_BATCH_LOAD
+        KV_NEEDS_GUARD = False
+
+    # K/V circular buffers; defaults to 1/1, optional 3/3 with CK-like LDS sequence.
+    LDS_K_TILE_SIZE = BLOCK_N * K_STRIDE
+    if USE_HW_TR:
+        LDS_V_TILE_SIZE = BLOCK_N * V_STRIDE
+    else:
+        LDS_V_TILE_SIZE = HEAD_DIM * VT_STRIDE
+    LDS_K_TOTAL_SIZE = NUM_PREFETCH_K * LDS_K_TILE_SIZE
+    LDS_V_BASE = LDS_K_TOTAL_SIZE
+    LDS_V_TOTAL_SIZE = NUM_PREFETCH_V * LDS_V_TILE_SIZE
+    LDS_KV_TOTAL_SIZE = LDS_K_TOTAL_SIZE + LDS_V_TOTAL_SIZE
+
+    allocator = SmemAllocator(
+        None,
+        arch=gpu_arch,
+        global_sym_name=f"v4_swa_fwd_smem_M{BLOCK_M}_N{BLOCK_N}_W{swa_window}",
+    )
+    lds_kv_offset = allocator._align(allocator.ptr, 16)
+    allocator.ptr = lds_kv_offset + LDS_KV_TOTAL_SIZE * 2
+
+    @flyc.kernel(known_block_size=[BLOCK_SIZE, 1, 1])
+    def v4_swa_fwd_kernel(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        O: fx.Tensor,
+        LSE: fx.Tensor,
+        seq_len: fx.Int32,
+    ):
+        elem_type = dtype_to_elem_type(dtype_str)
+        compute_type = T.f32
+        q_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), Q)
+        k_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), K)
+        v_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), V)
+        o_ptr = _fly.extract_aligned_pointer_as_index(_llvm_ptr_ty(), O)
+        # LSE: f32 scalar writes via buffer_store.
+        lse_rsrc = buffer_ops.create_buffer_resource(LSE, max_size=True)
+
+        # All FP operations use aggressive fast-math (no NaN/Inf checks, reassociation).
+        # The unsafe_fp_math/fast_fp_math builder params control LLVM-level attributes only.
+        fm_fast = arith.FastMathFlags.fast
+        v4f16_type = T.vec(4, elem_type)
+        vxf16_type = T.vec(VEC_WIDTH, elem_type)
+        v8f16_type = T.vec(8, elem_type)
+        v16f32_type = T.vec(16, compute_type)
+        mfma_pack_type = v8f16_type if USE_K16 else v4f16_type
+        MFMA_LANE_K = 8 if USE_K16 else 4
+        _mfma_zero = ir.IntegerAttr.get(ir.IntegerType.get_signless(32), 0)
+        def _mfma(ods_fn, a, b, c):
+            return ods_fn(v16f32_type, a, b, c, _mfma_zero, _mfma_zero, _mfma_zero).result
+        def mfma_acc(a, b, c):
+            if dtype_str == "bf16":
+                if USE_K16:
+                    return _mfma(rocdl.mfma_f32_32x32x16_bf16, a, b, c)
+                a = vector.bitcast(T.i16x4, a)
+                b = vector.bitcast(T.i16x4, b)
+                return _mfma(rocdl.mfma_f32_32x32x8bf16_1k, a, b, c)
+            if USE_K16:
+                return _mfma(rocdl.mfma_f32_32x32x16_f16, a, b, c)
+            return _mfma(rocdl.mfma_f32_32x32x8f16, a, b, c)
+
+        seq_len_v = arith.index_cast(T.index, seq_len)
+
+        # ---- LDS view ----
+        base_ptr = allocator.get_base()
+        lds_kv = SmemPtr(
+            base_ptr,
+            lds_kv_offset,
+            elem_type,
+            shape=(LDS_KV_TOTAL_SIZE,),
+        ).get()
+
+        # ---- Thread / block indices ----
+        block_id = arith.index_cast(T.index, gpu.block_idx.x)
+        tid = arith.index_cast(T.index, gpu.thread_idx.x)
+
+        # ---- Wave decomposition ----
+        wave_id = tid // WARP_SIZE
+        lane = tid % WARP_SIZE
+        lane_mod_32 = lane % 32
+        lane_div_32 = lane // 32  # 0/1
+
+        # ---- ds_read_b64_tr_b16 lane decomposition ----
+        # Hardware does 4×4 transpose within blocks of 16 lanes.
+        # tr_k_group selects which of 4 K-rows within the block,
+        # tr_col_sub selects which 4-column sub-group within 16 columns.
+        tr_k_group = (lane % 16) // 4   # 0..3: K-row offset within 4-row group
+        tr_col_sub = lane % 4            # 0..3: 4-column sub-group
+        tr_col_half = (lane % 32) // 16  # 0 or 1: first/second 16-column half
+
+        # ---- ds_read_b64_tr_b16 helper ----
+
+        def ds_read_tr_v4f16(lds_elem_idx):
+            """Read v4f16 from LDS with hardware transpose.
+
+            Within each block of 16 lanes, the hardware performs a 4×4
+            transpose across 4 groups of 4 lanes.  After the transpose,
+            result[lane, elem_e] = Input[source_lane, lane%4] where
+            source_lane = e*4 + (lane%16)//4.  This naturally produces
+            the MFMA A-operand layout when per-lane addresses point to
+            the correct K-row and D-column sub-group.
+            """
+            byte_offset = lds_elem_idx * 2 + lds_kv_offset
+            byte_i64 = arith.index_cast(T.i64, byte_offset)
+            ptr = _llvm.IntToPtrOp(_llvm_lds_ptr_ty(), byte_i64).result
+            return rocdl.ds_read_tr16_b64(v4f16_type, ptr).result
+
+        # ---- Wave offsets ----
+        wave_q_offset = wave_id * ROWS_PER_WAVE
+
+        # ---- Decompose block_id ----
+        head_idx = block_id % NUM_HEADS
+        batch_q_tile_id = block_id // NUM_HEADS
+        num_q_tiles = (seq_len_v + BLOCK_M - 1) // BLOCK_M
+        q_tile_idx = batch_q_tile_id % num_q_tiles
+        batch_idx = batch_q_tile_id // num_q_tiles
+        q_start = q_tile_idx * BLOCK_M
+
+        # ---- V4 SWA: per-tile contiguous K-block range (wave-uniform) ----
+        # Q tile rows: [q_start, q_start + BLOCK_M). Union of visible K
+        # columns under SWA-causal: [q_start - W + 1, q_start + BLOCK_M).
+        # n_block_start = max(0, q_start - W + 1) // BLOCK_N
+        # n_block_end   = ceil(min(q_start + BLOCK_M, seq_len), BLOCK_N)
+        # Per-element causal/SWA/boundary mask still applied inside the loop.
+        SWA = arith.index(swa_window)
+        BN = arith.index(BLOCK_N)
+        BM = arith.index(BLOCK_M)
+        _zero_idx = arith.index(0)
+        _one_idx = arith.index(1)
+        # q_start - W + 1 -- compute as index arithmetic, then clamp.
+        _q_plus_one = q_start + _one_idx
+        # We need max(0, _q_plus_one - SWA). To avoid negative-index issues
+        # we test _q_plus_one >= SWA first.
+        _ge_w = arith.cmpi(arith.CmpIPredicate.sge, _q_plus_one, SWA)
+        _n_start_row = arith.select(_ge_w, _q_plus_one - SWA, _zero_idx)
+        n_block_start = _n_start_row // BN
+        _n_end_row_uncl = q_start + BM
+        _le_seq = arith.cmpi(arith.CmpIPredicate.sle, _n_end_row_uncl, seq_len_v)
+        n_end_row_cl = arith.select(_le_seq, _n_end_row_uncl, seq_len_v)
+        n_block_end = (n_end_row_cl + BN - _one_idx) // BN
+
+        # ---- Cooperative load decomposition ----
+        load_row_in_batch = tid // THREADS_PER_ROW_LOAD
+        load_lane_in_row = tid % THREADS_PER_ROW_LOAD
+        load_col_base = load_lane_in_row * VEC_WIDTH
+
+        # ---- Helper: global flat index ----
+        # BLHD: stride = (L*H*D, H*D, D, 1) → (token=b*L + l) * (H*D) + h*D + col
+        # BHLD: stride = (H*L*D, L*D, D, 1) → ((b*H + h) * L + l) * D + col
+        if layout_bhld:
+            bh_base_tokens = (batch_idx * NUM_HEADS + head_idx) * seq_len_v
+            if mqa_kv:
+                # K/V are [B, 1, Sk, D] -- drop head_idx from KV indexing.
+                bh_base_tokens_kv = batch_idx * seq_len_v
+            else:
+                bh_base_tokens_kv = bh_base_tokens
+
+            def global_idx(token_idx, col):
+                return (bh_base_tokens + token_idx) * arith.index(HEAD_DIM) + col
+
+            def global_idx_kv(token_idx, col):
+                return (bh_base_tokens_kv + token_idx) * arith.index(HEAD_DIM) + col
+        else:
+            def global_idx(token_idx, col):
+                token = batch_idx * seq_len_v + token_idx
+                return token * STRIDE_TOKEN + head_idx * HEAD_DIM + col
+            if mqa_kv:
+                # BLHD MQA: K/V token = batch_idx * seq_len_v + token_idx (no h*D added).
+                def global_idx_kv(token_idx, col):
+                    token = batch_idx * seq_len_v + token_idx
+                    return token * HEAD_DIM + col  # no STRIDE_TOKEN, no head_idx
+            else:
+                global_idx_kv = global_idx
+
+        def _gep_load(base_ptr, elem_idx, vec_type):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=elem_type,
+                              noWrapFlags=0)
+            return _llvm.LoadOp(vec_type, gep.result).result
+
+        def _gep_store(val, base_ptr, elem_idx):
+            idx_i64 = arith.index_cast(T.i64, elem_idx)
+            gep = _llvm.GEPOp(_llvm_ptr_ty(), base_ptr, [idx_i64],
+                              rawConstantIndices=[_LLVM_GEP_DYNAMIC],
+                              elem_type=elem_type,
+                              noWrapFlags=0)
+            _llvm.StoreOp(val, gep.result)
+
+        def load_global_f16x4(base_ptr, base_idx):
+            return _gep_load(base_ptr, base_idx, v4f16_type)
+
+        def load_global_mfma_pack(base_ptr, base_idx):
+            return _gep_load(base_ptr, base_idx, mfma_pack_type)
+
+        def load_global_f16xN(base_ptr, base_idx):
+            return _gep_load(base_ptr, base_idx, vxf16_type)
+
+        def bf16_trunc_pack_v4(f32_vals):
+            """Pack 4 f32 values into v4bf16 via bitwise truncation (upper 16 bits).
+            ~2 fewer instructions/element vs arith.TruncFOp round-to-nearest."""
+            _v2i32 = T.vec(2, T.i32)
+            _c16 = arith.constant(16, type=T.i32)
+            _cmask = arith.constant(0xFFFF0000, type=T.i32)
+            a0 = arith.ArithValue(f32_vals[0]).bitcast(T.i32)
+            b0 = arith.ArithValue(f32_vals[1]).bitcast(T.i32)
+            p0 = arith.OrIOp(arith.AndIOp(b0, _cmask).result,
+                             arith.ShRUIOp(a0, _c16).result).result
+            a1 = arith.ArithValue(f32_vals[2]).bitcast(T.i32)
+            b1 = arith.ArithValue(f32_vals[3]).bitcast(T.i32)
+            p1 = arith.OrIOp(arith.AndIOp(b1, _cmask).result,
+                             arith.ShRUIOp(a1, _c16).result).result
+            return vector.bitcast(v4f16_type, vector.from_elements(_v2i32, [p0, p1]))
+
+        def bf16_trunc_pack_v8(f32_vals):
+            """Pack 8 f32 values into v8bf16 via bitwise truncation (upper 16 bits)."""
+            _v4i32 = T.vec(4, T.i32)
+            _c16 = arith.constant(16, type=T.i32)
+            _cmask = arith.constant(0xFFFF0000, type=T.i32)
+            pairs = []
+            for j in range_constexpr(4):
+                a = arith.ArithValue(f32_vals[j * 2]).bitcast(T.i32)
+                b = arith.ArithValue(f32_vals[j * 2 + 1]).bitcast(T.i32)
+                p = arith.OrIOp(arith.AndIOp(b, _cmask).result,
+                                arith.ShRUIOp(a, _c16).result).result
+                pairs.append(p)
+            return vector.bitcast(v8f16_type, vector.from_elements(_v4i32, pairs))
+
+        def k_buf_base(buf_id):
+            if isinstance(buf_id, int):
+                return arith.index(buf_id * LDS_K_TILE_SIZE)
+            return buf_id * arith.index(LDS_K_TILE_SIZE)
+
+        def v_buf_base(buf_id):
+            if isinstance(buf_id, int):
+                return arith.index(LDS_V_BASE + buf_id * LDS_V_TILE_SIZE)
+            return arith.index(LDS_V_BASE) + buf_id * arith.index(LDS_V_TILE_SIZE)
+
+        # ---- K XOR swizzle: col ^ ((row & 7) << 4) at 16-element granularity ----
+        def _k_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(0x7)) << arith.index(4)
+            return col_idx ^ mask
+
+        # ---- Cooperative K load (row-major, XOR-swizzled) ----
+        def coop_load_k(tile_start, buf_id=0):
+            k_base = k_buf_base(buf_id)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    _if_k = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_k.then_block):
+                        g_idx = global_idx_kv(row_idx, load_col_base)
+                        lds_row = load_row_in_batch + row_offset
+                        swz_col = _k_swizzle(lds_row, load_col_base)
+                        lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                        vec = load_global_f16xN(k_ptr, g_idx)
+                        vector.store(vec, lds_kv, [lds_idx])
+                        scf.YieldOp([])
+                else:
+                    g_idx = global_idx_kv(row_idx, load_col_base)
+                    lds_row = load_row_in_batch + row_offset
+                    swz_col = _k_swizzle(lds_row, load_col_base)
+                    lds_idx = k_base + lds_row * K_STRIDE + swz_col
+                    vec = load_global_f16xN(k_ptr, g_idx)
+                    vector.store(vec, lds_kv, [lds_idx])
+
+        # ---- Cooperative V load ----
+        def _v_store_row_major(v_base, lds_row, vec):
+            lds_idx = v_base + lds_row * V_STRIDE + load_col_base
+            vector.store(vec, lds_kv, [lds_idx])
+
+        _v1_type = T.vec(1, elem_type) if not USE_HW_TR else None
+
+        def _v_store_transposed(v_base, lds_row, vec):
+            for _e in range_constexpr(VEC_WIDTH):
+                elem = vector.extract(vec, static_position=[_e], dynamic_position=[])
+                vt_d = load_col_base + _e
+                vt_idx = v_base + vt_d * VT_STRIDE + lds_row
+                v1 = vector.from_elements(_v1_type, [elem])
+                vector.store(v1, lds_kv, [vt_idx])
+
+        _v_store_to_lds = _v_store_row_major if USE_HW_TR else _v_store_transposed
+
+        def coop_load_v(tile_start, buf_id=0):
+            v_base = v_buf_base(buf_id)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    _if_v = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_v.then_block):
+                        g_idx = global_idx_kv(row_idx, load_col_base)
+                        lds_row = load_row_in_batch + row_offset
+                        vec = load_global_f16xN(v_ptr, g_idx)
+                        _v_store_to_lds(v_base, lds_row, vec)
+                        scf.YieldOp([])
+                else:
+                    g_idx = global_idx_kv(row_idx, load_col_base)
+                    lds_row = load_row_in_batch + row_offset
+                    vec = load_global_f16xN(v_ptr, g_idx)
+                    _v_store_to_lds(v_base, lds_row, vec)
+
+        def coop_load_v_global(tile_start):
+            """Issue global loads for V, return vectors (non-blocking)."""
+            vecs = []
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                row_idx = tile_start + load_row_in_batch + row_offset
+                g_idx = global_idx_kv(row_idx, load_col_base)
+                vecs.append(load_global_f16xN(v_ptr, g_idx))
+            return vecs
+
+        def coop_store_v_lds(vecs, buf_id=0):
+            """Write previously-loaded V vectors to LDS."""
+            v_base = v_buf_base(buf_id)
+            for batch in range_constexpr(NUM_BATCHES_KV):
+                row_offset = batch * ROWS_PER_BATCH_LOAD
+                if KV_NEEDS_GUARD:
+                    row_valid = arith.cmpi(
+                        arith.CmpIPredicate.ult,
+                        load_row_in_batch,
+                        arith.index(BLOCK_N),
+                    )
+                    _if_v = scf.IfOp(row_valid)
+                    with ir.InsertionPoint(_if_v.then_block):
+                        lds_row = load_row_in_batch + row_offset
+                        _v_store_to_lds(v_base, lds_row, vecs[batch])
+                        scf.YieldOp([])
+                else:
+                    lds_row = load_row_in_batch + row_offset
+                    _v_store_to_lds(v_base, lds_row, vecs[batch])
+
+        # ---- DMA loading for K (buffer_load_dwordx4 ... lds) ----
+        if ENABLE_DMA:
+            from flydsl._mlir.dialects import llvm
+            k_rsrc = buffer_ops.create_buffer_resource(K, max_size=True)
+            _lds_ptr_ty = _llvm_lds_ptr_ty()
+            DMA_BYTES = 16  # buffer_load_dwordx4 = 16 bytes per lane
+            DMA_BATCH_BYTES = BLOCK_SIZE * DMA_BYTES
+            K_TILE_BYTES = BLOCK_N * K_STRIDE * 2
+            NUM_DMA_K = K_TILE_BYTES // DMA_BATCH_BYTES
+            LANES_PER_K_ROW = HEAD_DIM * 2 // DMA_BYTES
+            ROWS_PER_DMA_BATCH = DMA_BATCH_BYTES // (HEAD_DIM * 2)
+            lds_kv_base_idx = _memref.extract_aligned_pointer_as_index(lds_kv)
+            _dma_size = arith.constant(DMA_BYTES, type=T.i32)
+            _dma_soff = arith.constant(0, type=T.i32)
+            _dma_off = arith.constant(0, type=T.i32)
+            _dma_aux = arith.constant(1, type=T.i32)
+
+            def coop_dma_k(tile_start, buf_id=0):
+                """Load K tile via DMA with XOR-swizzled global fetch."""
+                if isinstance(buf_id, int):
+                    k_lds_byte_base = lds_kv_base_idx + arith.index(buf_id * LDS_K_TILE_SIZE * 2)
+                else:
+                    k_lds_byte_base = lds_kv_base_idx + buf_id * arith.index(LDS_K_TILE_SIZE * 2)
+                for d in range_constexpr(NUM_DMA_K):
+                    lds_addr = (k_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_K_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH))
+                    swiz_col_f16 = (tid % LANES_PER_K_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(0x7)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    # Layout-aware global byte offset.
+                    if layout_bhld:
+                        # BHLD: ((b*H + h)*L + (tile_start + row)) * (D*2) + col_byte
+                        # MQA: ((b)*L + (tile_start + row)) * (D*2) + col_byte
+                        row_within_head = tile_start + row_in_tile
+                        global_byte = (
+                            (bh_base_tokens_kv + row_within_head)
+                            * arith.index(HEAD_DIM * 2)
+                            + col_byte
+                        )
+                    else:
+                        # BLHD: ((b*L + row) * (H*D) + h*D) * 2 + col_byte
+                        global_row = (batch_idx * seq_len_v + tile_start
+                                      + row_in_tile)
+                        if mqa_kv:
+                            global_byte = (global_row * arith.index(HEAD_DIM * 2)
+                                           + col_byte)
+                        else:
+                            global_byte = (global_row * arith.index(STRIDE_TOKEN * 2)
+                                           + head_idx * arith.index(HEAD_DIM * 2)
+                                           + col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+
+                    rocdl.raw_ptr_buffer_load_lds(
+                        k_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+        # ---- V XOR swizzle: col ^ ((row & 3) << 4) at 16-element granularity ----
+        def _v_swizzle(row_idx, col_idx):
+            mask = (row_idx & arith.index(0x3)) << arith.index(4)
+            return col_idx ^ mask
+
+        # ---- DMA loading for V (buffer_load_dwordx4 ... lds) ----
+        if ENABLE_DMA:
+            v_rsrc = buffer_ops.create_buffer_resource(V, max_size=True)
+            V_TILE_BYTES = BLOCK_N * V_STRIDE * 2
+            NUM_DMA_V = V_TILE_BYTES // DMA_BATCH_BYTES
+            LANES_PER_V_ROW = HEAD_DIM * 2 // DMA_BYTES
+            ROWS_PER_DMA_BATCH_V = DMA_BATCH_BYTES // (HEAD_DIM * 2)
+
+            def coop_dma_v(tile_start, buf_id=0):
+                """Load V tile via DMA with XOR-swizzled global fetch."""
+                if isinstance(buf_id, int):
+                    v_lds_byte_base = (lds_kv_base_idx
+                                       + arith.index((LDS_V_BASE + buf_id * LDS_V_TILE_SIZE) * 2))
+                else:
+                    v_lds_byte_base = (lds_kv_base_idx
+                                       + arith.index(LDS_V_BASE * 2)
+                                       + buf_id * arith.index(LDS_V_TILE_SIZE * 2))
+                for d in range_constexpr(NUM_DMA_V):
+                    lds_addr = (v_lds_byte_base
+                                + wave_id * arith.index(WARP_SIZE * DMA_BYTES)
+                                + arith.index(d * DMA_BATCH_BYTES))
+                    lds_i64 = arith.index_cast(T.i64, lds_addr)
+                    lds_lane0 = rocdl.readfirstlane(T.i64, lds_i64)
+                    lds_ptr = llvm.IntToPtrOp(_lds_ptr_ty, lds_lane0).result
+
+                    row_in_tile = (tid // LANES_PER_V_ROW
+                                   + arith.index(d * ROWS_PER_DMA_BATCH_V))
+                    swiz_col_f16 = (tid % LANES_PER_V_ROW) * (DMA_BYTES // 2)
+                    xor_mask = (row_in_tile & arith.index(0x3)) << arith.index(4)
+                    unsw_col_f16 = swiz_col_f16 ^ xor_mask
+                    col_byte = unsw_col_f16 * 2
+                    # Layout-aware global byte offset (see K DMA path above).
+                    if layout_bhld:
+                        row_within_head = tile_start + row_in_tile
+                        global_byte = (
+                            (bh_base_tokens_kv + row_within_head)
+                            * arith.index(HEAD_DIM * 2)
+                            + col_byte
+                        )
+                    else:
+                        global_row = (batch_idx * seq_len_v + tile_start
+                                      + row_in_tile)
+                        if mqa_kv:
+                            global_byte = (global_row * arith.index(HEAD_DIM * 2)
+                                           + col_byte)
+                        else:
+                            global_byte = (global_row * arith.index(STRIDE_TOKEN * 2)
+                                           + head_idx * arith.index(HEAD_DIM * 2)
+                                           + col_byte)
+                    voffset = arith.index_cast(T.i32, global_byte)
+
+                    rocdl.raw_ptr_buffer_load_lds(
+                        v_rsrc, lds_ptr, _dma_size, voffset,
+                        _dma_soff, _dma_off, _dma_aux,
+                    )
+
+        # ---- Preload Q^T B-operand packs once (register-resident) ----
+        # B operand uses j = lane_mod_32, k-subblock = lane_div_32*MFMA_LANE_K.
+        q_row = q_start + wave_q_offset + lane_mod_32
+        q_row_i32 = arith.index_cast(T.i32, q_row)
+        q_in_bounds = arith.cmpi(arith.CmpIPredicate.slt, q_row, seq_len_v)
+        q_row_safe = arith.select(q_in_bounds, q_row, arith.index(0))
+        c_zero_mfma_pack = arith.constant_vector(0.0, mfma_pack_type)
+        q_b_packs = []
+        for ks in range_constexpr(K_STEPS_QK):
+            q_col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+            g_idx = global_idx(q_row_safe, q_col)
+            raw = load_global_mfma_pack(q_ptr, g_idx)
+            q_b_packs.append(arith.select(q_in_bounds, raw, c_zero_mfma_pack))
+
+        # ---- Constants ----
+        c_neg_inf = arith.constant(-1.0e30, type=compute_type)  # finite -inf to keep diff_m_raw=0 in all-masked tiles
+        c_zero_f = arith.constant(0.0, type=compute_type)
+        c_one_f = arith.constant(1.0, type=compute_type)
+        c_sm_scale_log2e = arith.constant(sm_scale * _LOG2E, type=compute_type)
+        c_zero_v16f32 = arith.constant_vector(0.0, v16f32_type)
+        width_i32 = arith.constant(WARP_SIZE, type=T.i32)
+        shuf_32_i32 = arith.constant(32, type=T.i32)
+        c4_i32 = arith.constant(4, type=T.i32)
+        lane_i32 = arith.index_cast(T.i32, lane)
+        lane_xor_32_i32 = arith.XOrIOp(lane_i32, shuf_32_i32).result
+        lane_xor_32_byte = arith.MulIOp(lane_xor_32_i32, c4_i32).result
+
+        def reduction_peer(v_f32):
+            if REDUCE_MODE == "ds_bpermute":
+                v_i32 = arith.ArithValue(v_f32).bitcast(T.i32)
+                peer_i32 = rocdl.ds_bpermute(T.i32, lane_xor_32_byte, v_i32)
+                return arith.ArithValue(peer_i32).bitcast(compute_type)
+            return arith.ArithValue(v_f32).shuffle_xor(shuf_32_i32, width_i32)
+
+        # ---- SLA sparse outer loop: iterate over `topk` LUT entries ----
+        # N_SUBTILES == 1 by construction: each LUT entry covers exactly one
+        # BLOCK_N block. The inner `kv_sub` loop collapses to one iteration,
+        # and the dense kernel's intra-outer "next kv_sub" prefetch path is
+        # unused — we prefetch the next OUTER iteration (block_idx+1) instead.
+        assert N_SUBTILES == 1
+
+        # Loop-carried: [m_old, l_old, o_acc_chunks..., (buf_id if DMA dbuf)]
+        _use_dma_dbuf = ENABLE_DMA and not ENABLE_PREFETCH_3BUF and NUM_PREFETCH_K >= 2
+        init_args = [c_neg_inf, c_zero_f]
+        for _ in range_constexpr(D_CHUNKS):
+            init_args.append(c_zero_v16f32)
+        if _use_dma_dbuf:
+            init_args.append(arith.index(0))
+            # Prefetch the first SWA-window block (K AND V — Lever A V dbuf).
+            _init_kv_start = n_block_start * BN
+            coop_dma_k(_init_kv_start, buf_id=0)
+            coop_dma_v(_init_kv_start, buf_id=0)
+
+        for block_idx, inner_iter_args, loop_results in scf.for_(
+            n_block_start,
+            n_block_end,
+            _one_idx,
+            iter_args=init_args,
+        ):
+            m_running = inner_iter_args[0]
+            l_running = inner_iter_args[1]
+            o_accs = [
+                inner_iter_args[2 + i] for i in range_constexpr(D_CHUNKS)
+            ]
+            _cur_buf_id = inner_iter_args[2 + D_CHUNKS] if _use_dma_dbuf else None
+
+            # V4 SWA: block_idx is directly the K-block index.
+            kv_block_start = block_idx * BN
+            preload_k_count = 1  # N_SUBTILES == 1
+
+            if ENABLE_PREFETCH_3BUF:
+                # 3-buf prefetch for sparse: look up LUT[block_idx + pre_k] and
+                # fire DMA per slot. Bounded by (block_idx + pre_k) < topk.
+                for pre_k in range_constexpr(preload_k_count):
+                    pre_k_slot = CK_LDS_SEQ[pre_k % len(CK_LDS_SEQ)] % NUM_PREFETCH_K
+                    if pre_k == 0:
+                        pre_k_start = kv_block_start
+                    else:
+                        _pre_idx = block_idx + arith.index(pre_k)
+                        _pre_has = arith.cmpi(
+                            arith.CmpIPredicate.slt, _pre_idx, n_block_end)
+                        _pre_if = scf.IfOp(_pre_has)
+                        with ir.InsertionPoint(_pre_if.then_block):
+                            pre_k_start = _pre_idx * BN
+                            if ENABLE_DMA:
+                                coop_dma_k(pre_k_start, pre_k_slot)
+                            else:
+                                coop_load_k(pre_k_start, pre_k_slot)
+                            scf.YieldOp([])
+                        continue
+                    if ENABLE_DMA:
+                        coop_dma_k(pre_k_start, pre_k_slot)
+                    else:
+                        coop_load_k(pre_k_start, pre_k_slot)
+                if ENABLE_DMA:
+                    rocdl.s_waitcnt(0)
+                else:
+                    rocdl.sched_group_barrier(rocdl.mask_vmem_rd, 1, 0)
+                gpu.barrier()
+
+            for kv_sub in range_constexpr(N_SUBTILES):  # single iteration
+                kv_start = kv_block_start  # sparse: kv_sub == 0 always
+
+                if ENABLE_PREFETCH_3BUF:
+                    k_slot = CK_LDS_SEQ[kv_sub % len(CK_LDS_SEQ)] % NUM_PREFETCH_K
+                elif _use_dma_dbuf:
+                    _k_buf_id = _cur_buf_id
+                    rocdl.s_waitcnt(0)
+                    gpu.barrier()
+                    _next_k_buf_id = arith.index(1) - _k_buf_id
+                    _next_block_idx = block_idx + _one_idx
+                    _has_next = arith.cmpi(
+                        arith.CmpIPredicate.slt,
+                        _next_block_idx,
+                        n_block_end,
+                    )
+                    _if_dma = scf.IfOp(_has_next)
+                    with ir.InsertionPoint(_if_dma.then_block):
+                        _next_kv = _next_block_idx * BN
+                        coop_dma_k(_next_kv, _next_k_buf_id)
+                        # Lever A: also fire next V DMA into the same buf_id.
+                        coop_dma_v(_next_kv, _next_k_buf_id)
+                        scf.YieldOp([])
+                    rocdl.sched_barrier(0)
+                    k_base = k_buf_base(_k_buf_id)
+                elif ENABLE_DMA:
+                    # Single-buf DMA: fire the DMA, then wait + barrier inline.
+                    k_slot = 0
+                    coop_dma_k(kv_start, k_slot)
+                    rocdl.s_waitcnt(0)
+                    gpu.barrier()
+                else:
+                    k_slot = 0
+                    coop_load_k(kv_start, k_slot)
+                    gpu.barrier()
+                if not _use_dma_dbuf:
+                    k_base = k_buf_base(k_slot)
+
+                if not USE_HW_TR or (not ENABLE_DMA and not ENABLE_PREFETCH_3BUF):
+                    _v_vecs_prefetch = coop_load_v_global(kv_start)
+
+                # ==== GEMM1: bulk-read all K packs, then pipeline MFMAs ====
+                k_hi_offset = K_SUB_N * K_STRIDE
+                # XOR swizzle: col ^ ((row & 0x7) << 4) avoids LDS bank conflicts
+                k_swz_mask = (lane_mod_32 & arith.index(0x7)) << arith.index(4)
+
+                def _k_idx_lo(ks):
+                    col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+                    return k_base + lane_mod_32 * K_STRIDE + (col ^ k_swz_mask)
+
+                def _k_idx_hi(ks):
+                    col = arith.index(ks * K_STEP_QK) + lane_div_32 * MFMA_LANE_K
+                    return (k_base + k_hi_offset
+                            + lane_mod_32 * K_STRIDE + (col ^ k_swz_mask))
+
+                _QK_PREFETCH_DEPTH = 2
+                k_packs_lo = [None] * K_STEPS_QK
+                k_packs_hi = [None] * K_STEPS_QK
+                for p in range_constexpr(_QK_PREFETCH_DEPTH):
+                    k_packs_lo[p] = vector.load_op(
+                        mfma_pack_type, lds_kv, [_k_idx_lo(p)])
+                    if N_HALVES == 2:
+                        k_packs_hi[p] = vector.load_op(
+                            mfma_pack_type, lds_kv, [_k_idx_hi(p)])
+
+                if ENABLE_DMA and not ENABLE_PREFETCH_3BUF and not _use_dma_dbuf:
+                    # Single-buf DMA path: fire V into buf 0 inside the iter.
+                    coop_dma_v(kv_start, 0)
+                    rocdl.sched_barrier(0)
+
+                s_acc_lo = c_zero_v16f32
+                s_acc_hi = c_zero_v16f32
+                for ks in range_constexpr(K_STEPS_QK):
+                    s_acc_lo = mfma_acc(
+                        k_packs_lo[ks], q_b_packs[ks], s_acc_lo)
+                    if N_HALVES == 2:
+                        s_acc_hi = mfma_acc(
+                            k_packs_hi[ks], q_b_packs[ks], s_acc_hi)
+                    if ks + _QK_PREFETCH_DEPTH < K_STEPS_QK:
+                        k_packs_lo[ks + _QK_PREFETCH_DEPTH] = vector.load_op(
+                            mfma_pack_type, lds_kv,
+                            [_k_idx_lo(ks + _QK_PREFETCH_DEPTH)])
+                        if N_HALVES == 2:
+                            k_packs_hi[ks + _QK_PREFETCH_DEPTH] = vector.load_op(
+                                mfma_pack_type, lds_kv,
+                                [_k_idx_hi(ks + _QK_PREFETCH_DEPTH)])
+
+                # ==== Online softmax over BLOCK_N KV positions ====
+                s_raw_lo = []
+                s_raw_hi = []
+                for r in range_constexpr(16):
+                    s_raw_lo.append(vector.extract(
+                        s_acc_lo, static_position=[r], dynamic_position=[]))
+                    if N_HALVES == 2:
+                        s_raw_hi.append(vector.extract(
+                            s_acc_hi, static_position=[r], dynamic_position=[]))
+
+                # SWA causal + boundary mask, per element. For the MFMA
+                # 32x32 C-layout (BLOCK_M=32 rows, BLOCK_N=64 cols arranged
+                # as two 32-col halves):
+                #   row owner: q_row = q_start + wave_q_offset + lane_mod_32
+                #              (preloaded above as `q_row`)
+                #   col index in tile: lane_div_32*4 + (r//4)*8 + (r%4)
+                #   tile column 0..31 = lo half, 32..63 = hi half
+                # The kernel `kv_start = block_idx * BLOCK_N` is the LEFT edge
+                # of the lo half (kv_col_lo). kv_col_hi = kv_col_lo + 32.
+                # Mask conditions (set element to NEG_INF):
+                #   1) causal:   kv_col > q_row
+                #   2) SWA:      kv_col + W <= q_row     (window length W)
+                #   3) boundary: kv_col >= seq_len
+                # NEG_INF == -inf (sla_fwd c_neg_inf). The all-masked-tile
+                # case is safe because m_running=-inf and l_running=0; the
+                # subsequent (m, l) update is identity:
+                #   m_new = max(-inf, -inf) = -inf
+                #   corr = exp(0) by convention but actually NaN here -- so
+                #   we must avoid running the masked tile.
+                # Mitigation: n_block_start/n_block_end above already prune
+                # entire tiles outside the SWA window; the only tiles we run
+                # have AT LEAST one in-window element per warp row. The
+                # per-element mask handles the remaining partial overlap.
+                kv_start_i32 = arith.index_cast(T.i32, kv_start)
+                lane_div_32_i32 = arith.index_cast(T.i32, lane_div_32)
+                seq_len_i32 = arith.index_cast(T.i32, seq_len_v)
+                q_row_i32_mask = arith.index_cast(T.i32, q_row)
+                w_i32 = arith.constant(swa_window, type=T.i32)
+                # Always mask. Tile-level gate omitted (cost negligible vs MFMA).
+                _bool_ty = ir.IntegerType.get_signless(1)
+                tile_needs_mask = arith.constant(1, type=_bool_ty)
+                _MASK_N_OUT = 16 * N_HALVES
+                _mask_if = scf.IfOp(
+                    tile_needs_mask, [T.f32] * _MASK_N_OUT, has_else=True)
+                with ir.InsertionPoint(_mask_if.then_block):
+                    _m_lo = []
+                    _m_hi = []
+                    for r in range_constexpr(16):
+                        r_off_i32 = arith.constant(
+                            (r % 4) + (r // 4) * 8, type=T.i32)
+                        lane_off_i32 = arith.MulIOp(
+                            lane_div_32_i32,
+                            arith.constant(4, type=T.i32)).result
+                        kv_col_lo = arith.AddIOp(
+                            arith.AddIOp(
+                                kv_start_i32, lane_off_i32).result,
+                            r_off_i32).result
+                        # Boundary
+                        is_oob_lo = arith.cmpi(
+                            arith.CmpIPredicate.sge,
+                            kv_col_lo, seq_len_i32)
+                        # Causal: kv_col > q_row
+                        is_causal_lo = arith.cmpi(
+                            arith.CmpIPredicate.sgt,
+                            kv_col_lo, q_row_i32_mask)
+                        # SWA: kv_col + W <= q_row
+                        kv_plus_w_lo = arith.AddIOp(
+                            kv_col_lo, w_i32).result
+                        is_swa_lo = arith.cmpi(
+                            arith.CmpIPredicate.sle,
+                            kv_plus_w_lo, q_row_i32_mask)
+                        bad_lo = arith.OrIOp(
+                            arith.OrIOp(is_causal_lo, is_swa_lo).result,
+                            is_oob_lo).result
+                        _m_lo.append(arith.select(
+                            bad_lo, c_neg_inf, s_raw_lo[r]))
+                        if N_HALVES == 2:
+                            kv_col_hi = arith.AddIOp(
+                                kv_col_lo,
+                                arith.constant(K_SUB_N, type=T.i32)).result
+                            is_oob_hi = arith.cmpi(
+                                arith.CmpIPredicate.sge,
+                                kv_col_hi, seq_len_i32)
+                            is_causal_hi = arith.cmpi(
+                                arith.CmpIPredicate.sgt,
+                                kv_col_hi, q_row_i32_mask)
+                            kv_plus_w_hi = arith.AddIOp(
+                                kv_col_hi, w_i32).result
+                            is_swa_hi = arith.cmpi(
+                                arith.CmpIPredicate.sle,
+                                kv_plus_w_hi, q_row_i32_mask)
+                            bad_hi = arith.OrIOp(
+                                arith.OrIOp(is_causal_hi, is_swa_hi).result,
+                                is_oob_hi).result
+                            _m_hi.append(arith.select(
+                                bad_hi, c_neg_inf, s_raw_hi[r]))
+                    scf.YieldOp(_m_lo + _m_hi)
+                with ir.InsertionPoint(_mask_if.else_block):
+                    scf.YieldOp(s_raw_lo + s_raw_hi)
+                s_raw_lo = [_mask_if.results[i] for i in range(16)]
+                if N_HALVES == 2:
+                    s_raw_hi = [_mask_if.results[16 + i] for i in range(16)]
+                else:
+                    s_raw_hi = []
+
+                _max_fm = {"fastmath": fm_fast}
+                local_max = s_raw_lo[0]
+                for r in range_constexpr(15):
+                    local_max = arith.MaxNumFOp(local_max, s_raw_lo[r + 1], **_max_fm).result
+                if N_HALVES == 2:
+                    for r in range_constexpr(16):
+                        local_max = arith.MaxNumFOp(local_max, s_raw_hi[r], **_max_fm).result
+                peer_max = reduction_peer(local_max)
+                row_max = arith.MaxNumFOp(local_max, peer_max, **_max_fm).result
+                m_new_raw = arith.MaxNumFOp(m_running, row_max, **_max_fm).result
+
+                diff_m_raw = arith.SubFOp(m_running, m_new_raw, fastmath=fm_fast).result
+                diff_m_scaled = arith.MulFOp(diff_m_raw, c_sm_scale_log2e, fastmath=fm_fast).result
+                corr = arith.ArithValue(diff_m_scaled).exp2(fastmath=fm_fast)
+
+                scaled_max = arith.MulFOp(c_sm_scale_log2e, m_new_raw, fastmath=fm_fast).result
+                neg_scaled_max = arith.SubFOp(c_zero_f, scaled_max, fastmath=fm_fast).result
+
+                p_vals_lo = []
+                p_vals_hi = []
+                local_sum = c_zero_f
+                for r in range_constexpr(16):
+                    diff_lo = math_dialect.fma(s_raw_lo[r], c_sm_scale_log2e, neg_scaled_max)
+                    p_lo = arith.ArithValue(diff_lo).exp2(fastmath=fm_fast)
+                    p_vals_lo.append(p_lo)
+                    local_sum = arith.AddFOp(local_sum, p_lo, fastmath=fm_fast).result
+                if N_HALVES == 2:
+                    for r in range_constexpr(16):
+                        diff_hi = math_dialect.fma(s_raw_hi[r], c_sm_scale_log2e, neg_scaled_max)
+                        p_hi = arith.ArithValue(diff_hi).exp2(fastmath=fm_fast)
+                        p_vals_hi.append(p_hi)
+                        local_sum = arith.AddFOp(local_sum, p_hi, fastmath=fm_fast).result
+
+                peer_sum = reduction_peer(local_sum)
+                tile_sum = arith.AddFOp(local_sum, peer_sum, fastmath=fm_fast).result
+                l_corr = arith.MulFOp(corr, l_running, fastmath=fm_fast).result
+                l_new = arith.AddFOp(l_corr, tile_sum, fastmath=fm_fast).result
+
+                # ==== Rescale O accumulators ====
+                # Lever B: defer per-dc rescale to inside the PV loop so all 16
+                # corr-multiplied o_accs are not live simultaneously. This shrinks
+                # the register live range and (we hope) reduces VGPR spill.
+                corr_vec = vector.broadcast(v16f32_type, corr)
+                if not USE_HW_TR:
+                    o_accs[0] = arith.MulFOp(o_accs[0], corr_vec, fastmath=fm_fast).result
+                # USE_HW_TR: rescale happens inline in the PV loop below.
+
+                if ENABLE_PREFETCH_3BUF and (kv_sub + preload_k_count) < N_SUBTILES:
+                    next_k_sub = kv_sub + preload_k_count
+                    next_k_start = kv_block_start + next_k_sub * BLOCK_N
+                    next_k_slot = (
+                        CK_LDS_SEQ[next_k_sub % len(CK_LDS_SEQ)] % NUM_PREFETCH_K
+                    )
+                    if ENABLE_DMA:
+                        coop_dma_k(next_k_start, next_k_slot)
+                    else:
+                        coop_load_k(next_k_start, next_k_slot)
+
+                if ENABLE_PREFETCH_3BUF:
+                    v_slot = CK_LDS_SEQ[kv_sub % len(CK_LDS_SEQ)] % NUM_PREFETCH_V
+                    v_base = v_buf_base(v_slot)
+                    coop_load_v(kv_start, v_slot)
+                    rocdl.sched_group_barrier(rocdl.mask_dswr, 1, 0)
+                    gpu.barrier()
+                elif _use_dma_dbuf:
+                    # Lever A: V is in the same buf_id as K (dbuf). The
+                    # s_waitcnt(0) + barrier issued at the K branch already
+                    # waited for the CURRENT V tile (fired in PREVIOUS iter,
+                    # or as part of the pre-loop prefetch for iter 0).
+                    v_base = v_buf_base(_k_buf_id)
+                elif ENABLE_DMA:
+                    v_base = v_buf_base(0)
+                    rocdl.s_waitcnt(0)
+                    gpu.barrier()
+                else:
+                    v_slot = 0
+                    v_base = v_buf_base(v_slot)
+                    _waitcnt_vm_n(0)
+                    coop_store_v_lds(_v_vecs_prefetch, v_slot)
+                    rocdl.sched_group_barrier(rocdl.mask_dswr, 1, 0)
+                    gpu.barrier()
+
+                # ==== Build P packs for lo and hi halves ====
+                if dtype_str == "bf16" and not USE_K16:
+                    p_packs_lo = []
+                    p_packs_hi = []
+                    for pks in range_constexpr(PV_K_STEPS):
+                        p_base = pks * 4
+                        p_packs_lo.append(bf16_trunc_pack_v4(
+                            p_vals_lo[p_base:p_base+4]))
+                        if N_HALVES == 2:
+                            p_packs_hi.append(bf16_trunc_pack_v4(
+                                p_vals_hi[p_base:p_base+4]))
+                elif dtype_str == "bf16" and USE_K16:
+                    p_packs_lo = []
+                    p_packs_hi = []
+                    for pks in range_constexpr(PV_K_STEPS):
+                        p_base = pks * 8
+                        p_packs_lo.append(bf16_trunc_pack_v8(
+                            p_vals_lo[p_base:p_base+8]))
+                        if N_HALVES == 2:
+                            p_packs_hi.append(bf16_trunc_pack_v8(
+                                p_vals_hi[p_base:p_base+8]))
+                else:
+                    p_f16_lo = []
+                    p_f16_hi = []
+                    for r in range_constexpr(16):
+                        p_f16_lo.append(arith.trunc_f(elem_type, p_vals_lo[r]))
+                        if N_HALVES == 2:
+                            p_f16_hi.append(arith.trunc_f(elem_type, p_vals_hi[r]))
+
+                    if USE_K16:
+                        p_packs_lo = []
+                        p_packs_hi = []
+                        for pks in range_constexpr(PV_K_STEPS):
+                            p_base = pks * 8
+                            p_packs_lo.append(vector.from_elements(v8f16_type, [
+                                p_f16_lo[p_base+0], p_f16_lo[p_base+1],
+                                p_f16_lo[p_base+2], p_f16_lo[p_base+3],
+                                p_f16_lo[p_base+4], p_f16_lo[p_base+5],
+                                p_f16_lo[p_base+6], p_f16_lo[p_base+7]]))
+                            if N_HALVES == 2:
+                                p_packs_hi.append(vector.from_elements(v8f16_type, [
+                                    p_f16_hi[p_base+0], p_f16_hi[p_base+1],
+                                    p_f16_hi[p_base+2], p_f16_hi[p_base+3],
+                                    p_f16_hi[p_base+4], p_f16_hi[p_base+5],
+                                    p_f16_hi[p_base+6], p_f16_hi[p_base+7]]))
+                    else:
+                        p_packs_lo = []
+                        p_packs_hi = []
+                        for pks in range_constexpr(PV_K_STEPS):
+                            p_base = pks * 4
+                            p_packs_lo.append(vector.from_elements(v4f16_type, [
+                                p_f16_lo[p_base], p_f16_lo[p_base+1],
+                                p_f16_lo[p_base+2], p_f16_lo[p_base+3]]))
+                            if N_HALVES == 2:
+                                p_packs_hi.append(vector.from_elements(v4f16_type, [
+                                    p_f16_hi[p_base], p_f16_hi[p_base+1],
+                                    p_f16_hi[p_base+2], p_f16_hi[p_base+3]]))
+
+                # Build flat (dc, pks) schedule for interleaved GEMM2.
+                _steps = [(dc, pks)
+                          for dc in range(D_CHUNKS)
+                          for pks in range(PV_K_STEPS)]
+                TOTAL_PV = len(_steps)
+
+                def _read_v_pack(step_idx):
+                    dc, pks = _steps[step_idx]
+                    vh = None
+                    if USE_HW_TR:
+                        d_col = (arith.index(dc * D_CHUNK)
+                                 + tr_col_half * 16 + tr_col_sub * 4)
+                        k_row = (arith.index(pks * PV_K_STEP)
+                                 + lane_div_32 * 4 + tr_k_group)
+                        _d_col_eff = _v_swizzle(k_row, d_col) if ENABLE_DMA else d_col
+                        lds_lo = v_base + k_row * V_STRIDE + _d_col_eff
+                        if N_HALVES == 2:
+                            lds_hi = lds_lo + arith.index(K_SUB_N * V_STRIDE)
+                        if USE_K16:
+                            vl_a = ds_read_tr_v4f16(lds_lo)
+                            vl_b = ds_read_tr_v4f16(
+                                lds_lo + arith.index(8 * V_STRIDE))
+                            vl = vector.shuffle(
+                                vl_a, vl_b, [0, 1, 2, 3, 4, 5, 6, 7])
+                            if N_HALVES == 2:
+                                vh_a = ds_read_tr_v4f16(lds_hi)
+                                vh_b = ds_read_tr_v4f16(
+                                    lds_hi + arith.index(8 * V_STRIDE))
+                                vh = vector.shuffle(
+                                    vh_a, vh_b, [0, 1, 2, 3, 4, 5, 6, 7])
+                        else:
+                            vl = ds_read_tr_v4f16(lds_lo)
+                            if N_HALVES == 2:
+                                vh = ds_read_tr_v4f16(lds_hi)
+                    else:
+                        d_pos = arith.index(dc * D_CHUNK) + lane_mod_32
+                        k_base = arith.index(pks * PV_K_STEP) + lane_div_32 * 4
+                        v_lo_idx = v_base + d_pos * VT_STRIDE + k_base
+                        vl = vector.load(v4f16_type, lds_kv, [v_lo_idx])
+                        if N_HALVES == 2:
+                            v_hi_idx = v_lo_idx + arith.index(K_SUB_N)
+                            vh = vector.load(v4f16_type, lds_kv, [v_hi_idx])
+                    return vl, vh
+
+                # Pre-read V for the first step.
+                v_lo_cur, v_hi_cur = _read_v_pack(0)
+
+                # ==== GEMM2: O += V^T_lo @ P_lo (+ V^T_hi @ P_hi if N_HALVES==2) ====
+                for si in range_constexpr(TOTAL_PV):
+                    dc, pks = _steps[si]
+                    if si + 1 < TOTAL_PV:
+                        v_lo_nxt, v_hi_nxt = _read_v_pack(si + 1)
+                    # Lever B: per-dc inline rescale (USE_HW_TR path).
+                    # On the first PV pack for each dc, rescale o_accs[dc] just
+                    # before its first accumulate; keeps live range small.
+                    if USE_HW_TR and pks == 0:
+                        o_accs[dc] = arith.MulFOp(
+                            o_accs[dc], corr_vec, fastmath=fm_fast,
+                        ).result
+                    o_accs[dc] = mfma_acc(
+                        v_lo_cur, p_packs_lo[pks], o_accs[dc])
+                    if N_HALVES == 2:
+                        o_accs[dc] = mfma_acc(
+                            v_hi_cur, p_packs_hi[pks], o_accs[dc])
+                    if not USE_HW_TR and dc == 0 and pks < D_CHUNKS - 1:
+                        o_accs[pks + 1] = arith.MulFOp(
+                            o_accs[pks + 1], corr_vec, fastmath=fm_fast,
+                        ).result
+                    if si + 1 < TOTAL_PV:
+                        v_lo_cur = v_lo_nxt
+                        v_hi_cur = v_hi_nxt
+
+                m_running = m_new_raw
+                l_running = l_new
+
+            _yield_args = [m_running, l_running] + o_accs
+            if _use_dma_dbuf:
+                if N_SUBTILES % 2 == 1:
+                    _yield_args.append(arith.index(1) - _cur_buf_id)
+                else:
+                    _yield_args.append(_cur_buf_id)
+            yield _yield_args
+
+        # ---- Normalize and store O (skip OOB rows for partial Q tiles) ----
+        m_final = loop_results[0]
+        l_final = loop_results[1]
+        o_finals = [
+            loop_results[2 + dc] for dc in range_constexpr(D_CHUNKS)
+        ]
+
+        inv_l = arith.DivFOp(
+            c_one_f,
+            l_final,
+            fastmath=fm_fast,
+        ).result
+        inv_l_vec = vector.broadcast(v16f32_type, inv_l)
+
+        # V4 LSE in raw-e scaled domain to match Triton ref:
+        #   lse = m_final * sm_scale + ln(l_final)
+        # (Triton stores m_i + tl.log(l_i) where m_i is in qk*sm_scale domain
+        #  already; our m_final is raw qk so we scale here.)
+        c_sm_scale_f = arith.constant(float(sm_scale), type=compute_type)
+        scaled_m_final = arith.MulFOp(
+            m_final, c_sm_scale_f, fastmath=fm_fast,
+        ).result
+        ln_l_final = math_dialect.log(l_final, fastmath=fm_fast)
+        lse_val = arith.AddFOp(
+            scaled_m_final, ln_l_final, fastmath=fm_fast,
+        ).result
+
+        # O and LSE stores share the Q-row in-bounds guard. Note: the MFMA
+        # 32x32 register layout has the four rows held by this lane at offsets
+        # (0, 8, 16, 24) from the base (q_row = q_start + wave_q_offset +
+        # lane_mod_32). The O store already uses these offsets; for LSE we
+        # need to pick the ROW owner (lane_div_32 == 0 && lane_mod_32 < 32)
+        # and write one f32 per Q row. Simpler approach: every lane with
+        # lane_div_32 == 0 writes its lane_mod_32 row to LSE (32 rows per
+        # wave, one wave per Q tile row group). Matches the way `q_row` was
+        # computed for the Q preload at line 592.
+        _o_guard = scf.IfOp(q_in_bounds, [], has_else=False)
+        with ir.InsertionPoint(_o_guard.then_block):
+            for dc in range_constexpr(D_CHUNKS):
+                o_norm_vec = arith.MulFOp(
+                    o_finals[dc],
+                    inv_l_vec,
+                    fastmath=fm_fast,
+                ).result
+                for r in range_constexpr(16):
+                    o_val = vector.extract(
+                        o_norm_vec,
+                        static_position=[r],
+                        dynamic_position=[],
+                    )
+                    o_f16 = arith.trunc_f(elem_type, o_val)
+
+                    d_row_rel = lane_div_32 * 4 + (r // 4) * 8 + (r % 4)
+                    d_col = arith.index(dc * D_CHUNK) + d_row_rel
+                    o_global = global_idx(q_row, d_col)
+                    _gep_store(o_f16, o_ptr, o_global)
+
+            # LSE store: one f32 per Q row. Wave-lane layout for 32x32 MFMA
+            # holds one row per lane in lane_div_32==0. Gate on lane_div_32
+            # == 0 to avoid 2x duplicate stores (the lane_div_32==1 copy has
+            # the same q_row and the same lse_val).
+            _is_row_owner = arith.cmpi(
+                arith.CmpIPredicate.eq,
+                lane_div_32,
+                arith.index(0),
+            )
+            _lse_if = scf.IfOp(_is_row_owner, [], has_else=False)
+            with ir.InsertionPoint(_lse_if.then_block):
+                # Flat LSE index: (batch*NUM_HEADS + head)*L + q_row
+                lse_off = (
+                    (batch_idx * NUM_HEADS + head_idx) * seq_len_v + q_row
+                )
+                lse_off_i32 = arith.index_cast(T.i32, lse_off)
+                buffer_ops.buffer_store(lse_val, lse_rsrc, lse_off_i32)
+                scf.YieldOp([])
+            scf.YieldOp([])
+
+    @flyc.jit
+    def launch_v4_swa_fwd(
+        Q: fx.Tensor,
+        K: fx.Tensor,
+        V: fx.Tensor,
+        O: fx.Tensor,
+        LSE: fx.Tensor,
+        batch_size: fx.Int32,
+        seq_len: fx.Int32,
+        stream: fx.Stream = fx.Stream(None),
+    ):
+        allocator.finalized = False
+        ctx = CompilationContext.get_current()
+        with ir.InsertionPoint(ctx.gpu_module_body):
+            allocator.finalize()
+
+        bs_idx = arith.index_cast(T.index, batch_size)
+        sl_idx = arith.index_cast(T.index, seq_len)
+        num_q_tiles = (sl_idx + BLOCK_M - 1) // BLOCK_M
+        grid_x = bs_idx * num_q_tiles * NUM_HEADS
+
+        launcher = v4_swa_fwd_kernel(Q, K, V, O, LSE, seq_len)
+
+        if waves_per_eu is not None:
+            _wpe = int(waves_per_eu)
+            if _wpe >= 1:
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.waves_per_eu"] = ir.IntegerAttr.get(
+                            T.i32,
+                            _wpe,
+                        )
+        if flat_work_group_size is not None:
+            _fwgs = int(flat_work_group_size)
+            if _fwgs >= 1:
+                flat_wg_attr = ir.StringAttr.get(f"{_fwgs},{_fwgs}")
+                for op in ctx.gpu_module_body.operations:
+                    if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                        op.attributes["rocdl.flat_work_group_size"] = flat_wg_attr
+
+        passthrough_entries = []
+        if daz:
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("denormal-fp-math-f32"),
+                ir.StringAttr.get("preserve-sign,preserve-sign"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("no-nans-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+            passthrough_entries.append(ir.ArrayAttr.get([
+                ir.StringAttr.get("unsafe-fp-math"),
+                ir.StringAttr.get("true"),
+            ]))
+        for op in ctx.gpu_module_body.operations:
+            if getattr(op, "OPERATION_NAME", None) == "gpu.func":
+                op.attributes["passthrough"] = ir.ArrayAttr.get(passthrough_entries)
+
+        launcher.launch(
+            grid=(grid_x, 1, 1),
+            block=(BLOCK_SIZE, 1, 1),
+            stream=stream,
+        )
+
+    # Best MI355X FMHA numbers so far were measured with ROCm/llvm-project
+    # `felix/tune_fmha` at c8cf6da4367c010c7cbbb7789a9c4349e7407619.
+    # Other LLVM revisions can compile/run this kernel, but usually leave a
+    # few percent of peak throughput on the table.
+    _fmha_compile_hints = {
+        "fast_fp_math": fast_fp_math,
+        "unsafe_fp_math": unsafe_fp_math,
+        "llvm_options": {
+            "enable-post-misched": False,
+            "lsr-drop-solution": True,
+        },
+    }
+
+    def _launch(*args, **kwargs):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return launch_v4_swa_fwd(*args, **kwargs)
+
+    def _compile(Q, K, V, O, LSE, batch_size, seq_len, stream=None):
+        with CompilationContext.compile_hints(_fmha_compile_hints):
+            return flyc.compile(
+                launch_v4_swa_fwd, Q, K, V, O, LSE, batch_size, seq_len,
+                fx.Stream(stream))
+
+    _launch.compile = _compile
+
+    return _launch
+
+
+build_v4_swa_fwd_module_primary = build_v4_swa_fwd_module

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton/v4_attention_bwd.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton/v4_attention_bwd.py
@@ -1689,9 +1689,16 @@ def _launch_v4_attention_bwd(
         # >1 splits the head loop and uses ``tl.atomic_add`` for dKV.
         # The dense-bench sweep showed head-split is essentially neutral on
         # MI355 at H=64 (HBM/atomic-bound, not compute-bound), so default 1.
+        # BUT that result does NOT hold for the MQA/HQ>=128 (V4-Pro) SWA dkv
+        # shape: at HQ=128/HK=1 the HG=1 grid is 1 workgroup/CU (occ=1) with each
+        # program serially grinding all 128 heads -> tail/pipeline-fill bound.
+        # HG=2 doubles the grid + fills the idle MFMA cycles (grad cos ~1.0);
+        # HG=4/8 regress. So default the MQA/HQ>=128 case to 2; still
+        # overridable via PRIMUS_V4_ATTN_BWD_DKV_HEAD_GROUPS.
         num_head_groups = 1
         if HQ > HK:
-            target = int(os.getenv("PRIMUS_V4_ATTN_BWD_DKV_HEAD_GROUPS", "1"))
+            _hg_default = "2" if (HQ >= 64 and HK == 1) else "1"
+            target = int(os.getenv("PRIMUS_V4_ATTN_BWD_DKV_HEAD_GROUPS", _hg_default))
             while target > 1 and HQ % target != 0:
                 target //= 2
             num_head_groups = max(1, target)
@@ -1902,7 +1909,11 @@ def _launch_v4_attention_bwd(
                 # block_m. dKV benefits from BM=64 (fewer programs each loading
                 # a wider Q tile); pool kernel benefits from a smaller BM (more
                 # programs => more parallelism over the head loop).
-                pool_block_m = int(os.getenv("PRIMUS_V4_ATTN_BWD_POOL_BLOCK_M", str(BLOCK_M)))
+                # gfx950/MI355X: the pool kernel scales with program count, so
+                # BM=16 (vs the dKV default 32) speeds up the full HCA backward
+                # (cos ~1.0). Only the pool path reads this, so SWA bwd is
+                # unaffected. Env-overridable.
+                pool_block_m = int(os.getenv("PRIMUS_V4_ATTN_BWD_POOL_BLOCK_M", "16"))
                 pool_grid = (triton.cdiv(Sq, pool_block_m), B)
                 _v4_attention_bwd_dkv_pool_kernel[pool_grid](
                     q,

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton/v4_attention_fwd.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton/v4_attention_fwd.py
@@ -414,7 +414,11 @@ def _launch_v4_attention_fwd(
     # Env-overridable so future shape regressions can fall back without
     # rebuilding. The defaults are the per-shape winner from the R2
     # sweep (`p57/r2_sweep_local.sh`).
-    BLOCK_M = int(os.getenv("PRIMUS_V4_ATTN_FWD_BLOCK_M", "64"))
+    # gfx950/MI355X: the HCA fwd path wins at BLOCK_M=128 (cos ~1.0), but pure
+    # SWA fwd regresses at 128 (wants 64). Gate on the same
+    # ``hca_local_seqlen`` discriminator used for the stage default below.
+    _default_block_m_fwd = "128" if hca_local_seqlen else "64"
+    BLOCK_M = int(os.getenv("PRIMUS_V4_ATTN_FWD_BLOCK_M", _default_block_m_fwd))
     BLOCK_N = int(os.getenv("PRIMUS_V4_ATTN_FWD_BLOCK_N", "16"))
     NUM_WARPS_FWD = int(os.getenv("PRIMUS_V4_ATTN_FWD_WARPS", "8"))
     _default_stages_fwd = "1" if hca_local_seqlen else "2"

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/v4_attention.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/v4_attention.py
@@ -42,7 +42,7 @@ from typing import Optional
 
 import torch
 
-from primus.backends.megatron.core.transformer.v4_attention_kernels import _tilelang
+from primus.backends.megatron.core.transformer.v4_attention_kernels import _flydsl, _tilelang
 from primus.backends.megatron.core.transformer.v4_attention_kernels._triton.v4_attention_bwd import (
     _launch_v4_attention_bwd,
 )
@@ -188,6 +188,7 @@ def v4_attention(
     scale: float,
     hca_local_seqlen: int = 0,
     use_tilelang: bool = False,
+    use_flydsl: bool = False,
 ) -> torch.Tensor:
     """Triton- or tilelang-backed V4 dense / HCA attention.
 
@@ -255,6 +256,22 @@ def v4_attention(
             swa_window=swa_window,
             attn_dropout=attn_dropout,
             training=training,
+            scale=scale,
+            hca_local_seqlen=hca_local_seqlen,
+        )
+    # FlyDSL backend hook (forward-only; soft-dep, default off). Mirrors the
+    # _tilelang hook: short-circuits on enabled=False so FlyDSL is never
+    # imported on the common path, and falls back to Triton if the runtime
+    # or the kernel is unavailable. Training (autograd) still flows through
+    # V4AttentionFn below; this path is for inference/eval.
+    if _flydsl.should_dispatch("v4_attention_fwd", enabled=use_flydsl):
+        return _flydsl.v4_attention_fwd_flydsl(
+            q,
+            k,
+            v,
+            sink=sink,
+            swa_window=swa_window,
+            additive_mask=additive_mask,
             scale=scale,
             hca_local_seqlen=hca_local_seqlen,
         )

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/v4_csa_attention.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/v4_csa_attention.py
@@ -59,7 +59,7 @@ from typing import Optional
 
 import torch
 
-from primus.backends.megatron.core.transformer.v4_attention_kernels import _tilelang
+from primus.backends.megatron.core.transformer.v4_attention_kernels import _flydsl, _tilelang
 from primus.backends.megatron.core.transformer.v4_attention_kernels._triton.v4_csa_attention_bwd import (
     _launch_v4_csa_attention_bwd,
     _launch_v4_csa_attention_pool_bwd,
@@ -274,6 +274,7 @@ def v4_csa_attention(
     training: bool,
     scale: float,
     use_tilelang: bool = False,
+    use_flydsl: bool = False,
 ) -> torch.Tensor:
     """Triton-backed V4 CSA fused attention.
 
@@ -329,6 +330,23 @@ def v4_csa_attention(
             attn_dropout=attn_dropout,
             training=training,
             scale=scale,
+        )
+    # FlyDSL CSA backend hook (forward-only; soft-dep, default off).
+    # Short-circuits on enabled=False; falls back to Triton if the
+    # runtime/kernel is unavailable. Inference/eval path -- training flows
+    # through V4CSAAttentionFn below.
+    if _flydsl.should_dispatch("v4_csa_attention_fwd", enabled=use_flydsl):
+        return _flydsl.v4_csa_attention_fwd_flydsl(
+            q,
+            k_local,
+            v_local,
+            gathered,
+            sparse_mask=sparse_mask,
+            sink=sink,
+            swa_window=swa_window,
+            scale=scale,
+            attn_dropout=attn_dropout,
+            training=training,
         )
     return V4CSAAttentionFn.apply(
         q,

--- a/tests/unit_tests/megatron/transformer/deepseek_v4/test_v4_p27_dispatch_precedence.py
+++ b/tests/unit_tests/megatron/transformer/deepseek_v4/test_v4_p27_dispatch_precedence.py
@@ -113,6 +113,11 @@ def _make_bare_attn(
     attn._use_v4_triton_csa_attention = bool(use_v4_triton_csa_attention)
     attn._use_v4_tilelang_attention = bool(use_v4_tilelang_attention)
     attn._use_v4_tilelang_csa_attention = bool(use_v4_tilelang_csa_attention)
+    # FlyDSL backend flags (forward-only, soft-dep). The bare object skips
+    # __init__, so set them explicitly; these precedence tests never enable
+    # FlyDSL, so default OFF (matches the Triton/eager dispatch under test).
+    attn._use_v4_flydsl_attention = False
+    attn._use_v4_flydsl_csa_attention = False
     return attn
 
 


### PR DESCRIPTION
 DeepSeek-V4 attention kernel work (flydsl for gfx950, and triton tunning), flydsl default-OFF;.

- FlyDSL attention backend: opt-in alternate kernel suite (gfx950/MI355X) structured like the sibling _tilelang package. Ships the 13-module import closure (fwd SWA/HCA/CSA + bwd dKV/dQ). Soft-dependency: imports zero FlyDSL on the default-off path, falls back to Triton when the runtime is absent. Config flags use_v4_flydsl_attention / use_v4_flydsl_csa_attention plumbed through DeepseekV4Attention as use_flydsl=.
- MI355X Triton tuning: three shape-gated, env-overridable launch-param defaults (bwd dKV NUM_HEAD_GROUPS 1->2; fwd HCA BLOCK_M 64->128; bwd HCA pool BLOCK_M 32->16). No kernel-logic change; cos-gated.
- Test: set the FlyDSL flags in the _make_bare_attn dispatch-precedence helper (it builds the attn via __new__, bypassing __init__).
