### PR TITLE
ci: supply-chain hardening (pin actions, Dependabot, Scorecard, release attestations)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,48 @@
+# CODEOWNERS for Primus
+#
+# Order matters: the LAST matching pattern takes precedence. The broad
+# fallback stays first so high-risk paths below can override it with
+# dedicated reviewers. See:
+# https://docs.github.com/articles/about-code-owners
 
-* @Xiaoming-AMD @wenxie-amd @limou102
+# ---------------------------------------------------------------------------
+# Default fallback owners (everything not matched by a more specific rule)
+# ---------------------------------------------------------------------------
+*                               @Xiaoming-AMD @wenxie-amd @limou102
+
+# ---------------------------------------------------------------------------
+# CI/CD and automation — highest-risk, require explicit review
+# ---------------------------------------------------------------------------
+/.github/                       @Xiaoming-AMD @wenxie-amd @limou102
+/.github/workflows/             @Xiaoming-AMD @wenxie-amd @limou102
+/.github/CODEOWNERS             @Xiaoming-AMD @wenxie-amd @limou102
+
+# ---------------------------------------------------------------------------
+# Release
+# ---------------------------------------------------------------------------
+/.github/workflows/release-build-wheel.yml   @Xiaoming-AMD @wenxie-amd @limou102
+
+# ---------------------------------------------------------------------------
+# Docker images / build inputs (CI + release Dockerfiles)
+# ---------------------------------------------------------------------------
+/.github/workflows/docker/          @Xiaoming-AMD @wenxie-amd @limou102
+/.github/workflows/docker-release/  @Xiaoming-AMD @wenxie-amd @limou102
+
+# ---------------------------------------------------------------------------
+# Dependencies & packaging
+# ---------------------------------------------------------------------------
+/pyproject.toml                 @Xiaoming-AMD @wenxie-amd @limou102
+/requirements.txt               @Xiaoming-AMD @wenxie-amd @limou102
+/requirements-jax.txt           @Xiaoming-AMD @wenxie-amd @limou102
+/requirements-torchft.txt       @Xiaoming-AMD @wenxie-amd @limou102
+
+# ---------------------------------------------------------------------------
+# Core framework & GPU/runtime backends
+# ---------------------------------------------------------------------------
+/primus/core/                   @Xiaoming-AMD @wenxie-amd @limou102
+/primus/backends/               @Xiaoming-AMD @wenxie-amd @limou102
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+/tests/                         @Xiaoming-AMD @wenxie-amd @limou102

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Keep GitHub Actions versions current (and surface SHA updates).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Python runtime dependencies.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+
+  # Base images used by the CI Docker build context.
+  - package-ecosystem: "docker"
+    directory: "/.github/workflows/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set commit hash to env
         run: echo "PRIMUS_TURBO_COMMIT=${PRIMUS_TURBO_COMMIT}" >> $GITHUB_ENV
       - name: Checkout Repo Primus-Turbo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AMD-AIG-AIMA/Primus-Turbo
           submodules: "recursive"
@@ -52,7 +52,7 @@ jobs:
           echo "✅ [build primus-turbo] ended at: $(date)"
           echo "⏱️ [build primus-turbo] Total elapsed time: ${elapsed} seconds"
       - run: echo "🎉 Begin Primus Benchmark."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Show Environment Info
@@ -233,7 +233,7 @@ jobs:
       - name: Set commit hash to env
         run: echo "PRIMUS_TURBO_COMMIT=${PRIMUS_TURBO_COMMIT}" >> $GITHUB_ENV
       - name: Checkout Repo Primus-Turbo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AMD-AIG-AIMA/Primus-Turbo
           submodules: "recursive"
@@ -262,7 +262,7 @@ jobs:
           echo "✅ [build primus-turbo] ended at: $(date)"
           echo "⏱️ [build primus-turbo] Total elapsed time: ${elapsed} seconds"
       - run: echo "🎉 Begin Primus Benchmark."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Show Environment Info
@@ -396,7 +396,7 @@ jobs:
       - name: Set commit hash to env
         run: echo "PRIMUS_TURBO_COMMIT=${PRIMUS_TURBO_COMMIT}" >> $GITHUB_ENV
       - name: Checkout Repo Primus-Turbo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: AMD-AIG-AIMA/Primus-Turbo
           submodules: "recursive"
@@ -427,7 +427,7 @@ jobs:
           echo "✅ [build primus-turbo] ended at: $(date)"
           echo "⏱️ [build primus-turbo] Total elapsed time: ${elapsed} seconds"
       - run: echo "🎉 Begin Primus Benchmark."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Show Environment Info
@@ -514,7 +514,7 @@ jobs:
     #runs-on: [primus-lm-bench-multinode-p8hz7]
     #steps:
       #- run: echo "🎉 Begin Primus Benchmark."
-      #- uses: actions/checkout@v4
+      #- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         #with:
           #submodules: recursive
       #- name: Show Environment Info

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,20 @@ jobs:
       - name: Run pre-commit (all hooks, all files)
         run: pre-commit run --all-files --show-diff-on-failure
 
+  # Flag PRs that introduce known-vulnerable dependencies. Warn-only during
+  # burn-in; drop warn-only to turn it into a hard gate once the team is ready.
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@e58c696e52cac8e62d61cc21fda89565d71505d7 # v4.3.1
+        with:
+          fail-on-severity: high
+          warn-only: true
+
   build-docker:
     needs: [code-lint]
     runs-on: build-docker

--- a/.github/workflows/deploy-backend-gap-dashboard.yml
+++ b/.github/workflows/deploy-backend-gap-dashboard.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -56,10 +56,10 @@ jobs:
             --output-dir "${{ runner.temp }}/backend-gap-site/simple"
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ${{ runner.temp }}/backend-gap-site
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release-build-wheel.yml
+++ b/.github/workflows/release-build-wheel.yml
@@ -38,12 +38,12 @@ jobs:
       attestations: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         # third_party submodules are NOT needed: the wheel only ships the
         # primus package + runner/ toolkit, not the vendored backends.
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -143,7 +143,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Generate SBOM (SPDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           path: dist/
           format: spdx-json
@@ -151,12 +151,12 @@ jobs:
           output-file: dist/primus-sbom.spdx.json
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: "dist/*.whl, dist/*.tar.gz"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: primus-dist
           path: dist/*

--- a/.github/workflows/release-build-wheel.yml
+++ b/.github/workflows/release-build-wheel.yml
@@ -11,12 +11,15 @@ on:
         description: "Existing release tag to upload the built wheel to (optional). Leave empty to only produce a build artifact."
         required: false
         default: ""
+      allow_clobber:
+        description: "Overwrite existing release assets with the same name (use only for intentional re-uploads)."
+        required: false
+        type: boolean
+        default: false
 
+# Default to read-only; the build-wheel job opts into the writes it needs.
 permissions:
-  contents: write
-  # Needed to trigger the dashboard workflow (workflow_dispatch) so it can
-  # refresh the GitHub Pages pip index after the wheel is attached to the release.
-  actions: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,6 +28,14 @@ concurrency:
 jobs:
   build-wheel:
     runs-on: ubuntu-latest
+    permissions:
+      # Upload assets to the GitHub Release.
+      contents: write
+      # Dispatch the dashboard workflow to refresh the pip index.
+      actions: write
+      # Keyless signing for build provenance attestation.
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -124,6 +135,26 @@ jobs:
           echo "--- primus-cli --version ---"
           /tmp/primus-smoke/bin/primus-cli --version
 
+      - name: Generate SHA256 checksums
+        run: |
+          cd dist
+          sha256sum *.whl *.tar.gz > SHA256SUMS
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          path: dist/
+          format: spdx-json
+          artifact-name: primus-sbom.spdx.json
+          output-file: dist/primus-sbom.spdx.json
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*.whl, dist/*.tar.gz"
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -136,9 +167,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.tag.outputs.tag }}
+          # `release` events never clobber; manual dispatch may opt in.
+          ALLOW_CLOBBER: ${{ github.event.inputs.allow_clobber }}
         run: |
+          CLOBBER=""
+          if [[ "${ALLOW_CLOBBER}" == "true" ]]; then
+            echo "allow_clobber=true: existing assets with the same name will be overwritten."
+            CLOBBER="--clobber"
+          fi
           echo "Uploading build artifacts to release ${TAG}"
-          gh release upload "${TAG}" dist/*.whl dist/*.tar.gz --clobber
+          gh release upload "${TAG}" \
+            dist/*.whl dist/*.tar.gz dist/SHA256SUMS dist/primus-sbom.spdx.json \
+            ${CLOBBER}
 
       # After the wheel is on the release, kick the dashboard workflow so it
       # regenerates the GitHub Pages PEP 503 index (which links to release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Weekly (Mondays 04:00 UTC).
+    - cron: "0 4 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload results to the code-scanning dashboard.
+      security-events: write
+      # Publish results to the OpenSSF API (keyless via OIDC).
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Hardens the CI/CD supply chain without changing any training/runtime code.

1. **CODEOWNERS — path-specific high-risk ownership.** Replace the single
   wildcard owner with explicit rules for `/.github/`, the release workflow,
   Docker build inputs, dependency manifests (`pyproject.toml` + `requirements*.txt`),
   core framework (`/primus/core/`) and GPU backends (`/primus/backends/`), and
   `/tests/`. Last-match-wins ordering, broad fallback kept first.

2. **Supply-chain automation.**
   - `dependabot.yml`: weekly updates for `github-actions`, `pip`, and the CI
     Docker base image (also surfaces SHA bumps for pinned actions).
   - `dependency-review.yml`: flags known-vulnerable deps on PRs. Starts in
     `warn-only` mode (burn-in); flip to `fail-on-severity: high` later.
   - `scorecard.yml`: weekly OpenSSF Scorecard, publishes SARIF to code scanning.

3. **Release wheel hardening** (`release-build-wheel.yml`): drop workflow-level
   write permissions (build job opts in), emit `SHA256SUMS` + SPDX SBOM, attest
   build provenance, and stop passing `--clobber` by default (manual dispatch can
   opt in via `allow_clobber`).