### PR TITLE
fix(runner): honor PRIMUS_LOG_LEVEL in prepare/hook scripts

### DIFF
--- a/examples/megatron/prepare.py
+++ b/examples/megatron/prepare.py
@@ -266,7 +266,9 @@ def build_megatron_helper(primus_path: Path, patch_args: Path, backend_path: str
     dataset_cpp_dir = megatron_path / "megatron/core/datasets"
     log_info(f"Building Megatron dataset helper in {dataset_cpp_dir}")
 
-    ret = subprocess.run(["make"], cwd=dataset_cpp_dir)
+    # `-s` silences make's "Nothing to be done"/recipe echo on no-op rebuilds;
+    # real compiler errors still surface and are handled below.
+    ret = subprocess.run(["make", "-s"], cwd=dataset_cpp_dir)
     if ret.returncode != 0:
         log_error_and_exit("Building Megatron C++ helper failed.")
 

--- a/primus/pretrain.py
+++ b/primus/pretrain.py
@@ -13,6 +13,15 @@ from primus.core.launcher.config import PrimusConfig
 from primus.core.launcher.parser import add_pretrain_parser, load_primus_config
 
 
+def _info_enabled() -> bool:
+    """True when PRIMUS_LOG_LEVEL permits INFO-level chatter (DEBUG/INFO).
+
+    Mirrors the level gating in runner/lib/common.sh so informational prints are
+    silenced when the user sets PRIMUS_LOG_LEVEL=WARN/ERROR.
+    """
+    return os.environ.get("PRIMUS_LOG_LEVEL", "INFO").upper() in ("DEBUG", "INFO")
+
+
 # Lazy backend loader
 def load_backend_trainer(framework: str):
     if framework == "megatron":
@@ -117,7 +126,8 @@ def setup_backend_path(framework: str, backend_path=None, verbose: bool = True):
     if framework == "maxtext" and (deps_sync_path / "src").exists():
         deps_sync_path = deps_sync_path / "src"
     candidate_paths.append(str(deps_sync_path))
-    print(f"[Primus] candidate_paths: {candidate_paths}")
+    if verbose and _info_enabled():
+        print(f"[Primus] candidate_paths: {candidate_paths}")
 
     # Normalize & deduplicate
     candidate_paths = list(dict.fromkeys(os.path.normpath(os.path.abspath(p)) for p in candidate_paths))
@@ -127,7 +137,7 @@ def setup_backend_path(framework: str, backend_path=None, verbose: bool = True):
         if os.path.exists(path):
             if path not in sys.path:
                 sys.path.insert(0, path)
-                if verbose:
+                if verbose and _info_enabled():
                     print(f"[Primus] sys.path.insert: {path}")
             return path  # Return the first valid path
 

--- a/runner/helpers/execute_hooks.sh
+++ b/runner/helpers/execute_hooks.sh
@@ -86,11 +86,17 @@ execute_hooks() {
             local hook_output
             local exit_code
 
+            # Internal protocol lines (env.*/extra.*) are consumed by the parser
+            # below and reported via level-aware "[Hooks] ..." messages, so they
+            # are filtered from the real-time terminal copy to avoid raw noise.
+            # The full output is still captured (tee stdout) for parsing.
+            local _hook_proto_re='^(env|extra)\.[A-Za-z_]'
+
             if [[ "$hook_file" == *.sh ]]; then
                 # Only main node prints hook raw output in real-time.
                 # Use set -o pipefail to propagate exit code through pipe
                 if [[ "${NODE_RANK:-0}" -eq 0 ]]; then
-                    hook_output="$(set -o pipefail; bash "$hook_file" "${args[@]}" 2>&1 | tee /dev/stderr)"
+                    hook_output="$(set -o pipefail; bash "$hook_file" "${args[@]}" 2>&1 | tee >(grep -vE "$_hook_proto_re" >&2))"
                     exit_code=$?
                 else
                     hook_output="$(bash "$hook_file" "${args[@]}" 2>&1)"
@@ -98,7 +104,7 @@ execute_hooks() {
                 fi
             elif [[ "$hook_file" == *.py ]]; then
                 if [[ "${NODE_RANK:-0}" -eq 0 ]]; then
-                    hook_output="$(set -o pipefail; python3 "$hook_file" "${args[@]}" 2>&1 | tee /dev/stderr)"
+                    hook_output="$(set -o pipefail; python3 "$hook_file" "${args[@]}" 2>&1 | tee >(grep -vE "$_hook_proto_re" >&2))"
                     exit_code=$?
                 else
                     hook_output="$(python3 "$hook_file" "${args[@]}" 2>&1)"

--- a/runner/helpers/hook_common.sh
+++ b/runner/helpers/hook_common.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Shared logging for runner hook scripts (prepare_experiment, install hooks, …).
+# Source from any hook under runner/helpers/hooks/**:
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/hook_common.sh"
+# (adjust ../ count: pretrain hooks use ../../../hook_common.sh)
+###############################################################################
+
+if [[ -n "${__PRIMUS_COMMON_SOURCED:-}" ]]; then
+    return 0 2>/dev/null || true
+fi
+
+_hook_common_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=/dev/null
+source "${_hook_common_dir}/lib/common.sh"

--- a/runner/helpers/hook_common.sh
+++ b/runner/helpers/hook_common.sh
@@ -9,7 +9,7 @@
 ###############################################################################
 
 if [[ -n "${__PRIMUS_COMMON_SOURCED:-}" ]]; then
-    return 0 2>/dev/null || true
+    return 0
 fi
 
 _hook_common_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/runner/helpers/hooks/06_fix_aiter_asm_dir.sh
+++ b/runner/helpers/hooks/06_fix_aiter_asm_dir.sh
@@ -34,6 +34,15 @@ import importlib.util, os, re, subprocess, sys
 
 TAG = "[fix_aiter_asm_dir]"
 
+# Honor PRIMUS_LOG_LEVEL: only emit informational lines at DEBUG/INFO.
+_LOG_LEVELS = {"DEBUG": 10, "INFO": 20, "WARN": 30, "ERROR": 40}
+_CUR_LEVEL = _LOG_LEVELS.get(os.environ.get("PRIMUS_LOG_LEVEL", "INFO").upper(), 20)
+
+
+def info(msg, **kw):
+    if _CUR_LEVEL <= _LOG_LEVELS["INFO"]:
+        print(msg, **kw)
+
 
 def find_aiter_core_and_hsa():
     """Return (core_py_path, aiter_meta_hsa_dir) or (None, None)."""
@@ -105,7 +114,7 @@ def normalize_core_py(core_path):
         try:
             with open(core_path, "w") as f:
                 f.write(content)
-            print(f"{TAG} Normalized AITER_ASM_DIR in {core_path} (removed gfx prefix)")
+            info(f"{TAG} Normalized AITER_ASM_DIR in {core_path} (removed gfx prefix)")
         except PermissionError:
             print(f"{TAG} Cannot write {core_path} (read-only)", file=sys.stderr)
 
@@ -118,7 +127,7 @@ def create_symlinks(hsa_dir, gfx):
     """
     gfx_dir = os.path.join(hsa_dir, gfx)
     if not os.path.isdir(gfx_dir):
-        print(f"{TAG} {gfx_dir} not found, skipping")
+        info(f"{TAG} {gfx_dir} not found, skipping")
         return 0, 0
 
     created = 0
@@ -143,7 +152,7 @@ def create_symlinks(hsa_dir, gfx):
                 os.unlink(dst)
                 os.symlink(src, dst)
                 repaired += 1
-                print(f"{TAG} Repaired stale symlink: {dst} -> {src} (was {cur_target})")
+                info(f"{TAG} Repaired stale symlink: {dst} -> {src} (was {cur_target})")
             except OSError as e:
                 print(f"{TAG} repair symlink {dst} -> {src} failed: {e}", file=sys.stderr)
             continue
@@ -163,7 +172,7 @@ def create_symlinks(hsa_dir, gfx):
 
 core_path, hsa_dir = find_aiter_core_and_hsa()
 if not hsa_dir:
-    print(f"{TAG} aiter_meta/hsa not found, skipping")
+    info(f"{TAG} aiter_meta/hsa not found, skipping")
     sys.exit(0)
 
 gfx = detect_gfx()
@@ -175,7 +184,7 @@ normalize_core_py(core_path)
 
 created, repaired = create_symlinks(hsa_dir, gfx)
 if created > 0 or repaired > 0:
-    print(f"{TAG} Symlink update done in {hsa_dir}: created={created}, repaired={repaired}")
+    info(f"{TAG} Symlink update done in {hsa_dir}: created={created}, repaired={repaired}")
 else:
-    print(f"{TAG} No symlinks needed (already present or {gfx}/ not found)")
+    info(f"{TAG} No symlinks needed (already present or {gfx}/ not found)")
 PYEOF

--- a/runner/helpers/hooks/projection/performance/megatron/prepare.py
+++ b/runner/helpers/hooks/projection/performance/megatron/prepare.py
@@ -168,7 +168,9 @@ def build_megatron_helper(primus_path: Path, patch_args: Path, backend_path: str
     dataset_cpp_dir = megatron_path / "megatron/core/datasets"
     log_info(f"Building Megatron dataset helper in {dataset_cpp_dir}")
 
-    ret = subprocess.run(["make"], cwd=dataset_cpp_dir)
+    # `-s` silences make's "Nothing to be done"/recipe echo on no-op rebuilds;
+    # real compiler errors still surface and are handled below.
+    ret = subprocess.run(["make", "-s"], cwd=dataset_cpp_dir)
     if ret.returncode != 0:
         log_error_and_exit("Building Megatron C++ helper failed.")
 

--- a/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
+++ b/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
@@ -26,15 +26,28 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Load shared logging so output honors PRIMUS_LOG_LEVEL (DEBUG/INFO/WARN/ERROR).
+# When invoked through primus-cli the LOG_* functions are already exported, but
+# sourcing here keeps the hook usable standalone and under `set -u`.
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../../../../hook_common.sh"
+
 DATA_PATH="${DATA_PATH:-${PRIMUS_ROOT}/data}"
 PIP_CACHE_DIR="${PIP_CACHE_DIR:-${DATA_PATH}/pip_cache}"
 
-echo "[INFO] Using pip cache: ${PIP_CACHE_DIR}"
+# Match pip verbosity to the active log level so WARN/ERROR runs stay quiet
+# (suppresses the "Requirement already satisfied" wall) while DEBUG/INFO keep it.
+PIP_FLAGS=()
+case "${PRIMUS_LOG_LEVEL:-INFO}" in
+  WARN|ERROR) PIP_FLAGS+=(-q -q) ;;
+esac
+
+LOG_INFO "Using pip cache: ${PIP_CACHE_DIR}"
 mkdir -p "${PIP_CACHE_DIR}"
 
 REQ_FILE="${SCRIPT_DIR}/requirements-megatron.txt"
 if [[ -f "${REQ_FILE}" ]] && grep -qE '^[[:space:]]*[^#[:space:]]' "${REQ_FILE}"; then
-  echo "[+] Installing Megatron dependencies..."
-  pip install --cache-dir="${PIP_CACHE_DIR}" -r "${REQ_FILE}"
-  echo "[OK] Megatron dependencies installed"
+  LOG_INFO "Installing Megatron dependencies..."
+  pip install "${PIP_FLAGS[@]}" --cache-dir="${PIP_CACHE_DIR}" -r "${REQ_FILE}"
+  LOG_SUCCESS "Megatron dependencies installed"
 fi

--- a/runner/helpers/hooks/train/pretrain/megatron/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/megatron/prepare.py
@@ -179,7 +179,9 @@ def build_megatron_helper(megatron_path: Path):
     dataset_cpp_dir = megatron_path / "megatron/core/datasets"
     log_info(f"Building Megatron dataset helper in {dataset_cpp_dir}")
 
-    ret = subprocess.run(["make"], cwd=dataset_cpp_dir)
+    # `-s` silences make's "Nothing to be done"/recipe echo on no-op rebuilds;
+    # real compiler errors still surface and are handled below.
+    ret = subprocess.run(["make", "-s"], cwd=dataset_cpp_dir)
     if ret.returncode != 0:
         log_error_and_exit("Building Megatron C++ helper failed.")
 

--- a/runner/helpers/hooks/train/pretrain/megatron_bridge/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/megatron_bridge/prepare.py
@@ -65,7 +65,9 @@ def build_megatron_helper(bridge_path: Path):
         return
 
     log_info(f"Building Megatron dataset C++ helper in {dataset_cpp_dir}")
-    ret = subprocess.run(["make"], cwd=dataset_cpp_dir)
+    # `-s` silences make's "Nothing to be done"/recipe echo on no-op rebuilds;
+    # real compiler errors still surface and are handled below.
+    ret = subprocess.run(["make", "-s"], cwd=dataset_cpp_dir)
     if ret.returncode != 0:
         log_error_and_exit("Building Megatron C++ dataset helper failed.")
     log_info("Megatron C++ dataset helper built successfully")

--- a/runner/helpers/hooks/train/pretrain/prepare_experiment.sh
+++ b/runner/helpers/hooks/train/pretrain/prepare_experiment.sh
@@ -25,6 +25,12 @@ shift 2
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PRIMUS_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
 
+# Load shared logging so output honors PRIMUS_LOG_LEVEL (DEBUG/INFO/WARN/ERROR).
+# When invoked through primus-cli the LOG_* functions are already exported, but
+# sourcing here keeps the hook usable standalone and under `set -u`.
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../../../hook_common.sh"
+
 CONFIG_FILE=""
 DATA_PATH="./data/"
 PATCH_ARGS="/tmp/primus_patch_args.txt"
@@ -63,7 +69,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$CONFIG_FILE" ]]; then
-    echo "[WARNING] prepare_experiment.sh: no --config provided, skipping framework dispatch" >&2
+    LOG_WARN "prepare_experiment.sh: no --config provided, skipping framework dispatch"
     exit 0
 fi
 
@@ -77,44 +83,49 @@ fi
 PATCH_DIR="$(dirname "$PATCH_ARGS")"
 mkdir -p "$PATCH_DIR"
 : > "$PATCH_ARGS"
-echo "[INFO] prepare_experiment.sh: patch args file: $PATCH_ARGS" >&2
+LOG_INFO "prepare_experiment.sh: patch args file: $PATCH_ARGS"
 
 # Route priority:
 #   1) --backend (explicit override)
 #   2) pre_trainer.framework from --config
 FRAMEWORK_FROM_CONFIG="$(python3 -c "
-import sys
+import os, sys
 from pathlib import Path
 
-print(f'[DEBUG] CONFIG_FILE: ${CONFIG_FILE}', file=sys.stderr)
+_DEBUG = os.environ.get('PRIMUS_LOG_LEVEL', 'INFO').upper() == 'DEBUG'
+def _dbg(m):
+    if _DEBUG:
+        print(f'[DEBUG] {m}', file=sys.stderr)
+
+_dbg('CONFIG_FILE: ${CONFIG_FILE}')
 
 sys.path.insert(0, '${PRIMUS_ROOT}')
 from primus.core.config.primus_config import load_primus_config, get_module_config
 
 cfg = load_primus_config(Path('${CONFIG_FILE}'), None)
-print(f'[DEBUG] cfg type: {type(cfg)}', file=sys.stderr)
+_dbg(f'cfg type: {type(cfg)}')
 
 pre_trainer = get_module_config(cfg, 'pre_trainer')
-print(f'[DEBUG] pre_trainer type: {type(pre_trainer)}', file=sys.stderr)
+_dbg(f'pre_trainer type: {type(pre_trainer)}')
 
 if pre_trainer is None:
-    print('[DEBUG] pre_trainer is None', file=sys.stderr)
+    _dbg('pre_trainer is None')
     sys.exit(1)
 
 if not hasattr(pre_trainer, 'framework'):
-    print('[DEBUG] pre_trainer has no framework attribute', file=sys.stderr)
+    _dbg('pre_trainer has no framework attribute')
     sys.exit(1)
 
-print(f'[DEBUG] pre_trainer.framework: {pre_trainer.framework}', file=sys.stderr)
+_dbg(f'pre_trainer.framework: {pre_trainer.framework}')
 
 print(pre_trainer.framework)
-" 2> >(tee /dev/stderr >&2) | tail -n 1 | tr -d '\r' || true)"
+" | tail -n 1 | tr -d '\r' || true)"
 
 if [[ -n "$BACKEND_OVERRIDE" ]]; then
     FRAMEWORK="$BACKEND_OVERRIDE"
     if [[ -n "$FRAMEWORK_FROM_CONFIG" ]]; then
         if [[ "$BACKEND_OVERRIDE" != "$FRAMEWORK_FROM_CONFIG" ]]; then
-            echo "[ERROR] prepare_experiment.sh: --backend=$BACKEND_OVERRIDE conflicts with framework=$FRAMEWORK_FROM_CONFIG from config" >&2
+            LOG_ERROR "prepare_experiment.sh: --backend=$BACKEND_OVERRIDE conflicts with framework=$FRAMEWORK_FROM_CONFIG from config"
             exit 1
         fi
     fi
@@ -123,7 +134,7 @@ else
 fi
 
 if [[ -z "$FRAMEWORK" ]]; then
-    echo "[WARNING] prepare_experiment.sh: no framework found (provide --backend or --config with pre_trainer.framework), skipping dispatch" >&2
+    LOG_WARN "prepare_experiment.sh: no framework found (provide --backend or --config with pre_trainer.framework), skipping dispatch"
     exit 0
 fi
 
@@ -151,11 +162,11 @@ if [[ -d "$FRAMEWORK_HOOK_DIR" ]]; then
     exit_code=0
     set +e
     for hook_file in "${SH_HOOK_FILES[@]}"; do
-        echo "[INFO] prepare_experiment.sh: executing shell hook $(basename "$hook_file")" >&2
+        LOG_INFO "prepare_experiment.sh: executing shell hook $(basename "$hook_file")"
         bash "$hook_file" "${HOOK_ARGS[@]}"
         exit_code=$?
         if [[ $exit_code -ne 0 ]]; then
-            echo "[ERROR] prepare_experiment.sh: shell hook failed: $hook_file (exit code: $exit_code)" >&2
+            LOG_ERROR "prepare_experiment.sh: shell hook failed: $hook_file (exit code: $exit_code)"
             exit $exit_code
         fi
     done
@@ -163,11 +174,11 @@ if [[ -d "$FRAMEWORK_HOOK_DIR" ]]; then
 fi
 
 if [[ ! -f "$FRAMEWORK_SCRIPT" ]]; then
-    echo "[WARNING] prepare_experiment.sh: backend prepare script not found: $FRAMEWORK_SCRIPT" >&2
+    LOG_WARN "prepare_experiment.sh: backend prepare script not found: $FRAMEWORK_SCRIPT"
     exit 0
 fi
 
-echo "[INFO] prepare_experiment.sh: framework=$FRAMEWORK script=$FRAMEWORK_SCRIPT" >&2
+LOG_INFO "prepare_experiment.sh: framework=$FRAMEWORK script=$FRAMEWORK_SCRIPT"
 
 CMD=(python3 "$FRAMEWORK_SCRIPT"
      --config "$CONFIG_FILE"
@@ -239,13 +250,13 @@ if [[ "$FRAMEWORK_DIR" == "megatron" ]]; then
             3)
                 TUNE_FILE="${HIPBLASLT_TUNING_OVERRIDE_FILE:-${TUNE_ROOT}/gemm_tune/${RESULT_FILE}}"
                 if [[ ! -f "$TUNE_FILE" ]]; then
-                    echo "[ERROR] prepare_experiment.sh: Missing tuning result file: $TUNE_FILE" >&2
+                    LOG_ERROR "prepare_experiment.sh: Missing tuning result file: $TUNE_FILE"
                     exit 1
                 fi
                 emit_env "HIPBLASLT_TUNING_OVERRIDE_FILE" "$TUNE_FILE"
                 ;;
             *)
-                echo "[ERROR] prepare_experiment.sh: Invalid PRIMUS_HIPBLASLT_TUNING_STAGE=$STAGE (expected 0/1/2/3)" >&2
+                LOG_ERROR "prepare_experiment.sh: Invalid PRIMUS_HIPBLASLT_TUNING_STAGE=$STAGE (expected 0/1/2/3)"
                 exit 1
                 ;;
         esac

--- a/runner/helpers/hooks/train/pretrain/utils.py
+++ b/runner/helpers/hooks/train/pretrain/utils.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import yaml
 
-
 # ---------- Logging ----------
 # Numeric severity used to honor PRIMUS_LOG_LEVEL (shared with runner/lib/common.sh).
 _LOG_LEVELS = {"DEBUG": 10, "INFO": 20, "WARN": 30, "ERROR": 40}

--- a/runner/helpers/hooks/train/pretrain/utils.py
+++ b/runner/helpers/hooks/train/pretrain/utils.py
@@ -13,6 +13,14 @@ import yaml
 
 
 # ---------- Logging ----------
+# Numeric severity used to honor PRIMUS_LOG_LEVEL (shared with runner/lib/common.sh).
+_LOG_LEVELS = {"DEBUG": 10, "INFO": 20, "WARN": 30, "ERROR": 40}
+
+
+def _current_log_level() -> int:
+    return _LOG_LEVELS.get(os.environ.get("PRIMUS_LOG_LEVEL", "INFO").upper(), 20)
+
+
 def get_node_rank() -> int:
     return int(os.environ.get("NODE_RANK", "0"))
 
@@ -21,8 +29,13 @@ def get_hostname():
     return socket.gethostname()
 
 
+def log_debug(msg):
+    if get_node_rank() == 0 and _current_log_level() <= _LOG_LEVELS["DEBUG"]:
+        print(f"[NODE-{get_node_rank()}({get_hostname()})] [DEBUG] {msg}", file=sys.stderr)
+
+
 def log_info(msg):
-    if get_node_rank() == 0:
+    if get_node_rank() == 0 and _current_log_level() <= _LOG_LEVELS["INFO"]:
         print(f"[NODE-{get_node_rank()}({get_hostname()})] [INFO] {msg}", file=sys.stderr)
 
 


### PR DESCRIPTION
Prepare/hook output bypassed the level-aware LOG_* helpers via raw echo/print, so setting PRIMUS_LOG_LEVEL=ERROR could not silence the INFO/DEBUG noise (hook info, embedded-python debug, pip "Requirement already satisfied" wall, [NODE-x] [INFO] and [Primus] path lines).

- utils.py: gate log_info (and add log_debug) by PRIMUS_LOG_LEVEL
- prepare_experiment.sh: route echoes through LOG_*, gate embedded python [DEBUG], and drop the duplicate `tee /dev/stderr` that printed debug lines twice; source hook_common.sh
- 00_install_requirements.sh: use LOG_*, and quiet pip (-q -q) on WARN/ERROR
- 06_fix_aiter_asm_dir.sh: gate informational prints behind log level
- pretrain.py: gate [Primus] candidate_paths/sys.path.insert prints
- execute_hooks.sh: keep env.*/extra.* protocol lines for parsing but filter them from the real-time terminal copy
- add runner/helpers/hook_common.sh shared logging bootstrap