### PR TITLE
Add CPU unit tests for backends and projection (+ OptimizerProfiler param fix)

### DIFF
--- a/primus/core/projection/module_profilers/optimizer.py
+++ b/primus/core/projection/module_profilers/optimizer.py
@@ -145,7 +145,7 @@ class OptimizerProfiler(BaseModuleProfiler):
         total_params_per_gpu = (non_expert_params + expert_params + shared_expert_params) // pp
 
         # Embedding + output layer params (only on first / last PP rank, amortise)
-        vocab_size = getattr(model_config, "vocab_size", 0) or 0
+        vocab_size = getattr(model_config, "padded_vocab_size", 0) or 0
         if vocab_size and pp > 0:
             embedding_params = vocab_size * hidden // tp
             output_params = vocab_size * hidden // tp

--- a/tests/trainer/test_megatron_trainer.py
+++ b/tests/trainer/test_megatron_trainer.py
@@ -7,9 +7,21 @@
 
 import os
 import re
+import socket
+import subprocess
+import sys
 import unittest
 
 from tests.utils import PrimusUT, run_training_script
+
+
+def _find_free_port() -> int:
+    """Ask the kernel for a free TCP port (bind to 0); avoids EADDRINUSE from
+    guessing a port that overlaps the ephemeral range or a not-yet-released one."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
 
 _GFX_TO_PLATFORM = {
     "gfx942": "MI300X",
@@ -763,6 +775,118 @@ class TestMegatronTrainerDeterministic(PrimusUT):
         )
 
         assert self.check_numerical_reproducility(stdout, stdout_ref)
+
+
+class TestProjectionSimulate(PrimusUT):
+    """Projection is an offline planner that training E2E never runs, so it gets no
+    E2E coverage otherwise. Two paths are exercised so the coverage .pth records them:
+
+    - simulate (no GPU): origami/SDPA backends, multinode scaling, CLI orchestration.
+      A dense + a MoE config; the MoE one adds the expert-parallel / All-to-All /
+      router / grouped-GEMM branches the dense config never reaches.
+    - benchmark (real GPU layer): _run_layer_benchmark / benchmark_layer /
+      memory_capture paths that simulate cannot reach, launched via primus-cli so
+      torchrun sets up the distributed env the real layer bench requires.
+
+    Projection auto-limits the stack to 1-2 layers, so all cases are quick."""
+
+    _DENSE = "llama3.1_8B-BF16-pretrain.yaml"
+    _MOE = "mixtral_8x7B_v0.1-BF16-pretrain.yaml"
+    _BENCH = "qwen2.5_7B-BF16-pretrain.yaml"
+
+    def _check(self, result) -> str:
+        # returncode is the robust E2E-smoke contract: projection raises on any
+        # real error (bad config/arch, missing data, gated model, ...) which the
+        # CLI turns into a non-zero exit. We deliberately do NOT assert on result
+        # text -- the result-line wording differs per path (simulate/benchmark,
+        # dense/MoE/PP) and is brittle to reword.
+        self.assertEqual(result.returncode, 0, msg=(result.stdout[-1500:] + result.stderr[-1500:]))
+        return result.stdout
+
+    def _run_simulate(self, suite: str, mode_flag: str, model: str, extra: list | None = None) -> str:
+        config = f"examples/megatron/configs/{GPU_PLATFORM}/{model}"
+        cmd = [
+            sys.executable,
+            "-m",
+            "primus.cli.main",
+            "projection",
+            suite,
+            "--config",
+            config,
+            mode_flag,
+            "simulate",
+            "--gpu-arch",
+            GPU_PLATFORM.lower(),
+            "--target-nodes",
+            "4",
+            *(extra or []),
+        ]
+        return self._check(subprocess.run(cmd, capture_output=True, text=True, env=os.environ.copy()))
+
+    def _run_benchmark(self, suite: str, mode_flag: str) -> str:
+        # Real GPU layer bench needs torchrun's distributed env -> go through
+        # the primus-cli launcher (a plain subprocess won't set NNODES/NODE_RANK).
+        config = f"examples/megatron/configs/{GPU_PLATFORM}/{self._BENCH}"
+        cmd = [
+            "bash",
+            "./runner/primus-cli",
+            "direct",
+            "--",
+            "projection",
+            suite,
+            "--config",
+            config,
+            mode_flag,
+            "benchmark",
+            "--benchmark-gpus",
+            "8",
+            "--target-nodes",
+            "2",
+        ]
+        env = os.environ.copy()
+        # Kernel-assigned free port so back-to-back GPU benches don't hit
+        # EADDRINUSE (a fixed/random port can clash with a not-yet-released
+        # previous run or the ephemeral range).
+        env["MASTER_PORT"] = str(_find_free_port())
+        return self._check(subprocess.run(cmd, capture_output=True, text=True, env=env))
+
+    def test_performance_simulate_dense(self):
+        self._run_simulate("performance", "--profiling-mode", self._DENSE)
+
+    def test_memory_simulate_dense(self):
+        self._run_simulate("memory", "--memory-mode", self._DENSE)
+
+    def test_performance_simulate_moe(self):
+        # --target-ep-size drives the expert-parallel projection path.
+        self._run_simulate("performance", "--profiling-mode", self._MOE, extra=["--target-ep-size", "8"])
+
+    def test_memory_simulate_moe(self):
+        self._run_simulate("memory", "--memory-mode", self._MOE)
+
+    def test_performance_simulate_pp(self):
+        # PP>1 is the only thing that runs the pipeline-scheduler simulator
+        # (simulator.py); the PP=1 configs all skip pipeline simulation.
+        self._run_simulate(
+            "performance", "--profiling-mode", self._DENSE, extra=["--pipeline_model_parallel_size", "4"]
+        )
+
+    def _require_2_gpus(self):
+        import torch
+
+        if not torch.cuda.is_available() or torch.cuda.device_count() < 2:
+            self.skipTest("projection benchmark needs >=2 GPUs")
+
+    def test_performance_benchmark(self):
+        # Real GPU layer bench: covers _run_layer_benchmark / benchmark_layer /
+        # utils.benchmark_layer that simulate can't reach.
+        self._require_2_gpus()
+        self._run_benchmark("performance", "--profiling-mode")
+
+    def test_memory_benchmark(self):
+        # Real GPU memory capture: covers memory_projection/benchmark.py +
+        # memory_capture.py (HBM peak hooks) that simulate can't reach.
+        self._require_2_gpus()
+        self._run_benchmark("memory", "--memory-mode")
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/backends/hummingbirdxt/test_hummingbirdxt_argument_builder.py
+++ b/tests/unit_tests/backends/hummingbirdxt/test_hummingbirdxt_argument_builder.py
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for HummingbirdXTArgBuilder.
+
+``_load_hummingbirdxt_default_args`` (which imports the external ``train`` module)
+is patched out so the pure merge/convert logic is testable without that package.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import primus.backends.hummingbirdxt.argument_builder as ab
+
+
+def _builder(defaults=None):
+    with mock.patch.object(
+        ab, "_load_hummingbirdxt_default_args", return_value=dict(defaults or {"lr": 0.1})
+    ):
+        return ab.HummingbirdXTArgBuilder()
+
+
+def test_init_seeds_from_defaults():
+    b = _builder({"lr": 0.1, "steps": 10})
+    d = b.to_dict()
+    assert d["lr"] == 0.1 and d["steps"] == 10
+
+
+def test_update_deep_merges_over_defaults_and_chains():
+    b = _builder({"lr": 0.1, "model": {"layers": 2}})
+    ret = b.update(SimpleNamespace(lr=0.2, model=SimpleNamespace(hidden=8)))
+    assert ret is b
+    d = b.to_dict()
+    assert d["lr"] == 0.2  # override
+    assert d["model"] == {"layers": 2, "hidden": 8}  # deep merge
+
+
+def test_to_dict_is_deep_copy():
+    b = _builder({"m": {"k": 1}})
+    b.to_dict()["m"]["k"] = 999
+    assert b.to_dict()["m"]["k"] == 1
+
+
+def test_to_namespace_and_finalize():
+    b = _builder({})
+    b.update(SimpleNamespace(model=SimpleNamespace(layers=4)))
+    assert b.finalize().model.layers == 4

--- a/tests/unit_tests/backends/maxtext/test_maxtext_argument_builder.py
+++ b/tests/unit_tests/backends/maxtext/test_maxtext_argument_builder.py
@@ -1,0 +1,47 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for MaxText argument builder helpers (no JAX import; run on the torch CI image)."""
+
+import os
+from types import SimpleNamespace
+
+import yaml
+
+from primus.backends.maxtext.argument_builder import (
+    MaxTextConfigBuilder,
+    export_params_to_yaml,
+    namespace_to_dict,
+)
+
+
+def test_config_builder_update_finalize_roundtrip():
+    b = MaxTextConfigBuilder()
+    ns = SimpleNamespace(steps=3, model="llama")
+    b.update(ns)
+    assert b.finalize() is ns
+
+
+def test_namespace_to_dict_recurses_nested_and_lists():
+    ns = SimpleNamespace(a=1, nested=SimpleNamespace(b=2), lst=[SimpleNamespace(c=3), 4])
+    assert namespace_to_dict(ns) == {"a": 1, "nested": {"b": 2}, "lst": [{"c": 3}, 4]}
+
+
+def test_namespace_to_dict_passes_scalars_through():
+    assert namespace_to_dict(5) == 5
+    assert namespace_to_dict("x") == "x"
+    assert namespace_to_dict({"k": SimpleNamespace(v=1)}) == {"k": {"v": 1}}
+
+
+def test_export_params_to_yaml_writes_loadable_file():
+    params = {"steps": 3, "model": "llama", "nested": {"lr": 0.1}}
+    path = export_params_to_yaml(params)
+    try:
+        assert os.path.exists(path)
+        with open(path) as f:
+            assert yaml.safe_load(f) == params
+    finally:
+        os.remove(path)

--- a/tests/unit_tests/backends/megatron_bridge/test_megatron_bridge_adapter.py
+++ b/tests/unit_tests/backends/megatron_bridge/test_megatron_bridge_adapter.py
@@ -1,0 +1,238 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for MegatronBridgeAdapter's ROCm-compat dependency-stub machinery.
+
+These shims let ``import megatron.bridge`` succeed without the NV-only optional
+stack (modelopt[torch], megatron-energon, VLM transformers classes). They are pure
+sys.modules/attribute/AST logic with real regression risk (the dunder-passthrough
+and sys.modules-before-sentinel rules are load-bearing), so they're worth a CPU test.
+
+Import is deferred into a fixture (like test_config_utils.py) so the package's
+torch-pulling __init__ doesn't run at collection time under the coverage C tracer.
+"""
+
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def adapter():
+    import primus.backends.megatron_bridge.megatron_bridge_adapter as m
+
+    return m
+
+
+@pytest.fixture
+def sys_modules_guard(adapter):
+    """Drop any stub modules a test injected, keeping tests isolated."""
+    prefixes = ("modelopt",) + adapter._BRIDGE_OPTIONAL_PACKAGES
+    before = set(sys.modules)
+    yield
+    for key in set(sys.modules) - before:
+        if any(key == p or key.startswith(p + ".") for p in prefixes):
+            sys.modules.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# _BridgeOptionalStub / _BridgeOptionalSentinel (module-level, env-independent)
+# ---------------------------------------------------------------------------
+def test_bridge_optional_stub_looks_like_namespace_package(adapter):
+    import os
+
+    stub = adapter._BridgeOptionalStub("megatron.bridge.models.qwen_vl")
+    assert stub.__file__ == os.devnull  # never "" (would read as builtin)
+    assert stub.__path__ == []
+    assert stub.__all__ == []  # `from stub import *` exports nothing
+    assert stub.__spec__ is None
+
+
+def test_bridge_optional_stub_dunder_access_raises_attributeerror(adapter):
+    # Must NOT mint a sentinel for dunders: Primus patch infra walks sys.modules
+    # and calls module.__file__.endswith(...); intercepting dunders would crash it.
+    stub = adapter._BridgeOptionalStub("pkg")
+    with pytest.raises(AttributeError):
+        stub.__some_missing_dunder__
+
+
+def test_bridge_optional_stub_mints_sentinel_for_normal_attr(adapter):
+    stub = adapter._BridgeOptionalStub("pkg")
+    cls = stub.SomeClass
+    # isinstance against a real object must be False (bridge relies on this)
+    assert isinstance(object(), cls) is False
+    # instantiating the sentinel is a loud, helpful error
+    with pytest.raises(RuntimeError, match="stubbed out by Primus"):
+        cls()
+
+
+def test_bridge_optional_stub_prefers_existing_sys_module(adapter):
+    # `import a.b.c as X` is `X = getattr(a.b, 'c')`; if a child stub already
+    # lives in sys.modules it must be returned instead of a fresh sentinel.
+    parent = adapter._BridgeOptionalStub("pkg")
+    child = adapter._BridgeOptionalStub("pkg.child")
+    sys.modules["pkg.child"] = child
+    try:
+        assert parent.child is child
+    finally:
+        sys.modules.pop("pkg.child", None)
+
+
+# ---------------------------------------------------------------------------
+# _install_bridge_optional_stubs (force the "missing" path via importlib mock)
+# ---------------------------------------------------------------------------
+def test_install_bridge_optional_stubs_injects_and_wires(adapter, monkeypatch, sys_modules_guard):
+    def _always_missing(name):
+        raise ImportError(f"forced-missing: {name}")
+
+    monkeypatch.setattr(adapter.importlib, "import_module", _always_missing)
+
+    stubbed = adapter._install_bridge_optional_stubs()
+
+    assert set(stubbed) == set(adapter._BRIDGE_OPTIONAL_PACKAGES)
+    for pkg in adapter._BRIDGE_OPTIONAL_PACKAGES:
+        assert isinstance(sys.modules.get(pkg), adapter._BridgeOptionalStub)
+    # parent -> child attribute wiring for dotted entries
+    for pkg in adapter._BRIDGE_OPTIONAL_PACKAGES:
+        if "." in pkg:
+            parent_name, child_name = pkg.rsplit(".", 1)
+            parent = sys.modules.get(parent_name)
+            if isinstance(parent, adapter._BridgeOptionalStub):
+                assert getattr(parent, child_name) is sys.modules[pkg]
+
+
+def test_install_bridge_optional_stubs_is_idempotent(adapter, monkeypatch, sys_modules_guard):
+    monkeypatch.setattr(
+        adapter.importlib,
+        "import_module",
+        lambda name: (_ for _ in ()).throw(ImportError(name)),
+    )
+    adapter._install_bridge_optional_stubs()
+    # second call: everything already in sys.modules -> nothing new stubbed
+    assert adapter._install_bridge_optional_stubs() == []
+
+
+# ---------------------------------------------------------------------------
+# _install_transformers_stub (transformers must be importable)
+# ---------------------------------------------------------------------------
+def test_install_transformers_stub_adds_placeholders_for_missing(adapter):
+    transformers = pytest.importorskip("transformers")
+
+    name, _used_by = adapter._TRANSFORMERS_PLACEHOLDER_CLASSES[0]
+    had_attr = hasattr(transformers, name)
+    original = getattr(transformers, name, None)
+    if had_attr:
+        delattr(transformers, name)
+    try:
+        stubbed = adapter._install_transformers_stub()
+        assert name in stubbed
+        placeholder = getattr(transformers, name)
+        assert getattr(placeholder, "_primus_placeholder", False) is True
+        with pytest.raises(RuntimeError, match="Primus placeholder"):
+            placeholder()
+    finally:
+        # restore: remove every placeholder we (or the call) injected
+        for cname, _ in adapter._TRANSFORMERS_PLACEHOLDER_CLASSES:
+            obj = getattr(transformers, cname, None)
+            if getattr(obj, "_primus_placeholder", False):
+                delattr(transformers, cname)
+        if had_attr:
+            setattr(transformers, name, original)
+
+
+def test_install_transformers_stub_skips_existing_classes(adapter):
+    transformers = pytest.importorskip("transformers")
+
+    name, _used_by = adapter._TRANSFORMERS_PLACEHOLDER_CLASSES[0]
+    sentinel = type("RealClass", (), {})
+    had_attr = hasattr(transformers, name)
+    original = getattr(transformers, name, None)
+    setattr(transformers, name, sentinel)
+    try:
+        stubbed = adapter._install_transformers_stub()
+        assert name not in stubbed  # already present -> not overwritten
+        assert getattr(transformers, name) is sentinel
+    finally:
+        for cname, _ in adapter._TRANSFORMERS_PLACEHOLDER_CLASSES:
+            obj = getattr(transformers, cname, None)
+            if getattr(obj, "_primus_placeholder", False):
+                delattr(transformers, cname)
+        if had_attr:
+            setattr(transformers, name, original)
+        elif hasattr(transformers, name):
+            delattr(transformers, name)
+
+
+# ---------------------------------------------------------------------------
+# _install_modelopt_stub: force the "missing" branch (env-independent).
+# The real modelopt[torch] is often half-installed on ROCm, so we drop any
+# cached modelopt modules and make every `import modelopt...` fail, which is
+# exactly the situation the stub exists to handle.
+# ---------------------------------------------------------------------------
+def test_install_modelopt_stub_injects_when_missing(adapter, monkeypatch, sys_modules_guard):
+    import builtins
+
+    real_import = builtins.__import__
+    for key in [k for k in sys.modules if k == "modelopt" or k.startswith("modelopt.")]:
+        monkeypatch.delitem(sys.modules, key, raising=False)
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("modelopt"):
+            raise ImportError("forced-missing modelopt for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert adapter._install_modelopt_stub() is True
+    for path in ("modelopt", "modelopt.torch", "modelopt.torch.distill"):
+        assert path in sys.modules
+
+    stub = sys.modules["modelopt.torch.distill"]
+    # dunder passthrough (must not mint sentinel; patch infra relies on this)
+    with pytest.raises(AttributeError):
+        stub.__some_missing_dunder__
+    # normal attr mints a sentinel: isinstance False, call raises a guiding error
+    sentinel_cls = stub.DistillationModel
+    assert isinstance(object(), sentinel_cls) is False
+    with pytest.raises(RuntimeError, match="nvidia-modelopt"):
+        sentinel_cls()
+
+
+# ---------------------------------------------------------------------------
+# detect_backend_version (AST parse of package_info.py; env-independent)
+# ---------------------------------------------------------------------------
+def test_detect_backend_version_parses_package_info(adapter, tmp_path, monkeypatch):
+    pkg_info = tmp_path / "megatron" / "bridge" / "package_info.py"
+    pkg_info.parent.mkdir(parents=True)
+    pkg_info.write_text('__version__ = "9.9.9-test"\nfoo = 1\n')
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    a = adapter.MegatronBridgeAdapter()
+    assert a.detect_backend_version() == "9.9.9-test"
+
+
+# ---------------------------------------------------------------------------
+# load_trainer_class (registry path + invalid stage; no trainer import)
+# ---------------------------------------------------------------------------
+def test_load_trainer_class_uses_registry(adapter, monkeypatch):
+    sentinel = type("DummyTrainer", (), {})
+    monkeypatch.setattr(
+        adapter.BackendRegistry,
+        "get_trainer_class",
+        staticmethod(lambda framework, stage: sentinel),
+    )
+    a = adapter.MegatronBridgeAdapter()
+    assert a.load_trainer_class("sft") is sentinel
+
+
+def test_load_trainer_class_invalid_stage_raises(adapter, monkeypatch):
+    def _miss(framework, stage):
+        raise ValueError("not registered")
+
+    monkeypatch.setattr(adapter.BackendRegistry, "get_trainer_class", staticmethod(_miss))
+    a = adapter.MegatronBridgeAdapter()
+    with pytest.raises(ValueError, match="Invalid stage"):
+        a.load_trainer_class("not-a-real-stage")

--- a/tests/unit_tests/backends/megatron_bridge/test_megatron_bridge_argument_builder.py
+++ b/tests/unit_tests/backends/megatron_bridge/test_megatron_bridge_argument_builder.py
@@ -1,0 +1,65 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for MegatronBridgeArgBuilder (pure config merge/convert).
+
+Import is deferred into a fixture (like test_config_utils.py) so the package's
+torch-pulling __init__ doesn't run at collection time under the coverage C tracer.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def ArgBuilder():
+    from primus.backends.megatron_bridge.argument_builder import (
+        MegatronBridgeArgBuilder,
+    )
+
+    return MegatronBridgeArgBuilder
+
+
+def test_update_deep_merges_and_chains(ArgBuilder):
+    b = ArgBuilder()
+    ret = b.update({"a": 1, "model": {"layers": 4}})
+    assert ret is b
+    b.update({"b": 2, "model": {"hidden": 8}})
+    d = b.to_dict()
+    assert d["a"] == 1 and d["b"] == 2
+    # nested dict is deep-merged, not replaced
+    assert d["model"] == {"layers": 4, "hidden": 8}
+
+
+def test_update_accepts_namespace(ArgBuilder):
+    b = ArgBuilder()
+    b.update(SimpleNamespace(x=1, nested=SimpleNamespace(y=2)))
+    d = b.to_dict()
+    assert d["x"] == 1
+    assert d["nested"]["y"] == 2
+
+
+def test_later_update_overrides_scalar(ArgBuilder):
+    b = ArgBuilder()
+    b.update({"k": 1})
+    b.update({"k": 2})
+    assert b.to_dict()["k"] == 2
+
+
+def test_to_dict_is_deep_copy(ArgBuilder):
+    b = ArgBuilder()
+    b.update({"m": {"k": 1}})
+    snapshot = b.to_dict()
+    snapshot["m"]["k"] = 999
+    assert b.to_dict()["m"]["k"] == 1  # builder state isolated from returned dict
+
+
+def test_finalize_returns_nested_namespace(ArgBuilder):
+    b = ArgBuilder()
+    b.update({"model": {"layers": 4}})
+    assert b.finalize().model.layers == 4  # finalize aliases to_namespace
+    assert b.to_namespace().model.layers == 4

--- a/tests/unit_tests/core/projection/test_performance_projection.py
+++ b/tests/unit_tests/core/projection/test_performance_projection.py
@@ -38,15 +38,35 @@ from primus.core.projection.performance_projection.projection import (  # noqa: 
     _add_io_layer_timings,
     _calculate_min_gpus,
     _calculate_single_node_config,
+    _compute_ep_mlp_scale,
     _compute_micro_batches,
+    _estimate_a2a_per_layer_ms,
+    _estimate_ep_communication_overhead,
+    _estimate_pp_communication_overhead,
     _extract_layer_type_timings,
+    _get_deepep_overlap_efficiency,
+    _get_parameter_memory,
     _has_dense_layers,
     _layer_needs_recompute_fwd_in_bwd,
     _limit_layers_for_projection,
+    _load_artifact,
+    _load_profiling_results,
     _normalized_recompute_layer_ids,
     _recompute_layer_count,
+    _reduction_info_from_artifact_metadata,
+    _rescale_expert_parallelism,
+    _save_profiling_results,
+    _summarize_bench_training_config,
     _upgrade_artifact_to_v2,
+    calculate_collective_communication_time,
+    extract_single_node_time_from_profiling,
     load_hardware_config,
+)
+from primus.core.projection.training_config import (  # noqa: E402
+    ModelConfig,
+    ModelParallelConfig,
+    RuntimeConfig,
+    TrainingConfig,
 )
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -399,3 +419,360 @@ def test_single_node_config_reduces_ep_for_moe():
     assert info["benchmark_ep"] == 8
     # num_experts reduced proportionally (experts_per_rank preserved = 1).
     assert info["benchmark_num_experts"] == 8
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _rescale_expert_parallelism (cap EP*TP at _MAX_EXPERT_PARALLEL_SIZE = 8)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_rescale_ep_noop_within_limit():
+    cfg = SimpleNamespace(
+        expert_model_parallel_size=4, tensor_model_parallel_size=1, context_parallel_size=1, num_experts=8
+    )
+    assert _rescale_expert_parallelism(cfg) is None
+    assert cfg.expert_model_parallel_size == 4
+
+
+def test_rescale_ep_caps_and_scales_experts():
+    cfg = SimpleNamespace(
+        expert_model_parallel_size=16, tensor_model_parallel_size=1, context_parallel_size=1, num_experts=32
+    )
+    info = _rescale_expert_parallelism(cfg)
+    assert (info["ep_before"], info["ep_after"]) == (16, 8)
+    assert cfg.expert_model_parallel_size == 8
+    assert cfg.num_experts == 16  # experts_per_rank (32/16=2) preserved -> 8*2
+
+
+def test_rescale_ep_folds_tp_into_budget():
+    # EP=8 is within the limit alone, but EP*TP=16 > 8, so EP is rescaled to 4.
+    cfg = SimpleNamespace(
+        expert_model_parallel_size=8, tensor_model_parallel_size=2, context_parallel_size=1, num_experts=8
+    )
+    info = _rescale_expert_parallelism(cfg)
+    assert info["ep_after"] == 4
+    assert cfg.expert_model_parallel_size == 4
+
+
+def test_rescale_ep_handles_missing_num_experts():
+    cfg = SimpleNamespace(
+        expert_model_parallel_size=16, tensor_model_parallel_size=1, context_parallel_size=1, num_experts=None
+    )
+    info = _rescale_expert_parallelism(cfg)
+    assert info["ep_after"] == 8
+    assert info["num_experts_after"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _get_deepep_overlap_efficiency / _compute_ep_mlp_scale
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("stage,eff", [(0, 0.65), (1, 0.75), (2, 0.80), (3, 0.85), (5, 0.85)])
+def test_deepep_overlap_efficiency(stage, eff):
+    assert _get_deepep_overlap_efficiency(SimpleNamespace(turbo_sync_free_moe_stage=stage)) == eff
+
+
+def test_deepep_overlap_efficiency_default_when_missing():
+    assert _get_deepep_overlap_efficiency(SimpleNamespace()) == 0.65
+
+
+def test_ep_mlp_scale_unity_when_ep_unchanged():
+    assert _compute_ep_mlp_scale(SimpleNamespace(), 8, 8) == 1.0
+
+
+def test_ep_mlp_scale_unity_when_experts_per_rank_preserved():
+    assert (
+        _compute_ep_mlp_scale(
+            SimpleNamespace(),
+            benchmark_ep=8,
+            original_ep=16,
+            original_num_experts=32,
+            benchmark_num_experts=16,
+        )
+        == 1.0
+    )
+
+
+def test_ep_mlp_scale_unity_fallback_without_expert_counts():
+    assert _compute_ep_mlp_scale(SimpleNamespace(), benchmark_ep=8, original_ep=16) == 1.0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Communication-time estimators (use the analytical collective model)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _comm_tc(**mp):
+    base_mp = dict(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        expert_model_parallel_size=1,
+        context_model_parallel_size=1,
+    )
+    base_mp.update(mp)
+    return SimpleNamespace(
+        model_parallel_config=SimpleNamespace(**base_mp),
+        model_config=SimpleNamespace(hidden_size=512, moe_router_topk=2),
+        runtime_config=SimpleNamespace(micro_batch_size=1, sequence_length=128, global_batch_size=8),
+    )
+
+
+@pytest.fixture
+def _single_node_env(monkeypatch):
+    monkeypatch.setenv("GPUS_PER_NODE", "8")
+    monkeypatch.setenv("NNODES", "1")
+
+
+def test_pp_comm_overhead_zero_for_single_stage(_single_node_env):
+    assert _estimate_pp_communication_overhead(_comm_tc(), pp_size=1) == 0.0
+
+
+def test_pp_comm_overhead_positive_for_multistage(_single_node_env):
+    assert _estimate_pp_communication_overhead(_comm_tc(), pp_size=2) > 0
+
+
+def test_a2a_per_layer_zero_without_ep(_single_node_env):
+    assert _estimate_a2a_per_layer_ms(_comm_tc(), ep=1) == 0.0
+
+
+def test_a2a_per_layer_positive_with_ep(_single_node_env):
+    assert _estimate_a2a_per_layer_ms(_comm_tc(expert_model_parallel_size=2), ep=2) > 0
+
+
+def test_ep_comm_overhead_zero_when_not_scaling_up(_single_node_env):
+    assert _estimate_ep_communication_overhead(_comm_tc(), original_ep=4, benchmark_ep=8) == (0.0, 0.0)
+
+
+def test_ep_comm_overhead_symmetric_when_scaling_up(_single_node_env):
+    fwd, bwd = _estimate_ep_communication_overhead(_comm_tc(), original_ep=4, benchmark_ep=2)
+    assert fwd == bwd
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _get_parameter_memory (param bytes/GB on a PP rank via the language-model spec)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _full_config(**mp):
+    return TrainingConfig(
+        model_config=ModelConfig(
+            num_layers=4,
+            hidden_size=512,
+            ffn_hidden_size=1024,
+            padded_vocab_size=32000,
+            num_attention_heads=8,
+            kv_channels=64,
+            num_query_groups=8,
+            swiglu=True,
+            num_experts=None,
+            moe_pattern=[0] * 4,
+        ),
+        runtime_config=RuntimeConfig(
+            global_batch_size=8, micro_batch_size=1, sequence_length=128, data_parallel_size=1
+        ),
+        model_parallel_config=ModelParallelConfig(**mp),
+    )
+
+
+def test_get_parameter_memory_positive_gb(_single_node_env, monkeypatch):
+    monkeypatch.setenv("RANK", "0")
+    assert _get_parameter_memory(_full_config(), pp_rank=0) > 0
+
+
+def test_get_parameter_memory_rank_out_of_range_raises(_single_node_env, monkeypatch):
+    monkeypatch.setenv("RANK", "0")
+    with pytest.raises(ValueError, match="out of range"):
+        _get_parameter_memory(_full_config(pipeline_model_parallel_size=2), pp_rank=5)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# extract_single_node_time_from_profiling (extrapolate profiled layers -> model)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _profiling_tc(moe_pattern, **mp):
+    base_mp = dict(recompute_granularity=None, recompute_num_layers=0, recompute_layer_ids=None)
+    base_mp.update(mp)
+    return SimpleNamespace(
+        model_config=SimpleNamespace(moe_pattern=moe_pattern),
+        model_parallel_config=SimpleNamespace(**base_mp),
+    )
+
+
+def test_extract_single_node_time_dense_with_io():
+    tc = _profiling_tc([0, 0, 0, 0])
+    pr = {
+        0: {"forward_time_ms": 2, "backward_time_ms": 3, "type": "dense"},
+        "embedding": {"forward_time_ms": 0.5, "backward_time_ms": 0.5},
+        "output": {"forward_time_ms": 1, "backward_time_ms": 1},
+    }
+    # avg_dense=5 * 4 layers = 20; + embedding 1 + output 2 = 23
+    assert extract_single_node_time_from_profiling(pr, tc) == pytest.approx(23.0)
+
+
+def test_extract_single_node_time_dense_and_moe_buckets():
+    tc = _profiling_tc([0, 1, 1, 1])  # 1 dense + 3 MoE
+    pr = {
+        0: {"forward_time_ms": 1, "backward_time_ms": 1, "type": "dense"},
+        1: {"forward_time_ms": 2, "backward_time_ms": 2, "type": "moe"},
+    }
+    # dense 2 * 1 + moe 4 * 3 = 14
+    assert extract_single_node_time_from_profiling(pr, tc) == pytest.approx(14.0)
+
+
+def test_extract_single_node_time_adds_full_recompute_overhead():
+    tc = _profiling_tc([0, 0, 0, 0], recompute_granularity="full", recompute_num_layers=4)
+    pr = {0: {"forward_time_ms": 2, "backward_time_ms": 3, "type": "dense"}}
+    # base 5 * 4 = 20; recompute all 4 dense layers adds avg_dense_fwd(2) * 4 = 8 -> 28
+    assert extract_single_node_time_from_profiling(pr, tc) == pytest.approx(28.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# artifact metadata helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_reduction_info_from_metadata_marks_adjusted():
+    md = {
+        "benchmark_pp": 1,
+        "benchmark_tp": 2,
+        "benchmark_ep": 8,
+        "benchmark_gpus": 16,
+        "original_pp": 2,
+        "original_tp": 2,
+        "original_ep": 16,
+        "original_cp": 1,
+        "original_num_experts": 64,
+        "benchmark_num_experts": 32,
+    }
+    info = _reduction_info_from_artifact_metadata(md, gpus_per_node=8)
+    assert info["adjusted"] is True
+    assert (info["original_ep"], info["benchmark_ep"]) == (16, 8)
+    # min GPUs = TP*PP*EP = 2*2*16 = 64 -> 8 nodes
+    assert info["original_nodes_required"] == 8
+
+
+def test_reduction_info_from_metadata_not_adjusted_when_identical():
+    md = {
+        "benchmark_pp": 1,
+        "benchmark_tp": 1,
+        "benchmark_ep": 1,
+        "original_pp": 1,
+        "original_tp": 1,
+        "original_ep": 1,
+    }
+    assert _reduction_info_from_artifact_metadata(md, gpus_per_node=8)["adjusted"] is False
+
+
+def test_summarize_bench_training_config_normalizes_recompute_ids():
+    tc = SimpleNamespace(
+        model_config=SimpleNamespace(num_layers=4, moe_pattern=[0, 1, 0, 1], num_experts=8),
+        model_parallel_config=SimpleNamespace(
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            recompute_granularity="full",
+            recompute_num_layers=2,
+            recompute_layer_ids="0,1",
+        ),
+        runtime_config=SimpleNamespace(micro_batch_size=1, sequence_length=128, global_batch_size=8),
+    )
+    s = _summarize_bench_training_config(tc)
+    assert s["num_layers"] == 4 and s["moe_pattern"] == [0, 1, 0, 1]
+    assert s["tensor_model_parallel_size"] == 2
+    assert s["recompute_layer_ids"] == [0, 1]  # parsed + sorted
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# artifact save/load roundtrip
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_save_load_profiling_roundtrip(tmp_path):
+    pr = {
+        0: {"forward_time_ms": 1.0, "type": "dense"},
+        1: {"forward_time_ms": 2.0, "type": "moe"},
+        "_memory_benchmark": {"peak": 123},
+    }
+    path = str(tmp_path / "artifact.json")
+    _save_profiling_results(pr, {"benchmark_ep": 8, "benchmark_tp": 2, "original_ep": 16}, path)
+    loaded, metadata = _load_profiling_results(path)
+    assert 0 in loaded and 1 in loaded  # int keys restored from JSON strings
+    assert loaded["_memory_benchmark"] == {"peak": 123}  # hoisted then re-injected
+    assert metadata["benchmark_ep"] == 8 and metadata["original_ep"] == 16
+
+
+def test_load_artifact_upgrades_v1_payload(tmp_path):
+    import json
+
+    path = str(tmp_path / "v1.json")
+    with open(path, "w") as f:
+        json.dump({"profiling_results": {"0": {"forward_time_ms": 1}}}, f)
+    payload = _load_artifact(path)
+    assert payload["schema_version"] == 2
+    assert payload["memory_results"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# calculate_collective_communication_time (analytical comm breakdown)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _full_moe_config(**mp):
+    return TrainingConfig(
+        model_config=ModelConfig(
+            num_layers=4,
+            hidden_size=512,
+            ffn_hidden_size=1024,
+            moe_ffn_hidden_size=1024,
+            padded_vocab_size=32000,
+            num_attention_heads=8,
+            kv_channels=64,
+            num_query_groups=8,
+            swiglu=True,
+            num_experts=8,
+            moe_router_topk=2,
+            moe_pattern=[1] * 4,
+        ),
+        runtime_config=RuntimeConfig(
+            global_batch_size=8, micro_batch_size=1, sequence_length=128, data_parallel_size=1
+        ),
+        model_parallel_config=ModelParallelConfig(**mp),
+    )
+
+
+def test_collective_comm_zero_for_single_gpu(_single_node_env):
+    tc = _full_config()
+    total, breakdown, msg, per_layer = calculate_collective_communication_time(
+        tc, num_nodes=1, gpus_per_node=8, tp=1, pp=1, ep=1, cp=1, dp=1
+    )
+    assert total == 0.0
+    assert breakdown["gradient_allreduce"] == 0.0 and breakdown["moe_a2a_fwd"] == 0.0
+    assert len(per_layer) == tc.model_config.num_layers
+
+
+def test_collective_comm_gradient_allreduce_with_dp(_single_node_env):
+    tc = _full_config()
+    _, breakdown, msg, _ = calculate_collective_communication_time(
+        tc, num_nodes=1, gpus_per_node=8, tp=1, pp=1, ep=1, cp=1, dp=4
+    )
+    assert breakdown["gradient_allreduce"] > 0
+    assert msg["gradient_allreduce_size"] > 0
+
+
+def test_collective_comm_moe_all_to_all(_single_node_env):
+    tc = _full_moe_config()
+    _, breakdown, msg, _ = calculate_collective_communication_time(
+        tc, num_nodes=2, gpus_per_node=8, tp=1, pp=1, ep=2, cp=1, dp=8
+    )
+    assert breakdown["moe_a2a_fwd"] > 0
+    assert msg["num_moe_layers"] == 4
+
+
+def test_collective_comm_fsdp_breakdown(_single_node_env):
+    tc = _full_config(use_torch_fsdp2=True)
+    _, breakdown, msg, _ = calculate_collective_communication_time(
+        tc, num_nodes=1, gpus_per_node=8, tp=1, pp=1, ep=1, cp=1, dp=4
+    )
+    assert breakdown["fsdp_allgather_fwd"] > 0
+    assert msg["fsdp_enabled"] is True

--- a/tests/unit_tests/core/projection/test_projection_extra.py
+++ b/tests/unit_tests/core/projection/test_projection_extra.py
@@ -1,0 +1,419 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""CPU unit tests for projection pieces not covered by test_projection_profilers.py:
+OptimizerProfiler, LossProfiler, transformer-layer aggregation/comm helpers,
+the collective-comm hardware-config builder, and the memory-report printers.
+
+All analytical / formula paths; no GPU benchmark or origami simulation backend.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from primus.core.projection.memory_projection.reports import (
+    _gb,
+    _pct,
+    compare_simulate_vs_benchmark,
+    print_per_rank_breakdown,
+    report_dict,
+)
+from primus.core.projection.module_profilers.attention import AttentionProfiler
+from primus.core.projection.module_profilers.collective_args import (
+    CollectiveArgs,
+    get_default_args,
+)
+from primus.core.projection.module_profilers.dense_mlp import DenseMLPProfiler
+from primus.core.projection.module_profilers.layer_norm import LayerNormProfiler
+from primus.core.projection.module_profilers.loss import (
+    _BW_EFFICIENCY,
+    _FALLBACK_HBM_BW_GBPS,
+    LossProfiler,
+)
+from primus.core.projection.module_profilers.moe_mlp import MoEMLPProfiler
+from primus.core.projection.module_profilers.optimizer import (
+    _ADAM_BYTES_PER_PARAM,
+    OptimizerProfiler,
+)
+from primus.core.projection.module_profilers.residual_add import ResidualAddProfiler
+from primus.core.projection.module_profilers.router import RouterProfiler
+from primus.core.projection.module_profilers.transformer_layer import (
+    DenseTransformerLayerProfiler,
+    MoETransformerLayerProfiler,
+    _estimate_layernorm_residual_time_ms,
+    _estimate_moe_a2a_time_ms,
+    _estimate_tp_allreduce_time_ms,
+    get_dense_transformer_layer_profiler_spec,
+    get_moe_transformer_layer_profiler_spec,
+)
+from primus.core.projection.training_config import (
+    ModelConfig,
+    ModelParallelConfig,
+    RuntimeConfig,
+    TrainingConfig,
+)
+
+HIDDEN = 512
+FFN = 1024
+N_LAYERS = 4
+VOCAB = 32000
+GB = 1024**3
+
+
+def _config(*, moe=False, fusion=False, **mp):
+    base = dict(
+        num_layers=N_LAYERS,
+        hidden_size=HIDDEN,
+        ffn_hidden_size=FFN,
+        padded_vocab_size=VOCAB,
+        num_attention_heads=8,
+        kv_channels=64,
+        num_query_groups=8,
+        swiglu=True,
+        cross_entropy_loss_fusion=fusion,
+    )
+    if moe:
+        base.update(num_experts=8, moe_ffn_hidden_size=FFN, moe_router_topk=2, moe_pattern=[1] * N_LAYERS)
+    else:
+        base.update(num_experts=None, moe_pattern=[0] * N_LAYERS)
+    return TrainingConfig(
+        model_config=ModelConfig(**base),
+        runtime_config=RuntimeConfig(global_batch_size=8, micro_batch_size=1, sequence_length=128),
+        model_parallel_config=ModelParallelConfig(**mp),
+    )
+
+
+class _FakeBackend:
+    def __init__(self, bw=5300.0):
+        self._bw = bw
+
+    @property
+    def hbm_bandwidth_gbps(self):
+        return self._bw
+
+    def name(self):
+        return "fake"
+
+
+@pytest.fixture
+def _single_node_env(monkeypatch):
+    """Single-node env so the collective-comm helpers see a known topology."""
+    monkeypatch.setenv("GPUS_PER_NODE", "8")
+    monkeypatch.setenv("NNODES", "1")
+
+
+# =============================== OptimizerProfiler ===============================
+# Dense, TP=PP=1: per layer = 4*h*h (attn) + 3*h*ffn (mlp); plus embedding+output
+# = 2 * padded_vocab_size * hidden. The vocab term is a regression guard for a bug
+# where OptimizerProfiler read model_config.vocab_size (a non-existent field, so it
+# was always 0) instead of padded_vocab_size.
+_EXPECTED_DENSE_PARAMS = N_LAYERS * (4 * HIDDEN * HIDDEN + 3 * HIDDEN * FFN) + 2 * VOCAB * HIDDEN
+
+
+def _opt(bw=5300.0, **mp):
+    return OptimizerProfiler(_config(**mp), gemm_backend=_FakeBackend(bw))
+
+
+def test_optimizer_activation_memory_is_zero():
+    assert _opt().estimated_activation_memory(batch_size=2, seq_len=128) == 0
+
+
+def test_optimizer_num_params_includes_embedding_and_output():
+    assert _opt().estimated_num_params() == _EXPECTED_DENSE_PARAMS
+
+
+def test_optimizer_step_time_follows_bandwidth_formula():
+    bw = 5300.0
+    total_bytes = _EXPECTED_DENSE_PARAMS * _ADAM_BYTES_PER_PARAM
+    assert _opt(bw=bw).estimated_step_time_ms() == pytest.approx(total_bytes / (bw * 1e9 / 1e3))
+
+
+def test_optimizer_distributed_optimizer_shards_by_dp():
+    full = _opt().estimated_step_time_ms(dp_size=4)
+    sharded = _opt(use_distributed_optimizer=True).estimated_step_time_ms(dp_size=4)
+    assert sharded == pytest.approx(full / 4)
+
+
+def test_optimizer_fsdp_shards_by_dp():
+    full = _opt().estimated_step_time_ms(dp_size=2)
+    sharded = _opt(use_torch_fsdp2=True).estimated_step_time_ms(dp_size=2)
+    assert sharded == pytest.approx(full / 2)
+
+
+def test_optimizer_pipeline_parallel_halves_params():
+    assert _opt(pipeline_model_parallel_size=2).estimated_num_params() == _EXPECTED_DENSE_PARAMS // 2
+
+
+def test_optimizer_tensor_parallel_reduces_params():
+    assert _opt(tensor_model_parallel_size=2).estimated_num_params() < _EXPECTED_DENSE_PARAMS
+
+
+def test_optimizer_missing_backend_raises():
+    p = OptimizerProfiler(_config(), gemm_backend=None)
+    with pytest.raises(AssertionError, match="requires a GEMM simulation backend"):
+        p.estimated_step_time_ms()
+
+
+def test_optimizer_backend_without_bandwidth_raises():
+    p = OptimizerProfiler(_config(), gemm_backend=_FakeBackend(None))
+    with pytest.raises(AssertionError, match="does not report hbm_bandwidth_gbps"):
+        p.estimated_step_time_ms()
+
+
+# ================================= LossProfiler =================================
+def test_loss_has_no_params():
+    assert LossProfiler(_config()).estimated_num_params() == 0
+
+
+def test_loss_activation_memory_formula():
+    # tokens * vocab_per_rank * 4 bytes (fp32 softmax), tp=cp=1
+    assert LossProfiler(_config()).estimated_activation_memory(2, 128) == 2 * 128 * VOCAB * 4
+
+
+def test_loss_activation_memory_zero_with_fusion():
+    assert LossProfiler(_config(fusion=True)).estimated_activation_memory(2, 128) == 0
+
+
+def test_loss_tensor_parallel_shards_vocab():
+    full = LossProfiler(_config()).estimated_activation_memory(1, 128)
+    sharded = LossProfiler(_config(tensor_model_parallel_size=4)).estimated_activation_memory(1, 128)
+    assert sharded == full // 4
+
+
+def test_loss_forward_equals_backward_and_positive():
+    p = LossProfiler(_config())
+    fwd, bwd = p.estimated_forward_time(2, 128), p.estimated_backward_time(2, 128)
+    assert fwd > 0 and fwd == pytest.approx(bwd)
+
+
+def test_loss_time_zero_with_fusion():
+    p = LossProfiler(_config(fusion=True))
+    assert p.estimated_forward_time(2, 128) == 0.0
+    assert p.estimated_backward_time(2, 128) == 0.0
+
+
+def test_loss_time_uses_fallback_bandwidth():
+    p = LossProfiler(_config())
+    tensor_bytes = 2 * 128 * VOCAB * 2  # bf16 logits
+    eff_bw = _FALLBACK_HBM_BW_GBPS * _BW_EFFICIENCY
+    assert p.estimated_forward_time(2, 128) == pytest.approx(3.0 * tensor_bytes / (eff_bw * 1e6))
+
+
+def test_loss_backend_bandwidth_speeds_up():
+    p = LossProfiler(_config())
+    fallback = p.estimated_forward_time(2, 128)
+    p.set_gemm_backend(_FakeBackend(8000.0))
+    assert p.estimated_forward_time(2, 128) < fallback
+
+
+# ============================== transformer layer ===============================
+def test_layernorm_residual_time_backward_heavier_than_forward():
+    fwd, bwd = _estimate_layernorm_residual_time_ms(_config(), 2, 128)
+    assert fwd > 0 and bwd > fwd  # 14 vs 12 memory passes
+
+
+def test_layernorm_residual_time_faster_with_higher_bandwidth():
+    base_fwd, _ = _estimate_layernorm_residual_time_ms(_config(), 2, 128)
+    fast_fwd, _ = _estimate_layernorm_residual_time_ms(_config(), 2, 128, gemm_backend=_FakeBackend(8000.0))
+    assert fast_fwd < base_fwd  # 8000 > fallback 5300
+
+
+def test_tp_allreduce_zero_without_tp(_single_node_env):
+    assert _estimate_tp_allreduce_time_ms(_config(tensor_model_parallel_size=1), 2, 128) == 0.0
+
+
+def test_tp_allreduce_positive_with_tp(_single_node_env):
+    assert _estimate_tp_allreduce_time_ms(_config(tensor_model_parallel_size=2), 2, 128) > 0
+
+
+def test_moe_a2a_zero_without_ep(_single_node_env):
+    assert _estimate_moe_a2a_time_ms(_config(moe=True, expert_model_parallel_size=1), 2, 128) == 0.0
+
+
+def test_moe_a2a_positive_with_ep(_single_node_env):
+    assert _estimate_moe_a2a_time_ms(_config(moe=True, expert_model_parallel_size=2), 2, 128) > 0
+
+
+def test_dense_layer_params_and_activation_aggregate_subprofilers():
+    cfg = _config()
+    subs = {
+        "layer_norm": LayerNormProfiler(cfg),
+        "self_attention": AttentionProfiler(cfg),
+        "residual_add": ResidualAddProfiler(cfg),
+        "mlp": DenseMLPProfiler(cfg),
+    }
+    layer = DenseTransformerLayerProfiler(cfg, subs)
+    assert layer.estimated_num_params() == (
+        subs["layer_norm"].estimated_num_params() * 3
+        + subs["self_attention"].estimated_num_params()
+        + subs["mlp"].estimated_num_params()
+        + subs["residual_add"].estimated_num_params() * 2
+    )
+    assert layer.estimated_activation_memory(1, 128) == (
+        subs["layer_norm"].estimated_activation_memory(1, 128) * 3
+        + subs["self_attention"].estimated_activation_memory(1, 128)
+        + subs["mlp"].estimated_activation_memory(1, 128)
+        + subs["residual_add"].estimated_activation_memory(1, 128) * 2
+    )
+
+
+def test_moe_layer_params_include_router():
+    cfg = _config(moe=True)
+    subs = {
+        "layer_norm": LayerNormProfiler(cfg),
+        "self_attention": AttentionProfiler(cfg),
+        "residual_add": ResidualAddProfiler(cfg),
+        "router": RouterProfiler(cfg),
+        "mlp": MoEMLPProfiler(cfg),
+    }
+    layer = MoETransformerLayerProfiler(cfg, subs)
+    assert layer.estimated_num_params() == (
+        subs["layer_norm"].estimated_num_params() * 3
+        + subs["self_attention"].estimated_num_params()
+        + subs["mlp"].estimated_num_params()
+        + subs["router"].estimated_num_params()
+        + subs["residual_add"].estimated_num_params() * 2
+    )
+
+
+def test_layer_profiler_specs_expose_expected_sub_profilers():
+    dense = get_dense_transformer_layer_profiler_spec(_config())
+    assert dense.profiler is DenseTransformerLayerProfiler
+    assert set(dense.sub_profiler_specs) == {"layer_norm", "self_attention", "residual_add", "mlp"}
+    moe = get_moe_transformer_layer_profiler_spec(_config())
+    assert moe.profiler is MoETransformerLayerProfiler
+    assert "router" in moe.sub_profiler_specs
+
+
+# ============================== collective_args =================================
+def test_collective_topology_mapping_from_parallelism():
+    args = get_default_args(num_nodes=4, gpus_per_node=8, tp=2, pp=2, ep=4, cp=1)
+    assert (args.node_size, args.pod_size, args.num_nodes) == (8, 32, 4)
+    assert (args.hp, args.pp, args.ep, args.cp) == (2, 2, 4, 1)
+
+
+def test_collective_bw_eff_applied_once_raw_preserved():
+    args = get_default_args()
+    assert args.node_bw == CollectiveArgs.node_bw * CollectiveArgs.bw_eff
+    assert args._raw_node_bw == CollectiveArgs.node_bw
+    assert args._raw_pod_bw == CollectiveArgs.pod_bw
+
+
+def test_collective_nics_default_to_gpus_when_none():
+    args = get_default_args(gpus_per_node=8, hardware_config={"nics_per_node": None})
+    assert args.nics_per_node == 8
+
+
+def test_collective_hardware_config_string_floats():
+    args = get_default_args(hardware_config={"node_bw": "2048", "bw_eff": "0.5"})
+    assert args._raw_node_bw == 2048.0
+    assert args.node_bw == 2048.0 * 0.5
+
+
+def test_collective_hardware_config_int_scientific_notation():
+    args = get_default_args(hardware_config={"ar_warmup_chunk_bytes": "1e3"})
+    assert args.ar_warmup_chunk_bytes == 1000
+    assert isinstance(args.ar_warmup_chunk_bytes, int)
+
+
+def test_collective_hardware_config_string_bool():
+    assert get_default_args(hardware_config={"switch_topology": "false"}).switch_topology is False
+
+
+def test_collective_unknown_key_warns_and_is_ignored(capsys):
+    args = get_default_args(hardware_config={"does_not_exist": 123})
+    assert not hasattr(args, "does_not_exist")
+    assert "Unknown hardware parameter" in capsys.readouterr().out
+
+
+# ============================== memory reports ==================================
+def _mock_projection(*, applied_correction=False, legacy_residual=False):
+    bd = {
+        "analytical_at_target_corrected": {
+            "static": {"params_bytes": 10 * GB, "grads_bytes": 10 * GB, "optimizer_bytes": 40 * GB},
+            "activations": {"transformer_layers_bytes": 5 * GB},
+            "deepep_buffers_bytes": GB,
+            "comm_buffers_bytes": GB,
+        },
+        "activation_correction": (
+            {
+                "applied_correction": True,
+                "correction_factors": {"attn": 1.1, "mlp": 0.9},
+                "uncorrected_activation_bytes": 4 * GB,
+                "corrected_activation_bytes": 5 * GB,
+            }
+            if applied_correction
+            else {"applied_correction": False}
+        ),
+        "safety_margin": 0.1,
+    }
+    if legacy_residual:
+        bd["residual_allocated_bytes"] = GB
+        bd["residual_reserved_bytes"] = 2 * GB
+    else:
+        bd["framework_overhead_bytes"] = GB
+        bd["live_tensor_excess_bytes"] = GB
+        bd["residual_total_bytes"] = 2 * GB
+    diag = {
+        "bench_global_peak_allocated_bytes": 50 * GB,
+        "bench_global_peak_reserved_bytes": 55 * GB,
+        "bench_world_size": 8,
+        "target_world_size": 64,
+        "analytical_share": 0.8,
+        "residual_share": 0.2,
+    }
+    return SimpleNamespace(
+        breakdown=bd, diagnostics=diag, point_estimate_bytes=60 * GB, upper_bound_bytes=70 * GB
+    )
+
+
+def test_reports_gb_and_pct_formatting():
+    assert _gb(1024**3) == "1.000 GB"
+    assert _pct(0.1234) == "12.3%"
+
+
+def test_print_per_rank_breakdown_fits_and_runs(capsys):
+    print_per_rank_breakdown(_mock_projection(), target_label="t", total_vram_bytes=192 * GB)
+    out = capsys.readouterr().out
+    assert "Per-rank peak memory" in out
+    assert "FITS" in out  # 192 GB ceiling > 60 GB point estimate
+
+
+def test_print_per_rank_breakdown_correction_oom_and_warning(capsys):
+    proj = _mock_projection(applied_correction=True)
+    proj.diagnostics["warning"] = "tight"
+    print_per_rank_breakdown(proj, total_vram_bytes=50 * GB)  # 50 < 60 -> OOM
+    out = capsys.readouterr().out
+    assert "Activation correction" in out
+    assert "OOM" in out
+    assert "[WARNING] tight" in out
+
+
+def test_print_per_rank_breakdown_legacy_residual(capsys):
+    print_per_rank_breakdown(_mock_projection(legacy_residual=True))
+    assert "Residual (bench peak" in capsys.readouterr().out
+
+
+def test_compare_simulate_vs_benchmark_runs(capsys):
+    proj = _mock_projection()
+    compare_simulate_vs_benchmark(
+        {"total_bytes": 58 * GB, "param_optimizer_bytes": 55 * GB, "activation_bytes": 3 * GB}, proj
+    )
+    assert "simulate vs benchmark" in capsys.readouterr().out
+
+
+def test_compare_simulate_vs_benchmark_accepts_int_total(capsys):
+    compare_simulate_vs_benchmark(58 * GB, _mock_projection())
+    assert "TOTAL (point estimate)" in capsys.readouterr().out
+
+
+def test_report_dict_snapshot():
+    proj = _mock_projection()
+    d = report_dict(proj)
+    assert d["point_estimate_bytes"] == proj.point_estimate_bytes
+    assert d["upper_bound_bytes"] == proj.upper_bound_bytes
+    assert "breakdown" in d and "diagnostics" in d


### PR DESCRIPTION
## Summary

CPU-only unit tests filling coverage gaps that E2E cannot reach.

###  backends (E2E shows no coverage gain for megatron_bridge / hummingbirdxt)
- **arg builders** — `maxtext`, `hummingbirdxt`, `megatron_bridge`: pure config
  merge/convert (deep_merge, namespace<->dict, yaml export); no framework imports,
  so they run on CPU.
- **`MegatronBridgeAdapter` stub machinery** — the ROCm-compat shims that let
  `import megatron.bridge` succeed without the NV-only stack (modelopt[torch],
  megatron-energon, VLM transformers classes): sys.modules/attribute/AST logic
  with load-bearing dunder-passthrough and sys.modules-before-sentinel rules.

### Projection (core/projection; offline planner — unit-tested here, plus a thin E2E smoke)

- **module profilers & reports** — OptimizerProfiler, LossProfiler, transformer-layer
  aggregation + comm-time timers, the collective hardware-config builder, and the
  memory-projection report printers.
- **`performance_projection/projection.py` engine helpers** — EP rescale, DeepEP/EP-MLP
  scaling, PP/A2A/EP comm estimators, per-rank param memory,
  `calculate_collective_communication_time`, `extract_single_node_time_from_profiling`,
  and artifact metadata/save-load roundtrip (v1 -> v2).
- **E2E smoke** — `primus-cli projection` simulate (dense / MoE / PP>1) and a small GPU
  benchmark run, so the offline planner's CLI entry path is exercised end-to-end too.

### Fix
- **`fix(projection)`**: `OptimizerProfiler._count_params_per_gpu` read
  `model_config.vocab_size` — a field `ModelConfig` does not define, so
  `getattr(..., 0)` was always 0 and embedding+output params were silently
  dropped from the Adam step-time estimate. Use `padded_vocab_size` (matching
  `EmbeddingProfiler`/`OutputLayerProfiler`). Caught by the new param-count
  assertion.