### PR TITLE
ci: limit Dependabot version updates to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,16 @@
 version: 2
+# Version updates for GitHub Actions only; CVEs are handled by Dependabot
+# security updates (enabled repo-wide).
 updates:
-  # Keep GitHub Actions versions current (and surface SHA updates).
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github-actions"
-
-  # Python runtime dependencies.
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "python"
-
-  # Base images used by the CI Docker build context.
-  - package-ecosystem: "docker"
-    directory: "/.github/workflows/docker"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "docker"


### PR DESCRIPTION
## Summary

Scope Dependabot **version updates** to GitHub Actions only, and rely on
Dependabot **security updates** (enabled repo-wide) to patch CVEs across all
ecosystems.

- Keep only the `github-actions` ecosystem, with all action bumps **grouped
  into a single PR** to cut review noise and keep pinned action SHAs fresh.
- Drop the `pip` and `docker` version-update configs: for a training framework
  those bumps are noise (deps track the base training image) and are bumped
  manually together with the image.
- Restore `labels` (`dependencies`, `github-actions`); both labels now exist in
  the repo, so Dependabot no longer warns about missing labels.