### PR TITLE
Add CPU unit tests for tuning agent / CLI / launcher, and fix single-process benchmark

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -384,6 +384,26 @@ jobs:
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data HSA_NO_SCRATCH_RECLAIM=1 \
           pytest  --maxfail=1 -s ./tests/trainer/test_torchtitan_trainer.py \
             --junitxml="${GITHUB_WORKSPACE}/test-reports/torchtitan-e2e.xml"
+      - name: Run Primus CLI tool smoke (benchmark / preflight, E2E coverage)
+        if: always()
+        continue-on-error: true
+        run: |
+          # Best-effort CLI smoke so primus/tools (GEMM / attention / RCCL
+          # benches + preflight probes) is exercised under the inherited E2E
+          # coverage injection. Never fails CI: coverage is kept up to any exit.
+          export HSA_NO_SCRATCH_RECLAIM=1
+          OUT="${{ env.UT_LOG_PATH }}/cli_smoke"; mkdir -p "$OUT"
+          cli() { python -m primus.cli.main "$@" || true; }
+          # single-GPU benches + preflight info
+          cli benchmark gemm --M 512 --N 512 --K 512 --duration 2 --output-file "$OUT/gemm.md"
+          cli benchmark gemm-dense --seqlen 256 --hidden-size 512 --intermediate-size 512 --duration 2 --output-file "$OUT/gemm_dense.md"
+          cli benchmark gemm-deepseek --seqlen 256 --hidden-size 512 --intermediate-size 512 --moe-intermediate-size 512 --duration 2 --output-file "$OUT/gemm_deepseek.md"
+          cli benchmark attention --backend flash --mbs-list 1,2 --report-csv-path "$OUT/attn.csv"
+          cli preflight --host --gpu --dump-path "$OUT/preflight"
+          # multi-GPU collectives (best-effort; strided needs >=8 GPUs)
+          NGPU=$(python -c "import torch; print(torch.cuda.device_count())" 2>/dev/null || echo 1)
+          [ "$NGPU" -ge 2 ] && torchrun --nproc_per_node="$NGPU" -m primus.cli.main benchmark rccl --op all_reduce all_gather --min-bytes 1K --max-bytes 256K --num-sizes 2 --iters 3 --warmup 1 --output-file "$OUT/rccl.md" || true
+          [ "$NGPU" -ge 8 ] && torchrun --nproc_per_node=8 -m primus.cli.main benchmark strided-allgather --sizes-mb 8 --iters 3 --warmup 1 || true
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/primus/tools/utils.py
+++ b/primus/tools/utils.py
@@ -98,8 +98,11 @@ try:
         return gathered
 
     def is_rank_0() -> bool:
-        if not dist.is_initialized():
-            raise RuntimeError("Distributed not initialized, cannot determine rank.")
+        # Single-process (no torchrun) is rank 0 by definition. This mirrors the
+        # world==1 fallback in gather_records so the benchmark tools can run
+        # standalone on a single GPU without initializing a process group.
+        if not (dist.is_available() and dist.is_initialized()):
+            return True
         return dist.get_rank() == 0
 
     def get_local_rank() -> int:

--- a/tests/unit_tests/agents/test_agent_cli.py
+++ b/tests/unit_tests/agents/test_agent_cli.py
@@ -1,0 +1,73 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the tuning-agent CLI (``cli.py``) arg parsing + early exits.
+
+The full main() pipeline (load_config -> evaluator -> LLM) is out of scope; we
+cover argument parsing and the missing-file guards that return before any heavy
+work.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("primus.agents.tuning_agent.cli")
+
+from primus.agents.tuning_agent.cli import _parse_args, main  # noqa: E402
+
+
+def test_parse_args_defaults():
+    ns = _parse_args(["--workload", "w.yaml", "--target-cluster", "tc.yaml"])
+    assert ns.mode == "full"
+    assert ns.profiling_mode == "simulate"
+    assert ns.seed_budget == 12
+    assert ns.dry_run is False and ns.seed_only is False
+
+
+def test_parse_args_flags_and_choices():
+    ns = _parse_args(
+        [
+            "--workload",
+            "w",
+            "--target-cluster",
+            "tc",
+            "--dry-run",
+            "--seed-only",
+            "--seed-budget",
+            "5",
+            "--mode",
+            "memory-real",
+            "--profiling-mode",
+            "benchmark",
+        ]
+    )
+    assert ns.dry_run is True and ns.seed_only is True
+    assert ns.seed_budget == 5 and ns.mode == "memory-real" and ns.profiling_mode == "benchmark"
+
+
+def test_parse_args_requires_workload_and_cluster():
+    with pytest.raises(SystemExit):
+        _parse_args(["--target-cluster", "tc"])
+    with pytest.raises(SystemExit):
+        _parse_args(["--workload", "w"])
+
+
+def test_parse_args_rejects_invalid_mode():
+    with pytest.raises(SystemExit):
+        _parse_args(["--workload", "w", "--target-cluster", "tc", "--mode", "bogus"])
+
+
+def test_main_returns_2_on_missing_workload(tmp_path):
+    rc = main(["--workload", str(tmp_path / "nope.yaml"), "--target-cluster", str(tmp_path / "tc.yaml")])
+    assert rc == 2
+
+
+def test_main_returns_2_on_missing_target_cluster(tmp_path):
+    wl = tmp_path / "wl.yaml"
+    wl.write_text("modules: {}\n")
+    rc = main(["--workload", str(wl), "--target-cluster", str(tmp_path / "nope.yaml")])
+    assert rc == 2

--- a/tests/unit_tests/agents/test_config.py
+++ b/tests/unit_tests/agents/test_config.py
@@ -1,0 +1,99 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for tuning-agent config loading (``config.py``)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("primus.agents.tuning_agent.config")
+
+from primus.agents.tuning_agent.config import (  # noqa: E402
+    AgentConfig,
+    _from_env,
+    _resolve_api_key,
+    load_config,
+)
+
+_CRED_ENV = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "LLM_API_KEY", "OPENAI_API_BASE", "LLM_MODEL")
+
+
+def test_resolve_api_key_priority(monkeypatch):
+    for k in _CRED_ENV:
+        monkeypatch.delenv(k, raising=False)
+    assert _resolve_api_key() == ""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k-anthropic")
+    assert _resolve_api_key() == "k-anthropic"
+    monkeypatch.setenv("OPENAI_API_KEY", "k-openai")
+    assert _resolve_api_key() == "k-openai"  # OPENAI wins (first in priority order)
+
+
+def test_from_env_treats_unset_and_empty_as_default(monkeypatch):
+    monkeypatch.delenv("PRIMUS_TEST_X", raising=False)
+    assert _from_env("PRIMUS_TEST_X", "fallback") == "fallback"
+    monkeypatch.setenv("PRIMUS_TEST_X", "")
+    assert _from_env("PRIMUS_TEST_X", "fallback") == "fallback"
+    monkeypatch.setenv("PRIMUS_TEST_X", "value")
+    assert _from_env("PRIMUS_TEST_X", "fallback") == "value"
+
+
+def test_load_config_parses_sections(tmp_path, monkeypatch):
+    for k in _CRED_ENV:
+        monkeypatch.delenv(k, raising=False)
+    tc = tmp_path / "target_cluster.yaml"
+    tc.write_text(
+        "target_cluster:\n"
+        "  name: testcluster\n"
+        "  num_nodes: 4\n"
+        "  gpus_per_node: 8\n"
+        "  gpu_arch: mi300x\n"
+        "available_for_benchmark:\n"
+        "  has_gpu: true\n"
+        "  benchmark_gpus: 8\n"
+        "optimization:\n"
+        "  hbm_capacity_gb: 256\n"
+        "  budget:\n"
+        "    max_proposals: 10\n"
+        "  axes:\n"
+        "    gbs: true\n"
+        "agent:\n"
+        "  llm:\n"
+        "    model: openai/gpt-4o\n"
+        "    timeout: 100\n"
+        "  prompt_extras:\n"
+        "    - hint one\n"
+    )
+    wl = tmp_path / "workload.yaml"
+    wl.write_text("modules: {}\n")
+
+    cfg = load_config(tc, wl)
+
+    assert isinstance(cfg, AgentConfig)
+    assert (cfg.target_cluster.name, cfg.target_cluster.num_nodes) == ("testcluster", 4)
+    assert cfg.target_cluster.gpu_arch == "mi300x"
+    assert cfg.benchmark_host.has_gpu is True and cfg.benchmark_host.benchmark_gpus == 8
+    assert cfg.optimization.hbm_capacity_gb == 256.0
+    assert cfg.optimization.budget.max_proposals == 10
+    assert cfg.optimization.axes["gbs"] is True  # YAML override merged in
+    assert cfg.optimization.axes["tp"] is True  # default axis preserved
+    assert cfg.llm.model == "openai/gpt-4o" and cfg.llm.timeout == 100
+    assert "hint one" in cfg.extra_prompt
+    assert "testcluster" in str(cfg.out_dir)  # default out_dir nests cluster name
+
+
+def test_load_config_rejects_non_mapping(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("- just\n- a\n- list\n")
+    with pytest.raises(ValueError, match="not a mapping"):
+        load_config(bad, tmp_path / "workload.yaml")
+
+
+def test_load_config_out_dir_override(tmp_path):
+    tc = tmp_path / "tc.yaml"
+    tc.write_text("target_cluster:\n  name: c\n")
+    cfg = load_config(tc, tmp_path / "wl.yaml", out_dir=tmp_path / "custom_out")
+    assert str(cfg.out_dir).endswith("custom_out")

--- a/tests/unit_tests/agents/test_plan.py
+++ b/tests/unit_tests/agents/test_plan.py
@@ -1,0 +1,92 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the tuning-agent deterministic seed planner (``plan.py``).
+
+build_seed_plan generates a capped, baseline-anchored set of legal TrialConfigs
+before the LLM runs. Pure CPU: derives legality + sweeps axes, no projection /
+LLM calls.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("primus.agents.tuning_agent.plan")
+
+from primus.agents.tuning_agent.config import (  # noqa: E402
+    AgentConfig,
+    BenchmarkHost,
+    LLMConfig,
+    OptimizationConfig,
+    TargetCluster,
+)
+from primus.agents.tuning_agent.plan import SeedPlan, build_seed_plan  # noqa: E402
+from primus.agents.tuning_agent.workload import ArchitectureRecord  # noqa: E402
+
+
+def _arch(moe: bool = False, **kw) -> ArchitectureRecord:
+    base = dict(
+        model_name="moe" if moe else "dense",
+        num_layers=32,
+        hidden_size=4096,
+        num_attention_heads=32,
+        seq_length=4096,
+        is_moe=moe,
+        global_batch_size=128,
+        micro_batch_size=2,
+    )
+    if moe:
+        base.update(num_experts=8, moe_router_topk=2)
+    base.update(kw)
+    return ArchitectureRecord(**base)
+
+
+def _cfg(num_nodes: int = 1, gpus_per_node: int = 8) -> AgentConfig:
+    return AgentConfig(
+        target_cluster=TargetCluster(num_nodes=num_nodes, gpus_per_node=gpus_per_node, gpu_arch="mi355x"),
+        benchmark_host=BenchmarkHost(),
+        optimization=OptimizationConfig(),
+        llm=LLMConfig(),
+    )
+
+
+# (moe, max_candidates): dense default cluster vs MoE branch (2 nodes for EP room).
+@pytest.mark.parametrize("moe, max_candidates", [(False, 6), (False, 3), (True, 12)])
+def test_seed_plan_nonempty_and_capped(moe, max_candidates):
+    nodes = 2 if moe else 1
+    plan = build_seed_plan(_arch(moe=moe), _cfg(num_nodes=nodes), max_candidates=max_candidates)
+    assert isinstance(plan, SeedPlan)
+    assert 0 < len(plan.candidates) <= max_candidates
+    assert plan.rationale  # non-empty explanation
+
+
+def test_seed_plan_includes_baseline_parallelism():
+    arch = _arch()
+    plan = build_seed_plan(arch, _cfg(), max_candidates=12)
+    baseline = (
+        arch.tensor_model_parallel_size,
+        arch.pipeline_model_parallel_size,
+        arch.expert_model_parallel_size,
+        arch.context_parallel_size,
+    )
+    # TrialConfig uses short axis names (tp/pp/ep/cp); ArchitectureRecord uses full names.
+    combos = {(c.tp, c.pp, c.ep, c.cp) for c in plan.candidates}
+    assert baseline in combos
+
+
+def test_seed_plan_moe_nonempty_and_capped():
+    # Exercises the MoE branch of build_seed_plan (EP axis derivation).
+    plan = build_seed_plan(_arch(moe=True), _cfg(num_nodes=2, gpus_per_node=8), max_candidates=12)
+    assert 0 < len(plan.candidates) <= 12
+
+
+def test_seed_plan_candidates_are_unique():
+    plan = build_seed_plan(_arch(), _cfg(), max_candidates=12)
+    serialized = [json.dumps(c.as_dict(), sort_keys=True) for c in plan.candidates]
+    assert len(serialized) == len(set(serialized))

--- a/tests/unit_tests/agents/test_scratchpad.py
+++ b/tests/unit_tests/agents/test_scratchpad.py
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the tuning-agent Scratchpad (plain-text note store)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("primus.agents.tuning_agent.scratchpad")
+
+from primus.agents.tuning_agent.scratchpad import Scratchpad  # noqa: E402
+
+
+def test_scratchpad_creates_empty_file_with_parents(tmp_path):
+    p = tmp_path / "nested" / "dir" / "sp.txt"
+    sp = Scratchpad(p)
+    assert p.exists()
+    assert sp.read() == ""
+
+
+def test_scratchpad_append_timestamps_and_accumulates(tmp_path):
+    sp = Scratchpad(tmp_path / "sp.txt")
+    msg = sp.append("first note")
+    assert "scratchpad updated" in msg
+    sp.append("second note")
+    body = sp.read()
+    assert "first note" in body and "second note" in body
+    assert body.count("\n") == 2  # one line per append
+
+
+def test_scratchpad_reset_clears(tmp_path):
+    sp = Scratchpad(tmp_path / "sp.txt")
+    sp.append("something")
+    sp.reset()
+    assert sp.read() == ""
+
+
+def test_scratchpad_read_missing_file_returns_empty(tmp_path):
+    sp = Scratchpad(tmp_path / "sp.txt")
+    sp.path.unlink()  # remove the file created in __init__
+    assert sp.read() == ""

--- a/tests/unit_tests/agents/test_tools.py
+++ b/tests/unit_tests/agents/test_tools.py
@@ -1,0 +1,44 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the tuning-agent tool helpers (``tools.py``).
+
+Covers the pure helpers (`_safe_load_json`, `_tag`); the LLM tool-belt itself
+holds live evaluator/history state and is out of scope here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("primus.agents.tuning_agent.tools")
+
+from primus.agents.tuning_agent.legality import TrialConfig  # noqa: E402
+from primus.agents.tuning_agent.tools import _safe_load_json, _tag  # noqa: E402
+
+
+def test_safe_load_json_passthrough_dict():
+    d = {"tp": 2}
+    assert _safe_load_json(d) is d
+
+
+def test_safe_load_json_parses_plain_json():
+    assert _safe_load_json('{"tp": 2, "pp": 4}') == {"tp": 2, "pp": 4}
+
+
+def test_safe_load_json_strips_code_fence():
+    assert _safe_load_json('```json\n{"ep": 8}\n```') == {"ep": 8}
+    assert _safe_load_json('```\n{"cp": 2}\n```') == {"cp": 2}
+
+
+def test_safe_load_json_returns_none_on_invalid():
+    assert _safe_load_json("not json") is None
+    assert _safe_load_json(123) is None  # non-str, non-dict
+
+
+def test_tag_encodes_parallelism_axes():
+    cfg = TrialConfig(tp=2, pp=4, ep=8, cp=1, mbs=2)
+    assert _tag(cfg, 7) == "007_tp2_pp4_ep8_cp1_mbs2"

--- a/tests/unit_tests/cli/test_benchmark_subcommand.py
+++ b/tests/unit_tests/cli/test_benchmark_subcommand.py
@@ -1,0 +1,116 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for ``benchmark.register_subcommand`` (pure argparse surface).
+
+Exercises only the parser wiring (suite registration, per-suite arg defaults
+and choice validation). This also covers the ``primus/tools/benchmark/*_args``
+helpers that ``register_subcommand`` imports to build each suite parser.
+``run()`` initializes torch.distributed and runs GPU/RCCL benches, so it is
+intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from primus.cli.subcommands import benchmark
+
+_SUITES = ["gemm", "attention", "gemm-dense", "gemm-deepseek", "strided-allgather", "rccl"]
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="primus")
+    subparsers = parser.add_subparsers(dest="cmd")
+    returned = benchmark.register_subcommand(subparsers)
+    return parser, returned
+
+
+def test_register_returns_parser_wired_to_run():
+    _, returned = _build_parser()
+    assert returned.get_default("func") is benchmark.run
+
+
+def test_suite_is_required():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["benchmark"])
+
+
+@pytest.mark.parametrize("suite", _SUITES)
+def test_each_suite_parses(suite):
+    parser, _ = _build_parser()
+    args = parser.parse_args(["benchmark", suite])
+    assert args.suite == suite
+
+
+def test_unknown_suite_rejected():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["benchmark", "bogus"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# gemm suite (tools/benchmark/gemm_bench_args)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_gemm_defaults():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["benchmark", "gemm"])
+    assert (args.M, args.N, args.K) == (4096, 4096, 4096)
+    assert args.dtype == "bf16"
+    assert args.trans_a is False and args.trans_b is False
+
+
+def test_gemm_dtype_choice_rejected():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["benchmark", "gemm", "--dtype", "int4"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# rccl suite (tools/benchmark/rccl_bench_args)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_rccl_defaults():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["benchmark", "rccl"])
+    assert args.scale == "log2"
+    assert args.min_bytes == "1K" and args.max_bytes == "128M"
+
+
+def test_rccl_op_accepts_multiple_values():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["benchmark", "rccl", "--op", "all_reduce", "all_gather"])
+    assert args.op == ["all_reduce", "all_gather"]
+
+
+def test_rccl_op_invalid_choice_rejected():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["benchmark", "rccl", "--op", "bogus_collective"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# attention suite (tools/benchmark/attention_bench_args)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_attention_defaults():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["benchmark", "attention"])
+    assert args.backend == "flash"
+    assert args.dtype == "bf16"
+
+
+def test_attention_backend_choice_rejected():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["benchmark", "attention", "--backend", "bogus"])

--- a/tests/unit_tests/cli/test_cli_main.py
+++ b/tests/unit_tests/cli/test_cli_main.py
@@ -66,3 +66,71 @@ def test_load_subcommands_requires_func(monkeypatch):
 
     with pytest.raises(RuntimeError, match="set_defaults"):
         cli_main._load_subcommands(subparsers, module_paths)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _discover_subcommands
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_discover_subcommands_maps_name_to_module_path():
+    cmds = cli_main._discover_subcommands()
+    assert cmds["train"] == "primus.cli.subcommands.train"
+    assert "projection" in cmds and "benchmark" in cmds
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _extract_command (argv -> subcommand name)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "argv, expected",
+    [
+        (["train", "--config", "x"], "train"),  # first positional
+        (["--debug", "train"], "train"),  # skip leading flags
+        (["--", "projection"], "projection"),  # token after --
+        (["--"], None),  # bare --
+        (["bogus"], "bogus"),  # unknown token returned verbatim
+        ([], None),  # empty
+        (["--debug"], None),  # all flags
+    ],
+)
+def test_extract_command(argv, expected):
+    assert cli_main._extract_command(argv, {"train", "projection"}) == expected
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _register_subcommand error paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _subparsers():
+    parser = argparse.ArgumentParser()
+    return parser.add_subparsers(dest="cmd")
+
+
+def test_register_subcommand_import_failure_raises(monkeypatch):
+    def boom(name):
+        raise ImportError("nope")
+
+    monkeypatch.setattr(cli_main.importlib, "import_module", boom)
+    with pytest.raises(RuntimeError, match="Failed to import"):
+        cli_main._register_subcommand(_subparsers(), "x.bad")
+
+
+def test_register_subcommand_missing_hook_raises(monkeypatch):
+    monkeypatch.setattr(cli_main.importlib, "import_module", lambda name: type("M", (), {})())
+    with pytest.raises(AttributeError, match="register_subcommand"):
+        cli_main._register_subcommand(_subparsers(), "x.nohook")
+
+
+def test_register_subcommand_returning_none_raises(monkeypatch):
+    def fake(name):
+        m = type("M", (), {})()
+        m.register_subcommand = lambda subparsers: None
+        return m
+
+    monkeypatch.setattr(cli_main.importlib, "import_module", fake)
+    with pytest.raises(RuntimeError, match="must return the parser"):
+        cli_main._register_subcommand(_subparsers(), "x.noret")

--- a/tests/unit_tests/cli/test_preflight_subcommand.py
+++ b/tests/unit_tests/cli/test_preflight_subcommand.py
@@ -1,0 +1,71 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for ``preflight.register_subcommand`` (pure argparse surface).
+
+Covers the parser wiring and the ``tools/preflight/preflight_args`` helper it
+imports (selection flags, --check-* aliases, defaults). ``run()`` probes GPU /
+network / host hardware and raises SystemExit, so it is out of scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from primus.cli.subcommands import preflight
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="primus")
+    subparsers = parser.add_subparsers(dest="cmd")
+    returned = preflight.register_subcommand(subparsers)
+    return parser, returned
+
+
+def test_register_returns_parser_wired_to_run():
+    _, returned = _build_parser()
+    assert returned.get_default("func") is preflight.run
+
+
+def test_defaults():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["preflight"])
+    assert args.check_host is False
+    assert args.check_gpu is False
+    assert args.check_network is False
+    assert args.perf_test is False
+    assert args.dist_timeout_sec == 120
+    assert args.dump_path == "output/preflight"
+    assert args.report_file_name == "preflight_report"
+    assert args.save_pdf is True
+
+
+def test_selection_flags():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["preflight", "--gpu", "--network"])
+    assert args.check_gpu is True
+    assert args.check_network is True
+    assert args.check_host is False
+
+
+def test_check_alias_maps_to_same_dest():
+    # --host and --check-host share dest=check_host.
+    parser, _ = _build_parser()
+    args = parser.parse_args(["preflight", "--check-host"])
+    assert args.check_host is True
+
+
+def test_disable_pdf_sets_store_false():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["preflight", "--disable-pdf"])
+    assert args.save_pdf is False
+
+
+def test_perf_test_flag():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["preflight", "--perf-test", "--plot"])
+    assert args.perf_test is True
+    assert args.plot is True

--- a/tests/unit_tests/cli/test_projection_subcommand.py
+++ b/tests/unit_tests/cli/test_projection_subcommand.py
@@ -1,0 +1,140 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for ``projection.register_subcommand`` (pure argparse surface).
+
+Only the parser wiring is exercised: suite registration, per-suite argument
+defaults, choice validation, and deprecated aliases. ``run()`` imports the
+backend / projection engines (GPU) and is intentionally out of scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from primus.cli.subcommands import projection
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="primus")
+    subparsers = parser.add_subparsers(dest="cmd")
+    returned = projection.register_subcommand(subparsers)
+    return parser, returned
+
+
+def test_register_returns_parser_wired_to_run():
+    _, returned = _build_parser()
+    assert returned.get_default("func") is projection.run
+
+
+def test_suite_is_required():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["projection"])
+
+
+@pytest.mark.parametrize("suite", ["memory", "performance", "both"])
+def test_each_suite_parses_config(suite):
+    parser, _ = _build_parser()
+    args = parser.parse_args(["projection", suite, "--config", "exp.yaml"])
+    assert args.suite == suite
+    assert args.config == "exp.yaml"
+
+
+def test_exp_alias_maps_to_config():
+    # add_pretrain_parser registers --config with a --exp alias.
+    parser, _ = _build_parser()
+    args = parser.parse_args(["projection", "memory", "--exp", "y.yaml"])
+    assert args.config == "y.yaml"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# memory suite
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_memory_defaults():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["projection", "memory", "--config", "x"])
+    assert args.memory_mode == "benchmark"
+    assert args.memory_safety_margin == pytest.approx(0.05)
+    assert args.pipeline_schedule_algorithm == "auto"
+    assert args.target_nodes is None
+    assert args.benchmark_gpus is None
+    assert args.save_benchmark is None
+    assert args.load_benchmark is None
+
+
+def test_memory_compute_baseline_alias_present():
+    # Memory side exposes --compute-baseline as a deprecated load alias.
+    parser, _ = _build_parser()
+    args = parser.parse_args(["projection", "memory", "--config", "x", "--compute-baseline", "a.json"])
+    assert args.compute_baseline == "a.json"
+
+
+def test_memory_save_profiling_alias_present():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["projection", "memory", "--config", "x", "--save-profiling", "out.json"])
+    assert args.save_profiling == "out.json"
+
+
+def test_memory_mode_invalid_choice_rejected():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["projection", "memory", "--config", "x", "--memory-mode", "bogus"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# performance suite
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_performance_defaults():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["projection", "performance", "--config", "x"])
+    assert args.profiling_mode == "benchmark"
+    assert args.sync_free_stage == 0
+    assert args.enable_zero_bubble is False
+    assert args.enable_deepep is False
+    assert args.gemm_backend is None
+
+
+def test_performance_store_true_flags():
+    parser, _ = _build_parser()
+    args = parser.parse_args(
+        ["projection", "performance", "--config", "x", "--enable-zero-bubble", "--enable-deepep"]
+    )
+    assert args.enable_zero_bubble is True
+    assert args.enable_deepep is True
+
+
+def test_performance_gemm_backend_choice_rejected():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["projection", "performance", "--config", "x", "--gemm-backend", "cutlass"])
+
+
+def test_performance_profiling_mode_choice_rejected():
+    parser, _ = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["projection", "performance", "--config", "x", "--profiling-mode", "bogus"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# both suite
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_both_exposes_safety_margin_but_not_memory_mode():
+    parser, _ = _build_parser()
+    args = parser.parse_args(["projection", "both", "--config", "x"])
+    # `both` always runs a fresh bench, so --memory-mode is not registered.
+    assert not hasattr(args, "memory_mode")
+    assert args.memory_safety_margin == pytest.approx(0.05)
+    # perf knobs are present on `both`.
+    assert args.profiling_mode == "benchmark"

--- a/tests/unit_tests/cli/test_train_subcommand.py
+++ b/tests/unit_tests/cli/test_train_subcommand.py
@@ -1,0 +1,40 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the train subcommand's runtime router (``_resolve_pretrain_runtime``).
+
+This selects the active core runtime vs the legacy pretrain flow; run()/register
+import heavy runtime modules and are out of scope.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("primus.cli.subcommands.train")
+
+from primus.cli.subcommands.train import _resolve_pretrain_runtime  # noqa: E402
+
+
+def test_runtime_defaults_to_core(monkeypatch):
+    monkeypatch.delenv("PRIMUS_TRAIN_RUNTIME", raising=False)
+    assert _resolve_pretrain_runtime(None) == "core"
+
+
+def test_runtime_explicit_legacy(monkeypatch):
+    monkeypatch.setenv("PRIMUS_TRAIN_RUNTIME", "legacy")
+    assert _resolve_pretrain_runtime(None) == "legacy"
+
+
+def test_runtime_explicit_core_case_insensitive(monkeypatch):
+    monkeypatch.setenv("PRIMUS_TRAIN_RUNTIME", "CORE")
+    assert _resolve_pretrain_runtime(None) == "core"
+
+
+def test_runtime_invalid_value_warns_and_falls_back_to_core(monkeypatch, capsys):
+    monkeypatch.setenv("PRIMUS_TRAIN_RUNTIME", "bogus")
+    assert _resolve_pretrain_runtime(None) == "core"
+    assert "Ignoring invalid" in capsys.readouterr().err

--- a/tests/unit_tests/core/launcher/test_parser.py
+++ b/tests/unit_tests/core/launcher/test_parser.py
@@ -11,9 +11,13 @@ from types import SimpleNamespace
 
 from primus.core.launcher.parser import (
     PrimusParser,
+    _add_common_train_args,
     _check_keys_exist,
     _deep_merge_namespace,
     _parse_kv_overrides,
+    _split_known_unknown,
+    add_posttrain_parser,
+    add_pretrain_parser,
 )
 from primus.core.utils import logger
 from tests.utils import PrimusUT
@@ -112,6 +116,67 @@ class TestPrimusParser(PrimusUT):
         self.assertEqual(ns.a, 10)
         self.assertEqual(ns.b.c, 20)
         self.assertEqual(ns.flag, True)
+
+    # ─────────────────────────────────────────────────────────────────────
+    # _split_known_unknown: split overrides into namespace-known vs delegated
+    # ─────────────────────────────────────────────────────────────────────
+
+    def test_split_known_unknown_flat(self):
+        ns = SimpleNamespace(a=1, b=2)
+        known, unknown = _split_known_unknown(ns, {"a": 10, "c": 30})
+        self.assertEqual(known, {"a": 10})
+        self.assertEqual(unknown, {"c": 30})
+
+    def test_split_known_unknown_nested_partial(self):
+        ns = SimpleNamespace(group=SimpleNamespace(x=1))
+        known, unknown = _split_known_unknown(ns, {"group": {"x": 2, "y": 3}})
+        self.assertEqual(known, {"group": {"x": 2}})
+        self.assertEqual(unknown, {"group": {"y": 3}})
+
+    def test_split_known_unknown_scalar_over_namespace_is_known(self):
+        # A scalar override on a namespace attribute is still "known" (no recursion).
+        ns = SimpleNamespace(group=SimpleNamespace(x=1))
+        known, unknown = _split_known_unknown(ns, {"group": 5})
+        self.assertEqual(known, {"group": 5})
+        self.assertEqual(unknown, {})
+
+    def test_split_known_unknown_empty_nested_not_propagated(self):
+        # If a nested dict has no known leaves, the parent key only lands in unknown.
+        ns = SimpleNamespace(group=SimpleNamespace(x=1))
+        known, unknown = _split_known_unknown(ns, {"group": {"y": 9}})
+        self.assertEqual(known, {})
+        self.assertEqual(unknown, {"group": {"y": 9}})
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Common train arg registration (--config/--exp, --data_path, ...)
+    # ─────────────────────────────────────────────────────────────────────
+
+    def test_add_pretrain_parser_surface(self):
+        p = argparse.ArgumentParser()
+        add_pretrain_parser(p)
+        args = p.parse_args(["--config", "x"])
+        self.assertEqual(args.config, "x")
+        self.assertEqual(args.data_path, "./data")
+        self.assertIsNone(args.backend_path)
+        self.assertIsNone(args.export_config)
+
+    def test_add_pretrain_parser_exp_alias(self):
+        p = argparse.ArgumentParser()
+        add_pretrain_parser(p)
+        args = p.parse_args(["--exp", "y"])
+        self.assertEqual(args.config, "y")
+
+    def test_add_posttrain_parser_matches_pretrain(self):
+        p = argparse.ArgumentParser()
+        add_posttrain_parser(p)
+        args = p.parse_args(["--config", "x"])
+        self.assertEqual(args.data_path, "./data")
+
+    def test_common_train_args_without_data_path(self):
+        p = argparse.ArgumentParser()
+        _add_common_train_args(p, include_data_path=False)
+        args = p.parse_args(["--config", "x"])
+        self.assertFalse(hasattr(args, "data_path"))
 
     def test_export_and_parse_cycle_with_real_yaml(self):
         """

--- a/tests/unit_tests/core/utils/test_env.py
+++ b/tests/unit_tests/core/utils/test_env.py
@@ -1,0 +1,74 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for primus.core.utils.env (distributed env parsing + safe flush)."""
+
+from __future__ import annotations
+
+from primus.core.utils import constant_vars as const
+from primus.core.utils.env import flush_before_hard_exit, get_torchrun_env
+
+_ENV = (
+    "RANK",
+    "WORLD_SIZE",
+    "NODE_RANK",
+    "NNODES",
+    "MASTER_ADDR",
+    "MASTER_PORT",
+    "LOCAL_RANK",
+    "LOCAL_WORLD_SIZE",
+)
+
+
+def _clear(monkeypatch):
+    for k in _ENV:
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_get_torchrun_env_defaults(monkeypatch):
+    _clear(monkeypatch)
+    e = get_torchrun_env()
+    assert e["rank"] == int(const.LOCAL_NODE_RANK)
+    assert e["world_size"] == int(const.LOCAL_WORLD_SIZE)
+    assert e["master_addr"] == const.LOCAL_MASTER_ADDR
+    assert e["master_port"] == int(const.LOCAL_MASTER_PORT)
+
+
+def test_get_torchrun_env_reads_torchrun_vars(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setenv("WORLD_SIZE", "8")
+    monkeypatch.setenv("MASTER_ADDR", "host-a")
+    monkeypatch.setenv("MASTER_PORT", "12345")
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.setenv("LOCAL_WORLD_SIZE", "4")
+    e = get_torchrun_env()
+    assert (e["rank"], e["world_size"]) == (3, 8)
+    assert e["master_addr"] == "host-a" and e["master_port"] == 12345
+    assert (e["local_rank"], e["local_world_size"]) == (1, 4)
+
+
+def test_get_torchrun_env_jax_fallback(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("NODE_RANK", "2")
+    monkeypatch.setenv("NNODES", "4")
+    e = get_torchrun_env()
+    assert (e["rank"], e["world_size"]) == (2, 4)
+
+
+def test_get_torchrun_env_torchrun_takes_precedence_over_jax(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("RANK", "5")
+    monkeypatch.setenv("NODE_RANK", "2")
+    monkeypatch.setenv("WORLD_SIZE", "16")
+    monkeypatch.setenv("NNODES", "4")
+    e = get_torchrun_env()
+    assert (e["rank"], e["world_size"]) == (5, 16)
+
+
+def test_flush_before_hard_exit_is_noop_without_coverage(monkeypatch):
+    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
+    flush_before_hard_exit()  # best-effort, must not raise

--- a/tests/unit_tests/core/utils/test_yaml_utils.py
+++ b/tests/unit_tests/core/utils/test_yaml_utils.py
@@ -1,0 +1,124 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for primus.core.utils.yaml_utils (namespace <-> dict + merge helpers).
+
+These pure helpers back the backend argument builders (dict_to_nested_namespace /
+nested_namespace_to_dict / deep_merge); no torch/framework imports.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from primus.core.utils.yaml_utils import (
+    check_key_in_namespace,
+    deep_merge_namespace,
+    delete_namespace_key,
+    dict_to_nested_namespace,
+    dump_namespace_to_yaml,
+    get_value_by_key,
+    has_key_in_namespace,
+    merge_namespace,
+    nested_namespace_to_dict,
+    override_namespace,
+    parse_nested_namespace_to_str,
+    set_value_by_key,
+)
+
+
+def test_dict_to_nested_namespace_recurses_into_lists_and_maps():
+    ns = dict_to_nested_namespace({"a": 1, "b": {"c": 2}, "l": [{"d": 3}, 4]})
+    assert ns.a == 1
+    assert ns.b.c == 2
+    assert ns.l[0].d == 3 and ns.l[1] == 4
+
+
+def test_dict_to_nested_namespace_passes_scalars_through():
+    assert dict_to_nested_namespace(5) == 5
+
+
+def test_nested_namespace_to_dict_roundtrips():
+    d = {"a": 1, "b": {"c": 2}, "l": [{"d": 3}]}
+    assert nested_namespace_to_dict(dict_to_nested_namespace(d)) == d
+
+
+def test_key_set_get_has_delete():
+    ns = SimpleNamespace(name="n")
+    set_value_by_key(ns, "x", 1)
+    assert has_key_in_namespace(ns, "x")
+    assert get_value_by_key(ns, "x") == 1
+    delete_namespace_key(ns, "x")
+    assert not has_key_in_namespace(ns, "x")
+
+
+def test_set_value_null_string_becomes_none():
+    ns = SimpleNamespace()
+    set_value_by_key(ns, "x", "null")
+    assert ns.x is None
+
+
+def test_set_value_rejects_override_unless_allowed():
+    ns = SimpleNamespace(x=1)
+    with pytest.raises(AssertionError):
+        set_value_by_key(ns, "x", 2)
+    set_value_by_key(ns, "x", 2, allow_override=True)
+    assert ns.x == 2
+
+
+def test_check_key_missing_raises():
+    ns = SimpleNamespace(name="cfg")
+    with pytest.raises(AssertionError, match="Failed to find key"):
+        check_key_in_namespace(ns, "missing")
+
+
+def test_deep_merge_namespace_inplace_preserves_nested_reference():
+    ns = SimpleNamespace(a=1, sub=SimpleNamespace(x=1))
+    sub_ref = ns.sub
+    deep_merge_namespace(ns, {"a": 2, "sub": {"y": 3}})
+    assert ns.a == 2
+    assert ns.sub.x == 1 and ns.sub.y == 3
+    assert ns.sub is sub_ref  # existing nested namespace updated in place
+
+
+def test_override_namespace_deep_merges_and_handles_none():
+    base = SimpleNamespace(a=1, b=SimpleNamespace(c=1))
+    override_namespace(base, SimpleNamespace(b=SimpleNamespace(d=2), e=3))
+    assert base.b.c == 1 and base.b.d == 2 and base.e == 3
+    override_namespace(base, None)  # no-op
+    assert base.a == 1
+
+
+def test_merge_namespace_skips_existing_by_default():
+    dst = SimpleNamespace(a=1)
+    merge_namespace(dst, SimpleNamespace(a=2, b=3))
+    assert dst.a == 1 and dst.b == 3  # existing 'a' kept, new 'b' added
+
+
+def test_merge_namespace_allow_override_and_excepts():
+    dst = SimpleNamespace(a=1)
+    merge_namespace(dst, SimpleNamespace(a=2), allow_override=True)
+    assert dst.a == 2
+
+    dst2 = SimpleNamespace()
+    merge_namespace(dst2, SimpleNamespace(a=1, secret=2), excepts=["secret"])
+    assert dst2.a == 1 and not has_key_in_namespace(dst2, "secret")
+
+
+def test_dump_namespace_to_yaml_roundtrip(tmp_path):
+    ns = SimpleNamespace(a=1, b=SimpleNamespace(c=2), lst=[1, 2])
+    path = tmp_path / "cfg.yaml"
+    dump_namespace_to_yaml(ns, str(path))
+    assert yaml.safe_load(path.read_text()) == {"a": 1, "b": {"c": 2}, "lst": [1, 2]}
+
+
+def test_parse_nested_namespace_to_str_is_json():
+    s = parse_nested_namespace_to_str(SimpleNamespace(a=1, b=SimpleNamespace(c=2)))
+    assert json.loads(s) == {"a": 1, "b": {"c": 2}}

--- a/tests/unit_tests/tools/test_utils.py
+++ b/tests/unit_tests/tools/test_utils.py
@@ -1,0 +1,66 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for primus.tools.utils single-process (no-torchrun) fallbacks.
+
+These guard the standalone path: the benchmark tools must run on a single GPU
+without an initialized process group. Pure CPU; no GPU / dist required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import torch.distributed as dist  # noqa: E402
+
+from primus.tools.utils import (  # noqa: E402
+    derive_path,
+    get_rank_world,
+    is_rank_0,
+    parse_bytes,
+    parse_sizes_list,
+    round_up_div,
+)
+
+
+def test_is_rank_0_true_without_dist():
+    # Regression: is_rank_0 used to raise when dist was not initialized, which
+    # crashed single-process `primus-cli benchmark gemm`. It must now treat the
+    # single-process case as rank 0 (mirroring gather_records' world==1 path).
+    assert not dist.is_initialized()
+    assert is_rank_0() is True
+
+
+def test_get_rank_world_defaults_single_process(monkeypatch):
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    assert get_rank_world() == (0, 1)
+
+
+def test_parse_bytes_suffixes():
+    assert parse_bytes("1K") == 1024
+    assert parse_bytes("2M") == 2 * 1024**2
+    assert parse_bytes("1G") == 1024**3
+    assert parse_bytes("4096") == 4096
+
+
+def test_parse_sizes_list():
+    assert parse_sizes_list("1K,2K") == {1024, 2048}
+    assert parse_sizes_list("") == set()
+
+
+def test_round_up_div():
+    assert round_up_div(10, 4) == 3
+    assert round_up_div(8, 4) == 2
+
+
+def test_derive_path():
+    assert derive_path("./r.md", "_rank") == "./r_rank.md"
+    assert derive_path("./r.csv.gz", "_t") == "./r_t.csv.gz"
+    assert derive_path("", "_x") == ""
+    assert derive_path("-", "_x") == ""


### PR DESCRIPTION
## Summary

CPU unit tests for the no-GPU surfaces of the tuning agent, CLI, and launcher,
plus a single-process benchmark fix and a CLI smoke step that brings
`primus/tools` under E2E coverage.

### Tuning agent (`primus/agents/tuning_agent/`)

Deterministic, no-LLM helpers used before any model call:

* **scratchpad** — file-backed note store (create / append / read / reset).
* **plan** — `build_seed_plan` seed candidates (capped, baseline-anchored, dense + MoE).
* **config** — `load_config` YAML parsing + `_resolve_api_key` / `_from_env`.
* **tools** — `_safe_load_json` and `_tag` helpers.
* **cli** — `_parse_args` defaults/flags/choices + `main()` missing-file guards.

### CLI dispatch (`primus/cli/`)

* **main.py** — `_extract_command`, `_discover_subcommands`, and `_register_subcommand` error paths.
* **subcommands/train.py** — `_resolve_pretrain_runtime` (core vs legacy routing).
* **subcommands/{projection,benchmark,preflight}.py** — `register_subcommand` parser
  wiring (suites, defaults, choice validation, deprecated aliases). This also covers the
  pure-argparse `primus/tools/*_args` helpers. `run()` (GPU / RCCL / hardware probe) is out of scope.

### Launcher / core utils

* **launcher/parser.py** — `_split_known_unknown` and `add_pretrain_parser` / `add_posttrain_parser`.
* **core/utils/yaml_utils.py** — namespace↔dict + deep-merge / override / merge helpers.
* **core/utils/env.py** — `get_torchrun_env` (torchrun + JAX fallback) + safe flush.

### Benchmark tools fix + E2E coverage

* **fix** — `is_rank_0()` now treats the no-dist case as rank 0 (mirroring `gather_records`'
  `world==1` path), so single-GPU `primus-cli benchmark gemm` no longer crashes.
* **tests** — CPU regression tests for `primus.tools.utils` single-process fallbacks and pure helpers.
* **ci** — best-effort CLI smoke step (benchmark / preflight) after the training E2E so
  `primus/tools` is exercised under the existing coverage injection. `continue-on-error`, never fails CI.

### Scope notes

* **Skipped on purpose**: `modules/trainer/*` (legacy), `agents/agent.py` (LLM loop),
  the backend trainers, and each subcommand `run()` — framework / GPU-heavy, covered by E2E.