### PR TITLE
feat(muon): batched grouped-expert Newton-Schulz orthogonalize (TP=1)

### DIFF
--- a/primus/backends/megatron/core/optimizer/moun.py
+++ b/primus/backends/megatron/core/optimizer/moun.py
@@ -3,6 +3,7 @@
 """Megatron muon optimizer wrapper to handle tensor-parallel."""
 
 import logging
+import os
 from typing import Any, Callable, Dict, List, Literal, Optional
 
 import torch
@@ -198,6 +199,22 @@ class TensorParallelMuon(OrthogonalizedOptimizer):
             # on the 3-D param indexes [E, N, K]; drop the leading expert axis for the
             # per-slice call (None under TP=1).
             slice_pdim = None if partition_dim is None or partition_dim == 0 else partition_dim - 1
+            if slice_pdim is None and os.environ.get("PRIMUS_MUON_BATCHED_NS", "1") != "0":
+                # Non-partitioned (TP=1) experts: orthogonalize ALL experts in a
+                # single batched Newton-Schulz instead of an E-long Python loop.
+                # emerging_optimizers>=0.4.0a0 ``newton_schulz`` accepts 3-D
+                # ``[E, N, K]`` natively (``batched_newton_schulz_step`` via
+                # ``torch.baddbmm``), so one call replaces E per-expert calls,
+                # folding E rounds of Python op-dispatch and the per-expert GEMM
+                # launches into one batched launch. ``scaled_orthogonalize_fn`` keys
+                # its scale on ``grad.size(-2)/(-1)`` (= N, K, shared across experts),
+                # so the single scalar applies to the whole batch -- numerically
+                # equivalent to the per-slice loop below.
+                #
+                # Partitioned experts (TP>1) keep the loop: the batched +
+                # ``partition_dim`` path is not exercised here. Set
+                # ``PRIMUS_MUON_BATCHED_NS=0`` to force the per-expert loop.
+                return self.scaled_orthogonalize_fn(grad, tp_group, None)
             return torch.stack(
                 [
                     self.scaled_orthogonalize_fn(grad[e], tp_group, slice_pdim)

--- a/tests/unit_tests/backends/megatron/test_muon_batched_orthogonalize.py
+++ b/tests/unit_tests/backends/megatron/test_muon_batched_orthogonalize.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+"""Parity test for the batched grouped-expert Newton-Schulz fast path in
+:meth:`TensorParallelMuon.orthogonalize`.
+
+At TP=1 the consolidated ``[E, N, K]`` expert momentum is orthogonalized in a
+single batched Newton-Schulz call (``PRIMUS_MUON_BATCHED_NS`` default-on)
+instead of an E-long per-expert Python loop. This asserts the batched path is
+numerically equivalent to the loop it replaces (the loop is still used for the
+partitioned TP>1 case, and is reachable via ``PRIMUS_MUON_BATCHED_NS=0``).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from primus.backends.megatron.core.optimizer.moun import (
+    HAVE_EMERGING_OPTIMIZERS,
+    TensorParallelMuon,
+)
+
+pytestmark = pytest.mark.skipif(
+    not HAVE_EMERGING_OPTIMIZERS,
+    reason="needs emerging_optimizers>=0.4.0a0 (batched 3-D newton_schulz)",
+)
+
+
+@pytest.mark.parametrize("shape", [(8, 64, 32), (6, 32, 48)])
+def test_batched_3d_orthogonalize_matches_loop(shape, monkeypatch):
+    """Batched 3-D orthogonalize == per-expert loop (CPU, fp32)."""
+    torch.manual_seed(0)
+    E, N, K = shape
+
+    # fp32 + "high" matmul precision so the comparison isn't masked by the
+    # bf16 ("medium") Newton-Schulz path; both branches use the same precision,
+    # so the only difference under test is batched-vs-loop reduction order.
+    prev_prec = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        p = torch.nn.Parameter(torch.zeros(E, N, K, dtype=torch.float32))
+        opt = TensorParallelMuon(
+            [p], lr=1e-3, coefficient_type="deepseekv4", extra_scale_factor=0.18
+        )
+        grad = torch.randn(E, N, K, dtype=torch.float32)
+
+        monkeypatch.setenv("PRIMUS_MUON_BATCHED_NS", "1")
+        batched = opt.orthogonalize(p, grad.clone())
+
+        monkeypatch.setenv("PRIMUS_MUON_BATCHED_NS", "0")
+        loop = opt.orthogonalize(p, grad.clone())
+
+        assert batched.shape == (E, N, K)
+        torch.testing.assert_close(batched, loop, rtol=1e-4, atol=1e-4)
+    finally:
+        torch.set_float32_matmul_precision(prev_prec)


### PR DESCRIPTION
At TP=1 the consolidated [E, N, K] grouped-expert momentum can be orthogonalized in one batched Newton-Schulz call instead of an E-long per-expert Python loop: emerging_optimizers>=0.4.0a0 newton_schulz accepts 3-D input natively (batched_newton_schulz_step via torch.baddbmm), so one call replaces E per-expert calls -- folding E rounds of Python op-dispatch and the per-expert GEMM launches into a single batched launch.

The per-window scale_factor keys on (N, K), which is shared across experts, so the single scalar applies to the whole batch; the result is numerically equivalent to the per-slice loop. Added a parity unit test asserting this.

Gated to the non-partitioned (TP=1) path -- partitioned experts (TP>1) keep the per-expert loop, since the batched + partition_dim path is not exercised here. PRIMUS_MUON_BATCHED_NS=0 forces the loop as an escape hatch.