### PR TITLE
feat(flux): core runtime + Megatron adapter scaffolding

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,11 +11,7 @@ permissions:
   contents: read
 
 env:
-<<<<<<< HEAD
   PRIMUS_TURBO_COMMIT: a04a233cbfb468dbe21600cbf9db70953428b25c # feat: force use nt layout gemm in bwd (#386)
-=======
-  PRIMUS_TURBO_COMMIT: 3cd482def8bb4814b1799fe481555559fff040b8 # Primus-Turbo main (0.3.x) - exposes mxfp4 gemm_fp4_impl(..., preshuffled=...)
->>>>>>> bffeb8ff (ci: bump Primus-Turbo/AITER pins for Flux diffusion (mxfp4) + skip CI on draft PRs)
   BENCHMARK_ROOT_DIR: /wekafs/primus/benchmark
 
 jobs:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -11,7 +11,11 @@ permissions:
   contents: read
 
 env:
+<<<<<<< HEAD
   PRIMUS_TURBO_COMMIT: a04a233cbfb468dbe21600cbf9db70953428b25c # feat: force use nt layout gemm in bwd (#386)
+=======
+  PRIMUS_TURBO_COMMIT: 3cd482def8bb4814b1799fe481555559fff040b8 # Primus-Turbo main (0.3.x) - exposes mxfp4 gemm_fp4_impl(..., preshuffled=...)
+>>>>>>> bffeb8ff (ci: bump Primus-Turbo/AITER pins for Flux diffusion (mxfp4) + skip CI on draft PRs)
   BENCHMARK_ROOT_DIR: /wekafs/primus/benchmark
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ on:
     tags:
       - "v*"
   pull_request:
+    # Re-list the implicit defaults (opened/synchronize/reopened) and add
+    # ready_for_review so flipping a Draft PR to Ready triggers its first run.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.event.merge_group.head_ref || github.ref }}
@@ -21,7 +24,7 @@ permissions:
 
 env:
   PRIMUS_TURBO_COMMIT: a04a233cbfb468dbe21600cbf9db70953428b25c # feat: force use nt layout gemm in bwd (#386)
-  PRIMUS_TURBO_AITER_COMMIT: 0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e # v0.14.0.post1
+  PRIMUS_TURBO_AITER_COMMIT: 0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e # AITER v0.1.14.post1 (tag commit) — required by Primus-Turbo main aiter_utils.py
   ROCSHMEM_COMMIT: 17ff985c026f9f97f85068647e863ab541dd5645 # Update version to 3.2.0 for 7.2.0 rocm release (#351) (#355)
   UCCL_COMMIT: 5afb4117893c58cc0c8557d9286336141a301053 # [EP]: fix fp8 error of internode_ll on amd gfx950 arch. (#710)
   TRITON_COMMIT: 88b227e23f0445f3f695bad05bbf1a363b4f50e0
@@ -69,6 +72,9 @@ jobs:
 
   build-docker:
     needs: [code-lint]
+    # Skip on Draft PRs (keep code-lint ungated); the event_name guard preserves
+    # push/tag and workflow_dispatch runs where github.event.pull_request is absent.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: build-docker
     strategy:
       matrix:
@@ -221,6 +227,7 @@ jobs:
       # PRIMUS_WORKDIR: /wekafs/primus-data/primus_safe_ci/torch
       PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32: 1
     needs: [code-lint]
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     # runs-on: [primus-lm-cicd-torch-j8knc]
     runs-on: [primus-lm-cicd-v26.3-tas8n-a16-40]
     steps:
@@ -499,6 +506,7 @@ jobs:
       # PRIMUS_WORKDIR: /wekafs/primus-data/primus_safe_ci/jax
       PRIMUS_WORKDIR: /mnt/apps_proxy/tas/0_public/primus_docker_jax_ci/actions-runner
     needs: [code-lint]
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: [primus-jax-tas-runner] # docker container primus_jax_github_runner on tas a16-31
     steps:
       - run: echo "🎉 Begin Primus-Turbo Checkout."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,13 @@ permissions:
   contents: read
 
 env:
+<<<<<<< HEAD
   PRIMUS_TURBO_COMMIT: a04a233cbfb468dbe21600cbf9db70953428b25c # feat: force use nt layout gemm in bwd (#386)
   PRIMUS_TURBO_AITER_COMMIT: 0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e # AITER v0.1.14.post1 (tag commit) — required by Primus-Turbo main aiter_utils.py
+=======
+  PRIMUS_TURBO_COMMIT: 3cd482def8bb4814b1799fe481555559fff040b8 # Primus-Turbo main (0.3.x) - exposes mxfp4 gemm_fp4_impl(..., preshuffled=...)
+  PRIMUS_TURBO_AITER_COMMIT: f299f579a63b8de4f008e19b6f8867dbfa9eaf39 # AITER v0.1.14.post1 (matches internal dev/bootstrap.sh)
+>>>>>>> bffeb8ff (ci: bump Primus-Turbo/AITER pins for Flux diffusion (mxfp4) + skip CI on draft PRs)
   ROCSHMEM_COMMIT: 17ff985c026f9f97f85068647e863ab541dd5645 # Update version to 3.2.0 for 7.2.0 rocm release (#351) (#355)
   UCCL_COMMIT: 5afb4117893c58cc0c8557d9286336141a301053 # [EP]: fix fp8 error of internode_ll on amd gfx950 arch. (#710)
   TRITON_COMMIT: 88b227e23f0445f3f695bad05bbf1a363b4f50e0

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ local/
 .gitmodules
 output
 experiment
-data
+/data/*
 pp_simulation_result

--- a/primus/backends/hummingbirdxt/hummingbirdxt_posttrain_trainer.py
+++ b/primus/backends/hummingbirdxt/hummingbirdxt_posttrain_trainer.py
@@ -11,8 +11,9 @@ from primus.core.utils.yaml_utils import nested_namespace_to_dict
 
 
 class HummingbirdXTPosttrainTrainer(BaseTrainer):
-    def __init__(self, backend_args: Any):
-        super().__init__(backend_args=backend_args)
+    def __init__(self, backend_args: Any = None, **kwargs):
+        # Accept and forward runtime context kwargs so BaseTrainer can filter them.
+        super().__init__(backend_args=backend_args, **kwargs)
 
     def setup(self):
         pass

--- a/primus/backends/maxtext/maxtext_pretrain_trainer.py
+++ b/primus/backends/maxtext/maxtext_pretrain_trainer.py
@@ -41,8 +41,11 @@ class MaxTextPretrainTrainer(BaseTrainer):
     Trainer class for MaxText pre-training.
     """
 
-    def __init__(self, backend_args: Any):
-        super().__init__(backend_args=backend_args)
+    def __init__(self, backend_args: Any = None, **kwargs):
+        # The core runtime instantiates every trainer with BaseModule-style
+        # context kwargs (module_name, primus_config, module_rank, ...). MaxText
+        # does not need them; accept and forward so BaseTrainer can filter them.
+        super().__init__(backend_args=backend_args, **kwargs)
 
         # Training state (populated in init())
         self.train_config: Optional[Any] = None

--- a/primus/backends/megatron/__init__.py
+++ b/primus/backends/megatron/__init__.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -12,3 +12,22 @@ from primus.core.backend.backend_registry import BackendRegistry
 BackendRegistry.register_adapter("megatron", MegatronAdapter)
 BackendRegistry.register_trainer_class(MegatronPretrainTrainer, "megatron")
 BackendRegistry.register_trainer_class(MegatronSFTTrainer, "megatron", "sft")
+
+# Export trainers for convenience
+# Use lazy import for FluxPretrainTrainer to avoid Megatron dependency
+# when importing data pipeline components
+__all__ = [
+    "MegatronAdapter",
+    "FluxPretrainTrainer",
+    "MegatronPretrainTrainer",
+    "MegatronSFTTrainer",
+]
+
+
+def __getattr__(name):
+    """Lazy import for trainer classes to avoid Megatron dependency on module import."""
+    if name == "FluxPretrainTrainer":
+        from primus.backends.megatron.flux_pretrain_trainer import FluxPretrainTrainer
+
+        return FluxPretrainTrainer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/primus/backends/megatron/megatron_adapter.py
+++ b/primus/backends/megatron/megatron_adapter.py
@@ -1,8 +1,11 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
+
+import importlib
+from typing import Optional
 
 import primus.backends.megatron.patches  # noqa: F401  # Register patches
 from primus.backends.megatron.argument_builder import MegatronArgBuilder
@@ -18,8 +21,27 @@ class MegatronAdapter(BackendAdapter):
         super().__init__(framework)
         self.third_party_dir_name = "Megatron-LM"
 
-    def load_trainer_class(self, stage: str = "pretrain"):
-        """Return the trainer class for the specified training stage."""
+    def load_trainer_class(self, stage: str = "pretrain", trainer_class: Optional[str] = None):
+        """
+        Return the Trainer class for the specified training stage or trainer class name.
+
+        Args:
+            stage: Training stage (e.g., "pretrain", "sft"). Defaults to "pretrain".
+            trainer_class: Optional specific trainer class name for dynamic loading.
+                          If provided, this takes precedence over stage-based selection.
+
+        Returns:
+            Trainer class
+
+        Raises:
+            ImportError: If trainer class cannot be imported
+            ValueError: If stage is invalid or trainer class is not found
+        """
+        # If trainer_class is specified, attempt dynamic loading
+        if trainer_class:
+            return self._load_trainer_class_by_name(trainer_class)
+
+        # Fallback to stage-based selection via the backend registry
         try:
             trainer_cls = BackendRegistry.get_trainer_class(self.framework, stage=stage)
         except (ValueError, AssertionError) as exc:
@@ -30,6 +52,76 @@ class MegatronAdapter(BackendAdapter):
 
         log_rank_0(f"[Primus:MegatronAdapter] Loaded trainer class: {trainer_cls.__name__}")
         return trainer_cls
+
+    def _load_trainer_class_by_name(self, trainer_class: str):
+        """
+        Dynamically load trainer class by name.
+
+        Args:
+            trainer_class: Trainer class name (e.g., "FluxPretrainTrainer", "MegatronPretrainTrainer")
+
+        Returns:
+            Trainer class
+
+        Raises:
+            ImportError: If trainer class cannot be imported
+            ValueError: If trainer class is not found
+        """
+        # Define trainer registry for Megatron backend
+        # This maps trainer class names to their module paths
+        MEGATRON_TRAINERS = {
+            "MegatronPretrainTrainer": "primus.backends.megatron.megatron_pretrain_trainer.MegatronPretrainTrainer",
+            "FluxPretrainTrainer": "primus.backends.megatron.flux_pretrain_trainer.FluxPretrainTrainer",
+        }
+
+        if trainer_class not in MEGATRON_TRAINERS:
+            # Try to load from common locations as fallback
+            log_rank_0(
+                f"[Primus:MegatronAdapter] Trainer '{trainer_class}' not in registry, attempting dynamic import..."
+            )
+
+            possible_paths = [
+                f"primus.backends.megatron.{trainer_class.lower()}.{trainer_class}",
+                f"primus.modules.trainer.megatron.{trainer_class.lower()}.{trainer_class}",
+                f"primus.backends.megatron.{trainer_class}",
+            ]
+
+            for module_path in possible_paths:
+                try:
+                    module_name, class_name = module_path.rsplit(".", 1)
+                    module = importlib.import_module(module_name)
+                    trainer_cls = getattr(module, class_name)
+                    log_rank_0(
+                        f"[Primus:MegatronAdapter] Successfully loaded trainer: {trainer_class} from {module_name}"
+                    )
+                    return trainer_cls
+                except (ImportError, AttributeError):
+                    continue
+
+            # If all attempts failed, provide helpful error message
+            available = list(MEGATRON_TRAINERS.keys())
+            raise ValueError(
+                f"Trainer class '{trainer_class}' not found.\n"
+                f"Available trainers: {', '.join(available) if available else 'none'}\n"
+                f"Hint: Set 'trainer_class' in your experiment YAML to a registered trainer "
+                f"(e.g. trainer_class: FluxPretrainTrainer), register it in MEGATRON_TRAINERS, "
+                f"or ensure it is importable from standard locations."
+            )
+
+        # Load from registry
+        trainer_path = MEGATRON_TRAINERS[trainer_class]
+        module_path, class_name = trainer_path.rsplit(".", 1)
+
+        try:
+            module = importlib.import_module(module_path)
+            trainer_cls = getattr(module, class_name)
+            log_rank_0(f"[Primus:MegatronAdapter] Loaded trainer: {trainer_class} from {module_path}")
+            return trainer_cls
+        except (ImportError, AttributeError) as e:
+            raise ImportError(
+                f"Failed to load trainer class '{trainer_class}' from '{module_path}': {e}\n"
+                f"Hint: Check that the module exists and the class name is correct."
+            ) from e
 
     def detect_backend_version(self) -> str:
         """Detect Megatron-LM version via AST parsing (avoids __init__.py execution)."""

--- a/primus/backends/megatron/megatron_base_trainer.py
+++ b/primus/backends/megatron/megatron_base_trainer.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -14,7 +14,6 @@ from primus.backends.megatron.training.global_vars import (
 )
 from primus.backends.megatron.training.mlflow_setup import upload_mlflow_artifacts
 from primus.core.trainer.base_trainer import BaseTrainer
-from primus.core.utils.env import flush_before_hard_exit
 from primus.modules.module_utils import log_rank_0, warning_rank_0
 
 
@@ -23,8 +22,83 @@ class MegatronBaseTrainer(BaseTrainer):
 
     def setup(self):
         """Setup Megatron runtime: set global vars and patch parse_args."""
+        self._ensure_megatron_path()
         set_primus_global_variables(self.backend_args)
         self._patch_parse_args()
+
+    def _ensure_megatron_path(self):
+        """Ensure Megatron-LM path is in sys.path before any megatron imports."""
+        import os
+        import sys
+        from pathlib import Path
+
+        # First, check if megatron is already importable
+        try:
+            import megatron  # type: ignore
+
+            return  # Path already set correctly
+        except ImportError:
+            pass
+
+        # Try multiple methods to find the Megatron-LM path
+        megatron_paths = []
+
+        # Method 1: From PRIMUS_PATH environment variable (most reliable)
+        primus_path = os.getenv("PRIMUS_PATH")
+        if primus_path:
+            megatron_path = Path(primus_path) / "third_party" / "Megatron-LM"
+            if megatron_path.exists():
+                megatron_paths.append(str(megatron_path))
+
+        # Method 2: From current working directory (works in container)
+        try:
+            cwd = Path.cwd()
+            # Check if we're in /workspace/Primus or a subdirectory
+            if "Primus" in str(cwd):
+                # Find the Primus root
+                primus_root = cwd
+                while primus_root.name != "Primus" and primus_root != primus_root.parent:
+                    primus_root = primus_root.parent
+                if primus_root.name == "Primus":
+                    megatron_path = primus_root / "third_party" / "Megatron-LM"
+                    if megatron_path.exists():
+                        megatron_paths.append(str(megatron_path))
+        except Exception:
+            pass
+
+        # Method 3: From current file location
+        try:
+            repo_root = Path(__file__).resolve().parents[3]
+            megatron_path = repo_root / "third_party" / "Megatron-LM"
+            if megatron_path.exists():
+                megatron_paths.append(str(megatron_path))
+        except Exception:
+            pass
+
+        # Method 4: Check if already in sys.path
+        for path in sys.path:
+            path_obj = Path(path)
+            if path_obj.exists():
+                megatron_pkg = path_obj / "megatron"
+                if megatron_pkg.exists() and megatron_pkg.is_dir():
+                    return  # Path already set correctly
+
+        # Add paths to sys.path if not already present
+        for path in megatron_paths:
+            if path not in sys.path:
+                sys.path.insert(0, path)
+                log_rank_0(f"[Primus:MegatronBaseTrainer] Added Megatron-LM to sys.path: {path}")
+
+        # Verify the path was set correctly by trying to import
+        try:
+            import megatron  # type: ignore
+
+            log_rank_0("[Primus:MegatronBaseTrainer] Successfully verified megatron import")
+        except ImportError as e:
+            log_rank_0(
+                f"[Primus:MegatronBaseTrainer] WARNING: Failed to import megatron after path setup: {e}"
+            )
+            log_rank_0(f"[Primus:MegatronBaseTrainer] sys.path: {sys.path[:5]}")
 
     def init(self):
         """Initialize Megatron training components."""
@@ -53,7 +127,14 @@ class MegatronBaseTrainer(BaseTrainer):
 
         if exit_fast and not on_error:
             log_rank_0("[MegatronBaseTrainer] PRIMUS_EXIT_FAST=1 -> os._exit(0)")
-            flush_before_hard_exit()
+            # Flush stdout/stderr so the final log lines are not lost.
+            try:
+                import sys
+
+                sys.stdout.flush()
+                sys.stderr.flush()
+            except Exception:  # pragma: no cover
+                pass
             os._exit(0)
 
     def _finalize_mlflow_artifacts(self):

--- a/primus/backends/megatron/megatron_pretrain_trainer.py
+++ b/primus/backends/megatron/megatron_pretrain_trainer.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -10,6 +10,70 @@ from primus.modules.module_utils import log_rank_0
 
 class MegatronPretrainTrainer(MegatronBaseTrainer):
     """Trainer for Megatron-LM pre-training."""
+
+    def get_forward_step(self):
+        """
+        Return forward step function for training loop.
+
+        Override this method in subclasses to provide custom forward step functions.
+        Default implementation returns GPT forward step.
+
+        Note: This method assumes Megatron-LM path is already set up by
+        MegatronBaseTrainer._ensure_megatron_path() during setup().
+
+        Returns:
+            Callable: Forward step function compatible with Megatron's training loop.
+        """
+        # Path should already be set by _ensure_megatron_path() during setup()
+        try:
+            from pretrain_gpt import forward_step  # type: ignore
+        except ImportError as e:
+            log_rank_0(f"[MegatronPretrainTrainer] Failed to import forward_step from pretrain_gpt: {e}")
+            log_rank_0(
+                "[MegatronPretrainTrainer] This indicates a configuration issue. "
+                "Ensure Megatron-LM is properly installed at third_party/Megatron-LM"
+            )
+            raise ImportError(
+                "Could not import forward_step from pretrain_gpt. "
+                "This indicates that Megatron-LM path setup failed during setup(). "
+                "Ensure Megatron-LM is properly installed and _ensure_megatron_path() succeeded."
+            ) from e
+        return forward_step
+
+    def get_datasets_provider(self):
+        """
+        Return dataset provider function for training.
+
+        Override this method in subclasses to provide custom dataset providers.
+        Default implementation returns GPT dataset provider.
+
+        Note: This method assumes Megatron-LM path is already set up by
+        MegatronBaseTrainer._ensure_megatron_path() during setup().
+
+        Returns:
+            Callable: Dataset provider function compatible with Megatron's training loop.
+        """
+        # Path should already be set by _ensure_megatron_path() during setup()
+        try:
+            from pretrain_gpt import train_valid_test_datasets_provider  # type: ignore
+        except ImportError as e:
+            log_rank_0(
+                f"[MegatronPretrainTrainer] Failed to import train_valid_test_datasets_provider "
+                f"from pretrain_gpt: {e}"
+            )
+            log_rank_0(
+                "[MegatronPretrainTrainer] This indicates a configuration issue. "
+                "Ensure Megatron-LM is properly installed at third_party/Megatron-LM"
+            )
+            raise ImportError(
+                "Could not import train_valid_test_datasets_provider from pretrain_gpt. "
+                "This indicates that Megatron-LM path setup failed during setup(). "
+                "Ensure Megatron-LM is properly installed and _ensure_megatron_path() succeeded."
+            ) from e
+
+        provider = train_valid_test_datasets_provider
+        provider.is_distributed = True  # Always True to match Megatron's behavior
+        return provider
 
     def train(self):
         """Execute Megatron pre-training."""
@@ -22,11 +86,10 @@ class MegatronPretrainTrainer(MegatronBaseTrainer):
 
         from primus.core.utils.import_utils import get_model_provider
 
-        # Determine model type (gpt or mamba) from backend_args
+        # Determine model type (gpt, mamba, or diffusion) from backend_args
         model_type = getattr(self.backend_args, "model_type", "gpt")
         log_rank_0(f"-detected model_type: {model_type}")
 
-        # Import the appropriate training components based on model_type
         if model_type == "mamba":
             from pretrain_mamba import (  # type: ignore
                 forward_step,
@@ -34,16 +97,16 @@ class MegatronPretrainTrainer(MegatronBaseTrainer):
             )
 
             log_rank_0("Using Mamba model provider and training components")
+            # Upstream pretrain entrypoints set this in their __main__ blocks, but Primus imports the
+            # provider directly and calls pretrain() programmatically. Without restoring this flag,
+            # only TP rank 0 enters dataset construction while the core dataset builder still issues
+            # distributed barriers, which deadlocks for TP>1.
+            train_valid_test_datasets_provider.is_distributed = True
         else:
-            from pretrain_gpt import (  # type: ignore
-                forward_step,
-                train_valid_test_datasets_provider,
-            )
-
-            log_rank_0("Using GPT model provider and training components")
-
-        # Configure training components
-        train_valid_test_datasets_provider.is_distributed = True
+            # Use overridable methods so subclasses (e.g. diffusion/Flux) can plug in their own
+            # forward_step / dataset_provider. Defaults pull from pretrain_gpt.
+            forward_step = self.get_forward_step()
+            train_valid_test_datasets_provider = self.get_datasets_provider()
 
         # Handle Megatron version differences (v0.12.0 vs newer with inprocess_restart)
         wrapped_pretrain = pretrain
@@ -65,12 +128,14 @@ class MegatronPretrainTrainer(MegatronBaseTrainer):
         if "store" in sig.parameters:
             kwargs["store"] = store
 
-        # Get model provider with correct model_type
-        # Only pass model_type if it's not the default to maintain compatibility
-        if model_type != "gpt":
-            model_provider = get_model_provider(model_type=model_type)
-        else:
-            model_provider = get_model_provider()
+        # Resolve model_provider: prefer subclass-provided attribute (e.g. diffusion/Flux),
+        # else fall back to registry-based lookup with model_type for mamba/gpt.
+        model_provider = getattr(self, "model_provider", None)
+        if model_provider is None:
+            if model_type != "gpt":
+                model_provider = get_model_provider(model_type=model_type)
+            else:
+                model_provider = get_model_provider()
         log_rank_0(f"-model_provider: {model_provider}")
 
         # Patch Megatron's get_forward_backward_func to support dump_pp_data
@@ -101,13 +166,21 @@ class MegatronPretrainTrainer(MegatronBaseTrainer):
         if hasattr(mt_training, "get_forward_backward_func"):
             mt_training.get_forward_backward_func = patched_get_forward_backward_func
 
-        wrapped_pretrain(
-            train_valid_test_datasets_provider,
-            model_provider,
-            ModelType.encoder_or_decoder,
-            forward_step,
-            **kwargs,
-        )
+        try:
+            wrapped_pretrain(
+                train_valid_test_datasets_provider,
+                model_provider,
+                ModelType.encoder_or_decoder,
+                forward_step,
+                **kwargs,
+            )
+            log_rank_0("[MegatronPretrainTrainer] pretrain() completed successfully")
+        except Exception as e:
+            log_rank_0(f"[MegatronPretrainTrainer] ERROR in pretrain(): {type(e).__name__}: {e}")
+            import traceback
+
+            log_rank_0(f"[MegatronPretrainTrainer] Traceback: {traceback.format_exc()}")
+            raise
 
         # Dump PP visualization data if enabled
         try:

--- a/primus/backends/megatron/megatron_sft_trainer.py
+++ b/primus/backends/megatron/megatron_sft_trainer.py
@@ -30,14 +30,15 @@ class MegatronSFTTrainer(MegatronBaseTrainer):
         - Common Megatron initialization patterns
     """
 
-    def __init__(self, backend_args: Any):
+    def __init__(self, backend_args: Any = None, **kwargs):
         """
         Initialize Megatron SFT trainer.
 
         Args:
             backend_args: Megatron-LM argument namespace (from MegatronArgBuilder)
+            **kwargs: Runtime context kwargs forwarded to BaseTrainer for filtering.
         """
-        super().__init__(backend_args=backend_args)
+        super().__init__(backend_args=backend_args, **kwargs)
 
         # Initialize LoRA if enabled
         self.peft = None

--- a/primus/backends/megatron/patches/__init__.py
+++ b/primus/backends/megatron/patches/__init__.py
@@ -8,6 +8,23 @@
 Megatron Patch Collection
 
 This module defines the public entrypoint for applying Megatron-specific patches.
+
+Registration vs. application (important for non-Flux / LLM users):
+    Importing this package eagerly imports every ``*_patches.py`` module, which
+    runs each module's ``@register_patch`` side effect. This registration is
+    GLOBAL: it happens for *every* Megatron job (LLM or diffusion), because
+    ``megatron_adapter`` imports this package unconditionally.
+
+    Registration only adds a patch to the registry; it does NOT apply it. Each
+    patch carries a ``condition=...`` predicate (typically gated on a config
+    flag such as ``torch_compile.enable``, ``use_fsdp2_fp8_all_gather``, or a
+    diffusion-specific arg) that is evaluated at ``run_patches`` time. A patch
+    whose condition is False is a no-op for that job.
+
+    Consequence: diffusion/Flux-specific patches are registered for LLM jobs but
+    should not take effect there. When adding a patch, make its ``condition``
+    precise so it cannot alter unrelated (e.g. non-Flux) training. An opt-in
+    "patch profile" mechanism could make this stricter in the future.
 """
 
 import importlib

--- a/primus/backends/megatron/patches/_patch_guard.py
+++ b/primus/backends/megatron/patches/_patch_guard.py
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Idempotency guard for monkeypatches that *wrap* (compose) a target callable.
+
+The core patch runner (``primus.core.patches``) has no built-in re-apply guard:
+running the same phase twice re-invokes every patch handler. For patches that
+replace a class method or module attribute outright that is harmless (the
+assignment is idempotent), but patches that *wrap* an existing callable -- e.g.
+the stacked ``train_step`` wrappers (FP8 cache refresh, delayed-scaling
+preamble, wall-clock timer) -- would wrap again on a second run and silently
+double their side effects.
+
+This helper records applied patch keys in a sentinel set attached to the
+*object that owns the wrapped attribute* (typically a module). Keying on the
+owner object -- which is stable across re-runs -- rather than on the wrapped
+callable makes the guard robust even when several wrappers compose on the same
+attribute.
+
+This lives under ``primus.backends.megatron.patches`` (feature-owned) on
+purpose: the shared ``primus.core.patches`` framework is inherited and must not
+grow feature-specific behavior.
+"""
+
+from typing import Any
+
+_SENTINEL_ATTR = "_primus_applied_patch_keys"
+
+
+def is_patched(target: Any, key: str) -> bool:
+    """Return True if ``key`` has already been applied to ``target``."""
+    applied = getattr(target, _SENTINEL_ATTR, None)
+    return applied is not None and key in applied
+
+
+def mark_patched(target: Any, key: str) -> None:
+    """Record that ``key`` has been applied to ``target``."""
+    applied = getattr(target, _SENTINEL_ATTR, None)
+    if applied is None:
+        applied = set()
+        setattr(target, _SENTINEL_ATTR, applied)
+    applied.add(key)

--- a/primus/backends/megatron/patches/args/__init__.py
+++ b/primus/backends/megatron/patches/args/__init__.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc.
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -19,6 +19,7 @@ registration but is provided for convenience.
 from . import (  # noqa: F401
     checkpoint_path_patches,
     data_path_split_patches,
+    hsdp_args_patches,
     iterations_to_skip_default_patches,
     logging_level_patches,
     mock_data_patches,
@@ -35,6 +36,7 @@ __all__ = [
     "wandb_config_patches",
     "logging_level_patches",
     "data_path_split_patches",
+    "hsdp_args_patches",
     "mock_data_patches",
     "sequence_parallel_tp1_patches",
     "iterations_to_skip_default_patches",

--- a/primus/backends/megatron/patches/args/checkpoint_path_patches.py
+++ b/primus/backends/megatron/patches/args/checkpoint_path_patches.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -20,20 +20,39 @@ def patch_checkpoint_path(ctx: PatchContext):
     """
     Configure checkpoint save path.
 
-    Sets args.save to <exp_root>/checkpoints and warns if user
-    provided a different path.
+    Behavior:
+      - args.save is None  (YAML explicitly set `save: null`, or unset):
+            user has opted out of saving — leave args.save = None so that
+            Megatron's `checkpoint_and_decide_exit` (training.py:2340) skips
+            save_checkpoint_and_time(...). This is what allows runs configured
+            with `save: null` + `save_interval: <any>` to avoid hitting the
+            checkpoint save path entirely.
+      - args.save is non-None:
+            user has opted in to saving — route the destination to
+            <exp_root>/checkpoints, warning if it differs from what the user
+            specified.
     """
     args = ctx.extra.get("backend_args", {})
     primus_config = ctx.extra.get("primus_config", {})
 
-    if args and primus_config.exp_root_path:
-        ckpt_path = os.path.abspath(os.path.join(primus_config.exp_root_path, "checkpoints"))
+    if not args or not primus_config.exp_root_path:
+        return
 
-        if hasattr(args, "save") and args.save is not None and args.save != ckpt_path:
-            log_rank_0(
-                f"[Patch:megatron.args.checkpoint_path][WARN] "
-                f"args.save is deprecated; overriding to: {ckpt_path}"
-            )
+    # Respect explicit opt-out via `save: null` in YAML.
+    if not hasattr(args, "save") or args.save is None:
+        log_rank_0(
+            "[Patch:megatron.args.checkpoint_path] "
+            "args.save is None (opt-out); skipping save-path override."
+        )
+        return
 
-        args.save = ckpt_path
-        log_rank_0(f"[Patch:megatron.args.checkpoint_path] save → {ckpt_path}")
+    ckpt_path = os.path.abspath(os.path.join(primus_config.exp_root_path, "checkpoints"))
+
+    if args.save != ckpt_path:
+        log_rank_0(
+            f"[Patch:megatron.args.checkpoint_path][WARN] "
+            f"args.save is deprecated; overriding to: {ckpt_path}"
+        )
+
+    args.save = ckpt_path
+    log_rank_0(f"[Patch:megatron.args.checkpoint_path] save → {ckpt_path}")

--- a/primus/backends/megatron/patches/args/hsdp_args_patches.py
+++ b/primus/backends/megatron/patches/args/hsdp_args_patches.py
@@ -1,0 +1,60 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+from primus.core.patches import PatchContext, register_patch
+from primus.modules.module_utils import log_kv_rank_0, log_rank_0
+
+
+@register_patch(
+    "megatron.args.hsdp",
+    backend="megatron",
+    phase="build_args",
+    description=(
+        "Map data_parallel_replicate_degree to Megatron's "
+        "num_distributed_optimizer_instances so that initialize_model_parallel "
+        "creates the HSDP process groups (intra-partial shard + inter-instance replicate)."
+    ),
+)
+def patch_hsdp_args(ctx: PatchContext):
+    """
+    Propagate data_parallel_replicate_degree through to Megatron.
+
+    data_parallel_replicate_degree is a Primus-only config key that is not
+    recognized by MegatronArgBuilder and would be silently dropped.  This
+    patch reads it from module_config.params, injects it into backend_args,
+    and -- when > 1 -- maps it to num_distributed_optimizer_instances so that
+    Megatron's parallel_state.initialize_model_parallel creates the required
+    intra-partial (shard) and inter-instance (replicate) process groups.
+    """
+    args = ctx.extra.get("backend_args")
+    module_config = ctx.extra.get("module_config")
+
+    if not args or not module_config:
+        return
+
+    replicate_degree = getattr(module_config.params, "data_parallel_replicate_degree", 1)
+    args.data_parallel_replicate_degree = replicate_degree
+
+    if replicate_degree > 1:
+        if not getattr(args, "use_torch_fsdp2", False):
+            raise ValueError("data_parallel_replicate_degree > 1 requires use_torch_fsdp2=True")
+
+        ckpt_fmt = getattr(args, "ckpt_format", "torch_dist")
+        if ckpt_fmt != "torch_dcp":
+            raise ValueError(
+                f"HSDP (data_parallel_replicate_degree={replicate_degree}) requires "
+                f"ckpt_format='torch_dcp', got '{ckpt_fmt}'. The torch_dist format's "
+                f"checkpoint offset logic assumes flat DP and is incompatible with a 2D mesh."
+            )
+
+        args.num_distributed_optimizer_instances = replicate_degree
+        log_rank_0(
+            f"[Patch:megatron.args.hsdp] HSDP enabled: "
+            f"data_parallel_replicate_degree={replicate_degree} "
+            f"-> num_distributed_optimizer_instances={replicate_degree}"
+        )
+
+    log_kv_rank_0("[Patch:megatron.args.hsdp] data_parallel_replicate_degree", str(replicate_degree))

--- a/primus/backends/megatron/patches/build_model_patches.py
+++ b/primus/backends/megatron/patches/build_model_patches.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc.
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -10,14 +10,16 @@ Megatron build_model / get_model patches.
 This module contains patches that modify Megatron's model construction
 behavior to better integrate with Primus.
 
-Current patch:
+Current patches:
     - Disable the second DDP construction inside ``torch.cuda.stream()``
       in ``megatron.training.training.get_model`` by temporarily replacing
       ``torch.cuda.stream`` with a no-op context manager while calling
       the original ``get_model``.
+    - Skip Float16Module wrapping when using FSDP2 FP32 param optimizer (model
+      parameters must stay in FP32 for FSDP2's MixedPrecisionPolicy).
 """
 
-from primus.core.patches import PatchContext, register_patch
+from primus.core.patches import PatchContext, get_args, register_patch
 from primus.modules.module_utils import log_rank_0
 
 
@@ -29,6 +31,7 @@ from primus.modules.module_utils import log_rank_0
         "Monkey patch megatron.training.training.get_model to disable the "
         "second DDP construction inside torch.cuda.stream()."
     ),
+    condition=lambda ctx: not getattr(get_args(ctx), "disable_build_model_patches", False),
 )
 def patch_megatron_get_model_disable_second_ddp(ctx: PatchContext) -> None:
     """
@@ -66,3 +69,59 @@ def patch_megatron_get_model_disable_second_ddp(ctx: PatchContext) -> None:
     setattr(_patched_get_model, "_primus_disable_second_ddp", True)
     training.get_model = _patched_get_model
     log_rank_0("[Patch:megatron.get_model] Disabled second DDP via torch.cuda.stream no-op wrapper")
+
+
+@register_patch(
+    "megatron.training.training.skip_float16_module",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Skip Float16Module wrapping when using FSDP2 FP32 param optimizer. "
+        "Model parameters must stay FP32 for FSDP2's MixedPrecisionPolicy to handle casting."
+    ),
+    priority=40,
+    condition=lambda ctx: (
+        getattr(get_args(ctx), "use_fsdp2_fp32_param_optimizer", False)
+        and getattr(get_args(ctx), "use_torch_fsdp2", False)
+        and getattr(get_args(ctx), "bf16", False)
+    ),
+)
+def patch_skip_float16_module(ctx: PatchContext) -> None:
+    """Replace Float16Module with a passthrough wrapper that preserves
+    the attributes Megatron's training loop expects (module, config,
+    vp_size, vp_stage, pg_collection) but does NOT convert parameters
+    to BF16/FP16.
+
+    This is necessary because FSDP2's MixedPrecisionPolicy handles
+    the FP32->BF16 casting during forward/backward, and Float16Module
+    would convert parameters to BF16 before FSDP2 wrapping, defeating
+    the purpose of FP32 parameter storage.
+    """
+    from megatron.core.transformer.module import MegatronModule
+
+    class _FSDP2PassthroughModule(MegatronModule):
+        """Drop-in replacement for Float16Module that keeps params in FP32."""
+
+        def __init__(self, config, module):
+            super().__init__(config)
+            self.config = config
+            self.add_module("module", module)
+            self.vp_size = config.virtual_pipeline_model_parallel_size
+            self.vp_stage = getattr(module, "vp_stage", None)
+            self.pg_collection = getattr(module, "pg_collection", None)
+
+        def set_input_tensor(self, input_tensor):
+            return self.module.set_input_tensor(input_tensor)
+
+        def forward(self, *inputs, **kwargs):
+            return self.module(*inputs, **kwargs)
+
+    import megatron.core.transformer.module as module_mod
+    import megatron.training.training as training_mod
+
+    module_mod.Float16Module = _FSDP2PassthroughModule
+    training_mod.Float16Module = _FSDP2PassthroughModule
+    log_rank_0(
+        "[Patch:skip_float16_module] Replaced Float16Module with FP32 passthrough "
+        "(FSDP2 MixedPrecisionPolicy handles BF16 casting)"
+    )

--- a/primus/backends/megatron/patches/distributed_init_patches.py
+++ b/primus/backends/megatron/patches/distributed_init_patches.py
@@ -1,0 +1,76 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Distributed initialization patches (FSDP2 only).
+
+Patches Megatron's _initialize_distributed to pass device_id to
+torch.distributed.init_process_group. Without device_id, RCCL guesses
+the GPU-to-rank mapping, which causes deadlocks on MI355X after the
+first FSDP2 iteration.
+
+This patch is gated on use_torch_fsdp2 because device_id triggers eager
+RCCL communicator creation for the world PG and all ~26 Megatron sub-groups,
+consuming ~768 MiB of additional GPU memory. Under DDP this extra allocation
+pushes large models over the GPU memory limit.
+"""
+
+import os
+
+import torch
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+@register_patch(
+    "megatron.distributed.init_process_group_device_id",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Inject device_id into torch.distributed.init_process_group to "
+        "prevent RCCL device mapping deadlocks on MI355X (FSDP2 only)."
+    ),
+    priority=10,
+    condition=lambda ctx: getattr(get_args(ctx), "use_torch_fsdp2", False),
+)
+def patch_init_process_group_device_id(ctx: PatchContext):
+    """
+    Wrap _initialize_distributed so that torch.distributed.init_process_group
+    receives an explicit device_id.
+
+    Megatron computes device_id = torch.device(f'cuda:{args.local_rank}') but
+    never passes it to init_process_group.  On MI355X with RCCL, the missing
+    device_id causes PyTorch to guess the GPU-to-rank mapping, leading to
+    deadlocks on the second FSDP2 iteration.
+    """
+    import megatron.training.initialize as init_module
+    import torch.distributed as dist
+
+    _orig_init_distributed = init_module._initialize_distributed
+
+    def _patched_initialize_distributed(get_embedding_ranks, get_position_embedding_ranks, store):
+        _orig_init_pg = dist.init_process_group
+
+        def _init_pg_with_device_id(*args, **kwargs):
+            if "device_id" not in kwargs and torch.cuda.is_available():
+                local_rank = int(os.environ.get("LOCAL_RANK", 0))
+                kwargs["device_id"] = torch.device(f"cuda:{local_rank}")
+                log_rank_0(
+                    f"[Patch:device_id] Injected device_id=cuda:{local_rank} " f"into init_process_group"
+                )
+            return _orig_init_pg(*args, **kwargs)
+
+        dist.init_process_group = _init_pg_with_device_id
+        try:
+            _orig_init_distributed(get_embedding_ranks, get_position_embedding_ranks, store)
+        finally:
+            dist.init_process_group = _orig_init_pg
+
+    init_module._initialize_distributed = _patched_initialize_distributed
+    log_rank_0(
+        "[Patch:device_id] Patched _initialize_distributed to inject " "device_id into init_process_group"
+    )

--- a/primus/backends/megatron/patches/env_patches.py
+++ b/primus/backends/megatron/patches/env_patches.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -25,6 +25,11 @@ from primus.modules.module_utils import log_kv_rank_0
     backend="megatron",
     phase="setup",
     description="Set CUDA_DEVICE_MAX_CONNECTIONS based on FSDP configuration",
+    condition=lambda ctx: not getattr(
+        getattr(ctx.extra.get("module_config"), "params", None),
+        "disable_env_patches",
+        False,
+    ),
 )
 def set_cuda_device_max_connections(ctx: PatchContext):
     """

--- a/primus/backends/megatron/patches/mp_sync_skip_patches.py
+++ b/primus/backends/megatron/patches/mp_sync_skip_patches.py
@@ -1,0 +1,63 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Skip redundant model-parallel synchronization when TP=1 and PP=1.
+
+When running pure data-parallel (TP=1, PP=1), the model-parallel process
+group has size 1.  The upstream Megatron ``train_step`` and ``training_log``
+unconditionally call ``logical_and_across_model_parallel_group`` and
+``reduce_max_stat_across_model_parallel_group`` which each issue an
+``all_reduce`` + ``.item()`` pair.  With a size-1 group these are no-ops
+that still force a GPU-to-CPU synchronization barrier, draining the
+asynchronous GPU pipeline.
+
+This patch replaces those two module-level names inside
+``megatron.training.training`` with lightweight pass-through functions
+that preserve the return-type contract (``bool`` and ``float | None``)
+without issuing any collective or ``.item()`` call.
+"""
+
+import torch
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _is_pure_dp(ctx: PatchContext) -> bool:
+    """True when TP=1 and PP=1 -- the MP group has size 1."""
+    args = get_args(ctx)
+    if args is None:
+        return False
+    tp = getattr(args, "tensor_model_parallel_size", 1)
+    pp = getattr(args, "pipeline_model_parallel_size", 1)
+    return tp == 1 and pp == 1
+
+
+@register_patch(
+    "megatron.training.skip_redundant_mp_sync",
+    backend="megatron",
+    phase="before_train",
+    description="Skip redundant model-parallel all-reduces when TP=1 and PP=1",
+    condition=_is_pure_dp,
+    priority=35,
+)
+def patch_skip_redundant_mp_sync(ctx: PatchContext):
+    import megatron.training.training as megatron_training
+
+    def _passthrough_logical_and(val):
+        return val
+
+    def _passthrough_reduce_max(val):
+        if val is None:
+            return None
+        if isinstance(val, torch.Tensor):
+            return val.item()
+        return val
+
+    megatron_training.logical_and_across_model_parallel_group = _passthrough_logical_and
+    megatron_training.reduce_max_stat_across_model_parallel_group = _passthrough_reduce_max
+    log_rank_0("[Patch:skip_redundant_mp_sync] " "Replaced MP sync functions with passthrough (TP=1, PP=1)")

--- a/primus/backends/megatron/training/global_vars.py
+++ b/primus/backends/megatron/training/global_vars.py
@@ -152,7 +152,7 @@ def _ensure_var_is_initialized(var, name):
 
 
 def _ensure_var_is_not_initialized(var, name):
-    """Make sure the input variable is not None."""
+    """Make sure the input variable is None (not yet initialized)."""
     assert var is None, "{} is already initialized.".format(name)
 
 

--- a/primus/backends/megatron_bridge/megatron_bridge_base_trainer.py
+++ b/primus/backends/megatron_bridge/megatron_bridge_base_trainer.py
@@ -36,20 +36,21 @@ class MegatronBridgeBaseTrainer(BaseTrainer):
         - Handle Megatron-Bridge specific initialization and setup
     """
 
-    def __init__(self, backend_args: Any):
+    def __init__(self, backend_args: Any = None, **kwargs):
         """
         Initialize Megatron-Bridge base trainer.
 
         Args:
             backend_args: Megatron-Bridge configuration as SimpleNamespace
                          (from MegatronBridgeArgBuilder)
+            **kwargs: Runtime context kwargs forwarded to BaseTrainer for filtering.
         """
         log_rank_0("=" * 80)
         log_rank_0("Initializing MegatronBridgeBaseTrainer...")
         log_rank_0("=" * 80)
 
         # Initialize BaseTrainer
-        super().__init__(backend_args=backend_args)
+        super().__init__(backend_args=backend_args, **kwargs)
         set_primus_global_variables(self.backend_args)
 
         import primus.backends.megatron.patches  # noqa: F401

--- a/primus/backends/megatron_bridge/megatron_bridge_posttrain_trainer.py
+++ b/primus/backends/megatron_bridge/megatron_bridge_posttrain_trainer.py
@@ -47,15 +47,16 @@ class MegatronBridgePosttrainTrainer(MegatronBridgeBaseTrainer):
     # Task type identifier for logging
     TASK_TYPE = "Post-training (SFT/Instruction Tuning)"
 
-    def __init__(self, backend_args: Any):
+    def __init__(self, backend_args: Any = None, **kwargs):
         """
         Initialize Megatron-Bridge posttrain trainer.
 
         Args:
             backend_args: Megatron-Bridge argument namespace (from MegatronBridgeArgBuilder)
+            **kwargs: Runtime context kwargs forwarded to BaseTrainer for filtering.
         """
         # Initialize MegatronBridgeBaseTrainer (which initializes BaseTrainer)
-        super().__init__(backend_args=backend_args)
+        super().__init__(backend_args=backend_args, **kwargs)
 
     def setup(self):
         """

--- a/primus/backends/megatron_bridge/megatron_bridge_pretrain_trainer.py
+++ b/primus/backends/megatron_bridge/megatron_bridge_pretrain_trainer.py
@@ -39,14 +39,15 @@ class MegatronBridgePretrainTrainer(MegatronBridgeBaseTrainer):
         - Unified training workflow and patch management
     """
 
-    def __init__(self, backend_args: Any):
+    def __init__(self, backend_args: Any = None, **kwargs):
         """
         Initialize Megatron-Bridge pretrain trainer.
 
         Args:
             backend_args: Megatron-Bridge argument namespace (from MegatronBridgeArgBuilder)
+            **kwargs: Runtime context kwargs forwarded to BaseTrainer for filtering.
         """
-        super().__init__(backend_args=backend_args)
+        super().__init__(backend_args=backend_args, **kwargs)
 
     def setup(self):
         """

--- a/primus/backends/torchtitan/torchtitan_pretrain_trainer.py
+++ b/primus/backends/torchtitan/torchtitan_pretrain_trainer.py
@@ -17,11 +17,14 @@ from primus.core.trainer.base_trainer import BaseTrainer
 class TorchTitanPretrainTrainer(BaseTrainer):
     """Trainer class for TorchTitan pre-training."""
 
-    def __init__(self, backend_args: Any):
+    def __init__(self, backend_args: Any = None, **kwargs):
         # Patch TorchTitan logger before any other initialization
         self._patch_torchtitan_logger()
 
-        super().__init__(backend_args=backend_args)
+        # The core runtime instantiates every trainer with BaseModule-style
+        # context kwargs (module_name, primus_config, module_rank, ...). Accept
+        # and forward them so BaseTrainer can filter them cooperatively.
+        super().__init__(backend_args=backend_args, **kwargs)
         self._trainer: Optional["Trainer"] = None  # type: ignore[name-defined]
 
     def _patch_torchtitan_logger(self):

--- a/primus/core/backend/backend_adapter.py
+++ b/primus/core/backend/backend_adapter.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -117,12 +117,18 @@ class BackendAdapter(ABC):
     # ============================================================================
 
     @abstractmethod
-    def load_trainer_class(self, stage: str = "pretrain"):
+    def load_trainer_class(self, stage: str = "pretrain", trainer_class: Optional[str] = None):
         """
         Return backend Trainer class registered in `BackendRegistry`.
 
+        Args:
+            stage: Training stage (e.g., "pretrain", "sft"). Defaults to "pretrain".
+            trainer_class: Optional specific trainer class name for dynamic loading.
+                          If provided, this takes precedence over stage-based selection.
+
         Default behavior:
-          - Lookup trainer via `BackendRegistry.get_trainer_class(self.framework, stage=stage)`
+          - If `trainer_class` is provided, attempt to dynamically load it
+          - Otherwise, lookup trainer via `BackendRegistry.get_trainer_class(self.framework, stage=stage)`
 
         Backends can override this method if they need special resolution rules.
         """

--- a/primus/core/backend/backend_registry.py
+++ b/primus/core/backend/backend_registry.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################

--- a/primus/core/config/primus_config.py
+++ b/primus/core/config/primus_config.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc.
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -53,7 +53,7 @@ def _normalize_module_for_runtime(module_cfg: SimpleNamespace, module_name: str)
     if not getattr(normalized, "name", None):
         setattr(normalized, "name", module_name)
 
-    reserved_keys = {"name", "framework", "config", "model", "params"}
+    reserved_keys = {"name", "framework", "config", "model", "params", "trainer_class"}
     # Start from any existing params dict/namespace if provided.
     existing_params = getattr(normalized, "params", {})
     params = _to_plain_dict(existing_params)
@@ -121,10 +121,25 @@ def load_primus_config(config_path: Path, cli_args: Any | None = None) -> Simple
     cfg.platform = platform_config
 
     # Build modules list from legacy PrimusConfig.module_keys/get_module_config.
-    cfg.modules = [
+    #
+    # `_normalize_module_for_runtime` deepcopies each module namespace before
+    # reshaping it, so `legacy_cfg` itself is left pristine. This is what makes
+    # it safe to expose `legacy_cfg` via `cfg._legacy` below: the legacy
+    # `PrimusConfig` that downstream consumers (e.g. `BaseModule`) read through
+    # `get_module_config(...)` keeps its original module shape.
+    modules: list[SimpleNamespace] = [
         _normalize_module_for_runtime(legacy_cfg.get_module_config(module_name), module_name)
         for module_name in getattr(legacy_cfg, "module_keys", [])
     ]
+
+    cfg.modules = modules
+
+    # Expose the underlying legacy PrimusConfig (additive, non-breaking) so the
+    # core runtime can reuse it instead of re-parsing the YAML a second time.
+    # BaseModule (inherited) still needs the PrimusConfig class interface
+    # (get_module_config method, set_global_variables, exp_* properties) that the
+    # SimpleNamespace above does not provide. `legacy_cfg` is pristine (see above).
+    cfg._legacy = legacy_cfg
 
     return cfg
 

--- a/primus/core/launcher/parser.py
+++ b/primus/core/launcher/parser.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
 from __future__ import annotations
 
 import argparse
@@ -275,6 +278,15 @@ class PrimusParser(object):
         for key in ("config", "model"):
             yaml_utils.check_key_in_namespace(module, key)
 
+        # ---- Preserve module-level attributes before loading presets ----
+        # Attributes like 'trainer_class' are at the module level in YAML
+        # and should be preserved even after loading config/model presets
+        preserved_attrs = {}
+        reserved_module_keys = {"name", "framework", "config", "model", "overrides", "params"}
+        for key, value in vars(module).items():
+            if key not in reserved_module_keys and not key.startswith("_"):
+                preserved_attrs[key] = value
+
         # ---- Load module config ----
         model_format = self.get_model_format(framework)
 
@@ -282,6 +294,11 @@ class PrimusParser(object):
         module_config = yaml_utils.dict_to_nested_namespace(module_config_dict)
         module_config.name = f"exp.modules.{module_name}.config"
         module_config.framework = framework
+
+        # Restore preserved module-level attributes
+        for key, value in preserved_attrs.items():
+            if not hasattr(module_config, key):  # Don't override if preset already has it
+                setattr(module_config, key, value)
 
         # ---- Load model config ----
         model_config_dict = PresetLoader.load(module.model, model_format, config_type="models")

--- a/primus/core/runtime/runtime_state.py
+++ b/primus/core/runtime/runtime_state.py
@@ -1,0 +1,34 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Runtime State Management for Training.
+
+This module provides a dedicated RuntimeState object for storing dynamic
+runtime metrics that change during training (e.g., image dimensions, timesteps).
+This is separate from backend_args (which is for configuration parameters).
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class RuntimeState:
+    """
+    Dedicated runtime state object for per-iteration training metrics.
+
+    This is separate from backend_args (which is for configuration) and
+    provides a clean place to store dynamic runtime metrics that change
+    during training (e.g., image dimensions, timesteps, etc.).
+    """
+
+    # Per-iteration metrics (updated each forward step)
+    last_metrics: Dict[str, Any] = field(default_factory=dict)
+
+    def update_metrics(self, metrics: Dict[str, Any]) -> None:
+        """Update last_metrics with new metrics from forward step."""
+        self.last_metrics.update(metrics)

--- a/primus/core/runtime/train_runtime.py
+++ b/primus/core/runtime/train_runtime.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc.
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
 #
 # Primus Runtime Orchestrator for Training
 #
@@ -23,6 +23,7 @@ from primus.core.config.primus_config import (
 )
 from primus.core.patches import run_patches
 from primus.core.runtime.logging import init_worker_logger
+from primus.core.runtime.runtime_state import RuntimeState
 from primus.core.utils.arg_utils import parse_cli_overrides
 from primus.core.utils.env_setup import setup_training_env
 from primus.core.utils.yaml_utils import (
@@ -56,6 +57,7 @@ class TrainContext:
     trainer: Any = None
     backend_args: Any = None
     backend_version: Optional[str] = None
+    runtime_state: Optional[RuntimeState] = None
 
     # Distributed context
     rank: int = 0
@@ -135,7 +137,9 @@ class PrimusRuntime:
             self.ctx.backend_version = None
         return self.ctx.backend_version
 
-    def _run_phase_patches(self, phase: str, backend_args: Any = None) -> None:
+    def _run_phase_patches(
+        self, phase: str, backend_args: Any = None, runtime_state: Optional[RuntimeState] = None
+    ) -> None:
         """
         Apply a patch phase in a single, runtime-owned place.
 
@@ -156,6 +160,7 @@ class PrimusRuntime:
                 "backend_args": backend_args,
                 "primus_config": self.ctx.primus_config,
                 "module_config": self.ctx.module_config,
+                "runtime_state": runtime_state,
             },
         )
 
@@ -174,6 +179,12 @@ class PrimusRuntime:
 
         primus_cfg = load_primus_config(cfg_path, self.args)
 
+        # Reuse the legacy PrimusConfig that load_primus_config already parsed
+        # (exposed as `_legacy`) instead of re-parsing the YAML a second time.
+        # BaseModule needs the PrimusConfig interface (get_module_config / global
+        # vars); the SimpleNamespace `primus_cfg` drives the new core runtime.
+        primus_config_obj = primus_cfg._legacy
+
         # Resolve module configuration via core helper.
         module_cfg = get_module_config(primus_cfg, module_name)
         available_modules = get_module_names(primus_cfg) or ["none"]
@@ -188,11 +199,12 @@ class PrimusRuntime:
             raise ValueError(f"[Primus:TrainRuntime] Module '{module_name}' missing 'framework'.")
 
         # Initialize TrainContext based on raw configuration (before CLI overrides).
+        # Use primus_config_obj (PrimusConfig) for BaseModule compatibility
         self.ctx = TrainContext(
             config_path=cfg_path,
             data_path=Path(getattr(self.args, "data_path", "./data")),
             module_name=module_name,
-            primus_config=primus_cfg,
+            primus_config=primus_config_obj,  # Use PrimusConfig object, not SimpleNamespace
             module_config=module_cfg,
             framework=framework,
         )
@@ -247,6 +259,10 @@ class PrimusRuntime:
         assert self.ctx is not None, "TrainContext must be initialized before backend adapter."
         backend_path = getattr(self.args, "backend_path", None)
 
+        # CRITICAL: Set up backend path BEFORE importing backend module
+        # This ensures megatron is importable when patches are loaded
+        self._setup_backend_path_early(backend=self.ctx.framework, backend_path=backend_path)
+
         adapter = BackendRegistry.get_adapter(backend=self.ctx.framework, backend_path=backend_path)
 
         assert (
@@ -257,6 +273,49 @@ class PrimusRuntime:
         adapter.setup_backend_path(backend_path=backend_path)
 
         self.ctx.adapter = adapter
+
+    def _setup_backend_path_early(self, backend: str, backend_path=None) -> None:
+        """Set up backend path before backend module is imported."""
+        import os
+        import sys
+        from pathlib import Path
+
+        # For Megatron backend, set up the path early
+        if backend == "megatron":
+            megatron_paths = []
+
+            # Method 1: From backend_path argument
+            if backend_path:
+                megatron_path = Path(backend_path)
+                if megatron_path.exists():
+                    megatron_paths.append(str(megatron_path))
+
+            # Method 2: From PRIMUS_PATH environment variable
+            primus_path = os.getenv("PRIMUS_PATH")
+            if primus_path:
+                megatron_path = Path(primus_path) / "third_party" / "Megatron-LM"
+                if megatron_path.exists():
+                    megatron_paths.append(str(megatron_path))
+
+            # Method 3: From current working directory
+            try:
+                cwd = Path.cwd()
+                if "Primus" in str(cwd):
+                    primus_root = cwd
+                    while primus_root.name != "Primus" and primus_root != primus_root.parent:
+                        primus_root = primus_root.parent
+                    if primus_root.name == "Primus":
+                        megatron_path = primus_root / "third_party" / "Megatron-LM"
+                        if megatron_path.exists():
+                            megatron_paths.append(str(megatron_path))
+            except Exception:
+                pass
+
+            # Add paths to sys.path if not already present
+            for path in megatron_paths:
+                if path not in sys.path:
+                    sys.path.insert(0, path)
+                    log_rank_0(f"[Primus:Runtime] Early setup: Added Megatron-LM to sys.path: {path}")
 
     def _initialize_trainer(self) -> None:
         assert (
@@ -273,8 +332,14 @@ class PrimusRuntime:
         backend_args = adapter.convert_config(module_config.params)
         self.ctx.backend_args = backend_args
 
+        # Create runtime state object (for dynamic per-iteration metrics)
+        # Initialize early so it's available for all patch phases
+        self.ctx.runtime_state = RuntimeState()
+
         # Phase: build_args (after args creation, before trainer instantiation)
-        self._run_phase_patches(phase="build_args", backend_args=backend_args)
+        self._run_phase_patches(
+            phase="build_args", backend_args=backend_args, runtime_state=self.ctx.runtime_state
+        )
 
         # Log final args after patches, then merge module_config.params into backend_args
         log_dict_aligned("Final backend args (after patches)", backend_args)
@@ -290,17 +355,63 @@ class PrimusRuntime:
             primus_only_params = {key: params_dict[key] for key in sorted(primus_only_keys)}
             log_dict_aligned("Primus-specific parameters", primus_only_params)
 
+        # Extract trainer_class from module_config BEFORE merging params into backend_args
+        # (After merge, module_config.params becomes backend_args, and trainer_class might be lost)
+        trainer_class = None
+
+        # First, check module_config directly (top-level attribute)
+        if hasattr(module_config, "trainer_class"):
+            trainer_class = module_config.trainer_class
+        # Second, check module_config.params (nested in params, BEFORE merge)
+        elif hasattr(module_config.params, "trainer_class"):
+            trainer_class = module_config.params.trainer_class
+
         # Merge backend_args into params (backend_args overrides params)
         merge_namespace(backend_args, module_config.params, allow_override=False, excepts=[])
         module_config.params = backend_args
 
-        # Load trainer class and instantiate
+        # Third, check backend_args (after merge, in case it was preserved)
+        if not trainer_class and hasattr(backend_args, "trainer_class"):
+            trainer_class = backend_args.trainer_class
+
+        # Log summary of trainer_class extraction (keep one summary log for troubleshooting)
+        if trainer_class:
+            log_rank_0(f"[TrainRuntime] Using trainer_class: {trainer_class}")
+        else:
+            log_rank_0(f"[TrainRuntime] WARNING: trainer_class not found, will use default for stage")
+
+        # Extract stage for fallback
         stage = getattr(module_config.params, "stage", "pretrain") or "pretrain"
-        TrainerClass = adapter.load_trainer_class(stage=stage)
-        trainer = TrainerClass(backend_args=backend_args)
+
+        log_rank_0(f"[TrainRuntime] Loading trainer: stage={stage}, trainer_class={trainer_class}")
+        # Only forward trainer_class to adapters that support it (Megatron). Other
+        # backend adapters keep their stage-only signature, so passing trainer_class
+        # unconditionally would raise TypeError on the shared core-runtime path.
+        trainer_cls = adapter.load_trainer_class(
+            stage=stage,
+            **({"trainer_class": trainer_class} if trainer_class else {}),
+        )
+        log_rank_0(f"[TrainRuntime] Loaded trainer class: {trainer_cls.__name__}")
+
+        # Initialize trainer with both BaseModule and BaseTrainer arguments
+        # BaseModule needs: module_name, primus_config, module_rank, module_world_size, module_master_addr, module_master_port
+        # BaseTrainer needs: backend_args
+        # Note: BaseModule.__init__ expects keyword arguments, not positional
+        trainer = trainer_cls(
+            backend_args=backend_args,
+            module_name=self.ctx.module_name,
+            primus_config=self.ctx.primus_config,
+            module_rank=self.ctx.rank,
+            module_world_size=self.ctx.world_size,
+            module_master_addr=self.ctx.master_addr,
+            module_master_port=self.ctx.master_port,
+        )
 
         assert trainer is not None, f"Failed to create trainer instance for framework '{self.ctx.framework}'."
         self.ctx.trainer = trainer
+
+        # Attach runtime_state to trainer instance for easy access in forward_step()
+        trainer.runtime_state = self.ctx.runtime_state
 
     def _run_trainer_lifecycle(self) -> None:
         assert (
@@ -320,18 +431,32 @@ class PrimusRuntime:
         trainer = self.ctx.trainer
 
         # 1) Optional setup phase
-        self._run_phase_patches(phase="setup", backend_args=self.ctx.backend_args)
+        self._run_phase_patches(
+            phase="setup", backend_args=self.ctx.backend_args, runtime_state=self.ctx.runtime_state
+        )
         _log_step("Setup", trainer.setup)
 
         # 2) Initialize training components
         _log_step("Init", trainer.init)
 
         # 3) Execute training
-        self._run_phase_patches(phase="before_train", backend_args=self.ctx.backend_args)
-        _log_step("Training", trainer.train)
+        self._run_phase_patches(
+            phase="before_train", backend_args=self.ctx.backend_args, runtime_state=self.ctx.runtime_state
+        )
+        import gc
+
+        gc.disable()
+        log_rank_0("Python GC disabled for training (matching NeMo memory management)")
+        try:
+            _log_step("Training", trainer.train)
+        finally:
+            gc.enable()
+            log_rank_0("Python GC re-enabled after training")
 
         # 4) Cleanup and finalize
-        self._run_phase_patches(phase="after_train", backend_args=self.ctx.backend_args)
+        self._run_phase_patches(
+            phase="after_train", backend_args=self.ctx.backend_args, runtime_state=self.ctx.runtime_state
+        )
         _log_step("Cleanup", trainer.cleanup)
 
     # --------------------------- Cleanup ---------------------------------- #

--- a/primus/core/trainer/base_trainer.py
+++ b/primus/core/trainer/base_trainer.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -45,26 +45,49 @@ class BaseTrainer(ABC):
         MegatronPretrainTrainer, TorchtitanPretrainTrainer, etc.
     """
 
-    def __init__(self, backend_args: Any):
+    def __init__(self, backend_args: Any = None, *args, **kwargs):
         """
         Initialize base trainer.
 
         Args:
             backend_args: Backend-specific arguments (e.g., from MegatronArgBuilder)
+            *args, **kwargs: Additional arguments (filtered to prevent reaching object.__init__())
 
         Note:
             Distributed environment and logging should be initialized globally
             before creating trainer instances.
         """
-        self.backend_args = backend_args
+        # Filter backend_args from kwargs if not provided as positional/keyword argument
+        if backend_args is None:
+            backend_args = kwargs.pop("backend_args", None)
 
-        # Resolve distributed environment directly from torchrun-style env vars
-        dist_env = get_torchrun_env()
-        self.rank = dist_env["rank"]
-        self.world_size = dist_env["world_size"]
-        self.local_rank = dist_env["local_rank"]
-        self.master_addr = dist_env["master_addr"]
-        self.master_port = dist_env["master_port"]
+        try:
+            from abc import ABC
+
+            ABC.__init__(self)
+
+            self.backend_args = backend_args
+
+            dist_env = get_torchrun_env()
+            self.rank = dist_env["rank"]
+            self.world_size = dist_env["world_size"]
+            self.local_rank = dist_env["local_rank"]
+            self.master_addr = dist_env["master_addr"]
+            self.master_port = dist_env["master_port"]
+
+            # Cooperative multiple inheritance: pass kwargs to BaseModule if present in MRO,
+            # otherwise call super().__init__() with no args to avoid object.__init__() error.
+            from primus.modules.base_module import BaseModule
+
+            if BaseModule in type(self).__mro__:
+                super().__init__(**kwargs)
+            else:
+                super().__init__()
+        except Exception:
+            import traceback
+
+            traceback.print_exc()
+            raise
 
     @abstractmethod
     def setup(self):

--- a/primus/modules/base_module.py
+++ b/primus/modules/base_module.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -28,8 +28,8 @@ class BaseModule(ABC):
         module_world_size: int,
         module_master_addr: str = None,
         module_master_port: int = None,
+        **kwargs,  # Accept extra kwargs for cooperative multiple inheritance
     ):
-        # module will be initialized by multiple worker processes
         self.module_name = module_name
 
         assert primus_config is not None
@@ -70,6 +70,25 @@ class BaseModule(ABC):
 
         # setup logger for worker
         self.setup_worker_logger(module_rank, module_world_size)
+
+        # Call super() for cooperative multiple inheritance
+        # MRO for MegatronTrainer: MegatronTrainer -> BaseTrainer -> BaseModule -> ABC -> object
+        #
+        # Flow:
+        # 1. MegatronTrainer.__init__() calls super().__init__() -> BaseTrainer.__init__()
+        # 2. BaseTrainer.__init__() consumes backend_args, then calls super().__init__(**kwargs) -> BaseModule.__init__()
+        #    Note: BaseTrainer passes kwargs containing module_name, primus_config, etc. to BaseModule
+        # 3. BaseModule.__init__() receives module_name, primus_config, etc. as positional/keyword args
+        #    The kwargs dict may still contain these keys, but BaseModule has already consumed them as positional args
+        # 4. BaseModule.__init__() calls super().__init__() -> ABC.__init__() -> object.__init__()
+        #
+        # The issue: If kwargs still contains keys, passing them to super() will eventually reach object.__init__()
+        # which doesn't accept arguments. We must ensure kwargs is empty or only contains args for the next class.
+        # Since the next class after BaseModule is ABC (which doesn't accept kwargs), we should not pass kwargs.
+
+        # Don't pass kwargs to super() - the next class in MRO is ABC, which doesn't need them
+        # All required args for BaseModule have been consumed as positional/keyword arguments above
+        super().__init__()
 
     @abstractmethod
     def init(self, *args, **kwargs):

--- a/primus/modules/module_utils.py
+++ b/primus/modules/module_utils.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -73,7 +73,14 @@ def log_kv_rank_0(key, value):
         log_func(key, value, module_name, function_name, line)
 
 
-def debug_rank_0(msg, *args, **kwargs):
+def debug_rank_0(*args, **kwargs):
+    if not args:
+        return
+    sep = kwargs.pop("sep", " ")
+    kwargs.pop("end", None)
+    kwargs.pop("file", None)
+    kwargs.pop("flush", None)
+    msg = sep.join(str(a) for a in args)
     log_func = logger.debug_with_caller
 
     caller = inspect.stack()[1]
@@ -86,7 +93,14 @@ def debug_rank_0(msg, *args, **kwargs):
         log_func(msg, module_name, function_name, line)
 
 
-def debug_rank_all(msg, *args, **kwargs):
+def debug_rank_all(*args, **kwargs):
+    if not args:
+        return
+    sep = kwargs.pop("sep", " ")
+    kwargs.pop("end", None)
+    kwargs.pop("file", None)
+    kwargs.pop("flush", None)
+    msg = sep.join(str(a) for a in args)
     log_func = logger.debug_with_caller
 
     caller = inspect.stack()[1]

--- a/primus/modules/trainer/megatron/pre_trainer.py
+++ b/primus/modules/trainer/megatron/pre_trainer.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -132,7 +132,13 @@ class MegatronPretrainTrainer(MegatronTrainer):
                 f"Megatron backend does not support unregistered config keys."
             )
 
-        super().__init__(*args, **kwargs)
+        try:
+            super().__init__(*args, **kwargs)
+        except Exception:
+            import traceback
+
+            traceback.print_exc()
+            raise
 
     def get_batch(self, data_iterator, vp_stage=None):
         """Generate a batch."""

--- a/primus/modules/trainer/megatron/trainer.py
+++ b/primus/modules/trainer/megatron/trainer.py
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
-# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -1072,6 +1072,14 @@ class MegatronTrainer(BaseTrainer, BaseModule):
                 checkpointing_context=self.checkpointing_context,
                 skip_load_to_model_and_opt=HAVE_FSDP2 and args.use_torch_fsdp2,
             )
+            if (
+                HAVE_FSDP2
+                and args.use_torch_fsdp2
+                and optimizer is not None
+                and hasattr(optimizer, "finalize_dist_ckpt_load")
+                and args.iteration > 0
+            ):
+                optimizer.finalize_dist_ckpt_load(args.iteration)
             timers("load-checkpoint").stop(barrier=True)
             timers.log(["load-checkpoint"])
             one_logger and one_logger.log_metrics(
@@ -1805,6 +1813,22 @@ class MegatronTrainer(BaseTrainer, BaseModule):
                 torch.cuda.nvtx.range_pop()
 
         timers("optimizer").stop()
+
+        if getattr(args, "use_fsdp2_fp8_all_gather", False):
+            from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+                precompute_fp8_scales_for_fsdp,
+            )
+
+            precompute_fp8_scales_for_fsdp(
+                model[0],
+                stochastic_rounding=getattr(args, "fp8_all_gather_stochastic_rounding", False),
+            )
+
+        # FSDP2FP32Optimizer returns grad_norm as a GPU tensor to avoid a
+        # torch.compile graph break inside the compiled optimizer.step().
+        # Materialize to float here, outside the compiled region.
+        if isinstance(grad_norm, torch.Tensor):
+            grad_norm = grad_norm.item()
 
         # when freezing sub-models we may have a mixture of successful and unsucessful ranks,
         # so we must gather across mp ranks

--- a/primus/modules/trainer/megatron/utils.py
+++ b/primus/modules/trainer/megatron/utils.py
@@ -487,6 +487,30 @@ def _get_sync_free_moe_options(args) -> dict:
     return sync_free_moe[stage]
 
 
+# FSDP2 custom optimizer selection flags. Each one monkeypatches
+# get_megatron_optimizer at the same priority (50), so at most one may be set.
+_FSDP2_OPTIMIZER_FLAGS = (
+    "use_fsdp2_fp32_param_optimizer",
+    "use_fsdp2_bf16_master_weight_optimizer",
+)
+
+
+def validate_fsdp2_optimizer_exclusivity(args) -> None:
+    """Ensure at most one FSDP2 custom optimizer flag is enabled.
+
+    Enabling more than one would silently let whichever optimizer patch applies
+    last win the monkeypatch, so raise ValueError to fail loudly at
+    arg-validation time (before training starts).
+    """
+    enabled = [flag for flag in _FSDP2_OPTIMIZER_FLAGS if getattr(args, flag, False)]
+    if len(enabled) > 1:
+        raise ValueError(
+            "Conflicting FSDP2 optimizer selection: at most one of "
+            f"{list(_FSDP2_OPTIMIZER_FLAGS)} may be enabled, but got {enabled}. "
+            "Enable exactly one."
+        )
+
+
 def validate_args_on_rocm(args):
     # Deterministic mode
     if args.deterministic_mode:
@@ -509,6 +533,9 @@ def validate_args_on_rocm(args):
     assert not getattr(
         args, "use_turbo_parallel_linear", False
     ), "use_turbo_parallel_linear has been removed; please use use_turbo_gemm instead."
+
+    validate_fsdp2_optimizer_exclusivity(args)
+
     use_turbo_gemm = getattr(args, "use_turbo_gemm", False)
     # Turbo FP8 linear check
     if args.fp8 and use_turbo_gemm:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,137 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import os
+import sys
+from pathlib import Path
+
+
+def _warmup_aiter_nondeterministic_mha_bwd() -> None:
+    """Load aiter's nondeterministic flash-attention backward kernel before TE.
+
+    aiter and TransformerEngine both statically bundle composable_kernel
+    (``ck_tile``). If ``transformer_engine`` is imported before aiter's
+    nondeterministic ``mha_bwd`` JIT module is first loaded, that kernel's
+    ``.so`` resolves its ck_tile host launch path against TE's (different) CK
+    copy and launches with an invalid grid/block config -> at runtime the
+    backward dies with::
+
+        HIP Function Failed (.../ck_tile/host/kernel_launch.hpp,110)
+        invalid configuration argument
+
+    Triggering one tiny nondeterministic backward here (in the root conftest's
+    ``pytest_configure``, before any test module imports TE) loads that kernel
+    against aiter's own CK first, after which it stays correct for the rest of
+    the session. The deterministic kernel is unaffected, so we only need to warm
+    the nondeterministic variant. Best-effort: never let warmup break the suite.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return
+
+        import math
+
+        import primus_turbo.pytorch as pt
+
+        q, k, v = (
+            torch.randn(1, 8, 1, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+            for _ in range(3)
+        )
+        out = pt.ops.flash_attn_func(
+            q,
+            k,
+            v,
+            dropout_p=0.0,
+            softmax_scale=1.0 / math.sqrt(64),
+            causal=False,
+            window_size=(-1, -1),
+            deterministic=False,
+            return_lse=False,
+        )
+        out.float().sum().backward()
+        torch.cuda.synchronize()
+    except Exception:
+        # Warmup is a best-effort mitigation; if aiter/CUDA is unavailable or
+        # the API shifts, fall through silently and let the affected tests
+        # surface their own errors.
+        pass
+
+
+def _selection_includes_megatron(config) -> bool:
+    """True if the pytest selection could include a backends/megatron suite.
+
+    Covers both the unit (``tests/unit_tests/backends/megatron``) and integration
+    (``tests/integration_tests/backends/megatron``) trees: the diffusion
+    integration tests run the same aiter attention backward and need the same
+    crash mitigations (deepbind hook + warmup).
+
+    Path-level heuristic only (does not inspect -k / -m); the mitigations are
+    best-effort, so a conservative path check is sufficient. Fails OPEN: any
+    detection error returns True, because a missed mitigation degrades to a hard
+    mha_bwd crash, not just a slowdown.
+
+    Uses ``config.args`` (populated post-parse, includes the default rootdir on
+    a bare run) rather than ``config.getoption("file_or_dir")`` (empty on a bare
+    run) -- do not "simplify" to the latter, it flips the empty-case semantics.
+    """
+    try:
+        base = Path(__file__).resolve().parent
+        megatron_dirs = (
+            base / "unit_tests" / "backends" / "megatron",
+            base / "integration_tests" / "backends" / "megatron",
+        )
+        args = list(getattr(config, "args", []) or [])
+        if not args:
+            return True  # whole-suite run (defensive; config.args is never empty)
+        for arg in args:
+            path = Path(str(arg).split("::", 1)[0]).resolve()
+            for megatron_dir in megatron_dirs:
+                # arg is the megatron dir, an ancestor of it, or a path inside it
+                if (
+                    path == megatron_dir
+                    or megatron_dir.is_relative_to(path)
+                    or path.is_relative_to(megatron_dir)
+                ):
+                    return True
+        return False
+    except Exception:
+        # Fail open: never let a detection error suppress the crash-prevention mitigations.
+        return True
+
+
+def pytest_configure(config):
+    project_root = Path(__file__).resolve().parent.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
+    megatron_path = os.environ.get("MEGATRON_PATH")
+    if megatron_path is None or not os.path.exists(megatron_path):
+        megatron_path = project_root / "third_party" / "Megatron-LM"
+    if str(megatron_path) not in sys.path:
+        sys.path.append(str(megatron_path))
+
+    # Only needed for the megatron suite, so skip for unrelated selections
+    # (fail-open: detection errors still run it).
+    if _selection_includes_megatron(config):
+        # ORDER MATTERS: install the aiter RTLD_DEEPBIND import hook BEFORE the
+        # warmup below (or any test) first imports aiter's mha backward
+        # extension. The hook wraps importlib.import_module so the pinned
+        # aiter::mha_bwd binds its own ck_tile instead of TE's stale vendored
+        # libmha (ROCm/aiter#1332); once ``module_fmha_v3_bwd`` is already in
+        # sys.modules the hook is a no-op, so the warmup MUST NOT run first or
+        # the hd128 backward launches with an invalid grid config and aborts the
+        # whole process. Mirrors the production megatron.turbo.aiter_deepbind
+        # before_train patch (which has no such ordering hazard).
+        from tests.utils import install_aiter_deepbind_hook
+
+        install_aiter_deepbind_hook()
+        # Must run before any test module imports transformer_engine. See the
+        # helper docstring for the aiter<->TE composable_kernel load-order issue.
+        _warmup_aiter_nondeterministic_mha_bwd()
+    else:
+        print("[conftest] skipping aiter mha_bwd mitigations (no megatron tests selected)")

--- a/tests/unit_tests/backends/megatron/conftest.py
+++ b/tests/unit_tests/backends/megatron/conftest.py
@@ -1,34 +1,63 @@
-###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
-#
-# See LICENSE for license information.
-###############################################################################
-"""
-Pytest fixtures for Megatron backend tests.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
 
-This conftest provides fixtures for tests that need Megatron parallel state
-initialization, such as tests for Primus Turbo layers and other Megatron-Core
-components that require distributed setup.
+"""
+Shared pytest fixtures for Megatron backend tests.
+
+Provides reusable fixtures for parallel state initialization used across
+optimizer, diffusion, and other Megatron test suites.
 """
 
 import os
-import socket
+from types import SimpleNamespace
 
 import pytest
 import torch
-import torch.distributed as dist
+
+from primus.core.utils import logger
 
 
-def _find_free_port() -> int:
-    """Ask the kernel for a free TCP port on localhost.
+@pytest.fixture(autouse=True, scope="session")
+def setup_logger():
+    """Initialize the Primus logger for megatron tests that use log_rank_0.
 
-    Binding to port 0 lets the OS pick a port that is guaranteed free at this
-    instant, which avoids the EADDRINUSE failures seen when guessing a random
-    port out of a fixed range that overlaps the ephemeral port range.
+    The Primus ``_logger`` global is ``None`` until configured, so tests that
+    log (e.g. test_warmup_convergence.py) raise ``AttributeError`` when run
+    without a prior logger-init. This session-scoped autouse fixture removes
+    that ordering dependency. Subdirectories may override it with an identically
+    named fixture (see diffusion/training/conftest.py).
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+    logger_cfg = logger.LoggerConfig(
+        exp_root_path=os.environ.get("UT_LOG_PATH", "ut_out"),
+        work_group="develop",
+        user_name="root",
+        exp_name="unittest",
+        module_name="UT-training",
+        file_sink_level="DEBUG",
+        stderr_sink_level="INFO",
+        node_ip="localhost",
+        rank=os.environ.get("RANK", 0),
+        world_size=os.environ.get("WORLD_SIZE", 1),
+    )
+    logger.setup_logger(logger_cfg, is_head=False)
+
+
+def _is_mxfp4_supported():
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from primus_turbo.pytorch.core.low_precision import check_mxfp4_support
+
+        supported, _ = check_mxfp4_support()
+        return supported
+    except ImportError:
+        return False
+
+
+requires_mxfp4 = pytest.mark.skipif(
+    not _is_mxfp4_supported(),
+    reason="Requires gfx950+ (MI355X) for MXFP4 support",
+)
 
 
 @pytest.fixture(scope="function")
@@ -48,31 +77,37 @@ def init_parallel_state():
 
     Example:
         @pytest.fixture(autouse=True)
-        def setup_parallel(self, init_parallel_state, monkeypatch):
+        def setup_parallel(self, init_parallel_state):
             '''Auto-use parallel state for this test class.'''
             pass
     """
-    # Only import after sys.path is set up (which happens in pytest_configure)
     from megatron.core import parallel_state as ps
 
     # Initialize torch.distributed if not already initialized
-    if not dist.is_initialized():
-        # Use a kernel-assigned free port to avoid conflicts with other running
-        # tests. Set MASTER_PORT explicitly (not setdefault) so a stale value
-        # left in the environment cannot diverge from the port we actually use.
-        port = _find_free_port()
-        os.environ["MASTER_ADDR"] = "127.0.0.1"
-        os.environ["MASTER_PORT"] = str(port)
+    if not torch.distributed.is_initialized():
+        import os
+        import socket
 
-        dist.init_process_group(
-            backend="nccl" if torch.cuda.is_available() else "gloo",
-            init_method=f"tcp://127.0.0.1:{port}",
-            world_size=1,
-            rank=0,
-        )
+        # Use OS-assigned ephemeral port to avoid TIME_WAIT conflicts
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
 
-    # Check if model parallel already initialized and destroy if so
-    # This ensures clean state for each test
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", str(port))
+
+        try:
+            torch.distributed.init_process_group(
+                backend="nccl" if torch.cuda.is_available() else "gloo",
+                init_method=f"tcp://127.0.0.1:{port}",
+                world_size=1,
+                rank=0,
+            )
+        except Exception as e:
+            pytest.skip(f"Could not initialize distributed: {e}")
+
+    # Check if model parallel already initialized
     if ps.model_parallel_is_initialized():
         ps.destroy_model_parallel()
 
@@ -88,22 +123,29 @@ def init_parallel_state():
     # This is required for:
     # 1. ColumnParallelLinear and other tensor parallel layers that use get_cuda_rng_tracker().fork()
     # 2. CUDA graph support in layers (enable_cuda_graph=True)
+    from megatron.core.tensor_parallel import random as tp_random
+
     if torch.cuda.is_available():
+        # Initialize RNG tracker with CUDA graph support BEFORE calling model_parallel_cuda_manual_seed
+        # Try Transformer Engine RNG tracker first (best for CUDA graphs, used by Megatron's own tests)
         try:
-            from megatron.core.tensor_parallel import random as tp_random
+            tp_random.initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
+        except (ImportError, AssertionError):
+            # Fallback to native PyTorch CUDA graph RNG support if TE not available
+            tp_random.initialize_rng_tracker(use_cudagraphable_rng=True, force_reset=True)
 
-            # Initialize RNG tracker with CUDA graph support BEFORE calling model_parallel_cuda_manual_seed
-            # Try Transformer Engine RNG tracker first (best for CUDA graphs, used by Megatron's own tests)
-            try:
-                tp_random.initialize_rng_tracker(use_te_rng_tracker=True, force_reset=True)
-            except (ImportError, AssertionError):
-                # Fallback to native PyTorch CUDA graph RNG support if TE not available
-                tp_random.initialize_rng_tracker(use_cudagraphable_rng=True, force_reset=True)
+        tp_random.model_parallel_cuda_manual_seed(42)
 
-            tp_random.model_parallel_cuda_manual_seed(42)
-        except ImportError:
-            # RNG tracker initialization is optional - skip if not available
-            pass
+    # Initialize Megatron global args with minimal defaults required by
+    # PrimusTurboLocalAttention and PrimusTorchFullyShardedDataParallel
+    from megatron.training.global_vars import set_args
+
+    set_args(
+        SimpleNamespace(
+            enable_turbo_attention_float8=False,
+            data_parallel_replicate_degree=1,
+        )
+    )
 
     yield
 
@@ -111,7 +153,12 @@ def init_parallel_state():
     if ps.model_parallel_is_initialized():
         ps.destroy_model_parallel()
 
+    # Reset Megatron global args
+    import megatron.training.global_vars as gvars
+
+    gvars._GLOBAL_ARGS = None
+
     # Cleanup torch.distributed for single-process tests
     # (In multi-process torchrun tests, the process group persists across tests)
-    if dist.is_initialized():
-        dist.destroy_process_group()
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_megatron_pretrain_trainer_overridable_methods.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_megatron_pretrain_trainer_overridable_methods.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for overridable methods in MegatronPretrainTrainer.
+
+Tests verify that get_forward_step() and get_datasets_provider() methods
+can be overridden by subclasses while maintaining backward compatibility.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any, List, Tuple
+
+import pytest
+import torch
+
+from primus.backends.megatron.megatron_pretrain_trainer import MegatronPretrainTrainer
+
+# train() imports the real megatron.core/training stack (transitively primus_turbo/TE), which
+# initializes CUDA at import time. Gate the two tests that call train() so they run only on GPU.
+requires_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="train() imports real megatron.core/training which initialize CUDA at import",
+)
+
+
+def _build_trainer(monkeypatch: pytest.MonkeyPatch) -> MegatronPretrainTrainer:
+    """Helper to build MegatronPretrainTrainer with a stubbed MegatronBaseTrainer."""
+
+    # Stub out MegatronBaseTrainer.__init__ to avoid real Megatron imports/patching.
+    def dummy_init(self, backend_args: Any = None):
+        self.backend_args = backend_args
+
+    monkeypatch.setattr(
+        "primus.backends.megatron.megatron_base_trainer.MegatronBaseTrainer.__init__",
+        dummy_init,
+    )
+
+    # Silence logging from the trainer module.
+    monkeypatch.setattr(
+        "primus.backends.megatron.megatron_pretrain_trainer.log_rank_0",
+        lambda *args, **kwargs: None,
+    )
+
+    backend_args = SimpleNamespace()
+
+    return MegatronPretrainTrainer(backend_args=backend_args)
+
+
+class TestMegatronPretrainTrainerOverridableMethods:
+    """Tests for overridable methods in MegatronPretrainTrainer."""
+
+    @requires_gpu
+    def test_backward_compatibility_gpt_training_still_works(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that existing GPT training still works (backward compatibility)."""
+        trainer = _build_trainer(monkeypatch)
+
+        calls: List[Tuple[tuple, dict]] = []
+
+        # Use the real megatron modules that train() imports; patch only the integration seams.
+        import megatron.core.pipeline_parallel as mpp
+        import megatron.training
+        import megatron.training.inprocess_restart as inprocess_restart
+        import megatron.training.training as mt_training
+        from megatron.core.enums import ModelType
+
+        def fake_pretrain(*args, **kwargs):
+            raise AssertionError("fake_pretrain was called directly; expected wrapped_pretrain to be used")
+
+        def wrapped_pretrain(*args, store=None, **kwargs):
+            calls.append((args, {"store": store, **kwargs}))
+
+        def fake_maybe_wrap(fn):
+            assert fn is fake_pretrain
+            return wrapped_pretrain, "STORE"
+
+        monkeypatch.setattr(megatron.training, "pretrain", fake_pretrain)
+        monkeypatch.setattr(inprocess_restart, "maybe_wrap_for_inprocess_restart", fake_maybe_wrap)
+
+        # train() reassigns get_forward_backward_func on both real modules; snapshot both through
+        # monkeypatch so they are restored and the mutation does not leak into later tests.
+        monkeypatch.setattr(mpp, "get_forward_backward_func", mpp.get_forward_backward_func)
+        monkeypatch.setattr(mt_training, "get_forward_backward_func", mt_training.get_forward_backward_func)
+
+        model_provider = object()
+        monkeypatch.setattr(
+            "primus.core.utils.import_utils.get_model_provider",
+            lambda *args, **kwargs: model_provider,
+        )
+
+        # pretrain_gpt is a Megatron example script, not importable here -> mock it via sys.modules.
+        train_valid_test_datasets_provider = SimpleNamespace(is_distributed=False)
+        pretrain_gpt_mod = types.SimpleNamespace(
+            forward_step="FORWARD_STEP",
+            train_valid_test_datasets_provider=train_valid_test_datasets_provider,
+        )
+        monkeypatch.setitem(sys.modules, "pretrain_gpt", pretrain_gpt_mod)
+
+        # Execute training
+        trainer.train()
+
+        # Verify backward compatibility: should work exactly as before
+        assert train_valid_test_datasets_provider.is_distributed is True
+        assert len(calls) == 1
+        (args, kwargs) = calls[0]
+
+        # Positional arguments should match expected GPT training pattern
+        assert args[0] is train_valid_test_datasets_provider
+        assert args[1] is model_provider
+        assert args[2] is ModelType.encoder_or_decoder
+        assert args[3] == "FORWARD_STEP"
+
+        assert kwargs == {"store": "STORE"}

--- a/tests/unit_tests/backends/megatron/patches/test_patch_guard.py
+++ b/tests/unit_tests/backends/megatron/patches/test_patch_guard.py
@@ -1,0 +1,75 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the feature-owned patch idempotency guard.
+
+These validate that:
+  - a guarded "wrapping" patch applies exactly once even if its handler runs
+    twice (e.g. before_train re-invoked), and
+  - distinct patches still compose (each wraps once), which is required for the
+    stacked train_step wrappers (FP8 cache, delayed scaling, wall-clock timer).
+"""
+
+from primus.backends.megatron.patches._patch_guard import is_patched, mark_patched
+
+
+class _FakeModule:
+    """Stand-in for ``megatron.training.training`` (a module object)."""
+
+
+def _apply_wrapping_patch(module, key):
+    """Mimic the guarded train_step wrap pattern used by the FP8/timer patches."""
+    if is_patched(module, key):
+        return
+    original = module.train_step
+
+    def wrapped(*args, **kwargs):
+        module.call_log.append(key)
+        return original(*args, **kwargs)
+
+    module.train_step = wrapped
+    mark_patched(module, key)
+
+
+def test_is_patched_false_before_mark():
+    module = _FakeModule()
+    assert not is_patched(module, "k")
+
+
+def test_mark_then_is_patched():
+    module = _FakeModule()
+    mark_patched(module, "k")
+    assert is_patched(module, "k")
+    assert not is_patched(module, "other")
+
+
+def test_guarded_wrap_applies_once_on_reapply():
+    module = _FakeModule()
+    module.call_log = []
+    module.train_step = lambda: "base"
+
+    # Apply the same patch twice (simulating before_train running twice).
+    _apply_wrapping_patch(module, "megatron.train_step.demo")
+    _apply_wrapping_patch(module, "megatron.train_step.demo")
+
+    module.train_step()
+    # Wrapped exactly once -> the side effect is recorded once per call.
+    assert module.call_log == ["megatron.train_step.demo"]
+
+
+def test_distinct_patches_still_compose():
+    module = _FakeModule()
+    module.call_log = []
+    module.train_step = lambda: "base"
+
+    _apply_wrapping_patch(module, "patch.a")
+    _apply_wrapping_patch(module, "patch.b")
+    # Re-run both: idempotent, so still only one layer each.
+    _apply_wrapping_patch(module, "patch.a")
+    _apply_wrapping_patch(module, "patch.b")
+
+    module.train_step()
+    assert sorted(module.call_log) == ["patch.a", "patch.b"]

--- a/tests/unit_tests/backends/megatron/test_megatron_adapter.py
+++ b/tests/unit_tests/backends/megatron/test_megatron_adapter.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -123,63 +123,6 @@ PATCH = 3
         assert "Cannot locate" in str(exc_info.value)
 
 
-class TestMegatronAdapterConfigConversion:
-    """Test configuration conversion from Primus to Megatron."""
-
-    @patch("primus.backends.megatron.megatron_adapter.MegatronArgBuilder")
-    @patch("primus.backends.megatron.megatron_adapter.log_rank_0")
-    def test_convert_config_basic(self, mock_log, mock_builder_class):
-        """Test basic config conversion workflow."""
-        # Setup mock builder
-        mock_builder = Mock()
-        mock_builder_class.return_value = mock_builder
-
-        # Mock finalize to return SimpleNamespace with args
-        mock_args = SimpleNamespace(
-            micro_batch_size=4,
-            global_batch_size=32,
-            seq_length=2048,
-        )
-        mock_builder.finalize.return_value = mock_args
-
-        # Create mock params
-        mock_params = {
-            "micro_batch_size": 4,
-            "global_batch_size": 32,
-            "seq_length": 2048,
-        }
-
-        # Test conversion
-        adapter = MegatronAdapter()
-        result = adapter.convert_config(mock_params)
-
-        # Verify builder was called correctly
-        mock_builder.update.assert_called_once_with(mock_params)
-        mock_builder.finalize.assert_called_once()
-
-        # Verify result
-        assert result == mock_args
-        assert result.micro_batch_size == 4
-        assert result.global_batch_size == 32
-        assert result.seq_length == 2048
-
-    @patch("primus.backends.megatron.megatron_adapter.MegatronArgBuilder")
-    @patch("primus.backends.megatron.megatron_adapter.log_rank_0")
-    def test_convert_config_empty_params(self, mock_log, mock_builder_class):
-        """Test config conversion with empty params dict."""
-        mock_builder = Mock()
-        mock_builder_class.return_value = mock_builder
-        mock_builder.finalize.return_value = SimpleNamespace()
-
-        mock_params = {}
-
-        adapter = MegatronAdapter()
-        result = adapter.convert_config(mock_params)
-
-        mock_builder.update.assert_called_once_with(mock_params)
-        assert isinstance(result, SimpleNamespace)
-
-
 class TestMegatronAdapterTrainerLoading:
     """Test trainer class loading."""
 
@@ -214,31 +157,127 @@ class TestMegatronAdapterTrainerLoading:
         assert "backend trainer not registered" in str(exc_info.value)
 
 
-class TestMegatronAdapterBackendPreparation:
-    """Test backend preparation workflow."""
+class TestMegatronAdapterDynamicTrainerLoading:
+    """Test dynamic trainer class loading by name."""
 
-    @patch("primus.modules.module_utils.log_rank_0")
-    def test_prepare_backend_success(self, mock_log):
-        """Test successful backend preparation."""
+    @patch("primus.backends.megatron.megatron_adapter.log_rank_0")
+    def test_load_trainer_class_by_name_takes_precedence_over_stage(self, mock_log):
+        """Test that trainer_class parameter takes precedence over stage."""
         adapter = MegatronAdapter()
-        mock_config = Mock()
 
-        # Should not raise - prepare_backend is inherited from BackendAdapter
-        adapter.prepare_backend(mock_config)
+        # Even with invalid stage, trainer_class should work
+        result = adapter.load_trainer_class(stage="invalid_stage", trainer_class="MegatronPretrainTrainer")
 
+        from primus.backends.megatron.megatron_pretrain_trainer import (
+            MegatronPretrainTrainer,
+        )
 
-class TestMegatronAdapterInitialization:
-    """Test MegatronAdapter initialization."""
+        assert result == MegatronPretrainTrainer
 
-    def test_initialization_default(self):
-        """Test adapter initialization with default framework name."""
+    @patch("primus.backends.megatron.megatron_adapter.log_rank_0")
+    def test_load_trainer_class_fallback_tries_multiple_paths(self, mock_log):
+        """Test fallback tries multiple import paths in order for unregistered trainers."""
+        import importlib
+
+        # Use a trainer name NOT in MEGATRON_TRAINERS to exercise the fallback
+        mock_trainer_class = type("CustomExperimentalTrainer", (), {})
+        mock_module = Mock()
+        mock_module.CustomExperimentalTrainer = mock_trainer_class
+
+        import_calls = []
+
+        def side_effect(module_name, *args, **kwargs):
+            import_calls.append(module_name)
+            if len(import_calls) <= 2:
+                raise ImportError(f"Path {len(import_calls)} failed")
+            return mock_module
+
+        with patch.object(importlib, "import_module", side_effect=side_effect):
+            adapter = MegatronAdapter()
+            result = adapter.load_trainer_class(trainer_class="CustomExperimentalTrainer")
+
+        assert result == mock_trainer_class
+        assert len(import_calls) == 3
+        assert "primus.backends.megatron.customexperimentaltrainer" in import_calls[0].lower()
+
+    @patch("primus.backends.megatron.megatron_adapter.log_rank_0")
+    def test_load_trainer_class_fallback_all_paths_fail(self, mock_log):
+        """Test error when all fallback paths fail."""
+        import importlib
+
+        # All import attempts fail
+        def side_effect(module_name, *args, **kwargs):
+            raise ImportError("Module not found")
+
+        with patch.object(importlib, "import_module", side_effect=side_effect):
+            adapter = MegatronAdapter()
+
+            with pytest.raises(ValueError) as exc_info:
+                adapter.load_trainer_class(trainer_class="NonExistentTrainer")
+
+        error_msg = str(exc_info.value)
+        # Verify exact error message format from implementation
+        assert "Trainer class 'NonExistentTrainer' not found" in error_msg
+        assert "Available trainers:" in error_msg
+        assert "Hint:" in error_msg
+        assert "MEGATRON_TRAINERS" in error_msg or "standard locations" in error_msg
+
+    @patch("primus.backends.megatron.megatron_adapter.log_rank_0")
+    def test_load_trainer_class_falsy_values_fall_back_to_stage(self, mock_log):
+        """Test that falsy trainer_class values (None, empty string) fall back to stage-based selection."""
         adapter = MegatronAdapter()
-        assert adapter.framework == "megatron"
 
-    def test_initialization_custom_framework(self):
-        """Test adapter initialization with custom framework name."""
-        adapter = MegatronAdapter(framework="custom_megatron")
-        assert adapter.framework == "custom_megatron"
+        from primus.backends.megatron.megatron_pretrain_trainer import (
+            MegatronPretrainTrainer,
+        )
+
+        # Test None falls back to stage
+        result = adapter.load_trainer_class(stage="pretrain", trainer_class=None)
+        assert result == MegatronPretrainTrainer
+
+        # Test empty string falls back to stage (falsy)
+        result = adapter.load_trainer_class(stage="pretrain", trainer_class="")
+        assert result == MegatronPretrainTrainer
+
+    def test_load_trainer_class_registry_import_error_provides_context(self):
+        """Test that import errors from registry provide helpful context."""
+        import importlib
+
+        def side_effect(module_name, *args, **kwargs):
+            raise ImportError("Module not found")
+
+        with patch.object(importlib, "import_module", side_effect=side_effect):
+            adapter = MegatronAdapter()
+
+            with pytest.raises(ImportError) as exc_info:
+                adapter.load_trainer_class(trainer_class="MegatronPretrainTrainer")
+
+        error_msg = str(exc_info.value)
+        # Verify exact error message format from implementation
+        assert "Failed to load trainer class 'MegatronPretrainTrainer'" in error_msg
+        assert "Hint:" in error_msg
+        assert "Check that the module exists" in error_msg
+
+    def test_load_trainer_class_registry_attribute_error_provides_context(self):
+        """Test that attribute errors from registry provide helpful context."""
+        import importlib
+
+        # Module imports but class doesn't exist
+        mock_module = Mock()
+        del mock_module.MegatronPretrainTrainer  # Ensure attribute doesn't exist
+
+        def side_effect(module_name, *args, **kwargs):
+            return mock_module
+
+        with patch.object(importlib, "import_module", side_effect=side_effect):
+            adapter = MegatronAdapter()
+
+            with pytest.raises(ImportError) as exc_info:
+                adapter.load_trainer_class(trainer_class="MegatronPretrainTrainer")
+
+        error_msg = str(exc_info.value)
+        assert "Failed to load trainer class" in error_msg
+        assert "Hint:" in error_msg
 
 
 class TestMegatronAdapterIntegration:

--- a/tests/unit_tests/backends/megatron/test_megatron_base_trainer.py
+++ b/tests/unit_tests/backends/megatron/test_megatron_base_trainer.py
@@ -1,0 +1,213 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Unit tests for MegatronBaseTrainer.
+
+Tests path resolution, parse_args patching, and setup orchestration.
+"""
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from primus.backends.megatron.megatron_base_trainer import MegatronBaseTrainer
+
+
+def _build_trainer(monkeypatch: pytest.MonkeyPatch, backend_args=None):
+    """Helper to build MegatronBaseTrainer with stubbed dependencies."""
+
+    # Create a concrete subclass for testing (MegatronBaseTrainer is abstract)
+    class ConcreteMegatronBaseTrainer(MegatronBaseTrainer):
+        def train(self):
+            pass
+
+    # Stub out BaseTrainer.__init__ to avoid real distributed env setup
+    def dummy_base_init(self, backend_args=None, *args, **kwargs):
+        self.backend_args = backend_args
+        self.rank = 0
+        self.world_size = 1
+        self.local_rank = 0
+        self.master_addr = "localhost"
+        self.master_port = 12345
+
+    monkeypatch.setattr(
+        "primus.core.trainer.base_trainer.BaseTrainer.__init__",
+        dummy_base_init,
+    )
+
+    # Silence logging
+    monkeypatch.setattr(
+        "primus.backends.megatron.megatron_base_trainer.log_rank_0",
+        lambda *args, **kwargs: None,
+    )
+
+    if backend_args is None:
+        backend_args = SimpleNamespace()
+
+    return ConcreteMegatronBaseTrainer(backend_args=backend_args)
+
+
+class TestMegatronBaseTrainer:
+    """Tests for MegatronBaseTrainer setup and path resolution."""
+
+    def test_ensure_megatron_path_from_primus_path_env(self, monkeypatch: pytest.MonkeyPatch):
+        """Test path resolution from PRIMUS_PATH environment variable."""
+        trainer = _build_trainer(monkeypatch)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            primus_path = Path(tmpdir) / "Primus"
+            megatron_path = primus_path / "third_party" / "Megatron-LM"
+            megatron_path.mkdir(parents=True)
+
+            monkeypatch.setenv("PRIMUS_PATH", str(primus_path))
+
+            # Force `import megatron` to raise ImportError by caching None in
+            # sys.modules.  Unlike mocking builtins.__import__, this leaves
+            # Python's import machinery intact for all other modules.
+            saved_megatron = sys.modules.get("megatron", _SENTINEL := object())
+            sys.modules["megatron"] = None
+            # Strip paths that either contain "megatron" in the name or have a
+            # megatron/ subdirectory, so Method 4 doesn't short-circuit.
+            original_path = sys.path[:]
+            sys.path[:] = [
+                p for p in sys.path if "megatron" not in p.lower() and not (Path(p) / "megatron").is_dir()
+            ]
+            try:
+                trainer._ensure_megatron_path()
+                assert str(megatron_path) in sys.path
+            finally:
+                sys.path[:] = original_path
+                if saved_megatron is _SENTINEL:
+                    sys.modules.pop("megatron", None)
+                else:
+                    sys.modules["megatron"] = saved_megatron
+
+    def test_ensure_megatron_path_from_cwd(self, monkeypatch: pytest.MonkeyPatch):
+        """Test path resolution from current working directory."""
+        trainer = _build_trainer(monkeypatch)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            primus_path = Path(tmpdir) / "Primus"
+            megatron_path = primus_path / "third_party" / "Megatron-LM"
+            megatron_path.mkdir(parents=True)
+
+            monkeypatch.delenv("PRIMUS_PATH", raising=False)
+
+            def mock_cwd():
+                return primus_path / "some" / "subdirectory"
+
+            monkeypatch.setattr(Path, "cwd", staticmethod(mock_cwd))
+
+            saved_megatron = sys.modules.get("megatron", _SENTINEL := object())
+            sys.modules["megatron"] = None
+            original_path = sys.path[:]
+            sys.path[:] = [
+                p for p in sys.path if "megatron" not in p.lower() and not (Path(p) / "megatron").is_dir()
+            ]
+            try:
+                trainer._ensure_megatron_path()
+                assert str(megatron_path) in sys.path
+            finally:
+                sys.path[:] = original_path
+                if saved_megatron is _SENTINEL:
+                    sys.modules.pop("megatron", None)
+                else:
+                    sys.modules["megatron"] = saved_megatron
+
+    def test_ensure_megatron_path_from_file_location(self, monkeypatch: pytest.MonkeyPatch):
+        """Test path resolution from current file location."""
+        trainer = _build_trainer(monkeypatch)
+
+        # Unset PRIMUS_PATH and mock cwd to not contain Primus
+        monkeypatch.delenv("PRIMUS_PATH", raising=False)
+        monkeypatch.setattr(Path, "cwd", staticmethod(lambda: Path("/some/other/path")))
+
+        # Mock __file__ to point to a Primus subdirectory
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            primus_path = Path(tmpdir) / "Primus"
+            megatron_path = primus_path / "third_party" / "Megatron-LM"
+            megatron_path.mkdir(parents=True)
+
+            # Mock __file__ to be in primus/backends/megatron/
+            fake_file = primus_path / "primus" / "backends" / "megatron" / "megatron_base_trainer.py"
+            fake_file.parent.mkdir(parents=True)
+            fake_file.touch()
+
+            def mock_resolve(self):
+                return fake_file
+
+            monkeypatch.setattr(Path, "resolve", mock_resolve)
+
+            saved_megatron = sys.modules.get("megatron", _SENTINEL := object())
+            sys.modules["megatron"] = None
+            original_path = sys.path[:]
+            # Isolate Method 3 (file-location) by neutralizing Method 4, which
+            # returns early if any sys.path entry already contains a real
+            # ``megatron`` package dir. A name-only filter misses a pip-installed
+            # megatron-core under site-packages (no "megatron" in the path name),
+            # so also drop entries that actually contain a ``megatron`` dir.
+            sys.path[:] = [
+                p for p in sys.path if "megatron" not in p.lower() and not (Path(p) / "megatron").is_dir()
+            ]
+            try:
+                trainer._ensure_megatron_path()
+                assert str(megatron_path) in sys.path
+            finally:
+                sys.path[:] = original_path
+                if saved_megatron is _SENTINEL:
+                    sys.modules.pop("megatron", None)
+                else:
+                    sys.modules["megatron"] = saved_megatron
+
+    def test_ensure_megatron_path_already_importable(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that path setup is skipped if megatron is already importable."""
+        trainer = _build_trainer(monkeypatch)
+
+        megatron_mod = types.ModuleType("megatron")
+        monkeypatch.setitem(sys.modules, "megatron", megatron_mod)
+
+        path_before = sys.path[:]
+        trainer._ensure_megatron_path()
+
+        assert sys.path == path_before
+
+    def test_patch_parse_args(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that parse_args is patched in both locations."""
+        trainer = _build_trainer(monkeypatch)
+
+        import megatron.training.arguments as megatron_args_mod
+        import megatron.training.initialize as megatron_init_mod
+
+        original_parse_args_args = megatron_args_mod.parse_args
+        original_parse_args_init = megatron_init_mod.parse_args
+
+        backend_args = SimpleNamespace(test_param="value")
+        trainer.backend_args = backend_args
+
+        try:
+            trainer._patch_parse_args()
+
+            assert megatron_args_mod.parse_args is not original_parse_args_args
+            assert megatron_init_mod.parse_args is not original_parse_args_init
+
+            result_args = megatron_args_mod.parse_args()
+            result_init = megatron_init_mod.parse_args()
+
+            assert result_args is backend_args
+            assert result_init is backend_args
+        finally:
+            megatron_args_mod.parse_args = original_parse_args_args
+            megatron_init_mod.parse_args = original_parse_args_init

--- a/tests/unit_tests/core/backend/test_backend_adapter.py
+++ b/tests/unit_tests/core/backend/test_backend_adapter.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -70,7 +70,7 @@ class DummyBackendAdapter(adapter_module.BackendAdapter):
             model_name=params.get("model") if isinstance(params, dict) else getattr(params, "model", None),
         )
 
-    def load_trainer_class(self, stage: str = "pretrain"):
+    def load_trainer_class(self, stage: str = "pretrain", trainer_class=None):
         self.load_trainer_calls += 1
         return DummyTrainer
 
@@ -97,21 +97,6 @@ def module_config():
 def primus_config():
     # Primus config is passed through to the trainer unchanged
     return SimpleNamespace(exp_name="unit-test-exp")
-
-
-def test_create_trainer_orchestrates_flow(monkeypatch, primus_config, module_config):
-    adapter = DummyBackendAdapter(framework="megatron", version="1.2.3")
-
-    # Abstract methods were called exactly once
-    adapter.prepare_backend(module_config)
-    adapter.convert_config(module_config.params)
-    adapter.load_trainer_class(stage="pretrain")
-    adapter.detect_backend_version()
-
-    assert adapter.prepare_calls == [module_config]
-    assert adapter.convert_calls == [module_config.params]
-    assert adapter.load_trainer_calls == 1
-    assert adapter.detect_version_calls == 1
 
 
 def test_adapter_setup_backend_path_with_explicit_path(tmp_path, monkeypatch):

--- a/tests/unit_tests/core/backend/test_backend_registry.py
+++ b/tests/unit_tests/core/backend/test_backend_registry.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -14,11 +14,6 @@ import pytest
 
 import primus.core.backend.backend_registry as registry_module
 from primus.core.backend.backend_adapter import BackendAdapter
-
-_SUPPORTS_TRAINER_CLASS_REGISTRY = all(
-    hasattr(registry_module.BackendRegistry, attr)
-    for attr in ("_trainer_classes", "register_trainer_class", "get_trainer_class", "has_trainer_class")
-)
 
 
 class MockAdapter(BackendAdapter):
@@ -45,12 +40,6 @@ class TestBackendRegistryErrorHandling:
         # Save original state
         self._original_adapters = registry_module.BackendRegistry._adapters.copy()
         registry_module.BackendRegistry._adapters.clear()
-        if hasattr(registry_module.BackendRegistry, "_trainer_classes"):
-            self._original_trainer_classes = registry_module.BackendRegistry._trainer_classes.copy()
-            registry_module.BackendRegistry._trainer_classes.clear()
-        else:
-            self._original_trainer_classes = None
-
         # Silence logging dependencies (logger may not be initialized in tests)
         self._orig_log_rank_0 = registry_module.log_rank_0
         registry_module.log_rank_0 = lambda *args, **kwargs: None
@@ -58,11 +47,6 @@ class TestBackendRegistryErrorHandling:
     def teardown_method(self):
         """Restore registry after each test."""
         registry_module.BackendRegistry._adapters = self._original_adapters
-        if (
-            hasattr(registry_module.BackendRegistry, "_trainer_classes")
-            and self._original_trainer_classes is not None
-        ):
-            registry_module.BackendRegistry._trainer_classes = self._original_trainer_classes
         registry_module.log_rank_0 = self._orig_log_rank_0
 
     def test_get_adapter_not_found_helpful_error(self):
@@ -75,13 +59,6 @@ class TestBackendRegistryErrorHandling:
         # when the backend module doesn't exist.
         with pytest.raises(ModuleNotFoundError, match="No module named 'primus.backends.non_existent'"):
             registry_module.BackendRegistry.get_adapter("non_existent")
-
-    def test_get_adapter_empty_registry_error(self):
-        """Test error message when no backends are registered."""
-        # get_adapter first calls _load_backend, which fails with ModuleNotFoundError
-        # when the backend module doesn't exist.
-        with pytest.raises(ModuleNotFoundError, match="No module named 'primus.backends.any_backend'"):
-            registry_module.BackendRegistry.get_adapter("any_backend")
 
     def test_get_adapter_creation_failure(self):
         """Test error handling when adapter creation fails."""
@@ -120,11 +97,6 @@ class TestBackendRegistryLazyLoading:
         # Reset adapter registry state
         self._original_adapters = registry_module.BackendRegistry._adapters.copy()
         registry_module.BackendRegistry._adapters.clear()
-        if hasattr(registry_module.BackendRegistry, "_trainer_classes"):
-            self._original_trainer_classes = registry_module.BackendRegistry._trainer_classes.copy()
-            registry_module.BackendRegistry._trainer_classes.clear()
-        else:
-            self._original_trainer_classes = None
 
         # Ensure backend module can be re-imported so that lazy loading
         # re-runs registration even if other tests imported it earlier.
@@ -139,11 +111,6 @@ class TestBackendRegistryLazyLoading:
     def teardown_method(self):
         """Restore registry after each test."""
         registry_module.BackendRegistry._adapters = self._original_adapters
-        if (
-            hasattr(registry_module.BackendRegistry, "_trainer_classes")
-            and self._original_trainer_classes is not None
-        ):
-            registry_module.BackendRegistry._trainer_classes = self._original_trainer_classes
         registry_module.log_rank_0 = self._orig_log_rank_0
 
         # Restore original backend module to avoid impacting other tests
@@ -156,11 +123,6 @@ class TestBackendRegistryLazyLoading:
         """Test that _try_load_backend handles non-existent backends gracefully."""
         with pytest.raises(ImportError):
             registry_module.BackendRegistry._try_load_backend("definitely_not_a_backend")
-
-    def test_try_load_backend_returns_bool(self):
-        """Test that _try_load_backend returns boolean."""
-        with pytest.raises(ImportError):
-            registry_module.BackendRegistry._try_load_backend("non_existent")
 
     def test_get_adapter_with_lazy_loading(self):
         """Test that get_adapter triggers lazy loading."""
@@ -188,25 +150,6 @@ class TestBackendRegistryLazyLoading:
         assert "backend1" in available
         assert "backend2" in available
         assert len(available) == 2
-
-    def test_list_available_backends_empty(self):
-        """Test listing when no backends registered."""
-        available = registry_module.BackendRegistry.list_available_backends()
-        assert available == []
-
-
-class TestBackendRegistryPathNames:
-    """Deprecated: path-name mapping removed; backend path resolution is owned by adapters."""
-
-    def test_path_name_mapping_removed(self):
-        pytest.skip("BackendRegistry path-name mapping removed; use adapter.third_party_dir_name.")
-
-
-class TestBackendRegistrySetupPath:
-    """Deprecated: setup_backend_path moved to BackendAdapter.setup_backend_path()."""
-
-    def test_setup_backend_path_removed(self):
-        pytest.skip("BackendRegistry.setup_backend_path removed; use adapter.setup_backend_path().")
 
 
 class TestBackendRegistryGetAdapterIntegration:
@@ -262,95 +205,6 @@ class TestBackendRegistryGetAdapterIntegration:
             registry_module.BackendRegistry.get_adapter("test_backend", backend_path="/non/existent/path")
 
 
-class TestBackendRegistryHasAdapter:
-    """Test has_adapter functionality."""
-
-    def setup_method(self):
-        """Clear registry before each test."""
-        self._original_adapters = registry_module.BackendRegistry._adapters.copy()
-        registry_module.BackendRegistry._adapters.clear()
-
-    def teardown_method(self):
-        """Restore registry after each test."""
-        registry_module.BackendRegistry._adapters = self._original_adapters
-
-    def test_has_adapter_true(self):
-        """Test has_adapter returns True for registered adapter."""
-        registry_module.BackendRegistry.register_adapter("test_backend", MockAdapter)
-
-        assert registry_module.BackendRegistry.has_adapter("test_backend") is True
-
-    def test_has_adapter_false(self):
-        """Test has_adapter returns False for non-registered adapter."""
-        assert registry_module.BackendRegistry.has_adapter("non_existent") is False
-
-
-@pytest.mark.skipif(
-    not _SUPPORTS_TRAINER_CLASS_REGISTRY,
-    reason="Trainer class registry is not available on BackendRegistry in this version.",
-)
-class TestBackendRegistryTrainerClasses:
-    """Test trainer class registration and retrieval."""
-
-    def setup_method(self):
-        """Clear trainer classes before each test."""
-        if not hasattr(registry_module.BackendRegistry, "_trainer_classes"):
-            pytest.skip("BackendRegistry has no _trainer_classes in this version.")
-        self._original_trainer_classes = registry_module.BackendRegistry._trainer_classes.copy()
-        registry_module.BackendRegistry._trainer_classes.clear()
-
-    def teardown_method(self):
-        """Restore trainer classes after each test."""
-        registry_module.BackendRegistry._trainer_classes = self._original_trainer_classes
-
-    def test_register_and_get_trainer_class(self):
-        """Test registering and retrieving trainer classes."""
-
-        class DummyTrainer:
-            pass
-
-        registry_module.BackendRegistry.register_trainer_class(DummyTrainer, "test_backend")
-
-        trainer_cls = registry_module.BackendRegistry.get_trainer_class("test_backend")
-        assert trainer_cls is DummyTrainer
-
-    def test_get_trainer_class_not_found(self):
-        """Test error when trainer class not registered."""
-        with pytest.raises(ValueError) as exc_info:
-            registry_module.BackendRegistry.get_trainer_class("non_existent_backend")
-
-        assert "No trainer class registered for backend 'non_existent_backend'" in str(exc_info.value)
-
-    def test_has_trainer_class(self):
-        """Test has_trainer_class reflects registration state."""
-
-        class DummyTrainer:
-            pass
-
-        assert registry_module.BackendRegistry.has_trainer_class("test_backend") is False
-        registry_module.BackendRegistry.register_trainer_class(DummyTrainer, "test_backend")
-        assert registry_module.BackendRegistry.has_trainer_class("test_backend") is True
-
-    def test_register_and_get_trainer_class_with_stage(self):
-        """Test trainer registration with explicit stage."""
-
-        class DummyTrainer:
-            pass
-
-        # Register with explicit stage "sft"
-        registry_module.BackendRegistry.register_trainer_class(DummyTrainer, "test_backend", stage="sft")
-
-        # Get with explicit stage "sft" should work
-        trainer_cls = registry_module.BackendRegistry.get_trainer_class("test_backend", stage="sft")
-        assert trainer_cls is DummyTrainer
-
-        # has_trainer_class with explicit stage should work
-        assert registry_module.BackendRegistry.has_trainer_class("test_backend", stage="sft") is True
-
-        # Default stage "pretrain" should not find it
-        assert registry_module.BackendRegistry.has_trainer_class("test_backend") is False
-
-
 class TestBackendRegistrySetupHooks:
     """Test setup hook registration and execution."""
 
@@ -402,6 +256,68 @@ class TestBackendRegistrySetupHooks:
 
         assert "[Primus:BackendSetup] Running 1 setup hooks for backend 'test_backend'." in captured.out
         assert "Error in setup hook" in captured.out
+
+
+class TestBackendRegistryTrainerClass:
+    """Test the trainer-class registry API.
+
+    ``register_trainer_class`` / ``get_trainer_class`` / ``has_trainer_class``
+    back the stage-based fallback in ``MegatronAdapter.load_trainer_class`` (and
+    the other backend adapters), so they must keep (backend, stage) keying and
+    raise on lookups for unregistered combinations.
+    """
+
+    def setup_method(self):
+        self._original_trainer_classes = registry_module.BackendRegistry._trainer_classes.copy()
+        registry_module.BackendRegistry._trainer_classes.clear()
+
+    def teardown_method(self):
+        registry_module.BackendRegistry._trainer_classes = self._original_trainer_classes
+
+    def test_register_and_get_trainer_class(self):
+        class DummyTrainer:
+            pass
+
+        registry_module.BackendRegistry.register_trainer_class(DummyTrainer, "megatron", stage="pretrain")
+
+        assert registry_module.BackendRegistry.get_trainer_class("megatron", stage="pretrain") is DummyTrainer
+        assert registry_module.BackendRegistry.has_trainer_class("megatron", stage="pretrain") is True
+
+    def test_register_defaults_to_pretrain_stage(self):
+        class DummyTrainer:
+            pass
+
+        # Default stage is "pretrain" for both register and lookup.
+        registry_module.BackendRegistry.register_trainer_class(DummyTrainer, "megatron")
+        assert registry_module.BackendRegistry.get_trainer_class("megatron") is DummyTrainer
+
+    def test_stage_is_part_of_the_key(self):
+        class PretrainTrainer:
+            pass
+
+        registry_module.BackendRegistry.register_trainer_class(PretrainTrainer, "megatron", stage="pretrain")
+
+        # A different stage for the same backend must NOT resolve to the
+        # pretrain class; it is a distinct registry key.
+        assert registry_module.BackendRegistry.has_trainer_class("megatron", stage="sft") is False
+        with pytest.raises(ValueError):
+            registry_module.BackendRegistry.get_trainer_class("megatron", stage="sft")
+
+    def test_get_unregistered_trainer_class_raises(self):
+        assert registry_module.BackendRegistry.has_trainer_class("nonexistent") is False
+        with pytest.raises(ValueError, match="No trainer class registered"):
+            registry_module.BackendRegistry.get_trainer_class("nonexistent")
+
+    def test_register_overwrites_same_key(self):
+        class TrainerA:
+            pass
+
+        class TrainerB:
+            pass
+
+        registry_module.BackendRegistry.register_trainer_class(TrainerA, "megatron", stage="pretrain")
+        registry_module.BackendRegistry.register_trainer_class(TrainerB, "megatron", stage="pretrain")
+        assert registry_module.BackendRegistry.get_trainer_class("megatron", stage="pretrain") is TrainerB
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/core/config/test_primus_config.py
+++ b/tests/unit_tests/core/config/test_primus_config.py
@@ -1,0 +1,61 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+from pathlib import Path
+
+from primus.core.config.primus_config import get_module_config, load_primus_config
+from tests.utils import PrimusUT
+
+# Top-level attributes that `_normalize_module_for_runtime` keeps in place; every
+# other public attribute is moved into `params` on the normalized copy.
+_RESERVED_KEYS = {"name", "framework", "config", "model", "params", "trainer_class"}
+
+_EXAMPLE_CONFIG = "examples/megatron/exp_pretrain.yaml"
+
+
+class TestLoadPrimusConfig(PrimusUT):
+    def test_exposes_legacy_primus_config(self):
+        """load_primus_config attaches the underlying legacy PrimusConfig as
+        `_legacy` so the core runtime can reuse it without re-parsing."""
+        cfg = load_primus_config(Path(_EXAMPLE_CONFIG), None)
+
+        self.assertTrue(hasattr(cfg, "_legacy"))
+        legacy = cfg._legacy
+        # The legacy object must still provide the PrimusConfig interface that
+        # BaseModule relies on.
+        self.assertTrue(callable(getattr(legacy, "get_module_config", None)))
+
+    def test_legacy_config_is_pristine_after_normalization(self):
+        """Regression guard for the Option A deepcopy nuance: normalization must
+        operate on deep copies, leaving `_legacy`'s module configs un-mutated.
+
+        With the previous in-place normalization, `delattr` stripped non-reserved
+        training params off the legacy module config (they were moved into
+        `params`). That made the exposed legacy config unusable for BaseModule.
+        Here we assert the legacy module configs still carry their original
+        top-level training params.
+        """
+        cfg = load_primus_config(Path(_EXAMPLE_CONFIG), None)
+        legacy = cfg._legacy
+
+        module_keys = list(getattr(legacy, "module_keys", []))
+        self.assertTrue(module_keys, "expected at least one module in example config")
+
+        for name in module_keys:
+            legacy_mod = legacy.get_module_config(name)
+            top_level = {k for k in vars(legacy_mod) if not k.startswith("_")}
+            # The legacy module must retain non-reserved top-level params; if the
+            # normalization had mutated it in place, these would be gone.
+            self.assertTrue(
+                top_level - _RESERVED_KEYS,
+                f"legacy module '{name}' was mutated/stripped by normalization",
+            )
+
+            # The normalized SimpleNamespace copy must still expose those same
+            # params under `.params` for the new runtime.
+            normalized = get_module_config(cfg, name)
+            self.assertIsNotNone(normalized)
+            self.assertTrue(hasattr(normalized, "params"))

--- a/tests/unit_tests/core/runtime/test_train_runtime.py
+++ b/tests/unit_tests/core/runtime/test_train_runtime.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -126,7 +126,7 @@ class TestPrimusRuntime(PrimusUT):
 
         # Use a dummy trainer that records the call order.
         class DummyTrainer:
-            def __init__(self, backend_args=None):
+            def __init__(self, backend_args=None, **kwargs):
                 self.calls = []
                 self.backend_args = backend_args
 
@@ -174,7 +174,7 @@ class TestPrimusRuntime(PrimusUT):
         with patch("primus.core.runtime.train_runtime.run_patches", side_effect=_fake_run_patches):
             # Dummy trainer
             class DummyTrainer:
-                def __init__(self, backend_args=None):
+                def __init__(self, backend_args=None, **kwargs):
                     self.backend_args = backend_args
 
                 def setup(self):
@@ -202,6 +202,350 @@ class TestPrimusRuntime(PrimusUT):
                 runtime.run_train_module(module_name="pre_trainer", overrides=[])
 
         assert phases == ["build_args", "setup", "before_train", "after_train"]
+
+
+class TestPrimusRuntimeTrainerClassSelection(PrimusUT):
+    """Test trainer class selection from config."""
+
+    def _build_args(self, config: str = "examples/megatron/exp_pretrain.yaml"):
+        """Build args for testing."""
+        import argparse
+
+        return argparse.Namespace(config=config, data_path="./data", backend_path=None)
+
+    def test_initialize_trainer_extracts_trainer_class_from_module_config_top_level(self):
+        """Test that trainer_class is extracted from module_config (top-level)."""
+        args = self._build_args()
+        runtime = PrimusRuntime(args=args)
+
+        # Create a mock adapter that records calls
+        mock_adapter = Mock()
+        mock_adapter.prepare_backend = Mock()
+        mock_adapter.convert_config = Mock(return_value=SimpleNamespace())
+
+        # Mock trainer class
+        mock_trainer_class = Mock()
+        mock_trainer_class.__name__ = "FluxPretrainTrainer"
+        mock_trainer_instance = Mock()
+        mock_trainer_class.return_value = mock_trainer_instance
+        mock_adapter.load_trainer_class = Mock(return_value=mock_trainer_class)
+
+        # Setup context with trainer_class in module_config (top-level)
+        runtime.ctx = SimpleNamespace(
+            config_path=Path("dummy.yaml"),
+            data_path=Path("./data"),
+            module_name="pre_trainer",
+            primus_config=SimpleNamespace(),
+            rank=0,
+            world_size=1,
+            master_addr="localhost",
+            master_port="12345",
+            module_config=SimpleNamespace(
+                framework="megatron",
+                trainer_class="FluxPretrainTrainer",  # Top-level attribute
+                params=SimpleNamespace(stage="pretrain"),
+            ),
+            framework="megatron",
+            adapter=mock_adapter,
+        )
+
+        # Mock patches and logging
+        with patch("primus.core.runtime.train_runtime.log_dict_aligned"), patch(
+            "primus.core.runtime.train_runtime.log_rank_0"
+        ) as mock_log, patch("primus.core.runtime.train_runtime.merge_namespace"), patch.object(
+            runtime, "_run_phase_patches"
+        ):
+
+            runtime._initialize_trainer()
+
+        # Verify adapter.load_trainer_class was called with trainer_class
+        mock_adapter.load_trainer_class.assert_called_once_with(
+            stage="pretrain", trainer_class="FluxPretrainTrainer"
+        )
+
+        # Verify logging indicates trainer_class usage
+        log_calls = [str(call) for call in mock_log.call_args_list]
+        assert any("Using trainer_class: FluxPretrainTrainer" in str(call) for call in log_calls)
+
+    def test_initialize_trainer_extracts_trainer_class_from_params_when_not_top_level(self):
+        """Test that trainer_class is extracted from params when not in top-level."""
+        args = self._build_args()
+        runtime = PrimusRuntime(args=args)
+
+        mock_adapter = Mock()
+        mock_adapter.prepare_backend = Mock()
+        # Critically, backend_args does NOT carry trainer_class. This isolates the
+        # params-extraction branch: the only way trainer_class can be resolved is
+        # from module_config.params (the post-merge backend_args fallback cannot
+        # mask a regression in that branch).
+        backend_args = SimpleNamespace(stage="pretrain")
+        mock_adapter.convert_config = Mock(return_value=backend_args)
+        mock_trainer_class = Mock()
+        mock_trainer_class.__name__ = "FluxPretrainTrainer"
+        mock_trainer_class.return_value = Mock()
+        mock_adapter.load_trainer_class = Mock(return_value=mock_trainer_class)
+
+        # trainer_class in params, NOT top-level (no top-level attribute)
+        runtime.ctx = SimpleNamespace(
+            config_path=Path("dummy.yaml"),
+            data_path=Path("./data"),
+            module_name="pre_trainer",
+            primus_config=SimpleNamespace(),
+            rank=0,
+            world_size=1,
+            master_addr="localhost",
+            master_port="12345",
+            module_config=SimpleNamespace(
+                framework="megatron",
+                # No trainer_class attribute here
+                params=SimpleNamespace(
+                    stage="pretrain",
+                    trainer_class="FluxPretrainTrainer",  # In params
+                ),
+            ),
+            framework="megatron",
+            adapter=mock_adapter,
+        )
+
+        with patch("primus.core.runtime.train_runtime.log_dict_aligned"), patch(
+            "primus.core.runtime.train_runtime.log_rank_0"
+        ), patch("primus.core.runtime.train_runtime.merge_namespace"), patch.object(
+            runtime, "_run_phase_patches"
+        ):
+            runtime._initialize_trainer()
+
+        # trainer_class must have been resolved from module_config.params and forwarded.
+        mock_adapter.load_trainer_class.assert_called_once_with(
+            stage="pretrain", trainer_class="FluxPretrainTrainer"
+        )
+
+    def test_initialize_trainer_top_level_takes_precedence_over_params(self):
+        """Test that top-level trainer_class takes precedence over params.trainer_class."""
+        args = self._build_args()
+        runtime = PrimusRuntime(args=args)
+
+        mock_adapter = Mock()
+        mock_adapter.prepare_backend = Mock()
+        mock_adapter.convert_config = Mock(return_value=SimpleNamespace())
+        mock_trainer_class = Mock()
+        mock_trainer_class.__name__ = "TopLevelTrainer"
+        mock_trainer_class.return_value = Mock()
+        mock_adapter.load_trainer_class = Mock(return_value=mock_trainer_class)
+
+        # Both top-level and params have trainer_class (top-level should win due to if/elif)
+        runtime.ctx = SimpleNamespace(
+            config_path=Path("dummy.yaml"),
+            data_path=Path("./data"),
+            module_name="pre_trainer",
+            primus_config=SimpleNamespace(),
+            rank=0,
+            world_size=1,
+            master_addr="localhost",
+            master_port="12345",
+            module_config=SimpleNamespace(
+                framework="megatron",
+                trainer_class="TopLevelTrainer",  # Top-level (checked first)
+                params=SimpleNamespace(
+                    stage="pretrain",
+                    trainer_class="ParamsTrainer",  # In params (should be ignored)
+                ),
+            ),
+            framework="megatron",
+            adapter=mock_adapter,
+        )
+
+        with patch("primus.core.runtime.train_runtime.log_dict_aligned"), patch(
+            "primus.core.runtime.train_runtime.log_rank_0"
+        ), patch("primus.core.runtime.train_runtime.merge_namespace"), patch.object(
+            runtime, "_run_phase_patches"
+        ):
+
+            runtime._initialize_trainer()
+
+        # Verify top-level trainer_class was used (not params)
+        mock_adapter.load_trainer_class.assert_called_once_with(
+            stage="pretrain", trainer_class="TopLevelTrainer"  # Top-level, not ParamsTrainer
+        )
+
+    def test_initialize_trainer_falls_back_to_stage_when_no_trainer_class(self):
+        """Test fallback to stage-based selection when trainer_class not specified."""
+        args = self._build_args()
+        runtime = PrimusRuntime(args=args)
+
+        mock_adapter = Mock()
+        mock_adapter.prepare_backend = Mock()
+        mock_adapter.convert_config = Mock(return_value=SimpleNamespace())
+        mock_trainer_class = Mock()
+        mock_trainer_class.__name__ = "MockTrainer"
+        mock_trainer_class.return_value = Mock()
+        mock_adapter.load_trainer_class = Mock(return_value=mock_trainer_class)
+
+        # No trainer_class specified anywhere
+        runtime.ctx = SimpleNamespace(
+            config_path=Path("dummy.yaml"),
+            data_path=Path("./data"),
+            module_name="pre_trainer",
+            primus_config=SimpleNamespace(),
+            rank=0,
+            world_size=1,
+            master_addr="localhost",
+            master_port="12345",
+            module_config=SimpleNamespace(
+                framework="megatron",
+                params=SimpleNamespace(stage="pretrain"),
+            ),
+            framework="megatron",
+            adapter=mock_adapter,
+        )
+
+        with patch("primus.core.runtime.train_runtime.log_dict_aligned"), patch(
+            "primus.core.runtime.train_runtime.log_rank_0"
+        ) as mock_log, patch("primus.core.runtime.train_runtime.merge_namespace"), patch.object(
+            runtime, "_run_phase_patches"
+        ):
+
+            runtime._initialize_trainer()
+
+        # Verify fallback to stage-based selection. When trainer_class is falsy
+        # the kwarg is omitted entirely (see train_runtime.py:390-392), so the
+        # adapter is called with stage only.
+        mock_adapter.load_trainer_class.assert_called_once_with(stage="pretrain")
+
+        # Verify logging indicates fallback
+        log_calls = [str(call) for call in mock_log.call_args_list]
+        assert any("trainer_class not found" in str(call) for call in log_calls)
+
+    def test_initialize_trainer_handles_empty_string_trainer_class(self):
+        """Test that empty string trainer_class falls back to stage."""
+        args = self._build_args()
+        runtime = PrimusRuntime(args=args)
+
+        mock_adapter = Mock()
+        mock_adapter.prepare_backend = Mock()
+        mock_adapter.convert_config = Mock(return_value=SimpleNamespace())
+        mock_trainer_class = Mock()
+        mock_trainer_class.__name__ = "MockTrainer"
+        mock_trainer_class.return_value = Mock()
+        mock_adapter.load_trainer_class = Mock(return_value=mock_trainer_class)
+
+        # Empty string trainer_class (falsy, should fall back)
+        runtime.ctx = SimpleNamespace(
+            config_path=Path("dummy.yaml"),
+            data_path=Path("./data"),
+            module_name="pre_trainer",
+            primus_config=SimpleNamespace(),
+            rank=0,
+            world_size=1,
+            master_addr="localhost",
+            master_port="12345",
+            module_config=SimpleNamespace(
+                framework="megatron",
+                trainer_class="",  # Empty string (falsy)
+                params=SimpleNamespace(stage="pretrain"),
+            ),
+            framework="megatron",
+            adapter=mock_adapter,
+        )
+
+        with patch("primus.core.runtime.train_runtime.log_dict_aligned"), patch(
+            "primus.core.runtime.train_runtime.log_rank_0"
+        ), patch("primus.core.runtime.train_runtime.merge_namespace"), patch.object(
+            runtime, "_run_phase_patches"
+        ):
+
+            runtime._initialize_trainer()
+
+        # Should fall back to stage (empty string is falsy): the trainer_class
+        # kwarg is omitted entirely (see train_runtime.py:390-392).
+        mock_adapter.load_trainer_class.assert_called_once_with(stage="pretrain")
+
+
+class TestPrimusRuntimeLifecycle(PrimusUT):
+    """Tests for PrimusRuntime trainer lifecycle execution."""
+
+    def _build_args(self, config: str = "examples/megatron/exp_pretrain.yaml") -> argparse.Namespace:
+        return argparse.Namespace(config=config, data_path="./data", backend_path=None)
+
+    def test_run_trainer_lifecycle_applies_patches_before_train(self):
+        """Test that patches are applied in before_train phase before train() is called."""
+        args = self._build_args()
+        runtime = PrimusRuntime(args=args)
+
+        train_called = []
+        patch_applied = []
+
+        class MockTrainer:
+            def setup(self):
+                pass
+
+            def init(self):
+                pass
+
+            def train(self):
+                train_called.append(1)
+                # Verify patch was applied before train
+                assert len(patch_applied) > 0
+
+            def cleanup(self, on_error=False):
+                pass
+
+        mock_trainer = MockTrainer()
+        runtime.ctx = SimpleNamespace(
+            trainer=mock_trainer, backend_args=SimpleNamespace(), runtime_state=None
+        )
+
+        def mock_run_phase_patches(phase, backend_args=None, runtime_state=None):
+            if phase == "before_train":
+                patch_applied.append(1)
+
+        runtime._run_phase_patches = mock_run_phase_patches
+
+        with patch("primus.core.runtime.train_runtime.log_rank_0"):
+            runtime._run_trainer_lifecycle()
+
+        # Verify patch was applied before train
+        assert len(patch_applied) == 1
+        assert len(train_called) == 1
+
+    def test_run_trainer_lifecycle_passes_backend_args_to_patches(self):
+        """Test that backend_args are passed to patch phases."""
+        args = self._build_args()
+        runtime = PrimusRuntime(args=args)
+
+        backend_args_received = []
+
+        class MockTrainer:
+            def setup(self):
+                pass
+
+            def init(self):
+                pass
+
+            def train(self):
+                pass
+
+            def cleanup(self, on_error=False):
+                pass
+
+        mock_trainer = MockTrainer()
+        test_backend_args = SimpleNamespace(test_param="value")
+        runtime.ctx = SimpleNamespace(
+            trainer=mock_trainer,
+            backend_args=test_backend_args,
+            runtime_state=None,
+        )
+
+        def mock_run_phase_patches(phase, backend_args=None, runtime_state=None):
+            backend_args_received.append(backend_args)
+
+        runtime._run_phase_patches = mock_run_phase_patches
+
+        with patch("primus.core.runtime.train_runtime.log_rank_0"):
+            runtime._run_trainer_lifecycle()
+
+        # Verify backend_args were passed to all patch phases
+        assert len(backend_args_received) == 3
+        assert all(args is test_backend_args for args in backend_args_received)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/core/trainer/test_base_trainer.py
+++ b/tests/unit_tests/core/trainer/test_base_trainer.py
@@ -1,95 +1,117 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
 
-"""Unit tests for BaseTrainer."""
+"""
+Unit tests for BaseTrainer.
+
+Tests initialization, MRO handling, distributed environment setup, and
+backend_args handling for the universal base trainer class.
+"""
 
 from types import SimpleNamespace
+
+import pytest
 
 from primus.core.trainer.base_trainer import BaseTrainer
 
 
-class DummyTrainer(BaseTrainer):
-    """Minimal concrete implementation of BaseTrainer for testing."""
-
-    def __init__(self, backend_args=None):
-        super().__init__(backend_args=backend_args)
-        self.train_calls: int = 0
-        self.setup_calls: int = 0
-        self.init_calls: int = 0
-
-    def init(self, *args, **kwargs):
-        """No-op init for testing."""
-        self.init_calls += 1
-        return None
-
-    def setup(self, *args, **kwargs):
-        """No-op setup for testing."""
-        self.setup_calls += 1
-        return None
-
-    def train(self):
-        self.train_calls += 1
-
-
 class TestBaseTrainer:
-    """Verify BaseTrainer interface and lifecycle."""
+    """Tests for BaseTrainer initialization and behavior."""
 
-    def test_trainer_stores_backend_args(self):
-        """Backend args should be stored on the trainer instance."""
-        backend_args = SimpleNamespace(lr=1e-4, batch_size=32)
-        trainer = DummyTrainer(backend_args=backend_args)
+    def test_init_sets_distributed_environment(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that distributed environment attributes are set correctly."""
+        mock_dist_env = {
+            "rank": 2,
+            "world_size": 8,
+            "local_rank": 1,
+            "master_addr": "192.168.1.1",
+            "master_port": 54321,
+        }
 
-        assert trainer.backend_args is backend_args
-        assert trainer.backend_args.lr == 1e-4
-        assert trainer.backend_args.batch_size == 32
+        monkeypatch.setattr(
+            "primus.core.trainer.base_trainer.get_torchrun_env",
+            lambda: mock_dist_env,
+        )
+        monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+        monkeypatch.setattr("sys.stderr.write", lambda *args, **kwargs: None)
 
-    def test_trainer_allows_none_backend_args(self):
-        """Trainer should accept None as backend_args."""
-        trainer = DummyTrainer(backend_args=None)
-        assert trainer.backend_args is None
+        # Create a concrete subclass for testing
+        class ConcreteBaseTrainer(BaseTrainer):
+            def setup(self):
+                pass
 
-    def test_trainer_train_method_executes(self):
-        """The train() method should execute correctly."""
-        backend_args = SimpleNamespace(lr=1e-4)
-        trainer = DummyTrainer(backend_args=backend_args)
+            def init(self):
+                pass
 
-        trainer.train()
+            def train(self):
+                pass
 
-        assert trainer.train_calls == 1
+        trainer = ConcreteBaseTrainer(backend_args=SimpleNamespace())
 
-    def test_trainer_lifecycle_methods_exist(self):
-        """Trainer should have setup, init, train, cleanup methods."""
+        assert trainer.rank == 2
+        assert trainer.world_size == 8
+        assert trainer.local_rank == 1
+        assert trainer.master_addr == "192.168.1.1"
+        assert trainer.master_port == 54321
+
+    def test_init_mro_with_base_module(self, monkeypatch: pytest.MonkeyPatch):
+        """Test MRO handling when BaseModule IS in inheritance chain (legacy pattern)."""
+        from primus.modules.base_module import BaseModule
+
+        # Create a class that inherits from both BaseTrainer and BaseModule
+        class LegacyTrainer(BaseTrainer, BaseModule):
+            def setup(self):
+                pass
+
+            def init(self):
+                pass
+
+            def train(self):
+                pass
+
+            def run(self):
+                pass  # BaseModule requires run() method
+
+        mock_dist_env = {
+            "rank": 0,
+            "world_size": 1,
+            "local_rank": 0,
+            "master_addr": "localhost",
+            "master_port": 12345,
+        }
+
+        monkeypatch.setattr(
+            "primus.core.trainer.base_trainer.get_torchrun_env",
+            lambda: mock_dist_env,
+        )
+        monkeypatch.setattr("builtins.print", lambda *args, **kwargs: None)
+        monkeypatch.setattr("sys.stderr.write", lambda *args, **kwargs: None)
+
+        # Mock BaseModule.__init__ to track if it's called with kwargs and provide required args
+        base_module_init_called = []
+
+        def tracked_init(
+            self, module_name="test", primus_config=None, module_rank=0, module_world_size=1, **kwargs
+        ):
+            base_module_init_called.append(("kwargs", kwargs))
+            # Don't call original_init, just track the call
+
+        monkeypatch.setattr(BaseModule, "__init__", tracked_init)
+
         backend_args = SimpleNamespace()
-        trainer = DummyTrainer(backend_args=backend_args)
+        trainer = LegacyTrainer(
+            backend_args=backend_args,
+            some_kwarg="value",
+            module_name="test",
+            primus_config=SimpleNamespace(),
+            module_rank=0,
+            module_world_size=1,
+        )
 
-        # All lifecycle methods should be callable
-        trainer.setup()
-        trainer.init()
-        trainer.train()
-        trainer.cleanup()
-
-        assert trainer.setup_calls == 1
-        assert trainer.init_calls == 1
-        assert trainer.train_calls == 1
-
-    def test_cleanup_accepts_on_error_flag(self):
-        """cleanup() should accept on_error parameter."""
-        trainer = DummyTrainer(backend_args=None)
-
-        # Should not raise
-        trainer.cleanup(on_error=False)
-        trainer.cleanup(on_error=True)
-
-    def test_trainer_has_distributed_env_attributes(self):
-        """Trainer should expose distributed environment attributes."""
-        trainer = DummyTrainer(backend_args=None)
-
-        # These attributes should exist (values depend on env)
-        assert hasattr(trainer, "rank")
-        assert hasattr(trainer, "world_size")
-        assert hasattr(trainer, "local_rank")
-        assert hasattr(trainer, "master_addr")
-        assert hasattr(trainer, "master_port")
+        # Verify BaseModule.__init__ was called with kwargs
+        assert len(base_module_init_called) > 0
+        assert "some_kwarg" in base_module_init_called[0][1]
+        assert trainer.backend_args is backend_args

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,17 +10,58 @@ import subprocess
 import sys
 import time
 import unittest
-import warnings
 from typing import Optional
 
 from primus.core.utils import logger
 
 TRAINING_COMPLETED_MARKER = "Training completed."
 
-# run_patcher's failure line ("[Patch] \u2717 Patch '<id>' failed..."); distinct
-# from a patch's own graceful "[SKIP]". run_patches doesn't fail training on it
-# (stop_on_error=False), so we surface it ourselves.
-PATCH_FAILURE_MARKER = "\u2717 Patch '"
+
+def skip_if_no_cuda(reason: str = "requires GPU (primus_turbo initializes CUDA at import)") -> None:
+    """Skip the calling test module at collection time when CUDA is unavailable.
+
+    Several Flux/diffusion test modules import ``primus_turbo`` (directly or
+    transitively), which initializes CUDA at import and raises on CPU-only
+    hosts. Call this at module scope *before* those imports so collection
+    succeeds without a GPU. It is a no-op when CUDA is present, so GPU CI still
+    runs every test.
+    """
+    import pytest
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip(reason, allow_module_level=True)
+
+
+def install_aiter_deepbind_hook() -> None:
+    """Install Primus' production RTLD_DEEPBIND import hook for aiter's mha kernels.
+
+    This invokes the exact mechanism the ``megatron.turbo.aiter_deepbind``
+    before_train patch uses in real training: it wraps ``importlib.import_module``
+    so aiter's pinned mha extensions bind their own ``aiter::mha_bwd`` instead of
+    transformer_engine's stale vendored ``libmha`` (ROCm/aiter#1332). On
+    gfx942/gfx950 that stale-symbol interposition otherwise makes Turbo's hd128
+    backward launch with an invalid grid config and crash the process.
+
+    Unit tests call ``flash_attn_func`` directly and never run the before_train
+    phase, so without this hook they hit the same crash the production patch
+    prevents. Call this at diffusion ``conftest`` import time so the hook is in
+    place before any test first imports the aiter mha modules (which happens
+    lazily on the first attention op). No-op when CUDA is unavailable or the hook
+    cannot be installed (e.g. CPU-only host).
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return
+        from primus.backends.megatron.patches.turbo.aiter_deepbind_patches import (
+            _install_deepbind_import_hook,
+        )
+    except Exception:
+        return
+
+    _install_deepbind_import_hook()
 
 
 class PrimusUT(unittest.TestCase):
@@ -49,25 +90,6 @@ class PrimusUT(unittest.TestCase):
 
     def tearDown(self):
         pass
-
-
-def _warn_on_patch_failures(tag: str, stdout_output: str) -> None:
-    """Warn (don't fail) when patches failed to apply during training.
-
-    A failed patch doesn't crash training and a 3-step smoke run can't prove it
-    was harmless, so we emit a GitHub Actions warning to keep it visible without
-    blocking CI. No-op for backends that don't emit the marker.
-    """
-    if PATCH_FAILURE_MARKER not in stdout_output:
-        return
-    failed = [ln.strip() for ln in stdout_output.splitlines() if PATCH_FAILURE_MARKER in ln]
-    msg = (
-        f"[{tag}] {len(failed)} patch(es) failed to apply during training "
-        f"(training still completed): " + " | ".join(failed[:10])
-    )
-    # GitHub Actions annotation: shows on the run/PR without failing the job.
-    print(f"::warning title=Primus patch failed to apply::{msg}")
-    warnings.warn(msg)
 
 
 def run_training_script(
@@ -128,8 +150,6 @@ def run_training_script(
                 f"not found in log output. Training may have failed silently.\n"
                 f"Log file: {train_log_path}"
             )
-
-        _warn_on_patch_failures(tag, stdout_output)
 
         return stdout_output, ""
 


### PR DESCRIPTION
Base of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Targets `feat/flux/ci-env` and auto-retargets to `main` once that merges. Every other content PR stacks on this one.

## What this changes
The shared runtime scaffolding the rest of the feature builds on: core runtime state + train-runtime wiring, the Megatron adapter and base/pretrain trainers, and a patch auto-loader (`patches/__init__.py`) that imports every `*_patches.py` in the package on import, so each later layer only drops in its own patch file with no registry edit. Also carries the shared test root (`tests/conftest.py`, `tests/utils.py`) and a one-line `.gitignore` change (the bare `data` ignore → root-anchored `/data/*`, and nothing else) that stops Git from ignoring the in-repo `data/` source and config directories the later layers add. Kept deliberately small so it can land first.

## Dependencies
Sequenced after the CI-pins PR (`feat/flux/ci-env`); no functional dependency on the turbo bump.

## Test plan
`pytest tests/unit_tests/core tests/unit_tests/backends/megatron`; lint/pre-commit clean. Validated locally on an AMD GPU container: 58 passed.

## Files
39 (core runtime, Megatron adapter/trainers, base patch loader, shared test root, `.gitignore`).
