### PR TITLE
feat(flux): FSDP2 fp32/bf16 optimizers + fp8 all-gather

### DIFF
--- a/primus/backends/megatron/core/distributed/fsdp2_fp8_all_gather.py
+++ b/primus/backends/megatron/core/distributed/fsdp2_fp8_all_gather.py
@@ -1,0 +1,654 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+FP8 all-gather tensor subclass for FSDP2.
+
+Wraps BF16 or FP32 parameters so that FSDP2 communicates FP8 data
+(1 byte/element) instead of BF16/FP32, reducing all-gather volume.
+
+Approach A: Keep Weight in FP8 After All-Gather.
+Uses a precomputed global scale (all-reduced amax across all shards) so that
+the unsharded FP8 weight has a single consistent scale, compatible with
+tensorwise GEMM on HIPBLASLT. After all-gather, the unsharded weight stays
+in FP8 via FP8UnshardedWeightTensor, saving ~50% memory vs BF16 baseline.
+
+Reference: torchao WeightWithDynamicFloat8CastTensor
+(ao/torchao/float8/fsdp_utils.py)
+"""
+
+import math
+from typing import Any, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.utils._pytree as pytree
+import triton
+import triton.language as tl
+from primus_turbo.pytorch.core.low_precision import (
+    Float8QuantConfig,
+    Format,
+    ScalingGranularity,
+    float8_e4m3,
+)
+from torch.distributed._tensor import DTensor
+from torch.distributed._tensor.placement_types import Partial, Replicate
+from torch.library import triton_op, wrap_triton
+
+_ops_to_preserve_subclass = {
+    torch.ops.aten.empty_like.default,
+    torch.ops.aten.new_zeros.default,
+    torch.ops.aten.slice.Tensor,
+    torch.ops.aten.copy_.default,
+    torch.ops.aten.view.default,
+    torch.ops.aten.as_strided.default,
+    torch.ops.aten._to_copy.default,
+    torch.ops.aten._pin_memory.default,
+    torch.ops.aten.split.Tensor,
+    torch.ops.aten.clone.default,
+}
+
+
+def _get_fp8_dtype(fmt: Format) -> torch.dtype:
+    if fmt == Format.E4M3:
+        return float8_e4m3
+    elif fmt == Format.HYBRID:
+        return float8_e4m3
+    else:
+        raise ValueError(f"Unsupported FP8 format for all-gather: {fmt}")
+
+
+@triton.jit
+def _quantize_fp8_prescaled_kernel(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    n_elements,
+    FP8_MAX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(input_ptr + offsets, mask=mask).to(tl.float32)
+    scale = tl.load(scale_ptr)
+    v = x * scale
+    v = tl.clamp(v, min=-FP8_MAX, max=FP8_MAX)
+    tl.store(output_ptr + offsets, v.to(output_ptr.dtype.element_ty), mask=mask)
+
+
+@triton_op("primus::quantize_fp8_prescaled", mutates_args=())
+def quantize_fp8_prescaled(
+    x: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    scale: torch.Tensor,
+    scale_inv: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    fp8_max = torch.finfo(fp8_dtype).max
+    output = torch.empty_like(x, dtype=fp8_dtype)
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    wrap_triton(_quantize_fp8_prescaled_kernel)[grid](
+        x,
+        output,
+        scale,
+        n_elements,
+        fp8_max,
+        BLOCK_SIZE=1024,
+    )
+    return output, scale_inv.clone()
+
+
+@quantize_fp8_prescaled.register_fake
+def _quantize_fp8_prescaled_fake(x, fp8_dtype, scale, scale_inv):
+    return torch.empty_like(x, dtype=fp8_dtype), scale_inv.clone()
+
+
+# ---------------------------------------------------------------------------
+# Stochastic rounding variant: adds uniform [-0.5, 0.5) noise before
+# truncation to make quantization error unbiased in expectation.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _quantize_fp8_prescaled_stochastic_kernel(
+    input_ptr,
+    output_ptr,
+    scale_ptr,
+    seed,
+    n_elements,
+    FP8_MAX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(input_ptr + offsets, mask=mask).to(tl.float32)
+    scale = tl.load(scale_ptr)
+    v = x * scale
+    v = tl.clamp(v, min=-FP8_MAX, max=FP8_MAX)
+    noise = tl.rand(seed, offsets) - 0.5
+    v_sr = v + noise
+    tl.store(output_ptr + offsets, v_sr.to(output_ptr.dtype.element_ty), mask=mask)
+
+
+@triton_op("primus::quantize_fp8_prescaled_stochastic", mutates_args=())
+def quantize_fp8_prescaled_stochastic(
+    x: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    scale: torch.Tensor,
+    scale_inv: torch.Tensor,
+    seed: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    fp8_max = torch.finfo(fp8_dtype).max
+    output = torch.empty_like(x, dtype=fp8_dtype)
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    wrap_triton(_quantize_fp8_prescaled_stochastic_kernel)[grid](
+        x,
+        output,
+        scale,
+        seed,
+        n_elements,
+        fp8_max,
+        BLOCK_SIZE=1024,
+    )
+    return output, scale_inv.clone()
+
+
+@quantize_fp8_prescaled_stochastic.register_fake
+def _quantize_fp8_prescaled_stochastic_fake(x, fp8_dtype, scale, scale_inv, seed):
+    return torch.empty_like(x, dtype=fp8_dtype), scale_inv.clone()
+
+
+@torch.compile(mode="max-autotune-no-cudagraphs")
+def _foreach_fp8_quantize(
+    inner_tensors: list[torch.Tensor],
+    fp8_outputs: list[torch.Tensor],
+    scales: torch.Tensor,
+    fp8_max: float,
+):
+    """Batch-quantize all FP8 parameters in a single fused operation.
+
+    Uses _foreach_* ops fused by torch.compile to replace 456 individual
+    kernel launches with ~1-2 fused kernels. Float32 intermediate ensures
+    bitwise equivalence with the per-tensor quantize_fp8_prescaled path.
+    """
+    scales_list = list(scales.unbind())
+    f32 = [t.float() for t in inner_tensors]
+    scaled = torch._foreach_mul(f32, scales_list)
+    clamped = torch._foreach_clamp_min(torch._foreach_clamp_max(scaled, fp8_max), -fp8_max)
+    torch._foreach_copy_(fp8_outputs, clamped)
+
+
+@torch.compile(mode="max-autotune-no-cudagraphs")
+def _foreach_fp8_quantize_stochastic(
+    inner_tensors: list[torch.Tensor],
+    fp8_outputs: list[torch.Tensor],
+    scales: torch.Tensor,
+    fp8_max: float,
+):
+    """Batch-quantize with stochastic rounding for unbiased FP8 quantization.
+
+    Same as _foreach_fp8_quantize but adds uniform [-0.5, 0.5) noise before
+    the truncating cast to FP8, making quantization error zero in expectation.
+    """
+    scales_list = list(scales.unbind())
+    f32 = [t.float() for t in inner_tensors]
+    scaled = torch._foreach_mul(f32, scales_list)
+    noise = [torch.rand_like(s) - 0.5 for s in scaled]
+    noisy = torch._foreach_add(scaled, noise)
+    clamped = torch._foreach_clamp_min(torch._foreach_clamp_max(noisy, fp8_max), -fp8_max)
+    torch._foreach_copy_(fp8_outputs, clamped)
+
+
+class WeightWithFP8AllGatherTensor(torch.Tensor):
+    """Tensor subclass that quantizes to FP8 before FSDP2 all-gather.
+
+    Wraps a BF16 or FP32 parameter tensor. FSDP2 calls fsdp_pre_all_gather
+    to get FP8-quantized data for the collective, then fsdp_post_all_gather
+    to return an FP8UnshardedWeightTensor (keeping weight in FP8).
+
+    Uses a precomputed global scale (set by precompute_fp8_scales_for_fsdp)
+    so all shards quantize with the same scale, producing a single consistent
+    scale for the unsharded weight.
+    """
+
+    @staticmethod
+    def __new__(cls, tensor: torch.Tensor, fp8_config: Float8QuantConfig):
+        if fp8_config.granularity != ScalingGranularity.TENSORWISE:
+            raise ValueError(
+                f"FP8 all-gather only supports TENSORWISE granularity, " f"got {fp8_config.granularity}"
+            )
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            tensor.size(),
+            strides=tensor.stride(),
+            storage_offset=tensor.storage_offset(),
+            dtype=tensor.dtype,
+            layout=tensor.layout,
+            device=tensor.device,
+            requires_grad=tensor.requires_grad,
+        )
+
+    def __init__(self, tensor: torch.Tensor, fp8_config: Float8QuantConfig):
+        self._fp8_config = fp8_config
+        self._tensor = tensor
+        # Transient: set by precompute_fp8_scales_for_fsdp(), NOT in
+        # __tensor_flatten__ (must be hashable/static for torch.compile guards).
+        self._precomputed_scale = None
+        self._precomputed_scale_inv = None
+        self._cached_fp8_data = None
+        self._use_cpp_quantize = False
+        self._stochastic_rounding = False
+        self._sr_counter = 0
+        self._deq_after_ag = False
+
+    def inner_data(self) -> torch.Tensor:
+        """Return the underlying data tensor (bypassing subclass dispatch)."""
+        return self._tensor
+
+    def fsdp_pre_all_gather(self, mesh):
+        if self._cached_fp8_data is not None:
+            return (self._cached_fp8_data,), (self._precomputed_scale_inv, self._tensor.numel())
+        fp8_dtype = _get_fp8_dtype(self._fp8_config.format)
+        if self._precomputed_scale is None:
+            raise RuntimeError(
+                "precompute_fp8_scales_for_fsdp() must be called before the first forward pass"
+            )
+        with torch.no_grad():
+            if self._use_cpp_quantize:
+                from primus_turbo.pytorch.ops.quantization import quantize_fp8
+
+                fp8_data, scale_inv = quantize_fp8(
+                    self._tensor,
+                    fp8_dtype,
+                    self._fp8_config.granularity,
+                    scale=self._precomputed_scale,
+                )
+            elif self._stochastic_rounding:
+                if self._precomputed_scale_inv is None:
+                    raise RuntimeError(
+                        "precompute_fp8_scales_for_fsdp() must set scale_inv before stochastic-rounding quantize"
+                    )
+                if not self._tensor.is_contiguous():
+                    raise RuntimeError("FP8 stochastic-rounding quantize requires contiguous input")
+                self._sr_counter += 1
+                fp8_data, scale_inv = quantize_fp8_prescaled_stochastic(
+                    self._tensor,
+                    fp8_dtype,
+                    self._precomputed_scale,
+                    self._precomputed_scale_inv,
+                    seed=self._sr_counter,
+                )
+            else:
+                if self._precomputed_scale_inv is None:
+                    raise RuntimeError("precompute_fp8_scales_for_fsdp() must set scale_inv for Triton path")
+                if not self._tensor.is_contiguous():
+                    raise RuntimeError("FP8 prescaled quantize requires contiguous input")
+                fp8_data, scale_inv = quantize_fp8_prescaled(
+                    self._tensor,
+                    fp8_dtype,
+                    self._precomputed_scale,
+                    self._precomputed_scale_inv,
+                )
+        return (fp8_data,), (scale_inv, self._tensor.numel())
+
+    def fsdp_post_all_gather(
+        self,
+        all_gather_outputs: Tuple[torch.Tensor, ...],
+        metadata: Any,
+        param_dtype: torch.dtype,
+        *,
+        out: Optional[torch.Tensor] = None,
+    ):
+        scale_inv, shard_numel = metadata
+        (fp8_gathered,) = all_gather_outputs
+
+        if self._deq_after_ag:
+            bf16_weight = fp8_gathered.to(torch.bfloat16) * scale_inv
+            if out is not None:
+                out.data.copy_(bf16_weight)
+                return
+            return bf16_weight, (fp8_gathered,)
+
+        if out is not None:
+            # Reshard path: FSDP already filled the FP8 buffer via
+            # all-gather into tracked storage. Just update the scale.
+            target = out.data if isinstance(out, nn.Parameter) else out
+            if isinstance(target, FP8UnshardedWeightTensor):
+                target._scale_inv = scale_inv
+            return
+        return FP8UnshardedWeightTensor(fp8_gathered, scale_inv, torch.bfloat16, self._fp8_config), (
+            fp8_gathered,
+        )
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs=None):
+        if func == torch.ops.aten.detach.default:
+            return WeightWithFP8AllGatherTensor(args[0]._tensor.detach(), args[0]._fp8_config)
+
+        if func == torch.ops.aten.copy_.default:
+            src = args[1]
+            if isinstance(src, WeightWithFP8AllGatherTensor):
+                src = src._tensor
+            args[0]._tensor.copy_(src)
+            return args[0]
+
+        fp8_config = None
+        inner_dtype = None
+
+        def unwrap(t):
+            nonlocal fp8_config, inner_dtype
+            if fp8_config is None:
+                fp8_config = t._fp8_config
+                inner_dtype = t._tensor.dtype
+            return t._tensor
+
+        args, kwargs = pytree.tree_map_only(WeightWithFP8AllGatherTensor, unwrap, (args, kwargs or {}))
+        out = func(*args, **kwargs)
+        if func not in _ops_to_preserve_subclass:
+            return out
+
+        if func == torch.ops.aten._to_copy.default:
+            target_dtype = (kwargs or {}).get("dtype", None)
+            if target_dtype is not None and target_dtype != inner_dtype:
+                return out
+
+        return pytree.tree_map_only(
+            torch.Tensor,
+            lambda x: WeightWithFP8AllGatherTensor(x, fp8_config),
+            out,
+        )
+
+    def __tensor_flatten__(self):
+        # Guard for torch.compile tracing: dynamo may inspect this tensor
+        # via __tensor_flatten__ during __init__ before attributes are set.
+        config = getattr(self, "_fp8_config", None)
+        if config is None or not hasattr(self, "_tensor"):
+            return [], {}
+        # Float8QuantConfig is a mutable dataclass (not hashable),
+        # so store fields individually as hashable metadata.
+        return ["_tensor"], {
+            "format": config.format,
+            "granularity": config.granularity,
+            "strategy": config.strategy,
+            "scale_dtype": config.scale_dtype,
+            "block_size": config.block_size,
+        }
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
+        config = Float8QuantConfig(
+            format=metadata["format"],
+            granularity=metadata["granularity"],
+            strategy=metadata["strategy"],
+            scale_dtype=metadata["scale_dtype"],
+            block_size=metadata["block_size"],
+        )
+        return WeightWithFP8AllGatherTensor(inner_tensors["_tensor"], config)
+
+    def __repr__(self):
+        return (
+            f"WeightWithFP8AllGatherTensor("
+            f"shape={list(self._tensor.shape)}, "
+            f"dtype={self._tensor.dtype}, "
+            f"device={self._tensor.device}, "
+            f"granularity={self._fp8_config.granularity})"
+        )
+
+
+_unsharded_ops_to_preserve = {
+    torch.ops.aten.as_strided.default,
+    torch.ops.aten.view.default,
+    torch.ops.aten.slice.Tensor,
+    torch.ops.aten.clone.default,
+}
+
+
+class FP8UnshardedWeightTensor(torch.Tensor):
+    """Lightweight wrapper for the unsharded FP8 weight after all-gather.
+
+    Holds raw FP8 data + scalar inverse scale. Declares dtype=orig_dtype
+    (bfloat16) so PyTorch shape/dtype inference sees BF16, but stores 1
+    byte/element. FP8 linear layers detect this subclass and extract the
+    pre-quantized data directly, skipping redundant quantization.
+    """
+
+    @staticmethod
+    def __new__(
+        cls,
+        fp8_data: torch.Tensor,
+        scale_inv: torch.Tensor,
+        orig_dtype: torch.dtype,
+        fp8_config: Float8QuantConfig,
+    ):
+        return torch.Tensor._make_wrapper_subclass(
+            cls,
+            fp8_data.size(),
+            strides=fp8_data.stride(),
+            storage_offset=fp8_data.storage_offset(),
+            dtype=orig_dtype,
+            layout=fp8_data.layout,
+            device=fp8_data.device,
+            requires_grad=False,
+        )
+
+    def __init__(
+        self,
+        fp8_data: torch.Tensor,
+        scale_inv: torch.Tensor,
+        orig_dtype: torch.dtype,
+        fp8_config: Float8QuantConfig,
+    ):
+        self._fp8_data = fp8_data
+        self._scale_inv = scale_inv
+        self._orig_dtype = orig_dtype
+        self._fp8_config = fp8_config
+
+    def get_fp8_data_and_scale_inv(self):
+        return self._fp8_data, self._scale_inv
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs=None):
+        if func == torch.ops.aten.detach.default:
+            # Must preserve subclass: nn.Parameter(data) calls detach()
+            # and asserts type(detach_result) == type(data).
+            self = args[0]
+            return FP8UnshardedWeightTensor(
+                self._fp8_data.detach(),
+                self._scale_inv.detach(),
+                self._orig_dtype,
+                self._fp8_config,
+            )
+
+        if func in _unsharded_ops_to_preserve:
+            self = args[0]
+            new_data = func(self._fp8_data, *args[1:], **(kwargs or {}))
+            return FP8UnshardedWeightTensor(new_data, self._scale_inv, self._orig_dtype, self._fp8_config)
+
+        raise NotImplementedError(
+            f"FP8UnshardedWeightTensor does not support {func}. "
+            f"Only FP8-aware module weights should be wrapped with FP8 all-gather."
+        )
+
+    def __tensor_flatten__(self):
+        config = getattr(self, "_fp8_config", None)
+        if config is None or not hasattr(self, "_fp8_data"):
+            return [], {}
+        return ["_fp8_data", "_scale_inv"], {
+            "orig_dtype": self._orig_dtype,
+            "format": config.format,
+            "granularity": config.granularity,
+            "strategy": config.strategy,
+            "scale_dtype": config.scale_dtype,
+            "block_size": config.block_size,
+        }
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, metadata, outer_size, outer_stride):
+        config = Float8QuantConfig(
+            format=metadata["format"],
+            granularity=metadata["granularity"],
+            strategy=metadata["strategy"],
+            scale_dtype=metadata["scale_dtype"],
+            block_size=metadata["block_size"],
+        )
+        return FP8UnshardedWeightTensor(
+            inner_tensors["_fp8_data"],
+            inner_tensors["_scale_inv"],
+            metadata["orig_dtype"],
+            config,
+        )
+
+    def __repr__(self):
+        return (
+            f"FP8UnshardedWeightTensor("
+            f"shape={list(self._fp8_data.shape)}, "
+            f"fp8_dtype={self._fp8_data.dtype}, "
+            f"orig_dtype={self._orig_dtype}, "
+            f"device={self._fp8_data.device})"
+        )
+
+
+def _wrap_fp8_weights_for_all_gather(
+    module: nn.Module,
+    fp8_config: Float8QuantConfig,
+    stochastic_rounding: bool = False,
+    deq_after_ag: bool = False,
+) -> int:
+    """Wrap FP8-eligible weight parameters with WeightWithFP8AllGatherTensor.
+
+    Must be called BEFORE fully_shard(). FSDP2 natively handles tensor
+    subclasses through fsdp_pre_all_gather/fsdp_post_all_gather.
+
+    Args:
+        stochastic_rounding: If True, use stochastic rounding during FP8
+            quantization to make quantization noise unbiased.
+        deq_after_ag: If True, dequantize FP8 back to BF16 after all-gather
+            and return a plain tensor. Downstream dynamic quantization will
+            produce a fresh scale from the actual assembled weight, avoiding
+            the numerical issues of keeping weight in FP8 with a global scale.
+
+    Returns the number of wrapped parameters.
+    """
+    wrapped_count = 0
+    for child in module.modules():
+        if not (hasattr(child, "_fp8_config") and hasattr(child, "weight")):
+            continue
+        w = child.weight
+        if w is not None and w.dtype in (torch.bfloat16, torch.float32) and w.requires_grad:
+            wrapper = WeightWithFP8AllGatherTensor(w.data, fp8_config)
+            wrapper._stochastic_rounding = stochastic_rounding
+            wrapper._deq_after_ag = deq_after_ag
+            child.weight = nn.Parameter(wrapper, requires_grad=True)
+            wrapped_count += 1
+    return wrapped_count
+
+
+@torch.no_grad()
+def precompute_fp8_scales_for_fsdp(
+    module: nn.Module,
+    cache_data: bool = True,
+    use_cpp_quantize: bool = False,
+    stochastic_rounding: bool = False,
+):
+    """Precompute global FP8 scales for all FP8-all-gather parameters.
+
+    Call after optimizer.step(), before next forward. Uses _foreach_norm
+    for fused amax computation and DTensor Partial("max") -> Replicate()
+    redistribution for a single batched all-reduce across all parameters.
+
+    Args:
+        module: The model module containing FP8-wrapped parameters.
+        cache_data: If True, batch-quantize all weights and cache the FP8 data
+            so fsdp_pre_all_gather skips per-layer quantization. If False, only
+            precompute scales; quantization happens on-demand per layer.
+        use_cpp_quantize: If True, use C++ quantize_fp8 from primus_turbo for
+            on-demand quantization (matching run_35). Skips fp8_outputs buffer
+            allocation and scale_inv computation when cache_data is False.
+        stochastic_rounding: If True, use stochastic rounding during batch
+            quantization to make quantization noise unbiased.
+    """
+    need_buffers = cache_data or not use_cpp_quantize
+    need_scale_inv = cache_data or not use_cpp_quantize
+
+    cache = getattr(module, "_fp8_scale_precompute_cache", None)
+    if cache is None:
+        fp8_dtensor_params = []
+        fp8_plain_params = []
+        inner_tensors = []
+        for param in module.parameters():
+            if isinstance(param, DTensor) and isinstance(param._local_tensor, WeightWithFP8AllGatherTensor):
+                fp8_dtensor_params.append(param)
+                inner_tensors.append(param._local_tensor._tensor)
+            elif isinstance(param, WeightWithFP8AllGatherTensor):
+                fp8_plain_params.append(param)
+                inner_tensors.append(param._tensor)
+
+        fp8_config = (
+            fp8_dtensor_params[0]._local_tensor._fp8_config
+            if fp8_dtensor_params
+            else fp8_plain_params[0]._fp8_config if fp8_plain_params else None
+        )
+        fp8_dtype = _get_fp8_dtype(fp8_config.format) if fp8_config else None
+
+        if need_buffers:
+            fp8_outputs = [torch.empty_like(t, dtype=fp8_dtype) for t in inner_tensors]
+        else:
+            fp8_outputs = []
+        all_local = [
+            p._local_tensor if isinstance(p, DTensor) else p for p in fp8_dtensor_params + fp8_plain_params
+        ]
+        cache = (
+            fp8_dtensor_params,
+            fp8_plain_params,
+            inner_tensors,
+            fp8_outputs,
+            all_local,
+            fp8_config,
+        )
+        module._fp8_scale_precompute_cache = cache
+
+    (
+        fp8_dtensor_params,
+        fp8_plain_params,
+        inner_tensors,
+        fp8_outputs,
+        all_local,
+        fp8_config,
+    ) = cache
+    if not inner_tensors:
+        return
+
+    local_amaxes = torch.stack(torch._foreach_norm(inner_tensors, ord=math.inf))
+
+    if fp8_dtensor_params:
+        mesh = fp8_dtensor_params[0].device_mesh
+        partial_amaxes = DTensor.from_local(local_amaxes, device_mesh=mesh, placements=[Partial("max")])
+        global_amaxes = partial_amaxes.redistribute(device_mesh=mesh, placements=[Replicate()]).to_local()
+    else:
+        global_amaxes = local_amaxes
+
+    fp8_max = torch.finfo(_get_fp8_dtype(fp8_config.format)).max
+    global_amaxes = global_amaxes.to(torch.float64).clamp(min=1e-12)
+    scales = (fp8_max / global_amaxes).to(torch.float32)
+    scale_invs = (1.0 / scales) if need_scale_inv else None
+
+    if cache_data:
+        if stochastic_rounding:
+            _foreach_fp8_quantize_stochastic(inner_tensors, fp8_outputs, scales, fp8_max)
+        else:
+            _foreach_fp8_quantize(inner_tensors, fp8_outputs, scales, fp8_max)
+
+    for i, local_t in enumerate(all_local):
+        local_t._precomputed_scale = scales[i]
+        local_t._precomputed_scale_inv = scale_invs[i] if scale_invs is not None else None
+        local_t._cached_fp8_data = fp8_outputs[i] if cache_data else None
+        local_t._use_cpp_quantize = use_cpp_quantize
+
+
+torch.serialization.add_safe_globals([WeightWithFP8AllGatherTensor])

--- a/primus/backends/megatron/core/distributed/torch_fully_sharded_data_parallel.py
+++ b/primus/backends/megatron/core/distributed/torch_fully_sharded_data_parallel.py
@@ -1,32 +1,68 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
 
-from typing import List, Optional
+from typing import Optional, Set
 
 import torch
-from megatron.core import tensor_parallel
+import torch.distributed as dist
+from megatron.core import parallel_state, tensor_parallel
+from megatron.core.distributed.data_parallel_base import _BaseDataParallel
 from megatron.core.distributed.distributed_data_parallel_config import (
     DistributedDataParallelConfig,
 )
-from megatron.core.distributed.torch_fully_sharded_data_parallel import (
-    TorchFullyShardedDataParallel,
-)
+from megatron.core.fp8_utils import is_float8tensor
 from megatron.core.models.common.embeddings.language_model_embedding import (
     LanguageModelEmbedding,
 )
 from megatron.core.models.common.embeddings.rotary_pos_embedding import RotaryEmbedding
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.transformer_layer import TransformerLayer
+from torch.distributed import ProcessGroup
 
 from primus.modules.module_utils import warning_rank_0
 
+try:
+    from torch.distributed import DeviceMesh
+    from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 
-class PrimusTorchFullyShardedDataParallel(TorchFullyShardedDataParallel):
+    HAVE_FSDP = True
+except ImportError:
+    HAVE_FSDP = False
+
+
+def _validate_mesh_ranks(rank_tensor, shard_group, replicate_group):
+    """Validate that mesh tensor slices match the actual process group ranks."""
+    current_rank = dist.get_rank()
+
+    shard_group_ranks = dist.get_process_group_ranks(shard_group)
+    for row in rank_tensor.tolist():
+        if current_rank in row:
+            if sorted(row) != sorted(shard_group_ranks):
+                raise RuntimeError(f"Mesh shard ranks {row} != group ranks {shard_group_ranks}")
+
+    replicate_group_ranks = dist.get_process_group_ranks(replicate_group)
+    for col_idx in range(rank_tensor.shape[1]):
+        col = rank_tensor[:, col_idx].tolist()
+        if current_rank in col:
+            if sorted(col) != sorted(replicate_group_ranks):
+                raise RuntimeError(f"Mesh replicate ranks {col} != group ranks {replicate_group_ranks}")
+
+
+class PrimusTorchFullyShardedDataParallel(_BaseDataParallel):
     """
-    Customized FSDP implementation for Primus framework, with pre-defined submodules to wrap.
+    Customized FSDP implementation for Primus framework with support for TransformerBlock.
+
+    For models using TransformerBlock (e.g., Flux with heterogeneous layers), FSDP wraps
+    the TransformerBlock itself rather than individual TransformerLayer subclasses to avoid
+    duplicate mesh_dim_names errors.
+
+    Key difference from base Megatron class:
+    - Prevents wrapping of modules that are descendants of already-wrapped modules
+    - This avoids the "Invalid mesh_dim_names ('dp', 'dp')" error when using TransformerBlock
+      with heterogeneous TransformerLayer subclasses.
     """
 
     def __init__(
@@ -34,20 +70,373 @@ class PrimusTorchFullyShardedDataParallel(TorchFullyShardedDataParallel):
         config: TransformerConfig,
         ddp_config: DistributedDataParallelConfig,
         module: torch.nn.Module,
-        sub_modules_to_wrap: Optional[List[torch.nn.Module]] = None,
+        sub_modules_to_wrap: Optional[Set[torch.nn.Module]] = None,
+        disable_bucketing: bool = False,
+        process_group: Optional[ProcessGroup] = None,
         **kwargs,
     ):
+        if not HAVE_FSDP:
+            raise RuntimeError("TorchFullyShardedDataParallel requires PyTorch >= 2.4.0 with FSDP 2 support.")
+
+        super().__init__(config=config, module=module)
+
+        # Store ddp_config for later access
+        self.ddp_config = ddp_config
+
+        if process_group is None:
+            self.process_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+        else:
+            self.process_group = process_group
+
         if sub_modules_to_wrap is None:
-            sub_modules_to_wrap = [
+            sub_modules_to_wrap = {
                 TransformerLayer,
                 LanguageModelEmbedding,
                 RotaryEmbedding,
                 tensor_parallel.ColumnParallelLinear,
-            ]
+            }
 
         if kwargs:
-            warning_rank_0(f"PrimusTorchFullyShardedDataParallel: not use args: {kwargs}")
+            warning_rank_0(f"PrimusTorchFullyShardedDataParallel: unused args: {kwargs}")
 
-        super().__init__(
-            config=config, ddp_config=ddp_config, module=module, sub_modules_to_wrap=sub_modules_to_wrap
-        )
+        # Build DeviceMesh from Megatron's process groups
+        from megatron.training import get_args
+
+        from primus.modules.module_utils import log_rank_0
+
+        args = get_args()
+        replicate_degree = getattr(args, "data_parallel_replicate_degree", 1)
+        dp_size = dist.get_world_size(self.process_group)
+
+        if replicate_degree > 1:
+            shard_group = parallel_state.get_data_parallel_group(
+                with_context_parallel=True, partial_data_parallel=True
+            )
+            replicate_group = parallel_state.get_inter_distributed_optimizer_instance_group()
+
+            shard_size = dist.get_world_size(shard_group)
+
+            full_dp_ranks = dist.get_process_group_ranks(self.process_group)
+            rank_tensor = torch.tensor(full_dp_ranks).reshape(replicate_degree, shard_size)
+
+            _validate_mesh_ranks(rank_tensor, shard_group, replicate_group)
+
+            mesh = DeviceMesh.from_group(
+                [replicate_group, shard_group],
+                device_type="cuda",
+                mesh=rank_tensor.tolist(),
+                mesh_dim_names=("dp_replicate", "dp_shard"),
+            )
+        else:
+            mesh = DeviceMesh.from_group(
+                self.process_group,
+                device_type="cuda",
+                mesh_dim_names=("dp",),
+            )
+
+        reshard_after_forward = getattr(self.ddp_config, "reshard_after_forward", True)
+
+        kwargs = {
+            "mesh": mesh,
+            "reshard_after_forward": reshard_after_forward,
+        }
+
+        # When params_dtype is FP32 but training is BF16 (FSDP2 FP32 param optimizer),
+        # add MixedPrecisionPolicy so FSDP2 casts to BF16 for forward/backward.
+        # param_dtype=bf16 is always required: it ensures forward inputs
+        # (activations) get cast to BF16. For params with FP8 AG extensions,
+        # FSDP2 uses fsdp_post_all_gather (unaffected by param_dtype).
+        # This matches TorchTitan where param_dtype is always set from config.
+        use_fp8_all_gather = getattr(args, "use_fsdp2_fp8_all_gather", False)
+        if config.params_dtype == torch.float32 and config.bf16:
+            mp_policy = MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.bfloat16,
+            )
+            kwargs["mp_policy"] = mp_policy
+            log_rank_0(
+                "FSDP2: MixedPrecisionPolicy(param_dtype=bf16, reduce_dtype=bf16) "
+                "[FP32 param optimizer: FSDP casts activations to BF16, BF16 reduce]"
+            )
+        elif (
+            config.params_dtype == torch.bfloat16
+            and config.bf16
+            and getattr(args, "use_fsdp2_bf16_master_weight_optimizer", False)
+        ):
+            # BF16 master weight optimizer: params are already BF16, so no
+            # param_dtype casting is needed. Setting param_dtype=None skips
+            # cast_forward_inputs entirely (avoids FP32→BF16 activation cast
+            # at every FSDP module boundary). reduce_dtype=bf16 halves
+            # ReduceScatter bandwidth; FP32 master weights in the optimizer
+            # still ensure full-precision parameter updates.
+            mp_policy = MixedPrecisionPolicy(
+                param_dtype=None,
+                reduce_dtype=torch.bfloat16,
+            )
+            kwargs["mp_policy"] = mp_policy
+            log_rank_0(
+                "FSDP2: MixedPrecisionPolicy(param_dtype=None, reduce_dtype=bf16) "
+                "[BF16 master weight optimizer: no cast_forward_inputs, BF16 reduce]"
+            )
+
+        if replicate_degree > 1:
+            log_rank_0(f"FSDP2 Configuration:")
+            log_rank_0(f"  mode: HSDP (replicate={replicate_degree}, shard={dp_size // replicate_degree})")
+            log_rank_0(
+                f"  reshard_after_forward: {reshard_after_forward} "
+                f"(ZeRO-{'3' if reshard_after_forward else '2'})"
+            )
+            log_rank_0(
+                f"  Data parallel size: {dp_size} "
+                f"(replicate={replicate_degree} x shard={dp_size // replicate_degree})"
+            )
+        else:
+            log_rank_0(f"FSDP2 Configuration:")
+            log_rank_0(f"  mode: FSDP")
+            log_rank_0(
+                f"  reshard_after_forward: {reshard_after_forward} "
+                f"(ZeRO-{'3' if reshard_after_forward else '2'})"
+            )
+            log_rank_0(f"  Data parallel size: {dp_size}")
+
+        # Helper functions to save/restore custom parameter attributes
+        def save_custom_attrs(module):
+            custom_attrs = {}
+            for name, param in module.named_parameters():
+                attrs = vars(param)
+                if is_float8tensor(param):
+                    # disable fp8 transpose cache and perform transposing fp8 weights
+                    # at each micro-batch because torch-FSDP doesn't recognize the
+                    # micro-batch id, thus removing unnecessary memory stores
+                    attrs["_fp8_attrs"]["transpose_invalid"] = False
+                    del attrs["_fp8_attrs"]["transpose"]
+                custom_attrs[name] = {k: v for k, v in attrs.items()}
+            return custom_attrs
+
+        def restore_custom_attrs(module, custom_attrs):
+            for name, param in module.named_parameters():
+                if name in custom_attrs:
+                    for attr_name, attr_value in custom_attrs[name].items():
+                        setattr(param, attr_name, attr_value)
+
+        # Save custom attributes that might be removed by FSDP
+        attrs = save_custom_attrs(self.module)
+
+        # FP8 all-gather validation
+        if (
+            use_fp8_all_gather
+            and isinstance(reshard_after_forward, int)
+            and not isinstance(reshard_after_forward, bool)
+        ):
+            raise ValueError(
+                "FP8 all-gather is incompatible with reshard_after_forward=int (partial reshard)"
+            )
+
+        # FSDP2 FP8 all-gather is incompatible with delayed scaling: the delayed
+        # forward re-quantizes the weight and does not handle the all-gathered
+        # FP8UnshardedWeightTensor subclass produced by the all-gather path, so
+        # the combination would miscompute. Reject it explicitly.
+        if use_fp8_all_gather:
+            from megatron.core.enums import Fp8Recipe
+
+            uses_delayed = (
+                getattr(config, "fp8_scaling_strategy", "dynamic") == "delayed"
+                or getattr(config, "fp8_recipe", None) == Fp8Recipe.delayed
+            )
+            if uses_delayed:
+                raise ValueError(
+                    "use_fsdp2_fp8_all_gather is incompatible with delayed FP8 scaling "
+                    "(fp8_recipe='delayed' / fp8_scaling_strategy='delayed'). Use a "
+                    "non-delayed recipe (e.g. tensorwise) with FSDP2 FP8 all-gather, or "
+                    "disable use_fsdp2_fp8_all_gather."
+                )
+
+        # Local transformer implementation does not support ColumnParallelLinear.
+        if config.transformer_impl == "local":
+            sub_modules_to_wrap = {
+                sub_module
+                for sub_module in sub_modules_to_wrap
+                if sub_module != tensor_parallel.ColumnParallelLinear
+            }
+        sub_modules_to_wrap = set(sub_modules_to_wrap)
+
+        # Process _fsdp_modules attribute
+        for sub_module in self.module.modules():
+            fsdp_modules = getattr(sub_module, "_fsdp_modules", [])
+            for f in fsdp_modules:
+                sub_modules_to_wrap.add(f)
+
+        fp8_ag_stochastic_rounding = getattr(args, "fp8_all_gather_stochastic_rounding", False)
+        fp8_ag_deq_after_ag = getattr(args, "fp8_all_gather_deq_requant", False)
+        if use_fp8_all_gather:
+            from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+                _wrap_fp8_weights_for_all_gather,
+            )
+            from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+                _build_fp8_config,
+            )
+
+            fp8_ag_config = _build_fp8_config(config)
+            wrapped_count = _wrap_fp8_weights_for_all_gather(
+                self.module,
+                fp8_ag_config,
+                stochastic_rounding=fp8_ag_stochastic_rounding,
+                deq_after_ag=fp8_ag_deq_after_ag,
+            )
+            sr_tag = " [stochastic rounding]" if fp8_ag_stochastic_rounding else ""
+            deq_tag = " [deq+requant]" if fp8_ag_deq_after_ag else ""
+            log_rank_0(
+                f"FSDP2: Wrapped {wrapped_count} params with FP8 all-gather "
+                f"(granularity={fp8_ag_config.granularity}){sr_tag}{deq_tag}"
+            )
+
+        # ============================================================================
+        # CUSTOM WRAPPING LOGIC: Skip descendants of already-wrapped modules
+        # ============================================================================
+        wrapped_modules_set = set()
+        wrapped_list = []
+
+        for sub_module in self.module.modules():
+            should_wrap = any(
+                isinstance(sub_module, sub_module_to_wrap) for sub_module_to_wrap in sub_modules_to_wrap
+            )
+            if not should_wrap:
+                continue
+
+            is_descendant = False
+            for wrapped_module in wrapped_modules_set:
+                if sub_module is not wrapped_module:
+                    for child in wrapped_module.modules():
+                        if child is sub_module:
+                            is_descendant = True
+                            break
+                    if is_descendant:
+                        break
+
+            if is_descendant:
+                continue
+
+            fully_shard(sub_module, **kwargs)
+            wrapped_modules_set.add(sub_module)
+            wrapped_list.append(sub_module)
+
+        log_rank_0(f"FSDP2: wrapped {len(wrapped_list)} inner modules + root")
+
+        prefetch_depth = getattr(self.config, "fsdp_prefetch_depth", 1)
+        for i, mod in enumerate(wrapped_list):
+            fwd_targets = wrapped_list[i + 1 : i + 1 + prefetch_depth]
+            if fwd_targets:
+                mod.set_modules_to_forward_prefetch(fwd_targets)
+
+            bwd_start = max(0, i - prefetch_depth)
+            bwd_targets = list(reversed(wrapped_list[bwd_start:i]))
+            if bwd_targets:
+                mod.set_modules_to_backward_prefetch(bwd_targets)
+
+        # Wrap the root module as required by the FSDP API
+        fully_shard(self.module, **kwargs)
+
+        if use_fp8_all_gather:
+            from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+                precompute_fp8_scales_for_fsdp,
+            )
+
+            cache_data = getattr(self.config, "fp8_precompute_data_cache", True)
+            use_cpp = getattr(self.config, "use_cpp_fp8_quantize", False)
+            precompute_fp8_scales_for_fsdp(
+                self.module,
+                cache_data=cache_data,
+                use_cpp_quantize=use_cpp,
+                stochastic_rounding=fp8_ag_stochastic_rounding,
+            )
+
+        restore_custom_attrs(self.module, attrs)
+
+        if getattr(args, "overlap_grad_norm", False):
+            from primus.backends.megatron.core.optimizer.incremental_grad_norm import (
+                IncrementalGradNormAccumulator,
+            )
+
+            # Use the shard group for the norm all-reduce (correct for both
+            # FSDP and HSDP). For HSDP, replicate-group ranks hold identical
+            # gradients after AR, so the full DP group would over-count.
+            if replicate_degree > 1:
+                norm_reduce_group = shard_group
+            else:
+                norm_reduce_group = self.process_group
+
+            accumulator = IncrementalGradNormAccumulator(
+                shard_process_group=norm_reduce_group,
+                device=torch.device("cuda"),
+            )
+            n_hooked = 0
+            for param in self.module.parameters():
+                if param.requires_grad:
+                    param.register_post_accumulate_grad_hook(accumulator.make_hook())
+                    n_hooked += 1
+            args._grad_norm_accumulator = accumulator
+            log_rank_0(f"FSDP2: Registered incremental grad norm hooks on {n_hooked} params")
+
+    def compile_model(self):
+        """
+        Delegate torch.compile to the underlying model's compile_model() method.
+
+        Traverses the FSDP2 module hierarchy (up to 3 levels deep) to find
+        the actual model (e.g., Flux) and calls its compile_model() if present.
+        Skipped if enable_torch_compile is False or no compile_model method is found.
+        """
+        from primus.modules.module_utils import log_rank_0
+
+        try:
+            from megatron.training import get_args
+
+            args = get_args()
+
+            # Check if compilation is enabled
+            if not getattr(args, "enable_torch_compile", False):
+                return
+
+        except Exception:
+            # If args not available, skip compilation
+            log_rank_0("  ℹ  Cannot access args for torch.compile settings, skipping")
+            return
+
+        # FSDP2 wraps models in FSDPFloat16Module, which itself wraps the actual model
+        # We need to traverse the hierarchy to find the actual model (e.g., Flux)
+        current_module = self.module
+        module_path = []
+
+        # Traverse up to 3 levels deep to find a module with compile_model
+        for depth in range(3):
+            module_type = type(current_module).__name__
+            module_path.append(module_type)
+
+            if hasattr(current_module, "compile_model") and callable(
+                getattr(current_module, "compile_model")
+            ):
+                log_rank_0(f"  Found compile_model at depth {depth}: {' -> '.join(module_path)}")
+                log_rank_0(f"  Calling compile_model on {module_type}...")
+                current_module.compile_model()
+                log_rank_0(f"    ✓ Model compilation complete")
+                return
+
+            # Try to go deeper if there's a 'module' attribute
+            if hasattr(current_module, "module"):
+                current_module = current_module.module
+            else:
+                break
+
+        # No compile_model found - log that we can't compile directly
+        # Note: We can't reassign self.module after FSDP wrapping, so if the underlying
+        # model doesn't have compile_model, we skip compilation. The model should implement
+        # compile_model if torch.compile is desired.
+        log_rank_0(f"  ℹ  No compile_model method found in module hierarchy: {' -> '.join(module_path)}")
+        log_rank_0(f"    (Model should implement compile_model() if torch.compile is desired)")
+
+    def finish_grad_sync(self, *args, **kwargs):
+        """No-op for FSDP2: gradient sync is handled by the FSDP runtime."""
+
+    def load_state_dict(self, state_dict, strict=True):
+        """
+        No-op because tensors are already loaded in-place by
+        `_load_base_checkpoint` with FSDP2."""

--- a/primus/backends/megatron/core/optimizer/fsdp2_bf16_master_weight_optimizer.py
+++ b/primus/backends/megatron/core/optimizer/fsdp2_bf16_master_weight_optimizer.py
@@ -1,0 +1,686 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+BF16 Master Weight optimizer for FSDP2 mixed precision training.
+
+Model parameters are stored natively in BF16 (no FP32-to-BF16 cast during
+all-gather), while FP32 master weight copies are maintained internally for
+optimizer precision. This follows Megatron's Float16OptimizerWithFloat16Params
+pattern adapted for FSDP2 DTensor parameters.
+
+Compared to the FP32 optimizer (fsdp2_fp32_optimizer.py), this eliminates
+the per-layer CopyFunctor<BFloat16, float> kernel in every forward all-gather,
+at the cost of +2 bytes/param for the FP32 master copy.
+
+Memory per parameter per GPU (sharded):
+    FP32 optimizer: 4 (FP32 param) + 4 (exp_avg) + 4 (exp_avg_sq) = 12 bytes
+    This optimizer: 2 (BF16 param) + 4 (FP32 master) + 4 + 4     = 14 bytes
+"""
+
+from itertools import chain
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+import torch
+from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+from megatron.core.dist_checkpointing.optimizer import (
+    get_param_id_to_sharded_param_map,
+    make_sharded_optimizer_tensor,
+    optim_state_to_sharding_state,
+)
+from megatron.core.optimizer.optimizer import MegatronOptimizer, _zero_grad_group_helper
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+
+from primus.modules.module_utils import log_rank_0
+
+if TYPE_CHECKING:
+    from megatron.core.process_groups_config import ProcessGroupCollection
+
+
+def _safe_log_rank_0(msg: str):
+    try:
+        log_rank_0(msg)
+    except (AttributeError, TypeError):
+        import torch.distributed as dist
+
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print(msg)
+
+
+class FSDP2BF16MasterWeightOptimizer(MegatronOptimizer):
+    """BF16 optimizer with FP32 master weights for FSDP2.
+
+    Model parameters live in BF16 (eliminating the FP32->BF16 cast in every
+    forward all-gather). FP32 master copies are maintained for the optimizer
+    step, matching Megatron's Float16OptimizerWithFloat16Params pattern.
+
+    Three parameter groups are tracked:
+        bf16_groups: original BF16 model parameters (what FSDP2 shards/all-gathers)
+        fp32_from_bf16_groups: FP32 master copies (what the optimizer steps on)
+        fp32_from_fp32_groups: natively FP32 params (e.g. LayerNorm), no master copy
+
+    Args:
+        optimizer: Base PyTorch optimizer (param_groups already point to FP32 masters).
+        config: OptimizerConfig from Megatron.
+        init_state_fn: Function to initialize optimizer state tensors.
+        bf16_groups: List of lists of original BF16 model parameters.
+        fp32_from_bf16_groups: List of lists of FP32 master weight copies.
+        fp32_from_fp32_groups: List of lists of natively FP32 parameters.
+    """
+
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        config: OptimizerConfig,
+        init_state_fn: Callable,
+        bf16_groups: List[List[torch.nn.Parameter]],
+        fp32_from_bf16_groups: List[List[torch.Tensor]],
+        fp32_from_fp32_groups: List[List[torch.nn.Parameter]],
+        use_foreach: bool = True,
+    ):
+        super().__init__(optimizer, config, init_state_fn)
+        self._scale = torch.tensor([1.0], dtype=torch.float, device="cuda")
+        self.is_stub_optimizer = optimizer is None
+
+        self.bf16_groups = bf16_groups
+        self.fp32_from_bf16_groups = fp32_from_bf16_groups
+        self.fp32_from_fp32_groups = fp32_from_fp32_groups
+
+        self._use_foreach = use_foreach
+        self._foreach_ready = False
+
+        from megatron.training import get_args
+
+        args = get_args()
+        self._grad_norm_accumulator = getattr(args, "_grad_norm_accumulator", None)
+        self._validate_count = 0
+
+    @torch.compiler.disable
+    @torch.no_grad()
+    def warmup_foreach_cache(self):
+        """Eagerly initialize the foreach cache before torch.compile wraps step().
+
+        Creates temporary zero gradients to satisfy _init_foreach_cache's
+        requirement that grads exist (including DTensor placements for the
+        assertion at line ~164), then clears them.
+        Must be called after FSDP wrapping but before torch.compile wraps
+        optimizer.step.
+        """
+        if self._foreach_ready or not self._use_foreach:
+            return
+
+        from torch.distributed.tensor import DTensor
+
+        for group in self.bf16_groups:
+            for p in group:
+                if p.grad is not None:
+                    continue
+                if isinstance(p.data, DTensor):
+                    local = torch.zeros(
+                        p.data.to_local().shape,
+                        dtype=p.dtype,
+                        device=p.device,
+                    )
+                    p.grad = DTensor.from_local(
+                        local,
+                        device_mesh=p.data.device_mesh,
+                        placements=p.data.placements,
+                    )
+                else:
+                    p.grad = torch.zeros(p.shape, dtype=p.dtype, device=p.device)
+        self._init_foreach_cache()
+        for group in self.bf16_groups:
+            for p in group:
+                p.grad = None
+
+    @torch.compiler.disable
+    @torch.no_grad()
+    def _init_foreach_cache(self):
+        """Build cached flat tensor lists for _foreach_copy_ batched operations.
+
+        Called lazily on first prepare_grads() invocation (grads must exist for
+        DTensor spec extraction). Uses public DTensor APIs only.
+        """
+        from torch.distributed.tensor import DTensor
+
+        try:
+            from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+                WeightWithFP8AllGatherTensor,
+            )
+
+            self._has_fp8_subclass = True
+        except ImportError:
+            self._has_fp8_subclass = False
+
+        bf16_flat = [p for group in self.bf16_groups for p in group]
+        fp32_flat = [p for group in self.fp32_from_bf16_groups for p in group]
+        self._bf16_flat = bf16_flat
+        self._fp32_flat = fp32_flat
+
+        bf16_inners = []
+        for p in bf16_flat:
+            t = p.data
+            if isinstance(t, DTensor):
+                t = t.to_local()
+            if self._has_fp8_subclass and isinstance(t, WeightWithFP8AllGatherTensor):
+                t = t.inner_data()
+            bf16_inners.append(t)
+        self._bf16_inners = bf16_inners
+
+        fp32_locals = []
+        for m in fp32_flat:
+            t = m
+            if isinstance(t, DTensor):
+                t = t.to_local()
+            fp32_locals.append(t)
+        self._fp32_locals = fp32_locals
+
+        fp32_grad_locals = [torch.empty_like(fl) for fl in fp32_locals]
+        self._fp32_grad_locals = fp32_grad_locals
+
+        fp32_grad_dtensors = []
+        for m, gl, bp in zip(fp32_flat, fp32_grad_locals, bf16_flat):
+            if isinstance(m, DTensor):
+                if m.placements != bp.grad.placements:
+                    raise RuntimeError(
+                        f"FP32 master placements {m.placements} != "
+                        f"BF16 grad placements {bp.grad.placements}"
+                    )
+                dg = DTensor.from_local(gl, device_mesh=m.device_mesh, placements=m.placements)
+            else:
+                dg = gl
+            fp32_grad_dtensors.append(dg)
+            m.grad = dg
+        self._fp32_grad_dtensors = fp32_grad_dtensors
+
+        self._foreach_ready = True
+        n_params = len(bf16_flat)
+        _safe_log_rank_0(
+            f"[FSDP2BF16MasterWeightOptimizer] foreach cache initialized: "
+            f"{n_params} params, fp8_subclass={self._has_fp8_subclass}"
+        )
+
+    def zero_grad(self, set_to_none=True):
+        if self.is_stub_optimizer:
+            return
+        if self._grad_norm_accumulator is not None:
+            self._grad_norm_accumulator.reset()
+        for group in self.bf16_groups:
+            _zero_grad_group_helper(group, set_to_none)
+        if not self._foreach_ready:
+            for group in self.fp32_from_bf16_groups:
+                _zero_grad_group_helper(group, set_to_none)
+        for group in self.fp32_from_fp32_groups:
+            _zero_grad_group_helper(group, set_to_none)
+
+    def get_loss_scale(self):
+        return self._scale
+
+    @torch.compiler.disable
+    @torch.no_grad()
+    def _prepare_grads_fallback(self) -> bool:
+        """Original per-parameter gradient copy (fallback path)."""
+        for bf16_group, fp32_group in zip(self.bf16_groups, self.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                if bf16_param.grad is not None:
+                    fp32_master.grad = bf16_param.grad.float()
+                    bf16_param.grad = None
+        return False
+
+    @torch.compiler.disable
+    def _validate_foreach_cache(self):
+        """Debug assertion: verify cached tensor refs haven't gone stale."""
+        from torch.distributed.tensor import DTensor
+
+        if self._has_fp8_subclass:
+            from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+                WeightWithFP8AllGatherTensor,
+            )
+        for i, p in enumerate(self._bf16_flat):
+            live = p.data
+            if isinstance(live, DTensor):
+                live = live.to_local()
+            if self._has_fp8_subclass and isinstance(live, WeightWithFP8AllGatherTensor):
+                live = live.inner_data()
+            if live.data_ptr() != self._bf16_inners[i].data_ptr():
+                raise RuntimeError(f"Cached tensor ref stale for param {i}")
+        self._validate_count += 1
+
+    @torch.no_grad()
+    def prepare_grads(self) -> bool:
+        """Copy BF16 gradients to FP32 master grads.
+
+        FSDP2 writes gradients to the BF16 model parameter's .grad attribute
+        (after FP32 reduce-scatter followed by cast to orig_dtype). We cast
+        them to FP32 for the optimizer step on master weights.
+
+        Falls back to per-parameter loop if foreach cache is not ready or
+        any grad is missing.
+        """
+        if not self._foreach_ready:
+            any_grad = any(p.grad is not None for group in self.bf16_groups for p in group)
+            if any_grad and self._use_foreach:
+                self._init_foreach_cache()
+            if not self._foreach_ready:
+                self._prepare_grads_fallback()
+                for fp32_group in self.fp32_from_fp32_groups:
+                    for fp32_param in fp32_group:
+                        if hasattr(fp32_param, "main_grad"):
+                            fp32_param.grad = fp32_param.main_grad
+                return False
+
+        from torch.distributed.tensor import DTensor
+
+        bf16_grad_locals = []
+        for p in self._bf16_flat:
+            if p.grad is None:
+                self._prepare_grads_fallback()
+                for fp32_group in self.fp32_from_fp32_groups:
+                    for fp32_param in fp32_group:
+                        if hasattr(fp32_param, "main_grad"):
+                            fp32_param.grad = fp32_param.main_grad
+                return False
+            g = p.grad
+            if isinstance(g, DTensor):
+                g = g.to_local()
+            bf16_grad_locals.append(g)
+
+        if self._validate_count < 3:
+            self._validate_foreach_cache()
+
+        torch._foreach_copy_(self._fp32_grad_locals, bf16_grad_locals)
+
+        for p in self._bf16_flat:
+            p.grad = None
+
+        for fp32_group in self.fp32_from_fp32_groups:
+            for fp32_param in fp32_group:
+                if hasattr(fp32_param, "main_grad"):
+                    fp32_param.grad = fp32_param.main_grad
+
+        return False
+
+    @torch.no_grad()
+    def clip_grad_norm(self, clip_grad: float) -> float | torch.Tensor:
+        """DTensor-native gradient clipping matching TorchTitan.
+
+        Operates on FP32 master grads (from prepare_grads) plus any natively
+        FP32 parameter grads.
+
+        When overlap_grad_norm is enabled, the squared norms have already been
+        accumulated in the RS stream via post_accumulate_grad_hooks on the
+        BF16 model params. The pre-computed norm is correct because
+        prepare_grads copies BF16->FP32 without scaling. The clipping is
+        applied to the FP32 master params.
+        """
+        all_params = list(chain.from_iterable(self.fp32_from_bf16_groups))
+        all_params.extend(chain.from_iterable(self.fp32_from_fp32_groups))
+
+        if self._grad_norm_accumulator is not None:
+            return self._grad_norm_accumulator.finalize(clip_grad, all_params)
+
+        from torch.distributed.tensor import DTensor
+
+        all_grads = []
+        for fp32_group in self.fp32_from_bf16_groups:
+            for p in fp32_group:
+                if p.grad is not None:
+                    all_grads.append(p.grad)
+        for fp32_group in self.fp32_from_fp32_groups:
+            for p in fp32_group:
+                if p.grad is not None:
+                    all_grads.append(p.grad)
+
+        if not all_grads:
+            return 0.0
+
+        total_norm = torch.nn.utils.get_total_norm(all_grads, norm_type=2.0, foreach=True)
+        if isinstance(total_norm, DTensor):
+            total_norm = total_norm.full_tensor()
+
+        torch.nn.utils.clip_grads_with_norm_(all_params, clip_grad, total_norm, foreach=True)
+        return total_norm
+
+    @torch.no_grad()
+    def step_with_ready_grads(self) -> bool:
+        """Step the optimizer on FP32 masters, then copy back to BF16 params."""
+        if self.is_stub_optimizer:
+            return True
+        timers = self.config.timers
+
+        if timers is not None:
+            timers("optimizer-inner-step", log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        self.optimizer.step()
+        if timers is not None:
+            timers("optimizer-inner-step").stop()
+
+        if timers is not None:
+            timers("optimizer-copy-main-to-model", log_level=1).start(
+                barrier=self.config.barrier_with_L1_time
+            )
+        self._copy_main_params_to_model_params()
+        if timers is not None:
+            timers("optimizer-copy-main-to-model").stop()
+
+        return True
+
+    def _copy_main_params_to_model_params(self):
+        """Copy FP32 master weights back to BF16 model parameters."""
+        if self._foreach_ready:
+            self._copy_main_to_model_foreach()
+        else:
+            self._copy_main_to_model_fallback()
+
+    def _copy_main_to_model_foreach(self):
+        torch._foreach_copy_(self._bf16_inners, self._fp32_locals)
+
+    @torch.compiler.disable
+    def _copy_main_to_model_fallback(self):
+        for bf16_group, fp32_group in zip(self.bf16_groups, self.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                bf16_param.data.copy_(fp32_master.data)
+
+    @torch.compiler.disable
+    def _copy_model_params_to_main_params(self):
+        """Copy BF16 model parameters to FP32 masters (for checkpoint reload)."""
+        if self._foreach_ready:
+            torch._foreach_copy_(self._fp32_locals, self._bf16_inners)
+        else:
+            self._copy_model_to_main_fallback()
+
+    @torch.compiler.disable
+    def _copy_model_to_main_fallback(self):
+        for bf16_group, fp32_group in zip(self.bf16_groups, self.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                fp32_master.data.copy_(bf16_param.data)
+
+    @torch.no_grad()
+    def step(self):
+        """Clip gradients and step. Always succeeds (no overflow for BF16)."""
+        timers = self.config.timers
+
+        found_inf_flag = self.prepare_grads()
+        if found_inf_flag:
+            return False, None, None
+
+        if timers is not None:
+            timers("optimizer-clip-main-grad", log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        grad_norm = None
+        if self.config.clip_grad > 0.0:
+            grad_norm = self.clip_grad_norm(self.config.clip_grad)
+        if timers is not None:
+            timers("optimizer-clip-main-grad").stop()
+
+        if timers is not None:
+            timers("optimizer-count-zeros", log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        num_zeros_in_grad = self.count_zeros() if self.config.log_num_zeros_in_grad else None
+        if timers is not None:
+            timers("optimizer-count-zeros").stop()
+
+        success = self.step_with_ready_grads()
+
+        return success, grad_norm, num_zeros_in_grad
+
+    def reload_model_params(self, state_dict=None):
+        """After loading a checkpoint, copy BF16 model params to FP32 masters."""
+        self._copy_model_params_to_main_params()
+
+    def state_dict(self, is_loading: bool = False):
+        if is_loading:
+            self.init_state_fn(self.optimizer, self.config)
+
+        state_dict = {}
+        state_dict["optimizer"] = self.optimizer.state_dict()
+        state_dict["fp32_from_fp16_params"] = self.fp32_from_bf16_groups
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        optimizer_key = "optimizer"
+        if optimizer_key not in state_dict:
+            optimizer_key = "optimizer_state_dict"
+
+        if "common_step" in state_dict[optimizer_key].get("state", {}):
+            common_step = state_dict[optimizer_key]["state"].pop("common_step")
+            self._restore_common_per_param_step(state_dict[optimizer_key], common_step)
+
+        state_dict[optimizer_key]["param_groups"] = self._filter_and_reorder_param_groups(
+            self.optimizer.param_groups, state_dict[optimizer_key]["param_groups"]
+        )
+        self.optimizer.load_state_dict(state_dict[optimizer_key])
+
+        # Restore FP32 master weights
+        if "fp32_from_fp16_params" in state_dict:
+            for current_group, saved_group in zip(
+                self.fp32_from_bf16_groups, state_dict["fp32_from_fp16_params"]
+            ):
+                for current_param, saved_param in zip(current_group, saved_group):
+                    current_param.data.copy_(saved_param.data)
+
+    def sharded_state_dict(
+        self,
+        model_sharded_state_dict: ShardedStateDict,
+        is_loading: bool = False,
+        metadata: Optional[dict] = None,
+    ):
+        if is_loading:
+            self.init_state_fn(self.optimizer, self.config)
+
+        state_dict = self.state_dict()
+
+        # Key on BF16 model params (not FP32 masters) for checkpoint sharding
+        # alignment with the model's sharded state dict
+        id_to_sharded_param_map = get_param_id_to_sharded_param_map(
+            model_sharded_state_dict,
+            chain.from_iterable(g for g in self.bf16_groups),
+        )
+
+        # Convert fp32_from_fp16_params to sharded tensors
+        if len(state_dict["fp32_from_fp16_params"]) != len(state_dict["optimizer"]["param_groups"]):
+            raise ValueError(
+                "state_dict fp32_from_fp16_params length does not match optimizer param_groups length"
+            )
+        state_dict["fp32_from_fp16_params"] = [
+            [
+                make_sharded_optimizer_tensor(
+                    id_to_sharded_param_map[param_id],
+                    fp32_param,
+                    prefix="optimizer.state.fp32_param",
+                )
+                for param_id, fp32_param in zip(state_group["params"], fp32_group)
+            ]
+            for fp32_group, state_group in zip(
+                state_dict["fp32_from_fp16_params"],
+                state_dict["optimizer"]["param_groups"],
+            )
+        ]
+
+        step = self._extract_common_per_param_step(state_dict["optimizer"])
+
+        optim_state_to_sharding_state(state_dict["optimizer"], id_to_sharded_param_map, exclude_keys="step")
+        if step:
+            state_dict["optimizer"]["state"]["common_step"] = step
+        return state_dict
+
+    def finalize_dist_ckpt_load(self, iteration):
+        """Restore optimizer step counter and sync FP32 masters to BF16 params.
+
+        After dist_checkpointing in-place load (skip_load_to_model_and_opt=True),
+        load_state_dict is not called, so we manually set steps and copy masters.
+        """
+        step_val = float(iteration)
+        for fp32_group in self.fp32_from_bf16_groups:
+            for p in fp32_group:
+                if p in self.optimizer.state and "step" in self.optimizer.state[p]:
+                    self.optimizer.state[p]["step"].fill_(step_val)
+        for fp32_group in self.fp32_from_fp32_groups:
+            for p in fp32_group:
+                if p in self.optimizer.state and "step" in self.optimizer.state[p]:
+                    self.optimizer.state[p]["step"].fill_(step_val)
+
+        self._copy_main_params_to_model_params()
+
+
+def get_fsdp2_bf16_master_weight_optimizer(
+    config: OptimizerConfig,
+    model_chunks: List[torch.nn.Module],
+    no_weight_decay_cond: Optional[Callable] = None,
+    scale_lr_cond: Optional[Callable] = None,
+    lr_mult: float = 1.0,
+    use_gloo_process_groups: bool = True,
+    default_skip_embedding_weight_decay: bool = False,
+    pg_collection: Optional["ProcessGroupCollection"] = None,
+    base_optimizer_cls=torch.optim.AdamW,
+    use_foreach: bool = True,
+    **optimizer_kwargs,
+) -> FSDP2BF16MasterWeightOptimizer:
+    """Factory function to create FSDP2 BF16 master weight optimizer.
+
+    Collects trainable parameters, creates FP32 master copies for BF16 params,
+    replaces param_group entries with FP32 masters, builds a fused AdamW, and
+    wraps in FSDP2BF16MasterWeightOptimizer.
+    """
+    all_params = []
+    for model_chunk in model_chunks:
+        for param in model_chunk.parameters():
+            if param.requires_grad:
+                all_params.append(param)
+
+    if not all_params:
+        raise ValueError("No trainable parameters found in model chunks!")
+
+    weight_decay = config.weight_decay
+    lr = config.lr
+    param_groups = []
+
+    if default_skip_embedding_weight_decay and no_weight_decay_cond is None:
+        embedding_params = []
+        non_embedding_params = []
+        for param in all_params:
+            is_embedding = False
+            for model_chunk in model_chunks:
+                for name, p in model_chunk.named_parameters():
+                    if p is param and "embed" in name.lower():
+                        is_embedding = True
+                        break
+                if is_embedding:
+                    break
+            if is_embedding:
+                embedding_params.append(param)
+            else:
+                non_embedding_params.append(param)
+
+        if embedding_params:
+            param_groups.append({"params": embedding_params, "weight_decay": 0.0, "lr": lr})
+        if non_embedding_params:
+            param_groups.append({"params": non_embedding_params, "weight_decay": weight_decay, "lr": lr})
+    elif no_weight_decay_cond is not None:
+        no_wd_params = []
+        wd_params = []
+        for param in all_params:
+            if no_weight_decay_cond(param):
+                no_wd_params.append(param)
+            else:
+                wd_params.append(param)
+        if no_wd_params:
+            param_groups.append({"params": no_wd_params, "weight_decay": 0.0, "lr": lr})
+        if wd_params:
+            param_groups.append({"params": wd_params, "weight_decay": weight_decay, "lr": lr})
+    else:
+        param_groups.append({"params": all_params, "weight_decay": weight_decay, "lr": lr})
+
+    if scale_lr_cond is not None and lr_mult != 1.0:
+        new_groups = []
+        for param_group in param_groups:
+            scaled = [p for p in param_group["params"] if scale_lr_cond(p)]
+            normal = [p for p in param_group["params"] if not scale_lr_cond(p)]
+            if normal:
+                new_groups.append({**param_group, "params": normal})
+            if scaled:
+                new_groups.append({**param_group, "params": scaled, "lr": param_group["lr"] * lr_mult})
+        param_groups = new_groups
+
+    # Create FP32 master copies and replace in param_groups
+    bf16_groups = []
+    fp32_from_bf16_groups = []
+    fp32_from_fp32_groups = []
+
+    for param_group in param_groups:
+        bf16_params_this_group = []
+        fp32_from_bf16_this_group = []
+        fp32_from_fp32_this_group = []
+
+        for i, param in enumerate(param_group["params"]):
+            if param.dtype in (torch.float16, torch.bfloat16):
+                bf16_params_this_group.append(param)
+                main_param = param.detach().clone().float()
+                param.main_param = main_param
+                param_group["params"][i] = main_param
+                fp32_from_bf16_this_group.append(main_param)
+            elif param.dtype == torch.float32:
+                fp32_from_fp32_this_group.append(param)
+            else:
+                _safe_log_rank_0(f"WARNING: unexpected param dtype {param.dtype}, treating as FP32")
+                fp32_from_fp32_this_group.append(param)
+
+        bf16_groups.append(bf16_params_this_group)
+        fp32_from_bf16_groups.append(fp32_from_bf16_this_group)
+        fp32_from_fp32_groups.append(fp32_from_fp32_this_group)
+
+    bf16_count = sum(len(g) for g in bf16_groups)
+    fp32_count = sum(len(g) for g in fp32_from_fp32_groups)
+    master_count = sum(len(g) for g in fp32_from_bf16_groups)
+
+    _safe_log_rank_0(
+        f"Creating FSDP2 BF16 master weight optimizer with "
+        f"{bf16_count + fp32_count:,} parameters in {len(param_groups)} param groups"
+    )
+
+    base_optimizer = base_optimizer_cls(
+        param_groups,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_eps,
+        fused=True,
+        **optimizer_kwargs,
+    )
+
+    for param_group in base_optimizer.param_groups:
+        param_group.setdefault("wd_mult", 1.0)
+        param_group.setdefault("lr_mult", 1.0)
+        param_group.setdefault("is_expert_parallel", False)
+        param_group.setdefault("is_decoupled_lr", False)
+        param_group.setdefault("default_config", True)
+
+    def init_state_fn(opt, config=None):
+        for group in opt.param_groups:
+            for p in group["params"]:
+                if len(opt.state[p]) == 0:
+                    opt.state[p]["step"] = torch.zeros((), dtype=torch.float32, device=p.device)
+                    opt.state[p]["exp_avg"] = torch.zeros_like(p.data)
+                    opt.state[p]["exp_avg_sq"] = torch.zeros_like(p.data)
+
+    optimizer = FSDP2BF16MasterWeightOptimizer(
+        optimizer=base_optimizer,
+        config=config,
+        init_state_fn=init_state_fn,
+        bf16_groups=bf16_groups,
+        fp32_from_bf16_groups=fp32_from_bf16_groups,
+        fp32_from_fp32_groups=fp32_from_fp32_groups,
+        use_foreach=use_foreach,
+    )
+
+    _safe_log_rank_0("=" * 80)
+    _safe_log_rank_0("[FSDP2BF16MasterWeightOptimizer Initialized]")
+    _safe_log_rank_0("  BF16 model params + FP32 master weights")
+    _safe_log_rank_0("  No FP32->BF16 cast in forward all-gather")
+    _safe_log_rank_0("  FP32 optimizer step + copy-back to BF16 per iteration")
+    _safe_log_rank_0(f"  BF16 parameters: {bf16_count:,} ({master_count:,} FP32 master copies)")
+    _safe_log_rank_0(f"  FP32 parameters: {fp32_count:,} (no master copy needed)")
+    _safe_log_rank_0(f"  Total trainable parameters: {bf16_count + fp32_count:,}")
+    _safe_log_rank_0("=" * 80)
+
+    optimizer.warmup_foreach_cache()
+
+    return optimizer

--- a/primus/backends/megatron/core/optimizer/fsdp2_fp32_optimizer.py
+++ b/primus/backends/megatron/core/optimizer/fsdp2_fp32_optimizer.py
@@ -1,0 +1,368 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+FP32 optimizer for FSDP2 mixed precision training.
+
+Uses the TorchTitan approach: model parameters are initialized in FP32,
+FSDP2's MixedPrecisionPolicy casts to BF16 for forward/backward, and
+the optimizer operates on FP32 parameters with FP32 states.
+
+This eliminates the "stale weights" problem of BF16 optimizer states
+while avoiding the master-copy duplication of Float16OptimizerWithFloat16Params.
+
+Memory impact vs BF16 optimizer (Flux 12B, 8 GPUs):
+    +3 GB/GPU for FP32 parameters (vs BF16)
+    +6 GB/GPU for FP32 optimizer states (vs BF16)
+    = +9 GB/GPU total
+
+Gradient clipping uses PyTorch-native DTensor-aware APIs matching TorchTitan.
+"""
+
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+import torch
+from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+from megatron.core.dist_checkpointing.optimizer import (
+    get_param_id_to_sharded_param_map,
+    optim_state_to_sharding_state,
+)
+from megatron.core.optimizer.optimizer import MegatronOptimizer
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+
+from primus.modules.module_utils import log_rank_0
+
+if TYPE_CHECKING:
+    from megatron.core.process_groups_config import ProcessGroupCollection
+
+
+def _safe_log_rank_0(msg: str):
+    try:
+        log_rank_0(msg)
+    except (AttributeError, TypeError):
+        import torch.distributed as dist
+
+        if not dist.is_initialized() or dist.get_rank() == 0:
+            print(msg)
+
+
+class FSDP2FP32Optimizer(MegatronOptimizer):
+    """FP32 optimizer for FSDP2 mixed precision training.
+
+    Extends MegatronOptimizer directly (not MixedPrecisionOptimizer).
+    Modeled on Megatron's own FP32Optimizer with two key differences:
+
+    1. prepare_grads is a no-op: FSDP2 writes gradients directly to param.grad
+       (no main_grad -> grad copy needed).
+    2. clip_grad_norm uses TorchTitan-style DTensor-native APIs:
+       torch.nn.utils.get_total_norm + clip_grads_with_norm_ for correct
+       norm computation across FSDP2's sharded DTensor parameters.
+
+    Args:
+        optimizer: Base PyTorch optimizer (e.g., AdamW with fused=True).
+        config: OptimizerConfig from Megatron.
+        init_state_fn: Function to initialize optimizer state tensors.
+    """
+
+    def __init__(
+        self,
+        optimizer: torch.optim.Optimizer,
+        config: OptimizerConfig,
+        init_state_fn: Callable,
+    ):
+        super().__init__(optimizer, config, init_state_fn)
+        self._scale = torch.tensor([1.0], dtype=torch.float, device="cuda")
+        self.is_stub_optimizer = optimizer is None
+
+        from megatron.training import get_args
+
+        args = get_args()
+        self._grad_norm_accumulator = getattr(args, "_grad_norm_accumulator", None)
+
+    def zero_grad(self, set_to_none=True):
+        if self.is_stub_optimizer:
+            return
+        if self._grad_norm_accumulator is not None:
+            self._grad_norm_accumulator.reset()
+        self.optimizer.zero_grad(set_to_none=set_to_none)
+
+    def get_loss_scale(self):
+        return self._scale
+
+    @torch.no_grad()
+    def prepare_grads(self) -> bool:
+        """No-op: FSDP2 writes gradients directly to param.grad."""
+        return False
+
+    @torch.no_grad()
+    def clip_grad_norm(self, clip_grad: float) -> float | torch.Tensor:
+        """DTensor-native gradient clipping matching TorchTitan.
+
+        Uses torch.nn.utils.get_total_norm which natively handles DTensor
+        gradients (returns a DTensor with _NormPartial placement that is
+        reduced via full_tensor()), then clips with foreach-optimized
+        clip_grads_with_norm_.
+
+        When overlap_grad_norm is enabled, the squared norms have already been
+        accumulated in the RS stream via post_accumulate_grad_hooks. Only a
+        single all-reduce + sqrt + clip is needed.
+        """
+        params = self.get_parameters()
+
+        if self._grad_norm_accumulator is not None:
+            return self._grad_norm_accumulator.finalize(clip_grad, params)
+
+        from torch.distributed.tensor import DTensor
+
+        grads = [p.grad for p in params if p.grad is not None]
+
+        if not grads:
+            return 0.0
+
+        total_norm = torch.nn.utils.get_total_norm(grads, norm_type=2.0, foreach=True)
+        if isinstance(total_norm, DTensor):
+            total_norm = total_norm.full_tensor()
+        torch.nn.utils.clip_grads_with_norm_(params, clip_grad, total_norm, foreach=True)
+        return total_norm
+
+    @torch.no_grad()
+    def step_with_ready_grads(self) -> bool:
+        if self.is_stub_optimizer:
+            return True
+        timers = self.config.timers
+
+        if timers is not None:
+            timers("optimizer-inner-step", log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        self.optimizer.step()
+        if timers is not None:
+            timers("optimizer-inner-step").stop()
+
+        return True
+
+    @torch.no_grad()
+    def step(self):
+        """Clip gradients and step. Always succeeds (no overflow for FP32)."""
+        timers = self.config.timers
+
+        found_inf_flag = self.prepare_grads()
+        if found_inf_flag:
+            return False, None, None
+
+        if timers is not None:
+            timers("optimizer-clip-main-grad", log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        grad_norm = None
+        if self.config.clip_grad > 0.0:
+            grad_norm = self.clip_grad_norm(self.config.clip_grad)
+        if timers is not None:
+            timers("optimizer-clip-main-grad").stop()
+
+        if timers is not None:
+            timers("optimizer-count-zeros", log_level=1).start(barrier=self.config.barrier_with_L1_time)
+        num_zeros_in_grad = self.count_zeros() if self.config.log_num_zeros_in_grad else None
+        if timers is not None:
+            timers("optimizer-count-zeros").stop()
+
+        success = self.step_with_ready_grads()
+
+        return success, grad_norm, num_zeros_in_grad
+
+    def reload_model_params(self, state_dict=None):
+        pass
+
+    def state_dict(self):
+        return self.optimizer.state_dict()
+
+    def load_state_dict(self, state_dict):
+        if "common_step" in state_dict.get("state", {}):
+            common_step = state_dict["state"].pop("common_step")
+            self._restore_common_per_param_step(state_dict, common_step)
+
+        state_dict["param_groups"] = self._filter_and_reorder_param_groups(
+            self.optimizer.param_groups, state_dict["param_groups"]
+        )
+        self.optimizer.load_state_dict(state_dict)
+
+    def sharded_state_dict(
+        self,
+        model_sharded_state_dict: ShardedStateDict,
+        is_loading: bool = False,
+        metadata: Optional[dict] = None,
+    ):
+        if is_loading:
+            self.init_state_fn(self.optimizer, self.config)
+
+        state_dict = self.state_dict()
+        id_to_sharded_param_map = get_param_id_to_sharded_param_map(
+            model_sharded_state_dict, self.get_parameters()
+        )
+        step = self._extract_common_per_param_step(state_dict)
+
+        optim_state_to_sharding_state(state_dict, id_to_sharded_param_map, exclude_keys="step")
+        if step:
+            state_dict["state"]["common_step"] = step
+        return state_dict
+
+    def finalize_dist_ckpt_load(self, iteration):
+        """Restore optimizer step counter after dist_checkpointing in-place load.
+
+        When skip_load_to_model_and_opt=True (FSDP2), load_state_dict is not
+        called, so common_step is never fanned out to per-parameter step
+        entries.  This fills step from the training iteration.
+        """
+        step_val = float(iteration)
+        for p in self.get_parameters():
+            if p in self.optimizer.state and "step" in self.optimizer.state[p]:
+                self.optimizer.state[p]["step"].fill_(step_val)
+
+
+def get_fsdp2_fp32_optimizer(
+    config: OptimizerConfig,
+    model_chunks: List[torch.nn.Module],
+    no_weight_decay_cond: Optional[Callable] = None,
+    scale_lr_cond: Optional[Callable] = None,
+    lr_mult: float = 1.0,
+    use_gloo_process_groups: bool = True,
+    default_skip_embedding_weight_decay: bool = False,
+    pg_collection: Optional["ProcessGroupCollection"] = None,
+    base_optimizer_cls=torch.optim.AdamW,
+    use_foreach: bool = False,
+    **optimizer_kwargs,
+) -> FSDP2FP32Optimizer:
+    """Factory function to create FSDP2 FP32 param optimizer from model chunks.
+
+    Collects trainable FP32 parameters, builds param groups with weight decay
+    and LR scaling, creates AdamW (fused or foreach), and wraps in
+    FSDP2FP32Optimizer.
+
+    Args:
+        config: OptimizerConfig from Megatron.
+        model_chunks: List of model modules (FSDP2-wrapped).
+        no_weight_decay_cond: Optional predicate for zero weight decay.
+        scale_lr_cond: Optional predicate for scaled learning rate.
+        lr_mult: Learning rate multiplier for scaled params.
+        use_gloo_process_groups: Unused (kept for API compatibility).
+        default_skip_embedding_weight_decay: Skip weight decay for embeddings
+            if no_weight_decay_cond not provided.
+        pg_collection: Unused (kept for API compatibility).
+        base_optimizer_cls: PyTorch optimizer class (default: AdamW).
+        use_foreach: If True, use foreach mode; if False (default), use fused.
+        **optimizer_kwargs: Additional kwargs for base optimizer.
+
+    Returns:
+        FSDP2FP32Optimizer instance.
+    """
+    all_params = []
+    for model_chunk in model_chunks:
+        for param in model_chunk.parameters():
+            if param.requires_grad:
+                all_params.append(param)
+
+    if not all_params:
+        raise ValueError("No trainable parameters found in model chunks!")
+
+    weight_decay = config.weight_decay
+    lr = config.lr
+    param_groups = []
+
+    if default_skip_embedding_weight_decay and no_weight_decay_cond is None:
+        embedding_params = []
+        non_embedding_params = []
+        for param in all_params:
+            is_embedding = False
+            for model_chunk in model_chunks:
+                for name, p in model_chunk.named_parameters():
+                    if p is param and "embed" in name.lower():
+                        is_embedding = True
+                        break
+                if is_embedding:
+                    break
+            if is_embedding:
+                embedding_params.append(param)
+            else:
+                non_embedding_params.append(param)
+
+        if embedding_params:
+            param_groups.append({"params": embedding_params, "weight_decay": 0.0, "lr": lr})
+        if non_embedding_params:
+            param_groups.append({"params": non_embedding_params, "weight_decay": weight_decay, "lr": lr})
+    elif no_weight_decay_cond is not None:
+        no_wd_params = []
+        wd_params = []
+        for param in all_params:
+            if no_weight_decay_cond(param):
+                no_wd_params.append(param)
+            else:
+                wd_params.append(param)
+        if no_wd_params:
+            param_groups.append({"params": no_wd_params, "weight_decay": 0.0, "lr": lr})
+        if wd_params:
+            param_groups.append({"params": wd_params, "weight_decay": weight_decay, "lr": lr})
+    else:
+        param_groups.append({"params": all_params, "weight_decay": weight_decay, "lr": lr})
+
+    if scale_lr_cond is not None and lr_mult != 1.0:
+        new_groups = []
+        for param_group in param_groups:
+            scaled = [p for p in param_group["params"] if scale_lr_cond(p)]
+            normal = [p for p in param_group["params"] if not scale_lr_cond(p)]
+            if normal:
+                new_groups.append({**param_group, "params": normal})
+            if scaled:
+                new_groups.append({**param_group, "params": scaled, "lr": param_group["lr"] * lr_mult})
+        param_groups = new_groups
+
+    _safe_log_rank_0(
+        f"Creating FSDP2 FP32 optimizer with {len(all_params):,} parameters "
+        f"in {len(param_groups)} param groups"
+    )
+
+    base_optimizer = base_optimizer_cls(
+        param_groups,
+        betas=(config.adam_beta1, config.adam_beta2),
+        eps=config.adam_eps,
+        fused=not use_foreach,
+        foreach=use_foreach,
+        **optimizer_kwargs,
+    )
+
+    for param_group in base_optimizer.param_groups:
+        param_group.setdefault("wd_mult", 1.0)
+        param_group.setdefault("lr_mult", 1.0)
+        param_group.setdefault("is_expert_parallel", False)
+        param_group.setdefault("is_decoupled_lr", False)
+        param_group.setdefault("default_config", True)
+
+    def init_state_fn(opt, config=None):
+        for group in opt.param_groups:
+            for p in group["params"]:
+                if len(opt.state[p]) == 0:
+                    opt.state[p]["step"] = torch.zeros((), dtype=torch.float32, device=p.device)
+                    opt.state[p]["exp_avg"] = torch.zeros_like(p.data)
+                    opt.state[p]["exp_avg_sq"] = torch.zeros_like(p.data)
+
+    optimizer = FSDP2FP32Optimizer(
+        optimizer=base_optimizer,
+        config=config,
+        init_state_fn=init_state_fn,
+    )
+
+    fp32_count = sum(1 for p in all_params if p.dtype == torch.float32)
+    bf16_count = sum(1 for p in all_params if p.dtype == torch.bfloat16)
+    other_count = len(all_params) - fp32_count - bf16_count
+
+    _safe_log_rank_0("=" * 80)
+    _safe_log_rank_0("[FSDP2FP32ParamOptimizer Initialized]")
+    _safe_log_rank_0("  TorchTitan-style: FP32 params + FSDP2 MixedPrecisionPolicy")
+    _safe_log_rank_0("  DTensor-native gradient clipping")
+    _safe_log_rank_0(f"  AdamW mode: {'foreach' if use_foreach else 'fused'}")
+    _safe_log_rank_0(f"  FP32 parameters: {fp32_count:,}")
+    _safe_log_rank_0(f"  BF16 parameters: {bf16_count:,}")
+    if other_count > 0:
+        _safe_log_rank_0(f"  Other dtype parameters: {other_count:,}")
+    _safe_log_rank_0(f"  Total trainable parameters: {len(all_params):,}")
+    _safe_log_rank_0("=" * 80)
+
+    return optimizer

--- a/primus/backends/megatron/core/optimizer/incremental_grad_norm.py
+++ b/primus/backends/megatron/core/optimizer/incremental_grad_norm.py
@@ -1,0 +1,90 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Incremental gradient norm accumulator for overlapping grad norm with FSDP2
+reduce-scatter.
+
+Registers a `register_post_accumulate_grad_hook` on each sharded parameter.
+FSDP2 fires these hooks inside the post-reduce stream (RS or AR stream)
+after the sharded gradient is assigned. Each hook accumulates ||grad||_2^2
+into a shared tensor. By the time the default stream synchronises
+(`_wait_for_post_backward`), the total squared norm is already computed.
+The optimizer's `clip_grad_norm` then only needs a single all-reduce + sqrt
++ clip — eliminating the per-parameter norm recomputation that would
+otherwise serialise after the last reduce-scatter.
+"""
+
+from typing import Callable
+
+import torch
+import torch.distributed as dist
+
+
+class IncrementalGradNormAccumulator:
+    """Accumulates squared L2 norms of sharded gradients in the RS stream.
+
+    Args:
+        shard_process_group: The FSDP shard process group used for the final
+            all-reduce of the accumulated squared norm. For HSDP this must be
+            the shard-only group (not the full DP group) because replicate-group
+            ranks hold identical gradients after the HSDP all-reduce.
+        device: CUDA device for the accumulator tensor.
+    """
+
+    def __init__(
+        self,
+        shard_process_group: dist.ProcessGroup,
+        device: torch.device,
+    ) -> None:
+        self._shard_pg = shard_process_group
+        self._total_norm_sq = torch.zeros((), dtype=torch.float32, device=device)
+
+    def reset(self) -> None:
+        """Zero the accumulator. Called from optimizer.zero_grad()."""
+        self._total_norm_sq.zero_()
+
+    def make_hook(self) -> Callable[[torch.Tensor], None]:
+        """Return a closure suitable for register_post_accumulate_grad_hook.
+
+        The hook extracts the local shard data (bypassing DTensor overhead)
+        and accumulates its squared L2 norm into ``_total_norm_sq``.
+        """
+        acc = self
+
+        def hook(param: torch.Tensor) -> None:
+            grad = param.grad
+            if grad is None:
+                return
+            local_grad = grad._local_tensor if hasattr(grad, "_local_tensor") else grad
+            acc._total_norm_sq.add_(local_grad.float().norm(2).pow_(2))
+
+        return hook
+
+    @torch.no_grad()
+    def finalize(
+        self,
+        clip_grad: float,
+        params,
+    ) -> torch.Tensor:
+        """All-reduce the accumulated norm, sqrt, clip, and return total_norm.
+
+        No additional stream synchronisation is needed here: by the time the
+        optimizer calls this method the default stream has already waited on
+        ``post_reduce_event`` via ``_wait_for_post_backward``, so the
+        accumulated value is visible.
+
+        Args:
+            clip_grad: Maximum gradient norm for clipping.
+            params: Iterable of parameters whose ``.grad`` will be clipped.
+
+        Returns:
+            The global L2 gradient norm (scalar tensor).
+        """
+        dist.all_reduce(self._total_norm_sq, op=dist.ReduceOp.SUM, group=self._shard_pg)
+        total_norm = self._total_norm_sq.sqrt_()
+        torch.nn.utils.clip_grads_with_norm_(params, clip_grad, total_norm, foreach=True)
+        return total_norm

--- a/primus/backends/megatron/patches/fsdp2_fp8_cache_patches.py
+++ b/primus/backends/megatron/patches/fsdp2_fp8_cache_patches.py
@@ -1,0 +1,98 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron train_step patch for FP8 all-gather cache refresh.
+
+The FP8 all-gather cache (populated by precompute_fp8_scales_for_fsdp) must be
+refreshed after every optimizer.step() so that the cached FP8 data reflects the
+updated weights.  Without this patch the cache is only populated once during
+FSDP setup and goes stale after the first iteration.
+
+This patch wraps Megatron's standalone train_step() to call
+precompute_fp8_scales_for_fsdp(model[0]) after the original train_step returns.
+"""
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _needs_fp8_cache_update(ctx: PatchContext) -> bool:
+    args = get_args(ctx)
+    return args is not None and getattr(args, "use_fsdp2_fp8_all_gather", False)
+
+
+@register_patch(
+    "megatron.training.train_step_fp8_cache_update",
+    backend="megatron",
+    phase="before_train",
+    description="Patch train_step to refresh FP8 all-gather cache after optimizer.step()",
+    condition=_needs_fp8_cache_update,
+    priority=45,
+)
+def patch_train_step_fp8_cache(ctx: PatchContext):
+    import megatron.training.training as megatron_training
+
+    from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+        precompute_fp8_scales_for_fsdp,
+    )
+    from primus.backends.megatron.patches._patch_guard import is_patched, mark_patched
+
+    _PATCH_KEY = "megatron.training.train_step_fp8_cache_update"
+    if is_patched(megatron_training, _PATCH_KEY):
+        log_rank_0("[Patch:train_step_fp8_cache_update] Already applied; skipping re-wrap.")
+        return
+
+    args = get_args(ctx)
+    cache_data = getattr(args, "fp8_precompute_data_cache", True)
+    use_cpp = getattr(args, "use_cpp_fp8_quantize", False)
+    stochastic_rounding = getattr(args, "fp8_all_gather_stochastic_rounding", False)
+
+    _original_train_step = megatron_training.train_step
+
+    def _patched_train_step(
+        forward_step_func,
+        data_iterator,
+        model,
+        optimizer,
+        opt_param_scheduler,
+        config,
+        forward_backward_func,
+        iteration=None,
+    ):
+        result = _original_train_step(
+            forward_step_func,
+            data_iterator,
+            model,
+            optimizer,
+            opt_param_scheduler,
+            config,
+            forward_backward_func,
+            iteration=iteration,
+        )
+        if _refresh_scales:
+            precompute_fp8_scales_for_fsdp(
+                model[0],
+                cache_data=cache_data,
+                use_cpp_quantize=use_cpp,
+                stochastic_rounding=stochastic_rounding,
+            )
+        return result
+
+    # When using the C++ quantize kernel without data caching, scales were
+    # already set once during FSDP setup and the C++ kernel uses them
+    # directly -- no per-step refresh needed (matches run_35 behavior).
+    _refresh_scales = cache_data or not use_cpp
+
+    megatron_training.train_step = _patched_train_step
+    mark_patched(megatron_training, _PATCH_KEY)
+    log_rank_0(
+        "[Patch:train_step_fp8_cache_update] "
+        f"Patched train_step to refresh FP8 all-gather cache after optimizer.step() "
+        f"(cache_data={cache_data}, use_cpp_quantize={use_cpp}, "
+        f"stochastic_rounding={stochastic_rounding}, "
+        f"refresh_scales={_refresh_scales})"
+    )

--- a/primus/backends/megatron/patches/optimizer_patches.py
+++ b/primus/backends/megatron/patches/optimizer_patches.py
@@ -1,0 +1,251 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron Optimizer Patches
+
+This module contains patches that modify Megatron's optimizer creation to use
+Primus-specific implementations when requested.
+"""
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+@register_patch(
+    "megatron.optimizer.fsdp2_fp32_param",
+    backend="megatron",
+    phase="before_train",
+    description="Patch get_megatron_optimizer for FSDP2 FP32 param optimizer (TorchTitan-style)",
+    priority=50,
+    condition=lambda ctx: (
+        getattr(get_args(ctx), "use_fsdp2_fp32_param_optimizer", False)
+        and getattr(get_args(ctx), "use_torch_fsdp2", False)
+        and getattr(get_args(ctx), "bf16", False)
+    ),
+)
+def patch_fsdp2_fp32_optimizer(ctx: PatchContext):
+    """Patch Megatron to use FSDP2 FP32 optimizer.
+
+    This optimizer uses FP32 parameters + FP32 optimizer states with FSDP2's
+    MixedPrecisionPolicy for BF16 forward/backward. Eliminates the stale
+    weights problem of BF16 optimizer states.
+    """
+    try:
+        import megatron.core.optimizer as optimizer_module
+        from megatron.training import training
+
+        from primus.backends.megatron.core.optimizer.fsdp2_fp32_optimizer import (
+            get_fsdp2_fp32_optimizer,
+        )
+
+        args = get_args(ctx)
+        use_foreach = getattr(args, "optimizer_foreach", False)
+
+        _MEGATRON_ONLY_KWARGS = {
+            "config_overrides",
+            "use_gloo_process_groups",
+            "dump_param_to_param_group_map",
+        }
+
+        def patched_get_megatron_optimizer(config, model_chunks, *args, **kwargs):
+            log_rank_0("=" * 80)
+            log_rank_0("[Using FSDP2 FP32 Param Optimizer (TorchTitan-style)]")
+            log_rank_0("  FP32 params + FP32 optimizer states")
+            log_rank_0("  FSDP2 MixedPrecisionPolicy handles BF16 compute")
+            log_rank_0("  DTensor-native gradient clipping")
+            log_rank_0(f"  AdamW mode: {'foreach' if use_foreach else 'fused'}")
+            log_rank_0("=" * 80)
+
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k not in _MEGATRON_ONLY_KWARGS}
+
+            return get_fsdp2_fp32_optimizer(
+                config=config,
+                model_chunks=model_chunks,
+                use_foreach=use_foreach,
+                **filtered_kwargs,
+            )
+
+        patched_count = 0
+        if hasattr(training, "get_megatron_optimizer"):
+            training.get_megatron_optimizer = patched_get_megatron_optimizer
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_fp32_param] " "Patched training.get_megatron_optimizer"
+            )
+            patched_count += 1
+
+        if hasattr(optimizer_module, "get_megatron_optimizer"):
+            optimizer_module.get_megatron_optimizer = patched_get_megatron_optimizer
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_fp32_param] "
+                "Patched optimizer_module.get_megatron_optimizer"
+            )
+            patched_count += 1
+
+        if patched_count == 0:
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_fp32_param] "
+                "WARNING: get_megatron_optimizer not found in either location!"
+            )
+        else:
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_fp32_param] "
+                f"Patched get_megatron_optimizer in {patched_count} location(s) "
+                "to use FSDP2FP32Optimizer"
+            )
+
+    except Exception as e:
+        log_rank_0(
+            f"[Patch:megatron.optimizer.fsdp2_fp32_param] "
+            f"WARNING: Failed to patch get_megatron_optimizer: {type(e).__name__}: {e}"
+        )
+        import traceback
+
+        log_rank_0(f"Traceback: {traceback.format_exc()}")
+
+
+@register_patch(
+    "megatron.optimizer.fsdp2_bf16_master_weight",
+    backend="megatron",
+    phase="before_train",
+    description="Patch get_megatron_optimizer for FSDP2 BF16 master weight optimizer",
+    priority=50,
+    condition=lambda ctx: (
+        getattr(get_args(ctx), "use_fsdp2_bf16_master_weight_optimizer", False)
+        and getattr(get_args(ctx), "use_torch_fsdp2", False)
+        and getattr(get_args(ctx), "bf16", False)
+    ),
+)
+def patch_fsdp2_bf16_master_weight_optimizer(ctx: PatchContext):
+    """Patch Megatron to use FSDP2 BF16 master weight optimizer.
+
+    This optimizer keeps model parameters in BF16 (no FP32->BF16 cast in
+    forward all-gather) and maintains FP32 master copies for optimizer
+    precision, matching Megatron's Float16OptimizerWithFloat16Params pattern.
+    """
+    try:
+        import megatron.core.optimizer as optimizer_module
+        from megatron.training import training
+
+        from primus.backends.megatron.core.optimizer.fsdp2_bf16_master_weight_optimizer import (
+            get_fsdp2_bf16_master_weight_optimizer,
+        )
+
+        args = get_args(ctx)
+        use_foreach = getattr(args, "optimizer_foreach", True)
+
+        _MEGATRON_ONLY_KWARGS = {
+            "config_overrides",
+            "use_gloo_process_groups",
+            "dump_param_to_param_group_map",
+        }
+
+        def patched_get_megatron_optimizer(config, model_chunks, *args, **kwargs):
+            log_rank_0("=" * 80)
+            log_rank_0("[Using FSDP2 BF16 Master Weight Optimizer]")
+            log_rank_0("  BF16 model params + FP32 master weights")
+            log_rank_0("  No FP32->BF16 cast in forward all-gather")
+            log_rank_0("  DTensor-native gradient clipping")
+            log_rank_0(f"  Foreach batching: {use_foreach}")
+            log_rank_0("=" * 80)
+
+            filtered_kwargs = {k: v for k, v in kwargs.items() if k not in _MEGATRON_ONLY_KWARGS}
+
+            return get_fsdp2_bf16_master_weight_optimizer(
+                config=config,
+                model_chunks=model_chunks,
+                use_foreach=use_foreach,
+                **filtered_kwargs,
+            )
+
+        patched_count = 0
+        if hasattr(training, "get_megatron_optimizer"):
+            training.get_megatron_optimizer = patched_get_megatron_optimizer
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_bf16_master_weight] "
+                "Patched training.get_megatron_optimizer"
+            )
+            patched_count += 1
+
+        if hasattr(optimizer_module, "get_megatron_optimizer"):
+            optimizer_module.get_megatron_optimizer = patched_get_megatron_optimizer
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_bf16_master_weight] "
+                "Patched optimizer_module.get_megatron_optimizer"
+            )
+            patched_count += 1
+
+        if patched_count == 0:
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_bf16_master_weight] "
+                "WARNING: get_megatron_optimizer not found in either location!"
+            )
+        else:
+            log_rank_0(
+                "[Patch:megatron.optimizer.fsdp2_bf16_master_weight] "
+                f"Patched get_megatron_optimizer in {patched_count} location(s) "
+                "to use FSDP2BF16MasterWeightOptimizer"
+            )
+
+    except Exception as e:
+        log_rank_0(
+            f"[Patch:megatron.optimizer.fsdp2_bf16_master_weight] "
+            f"WARNING: Failed to patch get_megatron_optimizer: {type(e).__name__}: {e}"
+        )
+        import traceback
+
+        log_rank_0(f"Traceback: {traceback.format_exc()}")
+
+
+@register_patch(
+    "megatron.optimizer.precision_aware_fp8_tensorwise",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Override precision-aware optimizer flag for local spec + tensorwise FP8, "
+        "enabling BF16 decoupled_grad path (no BF16-to-FP32 gradient cast)."
+    ),
+    priority=35,
+    condition=lambda ctx: (
+        getattr(get_args(ctx), "use_precision_aware_optimizer", False)
+        and getattr(get_args(ctx), "fp8_recipe", None) == "tensorwise"
+        and getattr(get_args(ctx), "transformer_impl", None) == "local"
+    ),
+)
+def patch_precision_aware_for_tensorwise(ctx: PatchContext):
+    """Enable precision-aware optimizer's decoupled_grad path for local spec + tensorwise FP8.
+
+    With local spec, parameters are BF16 (not Float8Tensor) -- FP8 quantization
+    happens inside per-module autograd Functions, transparent to the optimizer.
+    The upstream condition incorrectly excludes tensorwise FP8 because it was
+    designed for TE spec where Float8Tensor storage requires special handling.
+    """
+    try:
+        from megatron.core.optimizer.optimizer_config import OptimizerConfig
+
+        original_post_init = OptimizerConfig.__post_init__
+
+        def patched_post_init(self):
+            original_post_init(self)
+            if self.use_precision_aware_optimizer and self.fp8_recipe == "tensorwise":
+                self.use_precision_aware_optimizer_no_fp8_or_ds_fp8 = True
+
+        OptimizerConfig.__post_init__ = patched_post_init
+
+        log_rank_0(
+            "[Patch:megatron.optimizer.precision_aware_fp8_tensorwise] "
+            "Patched OptimizerConfig.__post_init__ to enable "
+            "decoupled_grad path for local spec + tensorwise FP8"
+        )
+
+    except Exception as e:
+        log_rank_0(
+            f"[Patch:megatron.optimizer.precision_aware_fp8_tensorwise] "
+            f"WARNING: Failed to patch OptimizerConfig: {type(e).__name__}: {e}"
+        )
+        import traceback
+
+        log_rank_0(f"Traceback: {traceback.format_exc()}")

--- a/primus/backends/megatron/patches/torch_fsdp2_patches.py
+++ b/primus/backends/megatron/patches/torch_fsdp2_patches.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -59,27 +59,40 @@ def patch_torch_fsdp(ctx: PatchContext):
         f"[Patch:megatron.fsdp.torch_fsdp2]   Patched megatron.training.training.torch_FSDP "
         f"-> {PrimusTorchFullyShardedDataParallel.__name__}"
     )
-    # Megatron Core 0.16 may pass new kwargs (e.g., force_all_reduce) into
-    # model_chunk.finish_grad_sync(). Keep FSDP2 path forward-compatible by
-    from megatron.core.distributed import data_parallel_base
 
-    original_start_grad_sync = data_parallel_base._BaseDataParallel.start_grad_sync
-    original_finish_grad_sync = data_parallel_base._BaseDataParallel.finish_grad_sync
+    # Patch get_data_parallel_group_if_dtensor to handle 2D HSDP meshes.
+    # The upstream implementation calls tensor.device_mesh.get_group() without mesh_dim,
+    # which fails for 2D meshes. For HSDP (dp_replicate, dp_shard), we return the
+    # shard group (innermost dim) since that's where parameters are actually sharded;
+    # replicas have identical gradients so we must not all-reduce across them.
+    import megatron.core.optimizer.clip_grads as clip_grads_module
+    import megatron.core.utils as mcore_utils
+    from megatron.training import utils as training_utils
 
-    if not getattr(original_start_grad_sync, "_primus_grad_sync_compat", False):
+    try:
+        from torch.distributed._tensor import DTensor
 
-        def _patched_start_grad_sync(self, *unused, **unused_kwargs):
-            return original_start_grad_sync(self, *unused)
+        HAVE_DTENSOR = True
+    except ImportError:
+        HAVE_DTENSOR = False
 
-        def _patched_finish_grad_sync(self, *unused, **unused_kwargs):
-            return original_finish_grad_sync(self)
+    def _get_data_parallel_group_if_dtensor(tensor, data_parallel_group=None):
+        if HAVE_DTENSOR and isinstance(tensor, DTensor):
+            mesh = tensor.device_mesh
+            if mesh.ndim > 1:
+                current_group = mesh.get_group(mesh_dim=-1)
+            else:
+                current_group = mesh.get_group()
+            if data_parallel_group is not None and current_group != data_parallel_group:
+                raise RuntimeError("DTensor mesh group does not match the expected data_parallel_group")
+            return current_group
+        return None
 
-        setattr(_patched_start_grad_sync, "_primus_grad_sync_compat", True)
-        setattr(_patched_finish_grad_sync, "_primus_grad_sync_compat", True)
-        data_parallel_base._BaseDataParallel.start_grad_sync = _patched_start_grad_sync
-        data_parallel_base._BaseDataParallel.finish_grad_sync = _patched_finish_grad_sync
-
-        log_rank_0(
-            "[Patch:megatron.fsdp.torch_fsdp2]   Patched _BaseDataParallel "
-            "start_grad_sync/finish_grad_sync to accept extra kwargs "
-        )
+    mcore_utils.get_data_parallel_group_if_dtensor = _get_data_parallel_group_if_dtensor
+    clip_grads_module.get_data_parallel_group_if_dtensor = _get_data_parallel_group_if_dtensor
+    if hasattr(training_utils, "get_data_parallel_group_if_dtensor"):
+        training_utils.get_data_parallel_group_if_dtensor = _get_data_parallel_group_if_dtensor
+    log_rank_0(
+        "[Patch:megatron.fsdp.torch_fsdp2]   Patched get_data_parallel_group_if_dtensor "
+        "for 2D HSDP mesh support"
+    )

--- a/tests/unit_tests/backends/megatron/diffusion/distributed/__init__.py
+++ b/tests/unit_tests/backends/megatron/diffusion/distributed/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Distributed tests for Flux diffusion model.
+
+Tests for FSDP2, pipeline parallelism, and other distributed training features.
+"""

--- a/tests/unit_tests/backends/megatron/diffusion/distributed/test_fsdp2_fp8_all_gather.py
+++ b/tests/unit_tests/backends/megatron/diffusion/distributed/test_fsdp2_fp8_all_gather.py
@@ -1,0 +1,528 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for FP8 all-gather tensor subclasses.
+
+Tests the FP8 all-gather subclasses in isolation (single GPU, no
+multi-GPU / NCCL required). Verifies:
+- WeightWithFP8AllGatherTensor: creation, pre/post all-gather with
+  precomputed scale, dispatch, flatten/unflatten
+- FP8UnshardedWeightTensor: creation, dispatch propagation, detach
+  dequantizes to BF16, unsupported ops raise NotImplementedError,
+  flatten/unflatten roundtrip, get_fp8_data_and_scale_inv()
+"""
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus_turbo.pytorch.core.low_precision import (
+    Float8QuantConfig,
+    Format,
+    ScalingGranularity,
+)
+
+from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+    FP8UnshardedWeightTensor,
+    WeightWithFP8AllGatherTensor,
+    _foreach_fp8_quantize,
+    _get_fp8_dtype,
+    quantize_fp8_prescaled,
+)
+
+_has_cuda = torch.cuda.is_available()
+requires_cuda = pytest.mark.skipif(not _has_cuda, reason="CUDA required")
+
+
+def _make_config():
+    return Float8QuantConfig(format=Format.E4M3, granularity=ScalingGranularity.TENSORWISE)
+
+
+def _make_wrapped(shape=(256, 512), device="cpu"):
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device=device)
+    wrapped = WeightWithFP8AllGatherTensor(tensor, _make_config())
+    return wrapped, tensor
+
+
+def _set_precomputed_scale(wrapped):
+    """Compute and set precomputed scale, scale_inv, and cached FP8 data for a single-rank scenario."""
+    fp8_dtype = _get_fp8_dtype(wrapped._fp8_config.format)
+    fp8_max = torch.finfo(fp8_dtype).max
+    amax = wrapped._tensor.abs().amax().float()
+    scale = fp8_max / amax.clamp(min=1e-12)
+    wrapped._precomputed_scale = scale
+    wrapped._precomputed_scale_inv = 1.0 / scale
+    fp8_data, _ = quantize_fp8_prescaled(
+        wrapped._tensor,
+        fp8_dtype,
+        scale,
+        wrapped._precomputed_scale_inv,
+    )
+    wrapped._cached_fp8_data = fp8_data
+
+
+def _make_fp8_unsharded(shape=(256, 512), device="cpu"):
+    """Create an FP8UnshardedWeightTensor from a BF16 source tensor."""
+    config = _make_config()
+    bf16_tensor = torch.randn(shape, dtype=torch.bfloat16, device=device)
+    fp8_dtype = _get_fp8_dtype(config.format)
+    fp8_max = torch.finfo(fp8_dtype).max
+    amax = bf16_tensor.abs().amax().float()
+    scale = fp8_max / amax.clamp(min=1e-12)
+    scale_inv = 1.0 / scale
+    fp8_data = (bf16_tensor.float() * scale).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+    return (
+        FP8UnshardedWeightTensor(fp8_data, scale_inv, torch.bfloat16, config),
+        bf16_tensor,
+        fp8_data,
+        scale_inv,
+    )
+
+
+class TestSubclassCreation:
+    def test_shape_dtype_device_preserved(self):
+        wrapped, orig = _make_wrapped()
+        assert wrapped.shape == orig.shape
+        assert wrapped.dtype == torch.bfloat16
+        assert wrapped.device == orig.device
+
+    def test_isinstance_tensor(self):
+        wrapped, _ = _make_wrapped()
+        assert isinstance(wrapped, torch.Tensor)
+        assert isinstance(wrapped, WeightWithFP8AllGatherTensor)
+
+    def test_inner_tensor_accessible(self):
+        wrapped, orig = _make_wrapped()
+        assert wrapped._tensor is orig
+
+    def test_tensorwise_only_validation(self):
+        config = Float8QuantConfig(format=Format.E4M3, granularity=ScalingGranularity.ROWWISE)
+        with pytest.raises(ValueError, match="TENSORWISE"):
+            WeightWithFP8AllGatherTensor(torch.randn(4, 4, dtype=torch.bfloat16), config)
+
+    def test_precomputed_scale_initially_none(self):
+        wrapped, _ = _make_wrapped()
+        assert wrapped._precomputed_scale is None
+
+
+@requires_cuda
+class TestPreAllGather:
+    def test_returns_one_input(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        _set_precomputed_scale(wrapped)
+        all_gather_inputs, metadata = wrapped.fsdp_pre_all_gather(None)
+        assert len(all_gather_inputs) == 1
+
+    def test_fp8_data_dtype(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        _set_precomputed_scale(wrapped)
+        (fp8_data,), _ = wrapped.fsdp_pre_all_gather(None)
+        assert fp8_data.dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e4m3fnuz,
+        )
+
+    def test_metadata_contains_scale_inv_and_numel(self):
+        wrapped, orig = _make_wrapped((128, 64), device="cuda")
+        _set_precomputed_scale(wrapped)
+        _, metadata = wrapped.fsdp_pre_all_gather(None)
+        scale_inv, shard_numel = metadata
+        assert scale_inv.dtype == torch.float32
+        assert shard_numel == 128 * 64
+
+    def test_fp8_data_shape_matches_input(self):
+        wrapped, orig = _make_wrapped((32, 64), device="cuda")
+        _set_precomputed_scale(wrapped)
+        (fp8_data,), _ = wrapped.fsdp_pre_all_gather(None)
+        assert fp8_data.numel() == orig.numel()
+
+    def test_asserts_without_precomputed_scale(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        with pytest.raises(RuntimeError, match="precompute_fp8_scales_for_fsdp"):
+            wrapped.fsdp_pre_all_gather(None)
+
+
+@requires_cuda
+class TestPostAllGather:
+    def _simulate_single_rank(self, wrapped):
+        """Simulate all-gather with a single rank (data passes through)."""
+        _set_precomputed_scale(wrapped)
+        (fp8_data,), metadata = wrapped.fsdp_pre_all_gather(None)
+        return (fp8_data,), metadata
+
+    def test_first_call_returns_fp8_unsharded_tensor(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        outputs, metadata = self._simulate_single_rank(wrapped)
+        result = wrapped.fsdp_post_all_gather(outputs, metadata, torch.bfloat16)
+        assert result is not None
+        tensor, inner_tensors = result
+        assert isinstance(tensor, FP8UnshardedWeightTensor)
+        assert tensor.dtype == torch.bfloat16
+        assert isinstance(inner_tensors, tuple)
+        assert len(inner_tensors) == 1
+
+    def test_steady_state_updates_scale(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        outputs, metadata = self._simulate_single_rank(wrapped)
+        # First call to get an FP8UnshardedWeightTensor
+        result = wrapped.fsdp_post_all_gather(outputs, metadata, torch.bfloat16)
+        fp8_unsharded, _ = result
+        # Simulate FSDP's reshard path: pass the FP8UnshardedWeightTensor
+        # directly as `out` (FSDP uses the unsharded_param, not nn.Parameter)
+        new_scale_inv = metadata[0] * 2.0
+        new_metadata = (new_scale_inv, metadata[1])
+        result = wrapped.fsdp_post_all_gather(outputs, new_metadata, torch.bfloat16, out=fp8_unsharded)
+        assert result is None
+        assert torch.equal(fp8_unsharded._scale_inv, new_scale_inv)
+
+
+@requires_cuda
+class TestRoundtripAccuracy:
+    def test_quantize_keeps_values(self):
+        torch.manual_seed(42)
+        wrapped, orig = _make_wrapped((128, 256), device="cuda")
+        _set_precomputed_scale(wrapped)
+        outputs, metadata = wrapped.fsdp_pre_all_gather(None)
+        result = wrapped.fsdp_post_all_gather(outputs, metadata, torch.bfloat16)
+        fp8_unsharded, _ = result
+        fp8_data, scale_inv = fp8_unsharded.get_fp8_data_and_scale_inv()
+        dequantized = fp8_data.to(torch.bfloat16) * scale_inv
+        dequantized = dequantized.view(orig.shape)
+        torch.testing.assert_close(dequantized, orig, rtol=0.05, atol=0.1)
+
+
+class TestTorchDispatch:
+    def test_preserves_subclass_for_standard_ops(self):
+        wrapped, _ = _make_wrapped((16, 16))
+        for op in [
+            lambda t: torch.empty_like(t),
+            lambda t: t.view(-1),
+            lambda t: t.clone(),
+            lambda t: t[0:8],
+        ]:
+            result = op(wrapped)
+            assert isinstance(
+                result, WeightWithFP8AllGatherTensor
+            ), f"Op should preserve subclass but got {type(result)}"
+
+    def test_unwraps_for_compute_ops(self):
+        wrapped, _ = _make_wrapped((16, 16))
+        plain = torch.randn(16, 16, dtype=torch.bfloat16)
+        result = wrapped + plain
+        assert type(result) is torch.Tensor
+        assert not isinstance(result, WeightWithFP8AllGatherTensor)
+
+    def test_copy_inplace_modifies_inner(self):
+        """copy_ modifies inner tensor in-place; target retains subclass type."""
+        wrapped, _ = _make_wrapped((8, 8))
+        target = torch.empty_like(wrapped)
+        target.copy_(wrapped)
+        assert isinstance(target, WeightWithFP8AllGatherTensor)
+        torch.testing.assert_close(target._tensor, wrapped._tensor)
+
+    def test_to_copy_dtype_change_unwraps(self):
+        """`.float()` should return a plain tensor (for FP32 master copies)."""
+        wrapped, _ = _make_wrapped((8, 8))
+        fp32 = wrapped.float()
+        assert fp32.dtype == torch.float32
+        assert not isinstance(fp32, WeightWithFP8AllGatherTensor)
+
+    def test_to_copy_same_dtype_preserves(self):
+        wrapped, _ = _make_wrapped((8, 8))
+        result = wrapped.to(torch.bfloat16)
+        assert isinstance(result, WeightWithFP8AllGatherTensor)
+
+    def test_detach_preserves_subclass(self):
+        """detach preserves subclass so nn.Parameter() and FSDP2 work correctly."""
+        wrapped, orig = _make_wrapped((8, 8))
+        detached = wrapped.detach()
+        assert isinstance(detached, WeightWithFP8AllGatherTensor)
+        assert detached._tensor.data_ptr() == wrapped._tensor.data_ptr()
+        assert detached._fp8_config.format == wrapped._fp8_config.format
+
+
+class TestTensorFlattenUnflatten:
+    def test_roundtrip(self):
+        wrapped, orig = _make_wrapped((32, 64))
+        inner_tensors_names, metadata = wrapped.__tensor_flatten__()
+        assert inner_tensors_names == ["_tensor"]
+        assert "format" in metadata
+        assert "granularity" in metadata
+
+        inner_tensors = {"_tensor": wrapped._tensor}
+        restored = WeightWithFP8AllGatherTensor.__tensor_unflatten__(
+            inner_tensors, metadata, wrapped.shape, wrapped.stride()
+        )
+        assert isinstance(restored, WeightWithFP8AllGatherTensor)
+        assert restored._tensor is orig
+        assert restored._fp8_config.format == Format.E4M3
+        assert restored._fp8_config.granularity == ScalingGranularity.TENSORWISE
+
+    def test_metadata_is_hashable(self):
+        wrapped, _ = _make_wrapped()
+        _, metadata = wrapped.__tensor_flatten__()
+        for key, value in metadata.items():
+            hash(value)
+
+    def test_precomputed_scale_not_in_metadata(self):
+        """_precomputed_scale is transient and must not appear in flatten metadata."""
+        wrapped, _ = _make_wrapped()
+        wrapped._precomputed_scale = torch.tensor(1.0)
+        _, metadata = wrapped.__tensor_flatten__()
+        assert "precomputed_scale" not in metadata
+        assert "_precomputed_scale" not in metadata
+
+
+# ============================================================================
+# FP8UnshardedWeightTensor tests
+# ============================================================================
+
+
+class TestFP8UnshardedWeightTensorCreation:
+    def test_shape_and_declared_dtype(self):
+        fp8_unsharded, _, fp8_data, _ = _make_fp8_unsharded((64, 32))
+        assert fp8_unsharded.shape == (64, 32)
+        assert fp8_unsharded.dtype == torch.bfloat16
+
+    def test_inner_fp8_data_accessible(self):
+        fp8_unsharded, _, fp8_data, scale_inv = _make_fp8_unsharded()
+        assert fp8_unsharded._fp8_data is fp8_data
+        assert torch.equal(fp8_unsharded._scale_inv, scale_inv)
+
+    def test_get_fp8_data_and_scale_inv(self):
+        fp8_unsharded, _, fp8_data, scale_inv = _make_fp8_unsharded()
+        data, sinv = fp8_unsharded.get_fp8_data_and_scale_inv()
+        assert data is fp8_data
+        assert torch.equal(sinv, scale_inv)
+
+
+class TestFP8UnshardedDispatch:
+    def test_as_strided_preserves_subclass(self):
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded((8, 8))
+        result = torch.as_strided(fp8_unsharded, (64,), (1,), 0)
+        assert isinstance(result, FP8UnshardedWeightTensor)
+        assert result.shape == (64,)
+
+    def test_view_preserves_subclass(self):
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded((8, 8))
+        result = fp8_unsharded.view(-1)
+        assert isinstance(result, FP8UnshardedWeightTensor)
+        assert result.shape == (64,)
+
+    def test_slice_preserves_subclass(self):
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded((16, 8))
+        result = fp8_unsharded[0:8]
+        assert isinstance(result, FP8UnshardedWeightTensor)
+        assert result.shape == (8, 8)
+
+    def test_clone_preserves_subclass(self):
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded((8, 8))
+        result = fp8_unsharded.clone()
+        assert isinstance(result, FP8UnshardedWeightTensor)
+
+    def test_detach_preserves_subclass(self):
+        """detach must preserve subclass (required by nn.Parameter wrapping)."""
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded((8, 8))
+        detached = fp8_unsharded.detach()
+        assert isinstance(detached, FP8UnshardedWeightTensor)
+        assert detached.dtype == torch.bfloat16
+
+    def test_unsupported_op_raises(self):
+        """Unsupported ops raise NotImplementedError (safety guard)."""
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded((8, 8))
+        with pytest.raises(NotImplementedError, match="does not support"):
+            fp8_unsharded + torch.zeros(8, 8, dtype=torch.bfloat16)
+
+
+class TestFP8UnshardedFlattenUnflatten:
+    def test_roundtrip(self):
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded((32, 64))
+        inner_names, metadata = fp8_unsharded.__tensor_flatten__()
+        assert set(inner_names) == {"_fp8_data", "_scale_inv"}
+        assert "orig_dtype" in metadata
+        assert "format" in metadata
+
+        inner_tensors = {
+            "_fp8_data": fp8_unsharded._fp8_data,
+            "_scale_inv": fp8_unsharded._scale_inv,
+        }
+        restored = FP8UnshardedWeightTensor.__tensor_unflatten__(
+            inner_tensors, metadata, fp8_unsharded.shape, fp8_unsharded.stride()
+        )
+        assert isinstance(restored, FP8UnshardedWeightTensor)
+        assert restored._orig_dtype == torch.bfloat16
+        # FP8 dtypes don't support torch.equal on CPU; compare via uint8 view
+        assert torch.equal(
+            restored._fp8_data.view(torch.uint8),
+            fp8_unsharded._fp8_data.view(torch.uint8),
+        )
+        assert torch.equal(restored._scale_inv, fp8_unsharded._scale_inv)
+
+    def test_metadata_is_hashable(self):
+        fp8_unsharded, _, _, _ = _make_fp8_unsharded()
+        _, metadata = fp8_unsharded.__tensor_flatten__()
+        for key, value in metadata.items():
+            hash(value)
+
+
+class TestFP8DataCache:
+    def test_cache_initially_none(self):
+        wrapped, _ = _make_wrapped()
+        assert wrapped._cached_fp8_data is None
+
+    @requires_cuda
+    def test_pre_all_gather_returns_cached_data(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        _set_precomputed_scale(wrapped)
+        assert wrapped._cached_fp8_data is not None
+        (fp8_data,), _ = wrapped.fsdp_pre_all_gather(mesh=None)
+        assert fp8_data.data_ptr() == wrapped._cached_fp8_data.data_ptr()
+
+    @requires_cuda
+    def test_pre_all_gather_fallback_without_cache(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        _set_precomputed_scale(wrapped)
+        wrapped._cached_fp8_data = None
+        (fp8_data,), (scale_inv, _) = wrapped.fsdp_pre_all_gather(mesh=None)
+        fp8_dtype = _get_fp8_dtype(wrapped._fp8_config.format)
+        assert fp8_data.dtype == fp8_dtype
+        assert fp8_data.shape == wrapped._tensor.shape
+
+    @requires_cuda
+    def test_cache_matches_direct_quantize(self):
+        wrapped, _ = _make_wrapped(device="cuda")
+        _set_precomputed_scale(wrapped)
+        cached = wrapped._cached_fp8_data
+        fp8_dtype = _get_fp8_dtype(wrapped._fp8_config.format)
+        fresh, _ = quantize_fp8_prescaled(
+            wrapped._tensor,
+            fp8_dtype,
+            wrapped._precomputed_scale,
+            wrapped._precomputed_scale_inv,
+        )
+        assert torch.equal(cached.view(torch.uint8), fresh.view(torch.uint8))
+
+    @requires_cuda
+    def test_cache_not_in_flatten_metadata(self):
+        # _set_precomputed_scale runs the Triton FP8 quantize kernel which
+        # requires a CUDA-resident tensor (no CPU dispatch). Match the other
+        # cache tests in this class which already use device="cuda".
+        wrapped, _ = _make_wrapped(device="cuda")
+        _set_precomputed_scale(wrapped)
+        inner_names, _ = wrapped.__tensor_flatten__()
+        assert "_cached_fp8_data" not in inner_names
+
+
+class TestForeachOptimizerOps:
+    """Tests for _foreach_copy_ batched operations used by the optimizer."""
+
+    @requires_cuda
+    def test_foreach_copy_bf16_to_fp32_matches_float(self):
+        """_foreach_copy_ BF16->FP32 matches per-tensor .float() (prepare_grads)."""
+        sizes = [(128, 256), (64,), (512, 512), (32, 16)]
+        bf16_tensors = [torch.randn(s, dtype=torch.bfloat16, device="cuda") for s in sizes]
+        ref_fp32 = [t.float() for t in bf16_tensors]
+
+        fp32_targets = [torch.empty(s, dtype=torch.float32, device="cuda") for s in sizes]
+        torch._foreach_copy_(fp32_targets, bf16_tensors)
+
+        for i in range(len(sizes)):
+            torch.testing.assert_close(
+                fp32_targets[i], ref_fp32[i], rtol=0, atol=0, msg=f"Mismatch at tensor {i} shape {sizes[i]}"
+            )
+
+    @requires_cuda
+    def test_foreach_copy_fp32_to_bf16_matches_copy(self):
+        """_foreach_copy_ FP32->BF16 matches per-tensor .copy_() (copy-back)."""
+        sizes = [(256, 128), (64,), (1024,)]
+        fp32_tensors = [torch.randn(s, dtype=torch.float32, device="cuda") for s in sizes]
+        ref_bf16 = [torch.empty(s, dtype=torch.bfloat16, device="cuda") for s in sizes]
+        for r, f in zip(ref_bf16, fp32_tensors):
+            r.copy_(f)
+
+        bf16_targets = [torch.empty(s, dtype=torch.bfloat16, device="cuda") for s in sizes]
+        torch._foreach_copy_(bf16_targets, fp32_tensors)
+
+        for i in range(len(sizes)):
+            torch.testing.assert_close(
+                bf16_targets[i], ref_bf16[i], rtol=0, atol=0, msg=f"Mismatch at tensor {i} shape {sizes[i]}"
+            )
+
+    @requires_cuda
+    def test_cache_extraction_fp8_wrapped(self):
+        """to_local() + inner_data() produces the correct inner tensor for FP8-wrapped params."""
+        wrapped, orig = _make_wrapped((128, 64), device="cuda")
+        inner = wrapped.inner_data()
+        assert inner is orig
+        assert inner.dtype == torch.bfloat16
+        assert inner.data_ptr() == orig.data_ptr()
+
+    @requires_cuda
+    def test_mixed_sizes_foreach_copy(self):
+        """_foreach_copy_ works with mixed tensor sizes in the same list."""
+        sizes = [(1,), (7,), (1024, 1024), (3, 5, 7), (131072,)]
+        bf16_list = [torch.randn(s, dtype=torch.bfloat16, device="cuda") for s in sizes]
+        fp32_list = [torch.empty(s, dtype=torch.float32, device="cuda") for s in sizes]
+        torch._foreach_copy_(fp32_list, bf16_list)
+        for i, (b, f) in enumerate(zip(bf16_list, fp32_list)):
+            torch.testing.assert_close(
+                f, b.float(), rtol=0, atol=0, msg=f"Mixed-size mismatch at tensor {i} shape {sizes[i]}"
+            )
+
+
+class TestForeachFP8Quantize:
+    """Tests for the compiled _foreach_fp8_quantize batch quantization helper."""
+
+    @requires_cuda
+    def test_matches_per_tensor_quantize(self):
+        """Verify _foreach_fp8_quantize is bitwise identical to quantize_fp8_prescaled."""
+        config = _make_config()
+        fp8_dtype = _get_fp8_dtype(config.format)
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        sizes = [1024, 4096, 131072, 524288]
+        tensors = [torch.randn(s, device="cuda", dtype=torch.bfloat16) for s in sizes]
+        amaxes = torch.stack([t.abs().amax().float() for t in tensors])
+        scales = (fp8_max / amaxes.clamp(min=1e-12)).to(torch.float32)
+        scale_invs = 1.0 / scales
+
+        ref_results = []
+        for i, t in enumerate(tensors):
+            fp8_data, _ = quantize_fp8_prescaled(
+                t,
+                fp8_dtype,
+                scales[i],
+                scale_invs[i],
+            )
+            ref_results.append(fp8_data)
+
+        fp8_outputs = [torch.empty_like(t, dtype=fp8_dtype) for t in tensors]
+        _foreach_fp8_quantize.__wrapped__(tensors, fp8_outputs, scales, fp8_max)
+
+        for i in range(len(tensors)):
+            assert torch.equal(
+                fp8_outputs[i].view(torch.uint8),
+                ref_results[i].view(torch.uint8),
+            ), f"Mismatch at tensor {i} (size {sizes[i]})"
+
+    @requires_cuda
+    def test_clamps_correctly(self):
+        """Verify out-of-range values are clamped to fp8_max, not NaN."""
+        config = _make_config()
+        fp8_dtype = _get_fp8_dtype(config.format)
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        tensor = torch.tensor([1.0, 1000.0, -1000.0, 0.001], device="cuda", dtype=torch.bfloat16)
+        scale = torch.tensor(fp8_max, device="cuda", dtype=torch.float32)
+        scales = scale.unsqueeze(0)
+
+        fp8_out = [torch.empty_like(tensor, dtype=fp8_dtype)]
+        _foreach_fp8_quantize.__wrapped__([tensor], fp8_out, scales, fp8_max)
+
+        result = fp8_out[0]
+        assert not result.float().isnan().any(), "NaN found in FP8 output"
+        assert result.float().abs().max() <= fp8_max

--- a/tests/unit_tests/backends/megatron/diffusion/distributed/test_fsdp2_transformer_impl.py
+++ b/tests/unit_tests/backends/megatron/diffusion/distributed/test_fsdp2_transformer_impl.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for FSDP2 transformer_impl wrapping logic.
+
+Tests that PrimusTorchFullyShardedDataParallel correctly excludes/includes
+ColumnParallelLinear based on transformer_impl setting, aligning with Megatron's pattern.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+from megatron.core import tensor_parallel
+from megatron.core.distributed.distributed_data_parallel_config import (
+    DistributedDataParallelConfig,
+)
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+from primus.backends.megatron.core.distributed import (
+    torch_fully_sharded_data_parallel as fsdp_mod,
+)
+from primus.backends.megatron.core.distributed.torch_fully_sharded_data_parallel import (
+    PrimusTorchFullyShardedDataParallel,
+)
+from tests.utils import PrimusUT
+
+
+class TestFSDP2TransformerImpl(PrimusUT):
+    """Tests for FSDP2 wrapping logic with transformer_impl."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        """Initialize parallel state for FSDP2 tests."""
+
+    def _build_and_collect_wrapped(self, transformer_impl):
+        """Construct the FSDP2 wrapper with fully_shard mocked at the call site.
+
+        Returns the list of module types that fully_shard was invoked on. The
+        mock must patch the name bound INSIDE the production module (it does
+        ``from torch.distributed.fsdp import fully_shard`` at import time), not
+        ``torch.distributed.fsdp.fully_shard`` -- otherwise the real kernel runs
+        and the wrapping decision is never exercised.
+        """
+
+        class MockModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                from megatron.core.tensor_parallel.layers import ColumnParallelLinear
+
+                inner = TransformerConfig(
+                    hidden_size=128,
+                    num_attention_heads=2,
+                    num_layers=1,
+                    transformer_impl=transformer_impl,
+                )
+                self.linear = ColumnParallelLinear(
+                    inner.hidden_size,
+                    inner.hidden_size,
+                    config=inner,
+                    init_method=lambda x: None,
+                )
+
+        model = MockModel().cuda()
+        config = TransformerConfig(
+            hidden_size=128,
+            num_attention_heads=2,
+            num_layers=1,
+            transformer_impl=transformer_impl,
+        )
+        ddp_config = DistributedDataParallelConfig()
+
+        wrapped_modules = []
+
+        def mock_fully_shard(module, **kwargs):
+            wrapped_modules.append(type(module))
+
+        with patch.object(fsdp_mod, "fully_shard", side_effect=mock_fully_shard):
+            PrimusTorchFullyShardedDataParallel(
+                config=config,
+                ddp_config=ddp_config,
+                module=model,
+            )
+        return wrapped_modules
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_fsdp2_excludes_column_parallel_linear_when_local(self):
+        """ColumnParallelLinear must be excluded when transformer_impl == 'local'."""
+        if not fsdp_mod.HAVE_FSDP:
+            pytest.skip("torch.distributed.fsdp (FSDP2) is unavailable")
+
+        wrapped_modules = self._build_and_collect_wrapped("local")
+
+        assert (
+            tensor_parallel.ColumnParallelLinear not in wrapped_modules
+        ), "ColumnParallelLinear should be excluded when transformer_impl == 'local'"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_fsdp2_includes_column_parallel_linear_when_not_local(self):
+        """Positive control: ColumnParallelLinear IS wrapped for non-local impl."""
+        if not fsdp_mod.HAVE_FSDP:
+            pytest.skip("torch.distributed.fsdp (FSDP2) is unavailable")
+
+        wrapped_modules = self._build_and_collect_wrapped("transformer_engine")
+
+        assert (
+            tensor_parallel.ColumnParallelLinear in wrapped_modules
+        ), "ColumnParallelLinear should be wrapped when transformer_impl != 'local'"

--- a/tests/unit_tests/backends/megatron/optimizer/test_fsdp2_bf16_master_weight_optimizer.py
+++ b/tests/unit_tests/backends/megatron/optimizer/test_fsdp2_bf16_master_weight_optimizer.py
@@ -1,0 +1,351 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for FSDP2BF16MasterWeightOptimizer.
+
+Tests focus on the core design properties:
+- FP32 master weights are created from BF16 model parameters
+- prepare_grads copies BF16 grads to FP32 master grads
+- Optimizer step updates FP32 masters and copies back to BF16 params
+- state_dict includes fp32_from_fp16_params key
+- Checkpoint save/load round-trip preserves values
+- sharded_state_dict integrates with Megatron's torch_dist checkpointing
+- finalize_dist_ckpt_load fills step counter and syncs params
+- Factory param group splitting (weight decay, LR scaling) works
+- Multi-step training actually reduces loss
+"""
+
+import pytest
+import torch
+from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
+
+from primus.backends.megatron.core.optimizer.fsdp2_bf16_master_weight_optimizer import (
+    get_fsdp2_bf16_master_weight_optimizer,
+)
+from tests.utils import PrimusUT
+
+
+def _make_optimizer_config(**overrides):
+    defaults = dict(
+        bf16=True,
+        fp16=False,
+        optimizer="adam",
+        lr=1e-4,
+        min_lr=1e-5,
+        weight_decay=0.01,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1e-8,
+        clip_grad=1.0,
+        use_precision_aware_optimizer=False,
+    )
+    defaults.update(overrides)
+    return OptimizerConfig(**defaults)
+
+
+def _make_model_and_optimizer(device="cpu"):
+    model = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.bfloat16, device=device)
+    config = _make_optimizer_config()
+    optimizer = get_fsdp2_bf16_master_weight_optimizer(
+        config=config,
+        model_chunks=[model],
+    )
+    return model, optimizer, config
+
+
+def _build_model_sharded_state_dict(model, prefix=""):
+    model_sd = model.state_dict(prefix=prefix, keep_vars=True)
+    return make_sharded_tensors_for_checkpoint(model_sd, prefix, {}, ())
+
+
+class TestFSDP2BF16MasterWeightOptimizer(PrimusUT):
+    """Tests for FSDP2BF16MasterWeightOptimizer core functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        pass
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_master_weights_are_fp32_clones_of_bf16(self):
+        """FP32 master weights must match BF16 params in value and shape."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        for bf16_group, fp32_group in zip(optimizer.bf16_groups, optimizer.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                assert bf16_param.dtype == torch.bfloat16
+                assert fp32_master.dtype == torch.float32
+                assert fp32_master.shape == bf16_param.shape
+                torch.testing.assert_close(fp32_master, bf16_param.float(), atol=0, rtol=0)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_main_param_attribute_set(self):
+        """BF16 params must have .main_param pointing to FP32 master."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        for bf16_group, fp32_group in zip(optimizer.bf16_groups, optimizer.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                assert hasattr(bf16_param, "main_param")
+                assert bf16_param.main_param is fp32_master
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_optimizer_operates_on_fp32_masters(self):
+        """Base optimizer's param_groups must contain FP32 masters, not BF16 params."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        for group in optimizer.optimizer.param_groups:
+            for p in group["params"]:
+                assert p.dtype == torch.float32, f"Optimizer param dtype is {p.dtype}, expected float32"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_prepare_grads_copies_to_fp32(self):
+        """prepare_grads must cast BF16 grads to FP32 on masters and clear BF16 grads."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.bfloat16, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+
+        for bf16_group in optimizer.bf16_groups:
+            for p in bf16_group:
+                assert p.grad is not None, "BF16 param should have grad before prepare_grads"
+
+        optimizer.prepare_grads()
+
+        for bf16_group in optimizer.bf16_groups:
+            for p in bf16_group:
+                assert p.grad is None, "BF16 grad should be cleared after prepare_grads"
+
+        for fp32_group in optimizer.fp32_from_bf16_groups:
+            for p in fp32_group:
+                assert p.grad is not None, "FP32 master should have grad after prepare_grads"
+                assert p.grad.dtype == torch.float32
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_step_updates_both_master_and_model(self):
+        """step() must update FP32 masters and copy back to BF16 params.
+
+        Uses high LR to ensure BF16 copy-back produces visible changes
+        (small updates can round to zero in BF16).
+        """
+        model = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.bfloat16, device="cuda")
+        config = _make_optimizer_config(lr=1e-1, clip_grad=1.0)
+        optimizer = get_fsdp2_bf16_master_weight_optimizer(config=config, model_chunks=[model])
+
+        bf16_before = {}
+        for name, p in model.named_parameters():
+            bf16_before[name] = p.data.clone()
+
+        x = torch.randn(2, 8, dtype=torch.bfloat16, device="cuda")
+        loss = (model(x) * 10.0).sum()
+        loss.backward()
+        success, grad_norm, num_zeros = optimizer.step()
+
+        assert success is True
+
+        for name, p in model.named_parameters():
+            assert not torch.equal(
+                p.data, bf16_before[name]
+            ), f"BF16 param '{name}' was not updated after step"
+
+        for bf16_group, fp32_group in zip(optimizer.bf16_groups, optimizer.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                expected = fp32_master.data.to(torch.bfloat16)
+                torch.testing.assert_close(bf16_param.data, expected, atol=0, rtol=0)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_optimizer_states_are_fp32(self):
+        """All optimizer states (exp_avg, exp_avg_sq) must be FP32."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.bfloat16, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+
+        for fp32_group in optimizer.fp32_from_bf16_groups:
+            for p in fp32_group:
+                state = optimizer.optimizer.state[p]
+                assert state["exp_avg"].dtype == torch.float32
+                assert state["exp_avg_sq"].dtype == torch.float32
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_state_dict_has_fp32_from_fp16_params_key(self):
+        """state_dict must include 'fp32_from_fp16_params' with FP32 master weights."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.bfloat16, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+
+        saved = optimizer.state_dict()
+        assert "optimizer" in saved
+        assert "fp32_from_fp16_params" in saved
+
+        for group in saved["fp32_from_fp16_params"]:
+            for param in group:
+                assert param.dtype == torch.float32
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_multi_step_loss_decreases(self):
+        """Run 10 steps and verify loss decreases."""
+        torch.manual_seed(42)
+        model = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.bfloat16, device="cuda")
+        config = _make_optimizer_config(lr=1e-2, clip_grad=0.0)
+        optimizer = get_fsdp2_bf16_master_weight_optimizer(config=config, model_chunks=[model])
+
+        x = torch.randn(4, 8, dtype=torch.bfloat16, device="cuda")
+        target = torch.randn(4, 8, dtype=torch.bfloat16, device="cuda")
+
+        loss_initial = None
+        loss_final = None
+        for _ in range(10):
+            optimizer.zero_grad()
+            output = model(x)
+            loss = ((output - target).float() ** 2).mean()
+            loss.backward()
+            optimizer.step()
+
+            if loss_initial is None:
+                loss_initial = loss.item()
+            loss_final = loss.item()
+
+        assert (
+            loss_final < loss_initial
+        ), f"Loss did not decrease: initial={loss_initial:.6f}, final={loss_final:.6f}"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_state_dict_round_trip(self):
+        """Verify state_dict save/load preserves FP32 master weights and optimizer states."""
+        model, optimizer, config = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.bfloat16, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+
+        saved_state = optimizer.state_dict()
+
+        original_masters = []
+        for group in saved_state["fp32_from_fp16_params"]:
+            original_masters.append([p.clone() for p in group])
+
+        original_opt_states = {}
+        for pid, pstate in saved_state["optimizer"]["state"].items():
+            original_opt_states[pid] = {
+                "exp_avg": pstate["exp_avg"].clone(),
+                "exp_avg_sq": pstate["exp_avg_sq"].clone(),
+            }
+
+        fresh_optimizer = get_fsdp2_bf16_master_weight_optimizer(config=config, model_chunks=[model])
+        fresh_optimizer.load_state_dict(saved_state)
+
+        loaded_state = fresh_optimizer.state_dict()
+        for saved_group, loaded_group in zip(original_masters, loaded_state["fp32_from_fp16_params"]):
+            for saved_p, loaded_p in zip(saved_group, loaded_group):
+                torch.testing.assert_close(loaded_p, saved_p)
+                assert loaded_p.dtype == torch.float32
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_sharded_state_dict_creates_sharded_tensors(self):
+        """Verify sharded_state_dict produces ShardedTensor entries."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        model_ssd = _build_model_sharded_state_dict(model)
+        opt_ssd = optimizer.sharded_state_dict(model_ssd, is_loading=True)
+
+        assert "optimizer" in opt_ssd
+        assert "fp32_from_fp16_params" in opt_ssd
+
+        # Check optimizer states are ShardedTensors
+        state_entries = opt_ssd["optimizer"]["state"]
+        assert len(state_entries) > 0
+        for pid, pstate in state_entries.items():
+            if isinstance(pstate, dict):
+                for key in ("exp_avg", "exp_avg_sq"):
+                    assert key in pstate
+                    assert isinstance(pstate[key], ShardedTensor)
+
+        # Check fp32_from_fp16_params are ShardedTensors
+        for group in opt_ssd["fp32_from_fp16_params"]:
+            for entry in group:
+                assert isinstance(entry, ShardedTensor)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_finalize_dist_ckpt_load(self):
+        """Verify finalize_dist_ckpt_load sets step counter and syncs params."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+        optimizer.init_state_fn(optimizer.optimizer)
+
+        # Modify FP32 masters to differ from BF16 params
+        for fp32_group in optimizer.fp32_from_bf16_groups:
+            for p in fp32_group:
+                p.data.add_(1.0)
+
+        iteration = 42
+        optimizer.finalize_dist_ckpt_load(iteration)
+
+        for fp32_group in optimizer.fp32_from_bf16_groups:
+            for p in fp32_group:
+                if p in optimizer.optimizer.state:
+                    step = optimizer.optimizer.state[p].get("step")
+                    if step is not None:
+                        assert step.item() == float(iteration)
+
+        # BF16 params should now match FP32 masters (copy-back happened)
+        for bf16_group, fp32_group in zip(optimizer.bf16_groups, optimizer.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                expected = fp32_master.data.to(torch.bfloat16)
+                torch.testing.assert_close(bf16_param.data, expected, atol=0, rtol=0)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_reload_model_params(self):
+        """Verify reload_model_params copies BF16 params to FP32 masters."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        # Manually change BF16 params (simulating checkpoint load)
+        for p in model.parameters():
+            p.data.fill_(0.5)
+
+        optimizer.reload_model_params()
+
+        for bf16_group, fp32_group in zip(optimizer.bf16_groups, optimizer.fp32_from_bf16_groups):
+            for bf16_param, fp32_master in zip(bf16_group, fp32_group):
+                torch.testing.assert_close(fp32_master, bf16_param.float(), atol=0, rtol=0)
+
+    def test_factory_applies_weight_decay_condition(self):
+        """Verify no_weight_decay_cond splits parameters into correct groups."""
+        model = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.bfloat16)
+        config = _make_optimizer_config(weight_decay=0.1)
+
+        def no_wd_for_bias(param):
+            return param.ndim == 1
+
+        optimizer = get_fsdp2_bf16_master_weight_optimizer(
+            config=config,
+            model_chunks=[model],
+            no_weight_decay_cond=no_wd_for_bias,
+        )
+
+        assert len(optimizer.optimizer.param_groups) == 2
+        wds = {pg["weight_decay"] for pg in optimizer.optimizer.param_groups}
+        assert 0.0 in wds
+        assert 0.1 in wds
+
+    def test_factory_handles_fp32_params(self):
+        """Verify FP32 params (e.g. LayerNorm) go to fp32_from_fp32_groups without master copy."""
+        model = torch.nn.Sequential(
+            torch.nn.Linear(8, 8, bias=False).to(dtype=torch.bfloat16),
+            torch.nn.LayerNorm(8).to(dtype=torch.float32),
+        )
+        config = _make_optimizer_config()
+        optimizer = get_fsdp2_bf16_master_weight_optimizer(config=config, model_chunks=[model])
+
+        total_bf16 = sum(len(g) for g in optimizer.bf16_groups)
+        total_fp32 = sum(len(g) for g in optimizer.fp32_from_fp32_groups)
+
+        assert total_bf16 == 1, f"Expected 1 BF16 param, got {total_bf16}"
+        assert total_fp32 == 2, f"Expected 2 FP32 params (LN weight+bias), got {total_fp32}"

--- a/tests/unit_tests/backends/megatron/optimizer/test_fsdp2_fp32_optimizer.py
+++ b/tests/unit_tests/backends/megatron/optimizer/test_fsdp2_fp32_optimizer.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for FSDP2FP32Optimizer.
+
+Tests focus on the core design properties of this optimizer:
+- Optimizer states are FP32 (the whole point)
+- state_dict format is raw PyTorch (not Megatron-wrapped)
+- Gradient clipping actually clips gradients
+- Optimizer step actually updates parameters and reduces loss
+- Checkpoint save/load round-trip preserves state values and dtypes
+- sharded_state_dict integrates with Megatron's torch_dist checkpointing
+- finalize_dist_ckpt_load fills step counter (FSDP2-specific)
+- Factory param group splitting (weight decay, LR scaling) works
+"""
+
+import pytest
+import torch
+from megatron.core.dist_checkpointing.mapping import ShardedTensor
+from megatron.core.optimizer.optimizer_config import OptimizerConfig
+from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
+
+from primus.backends.megatron.core.optimizer.fsdp2_fp32_optimizer import (
+    get_fsdp2_fp32_optimizer,
+)
+from tests.utils import PrimusUT
+
+
+def _make_optimizer_config(**overrides):
+    defaults = dict(
+        bf16=True,
+        fp16=False,
+        optimizer="adam",
+        lr=1e-4,
+        min_lr=1e-5,
+        weight_decay=0.01,
+        adam_beta1=0.9,
+        adam_beta2=0.999,
+        adam_eps=1e-8,
+        clip_grad=1.0,
+        use_precision_aware_optimizer=False,
+    )
+    defaults.update(overrides)
+    return OptimizerConfig(**defaults)
+
+
+def _make_model_and_optimizer(device="cpu"):
+    model = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.float32, device=device)
+    config = _make_optimizer_config()
+    optimizer = get_fsdp2_fp32_optimizer(
+        config=config,
+        model_chunks=[model],
+    )
+    return model, optimizer, config
+
+
+def _build_model_sharded_state_dict(model, prefix=""):
+    model_sd = model.state_dict(prefix=prefix, keep_vars=True)
+    return make_sharded_tensors_for_checkpoint(model_sd, prefix, {}, ())
+
+
+def _compute_grad_norm(model):
+    """Compute L2 gradient norm across all model parameters."""
+    total = 0.0
+    for p in model.parameters():
+        if p.grad is not None:
+            total += p.grad.float().norm().item() ** 2
+    return total**0.5
+
+
+class TestFSDP2FP32Optimizer(PrimusUT):
+    """Tests for FSDP2FP32Optimizer core functionality."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        pass
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_optimizer_states_are_fp32(self):
+        """The core invariant: all optimizer states must be FP32."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.float32, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+
+        for p in optimizer.get_parameters():
+            state = optimizer.optimizer.state[p]
+            assert (
+                state["exp_avg"].dtype == torch.float32
+            ), f"exp_avg dtype is {state['exp_avg'].dtype}, expected float32"
+            assert (
+                state["exp_avg_sq"].dtype == torch.float32
+            ), f"exp_avg_sq dtype is {state['exp_avg_sq'].dtype}, expected float32"
+            assert state["step"].dtype == torch.float32
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_state_dict_format_is_raw(self):
+        """state_dict must return raw PyTorch format, NOT a Megatron-wrapped
+        format ({"optimizer": {...}}).
+
+        This distinction is critical for checkpoint compatibility.
+        """
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.float32, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+
+        saved = optimizer.state_dict()
+        assert "state" in saved, "state_dict missing 'state' key"
+        assert "param_groups" in saved, "state_dict missing 'param_groups' key"
+        assert "optimizer" not in saved, (
+            "state_dict has 'optimizer' wrapper key -- this is the BFloat16Optimizer "
+            "format, not the raw format expected by FSDP2FP32Optimizer"
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_clip_grad_norm_clips_gradients(self):
+        """Verify clipping reduces grad norm to at most clip_value."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.float32, device="cuda")
+        loss = (model(x) * 100.0).sum()
+        loss.backward()
+
+        grad_norm_before = _compute_grad_norm(model)
+        assert grad_norm_before > 1.0, "Gradients too small to test clipping"
+
+        clip_value = 0.01
+        returned_norm = optimizer.clip_grad_norm(clip_value)
+        assert isinstance(
+            returned_norm, torch.Tensor
+        ), "clip_grad_norm should return a GPU tensor (deferred .item())"
+        returned_norm_f = returned_norm.item()
+
+        grad_norm_after = _compute_grad_norm(model)
+
+        assert (
+            abs(returned_norm_f - grad_norm_before) < 1e-3
+        ), f"Returned norm {returned_norm_f} should approximate pre-clip norm {grad_norm_before}"
+        assert (
+            grad_norm_after <= clip_value + 1e-6
+        ), f"Post-clip norm {grad_norm_after} exceeds clip_value {clip_value}"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_step_actually_updates_parameters(self):
+        """Verify optimizer.step() changes parameter values and returns
+        the (success, grad_norm, num_zeros) 3-tuple that Megatron's
+        training loop unpacks."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        params_before = {name: p.clone() for name, p in model.named_parameters()}
+
+        x = torch.randn(2, 8, dtype=torch.float32, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+        success, grad_norm, num_zeros = optimizer.step()
+
+        assert success is True
+        assert isinstance(
+            grad_norm, (float, torch.Tensor)
+        ), f"grad_norm should be float or Tensor, got {type(grad_norm)}"
+        grad_norm_f = grad_norm.item() if isinstance(grad_norm, torch.Tensor) else grad_norm
+        assert grad_norm_f > 0.0
+
+        for name, p in model.named_parameters():
+            assert not torch.equal(
+                p, params_before[name]
+            ), f"Parameter '{name}' was not updated by optimizer.step()"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_multi_step_loss_decreases(self):
+        """Run 10 steps and verify loss decreases, catching silent update failures."""
+        torch.manual_seed(42)
+        model = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.float32, device="cuda")
+        config = _make_optimizer_config(lr=1e-2, clip_grad=0.0)
+        optimizer = get_fsdp2_fp32_optimizer(config=config, model_chunks=[model])
+
+        x = torch.randn(4, 8, dtype=torch.float32, device="cuda")
+        target = torch.randn(4, 8, dtype=torch.float32, device="cuda")
+
+        loss_initial = None
+        loss_final = None
+        for _ in range(10):
+            optimizer.zero_grad()
+            output = model(x)
+            loss = ((output - target) ** 2).mean()
+            loss.backward()
+            optimizer.step()
+
+            if loss_initial is None:
+                loss_initial = loss.item()
+            loss_final = loss.item()
+
+        assert (
+            loss_final < loss_initial
+        ), f"Loss did not decrease: initial={loss_initial:.6f}, final={loss_final:.6f}"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_state_dict_round_trip(self):
+        """Verify state_dict save/load preserves values and FP32 dtypes."""
+        model, optimizer, config = _make_model_and_optimizer(device="cuda")
+
+        x = torch.randn(2, 8, dtype=torch.float32, device="cuda")
+        loss = model(x).sum()
+        loss.backward()
+        optimizer.step()
+
+        saved_state = optimizer.state_dict()
+
+        original_states = {}
+        for pid, pstate in saved_state["state"].items():
+            original_states[pid] = {
+                "exp_avg": pstate["exp_avg"].clone(),
+                "exp_avg_sq": pstate["exp_avg_sq"].clone(),
+            }
+
+        fresh_optimizer = get_fsdp2_fp32_optimizer(
+            config=config,
+            model_chunks=[model],
+        )
+        fresh_optimizer.load_state_dict(saved_state)
+
+        loaded_state = fresh_optimizer.state_dict()
+        for pid in original_states:
+            assert pid in loaded_state["state"]
+            torch.testing.assert_close(
+                loaded_state["state"][pid]["exp_avg"],
+                original_states[pid]["exp_avg"],
+            )
+            torch.testing.assert_close(
+                loaded_state["state"][pid]["exp_avg_sq"],
+                original_states[pid]["exp_avg_sq"],
+            )
+            assert loaded_state["state"][pid]["exp_avg"].dtype == torch.float32
+            assert loaded_state["state"][pid]["exp_avg_sq"].dtype == torch.float32
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_sharded_state_dict_creates_sharded_tensors(self):
+        """Verify sharded_state_dict produces ShardedTensor entries for torch_dist checkpointing."""
+        model, optimizer, _ = _make_model_and_optimizer(device="cuda")
+
+        model_ssd = _build_model_sharded_state_dict(model)
+        opt_ssd = optimizer.sharded_state_dict(model_ssd, is_loading=True)
+
+        assert "state" in opt_ssd
+        state_entries = opt_ssd["state"]
+        assert len(state_entries) > 0
+
+        for pid, pstate in state_entries.items():
+            if isinstance(pstate, dict):
+                for key in ("exp_avg", "exp_avg_sq"):
+                    assert key in pstate, f"Key '{key}' missing from state[{pid}]"
+                    assert isinstance(pstate[key], ShardedTensor)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_finalize_dist_ckpt_load(self):
+        """Verify finalize_dist_ckpt_load sets step counter from iteration."""
+        model, optimizer, config = _make_model_and_optimizer(device="cuda")
+
+        optimizer.init_state_fn(optimizer.optimizer)
+
+        iteration = 42
+        optimizer.finalize_dist_ckpt_load(iteration)
+
+        for p in optimizer.get_parameters():
+            if p in optimizer.optimizer.state:
+                step = optimizer.optimizer.state[p].get("step")
+                if step is not None:
+                    assert step.item() == float(iteration)
+
+    def test_init_state_fn_creates_fp32_states(self):
+        """Verify init_state_fn creates FP32 placeholders for checkpoint loading."""
+        model, optimizer, _ = _make_model_and_optimizer()
+
+        base_opt = optimizer.optimizer
+        for group in base_opt.param_groups:
+            for p in group["params"]:
+                assert len(base_opt.state[p]) == 0
+
+        optimizer.init_state_fn(base_opt)
+
+        for group in base_opt.param_groups:
+            for p in group["params"]:
+                state = base_opt.state[p]
+                assert state["exp_avg"].dtype == torch.float32
+                assert state["exp_avg_sq"].dtype == torch.float32
+                assert state["exp_avg"].shape == p.data.shape
+
+    def test_factory_applies_weight_decay_condition(self):
+        """Verify no_weight_decay_cond splits parameters into correct groups."""
+        model = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.float32)
+        config = _make_optimizer_config(weight_decay=0.1)
+
+        def no_wd_for_bias(param):
+            return param.ndim == 1
+
+        optimizer = get_fsdp2_fp32_optimizer(
+            config=config,
+            model_chunks=[model],
+            no_weight_decay_cond=no_wd_for_bias,
+        )
+
+        assert len(optimizer.optimizer.param_groups) == 2
+        wds = {pg["weight_decay"] for pg in optimizer.optimizer.param_groups}
+        assert 0.0 in wds
+        assert 0.1 in wds

--- a/tests/unit_tests/backends/megatron/patches/test_fsdp2_fp32_patches.py
+++ b/tests/unit_tests/backends/megatron/patches/test_fsdp2_fp32_patches.py
@@ -1,0 +1,488 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for FSDP2 FP32 optimizer patches.
+
+Tests:
+- FSDP2 FP32 optimizer patch condition evaluation and application
+- Float16Module skip patch condition evaluation and application
+- _FSDP2PassthroughModule preserves FP32 weights and passes through forward
+- Mutual exclusivity of bf16 and fsdp2_fp32 optimizer patches
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from primus.core.patches.context import PatchContext
+from primus.core.patches.patch_runner import run_patches
+
+
+def _build_patch_context(backend_args=None):
+    if backend_args is None:
+        backend_args = SimpleNamespace()
+    module_config = SimpleNamespace(params=backend_args)
+    return PatchContext(
+        backend="megatron",
+        phase="before_train",
+        extra={"backend_args": backend_args, "module_config": module_config},
+    )
+
+
+def _install_fake_megatron_modules(monkeypatch):
+    training_mod = types.ModuleType("megatron.training.training")
+    training_pkg = types.ModuleType("megatron.training")
+    training_pkg.training = training_mod
+
+    core_pkg = types.ModuleType("megatron.core")
+    optimizer_mod = types.ModuleType("megatron.core.optimizer")
+    core_pkg.optimizer = optimizer_mod
+
+    megatron_pkg = types.ModuleType("megatron")
+    megatron_pkg.training = training_pkg
+    megatron_pkg.core = core_pkg
+
+    monkeypatch.setitem(sys.modules, "megatron", megatron_pkg)
+    monkeypatch.setitem(sys.modules, "megatron.training", training_pkg)
+    monkeypatch.setitem(sys.modules, "megatron.training.training", training_mod)
+    monkeypatch.setitem(sys.modules, "megatron.core", core_pkg)
+    monkeypatch.setitem(sys.modules, "megatron.core.optimizer", optimizer_mod)
+
+    return training_mod, optimizer_mod
+
+
+def _install_fsdp2_fp32_stub(monkeypatch, optimizer_fn):
+    stub = types.ModuleType("primus.backends.megatron.core.optimizer.fsdp2_fp32_optimizer")
+    stub.get_fsdp2_fp32_optimizer = optimizer_fn
+    monkeypatch.setitem(
+        sys.modules,
+        "primus.backends.megatron.core.optimizer.fsdp2_fp32_optimizer",
+        stub,
+    )
+
+
+class TestFSDP2FP32OptimizerPatch:
+    """Tests for the FSDP2 FP32 optimizer patch."""
+
+    def test_patch_applies_when_all_conditions_met(self, monkeypatch):
+        from primus.backends.megatron.patches.optimizer_patches import (
+            patch_fsdp2_fp32_optimizer,
+        )
+
+        backend_args = SimpleNamespace(
+            use_fsdp2_fp32_param_optimizer=True,
+            use_torch_fsdp2=True,
+            bf16=True,
+        )
+        ctx = _build_patch_context(backend_args)
+
+        training_mod, optimizer_mod = _install_fake_megatron_modules(monkeypatch)
+        original = lambda *args, **kwargs: Mock()
+        training_mod.get_megatron_optimizer = original
+        optimizer_mod.get_megatron_optimizer = original
+
+        mock_optimizer = Mock()
+        _install_fsdp2_fp32_stub(monkeypatch, lambda *args, **kwargs: mock_optimizer)
+
+        monkeypatch.setattr(
+            "primus.backends.megatron.patches.optimizer_patches.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        patch_fsdp2_fp32_optimizer(ctx)
+
+        assert training_mod.get_megatron_optimizer is not original
+        assert optimizer_mod.get_megatron_optimizer is not original
+
+        result = training_mod.get_megatron_optimizer(Mock(), [Mock()])
+        assert result is mock_optimizer
+
+    @pytest.mark.parametrize(
+        "backend_args",
+        [
+            SimpleNamespace(use_fsdp2_fp32_param_optimizer=False, use_torch_fsdp2=True, bf16=True),
+            SimpleNamespace(use_fsdp2_fp32_param_optimizer=True, use_torch_fsdp2=False, bf16=True),
+            SimpleNamespace(use_fsdp2_fp32_param_optimizer=True, use_torch_fsdp2=True, bf16=False),
+        ],
+    )
+    def test_patch_skipped_when_any_condition_false(self, monkeypatch, backend_args):
+        import primus.backends.megatron.patches.optimizer_patches  # noqa: F401
+
+        monkeypatch.setattr(
+            "primus.core.patches.patch_runner.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "primus.core.patches.patch_runner.error_rank_0",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "primus.core.patches.patch.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        training_mod, optimizer_mod = _install_fake_megatron_modules(monkeypatch)
+        original = lambda *args, **kwargs: Mock()
+        training_mod.get_megatron_optimizer = original
+        optimizer_mod.get_megatron_optimizer = original
+
+        count = run_patches(
+            backend="megatron",
+            phase="before_train",
+            extra={"module_config": SimpleNamespace(params=backend_args)},
+            enabled_ids=["megatron.optimizer.fsdp2_fp32_param"],
+        )
+
+        assert count == 0
+        assert training_mod.get_megatron_optimizer is original
+
+    def test_patched_optimizer_filters_megatron_kwargs(self, monkeypatch):
+        from primus.backends.megatron.patches.optimizer_patches import (
+            patch_fsdp2_fp32_optimizer,
+        )
+
+        backend_args = SimpleNamespace(
+            use_fsdp2_fp32_param_optimizer=True,
+            use_torch_fsdp2=True,
+            bf16=True,
+        )
+        ctx = _build_patch_context(backend_args)
+
+        training_mod, optimizer_mod = _install_fake_megatron_modules(monkeypatch)
+        training_mod.get_megatron_optimizer = lambda *a, **kw: Mock()
+        optimizer_mod.get_megatron_optimizer = lambda *a, **kw: Mock()
+
+        received_kwargs = {}
+
+        def tracking_factory(**kwargs):
+            received_kwargs.update(kwargs)
+            return Mock()
+
+        _install_fsdp2_fp32_stub(monkeypatch, lambda *args, **kwargs: tracking_factory(**kwargs))
+
+        monkeypatch.setattr(
+            "primus.backends.megatron.patches.optimizer_patches.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        patch_fsdp2_fp32_optimizer(ctx)
+
+        training_mod.get_megatron_optimizer(
+            Mock(),
+            [Mock()],
+            config_overrides={"x": 1},
+            use_gloo_process_groups=True,
+            no_weight_decay_cond=Mock(),
+        )
+
+        assert "config_overrides" not in received_kwargs
+        assert "use_gloo_process_groups" not in received_kwargs
+        assert "no_weight_decay_cond" in received_kwargs
+
+
+class TestSkipFloat16ModulePatch:
+    """Tests for the Float16Module skip patch."""
+
+    def test_patch_replaces_float16_module(self, monkeypatch):
+        from primus.backends.megatron.patches.build_model_patches import (
+            patch_skip_float16_module,
+        )
+
+        backend_args = SimpleNamespace(
+            use_fsdp2_fp32_param_optimizer=True,
+            use_torch_fsdp2=True,
+            bf16=True,
+        )
+        ctx = _build_patch_context(backend_args)
+
+        monkeypatch.setattr(
+            "primus.backends.megatron.patches.build_model_patches.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        _install_fake_megatron_modules(monkeypatch)
+
+        transformer_pkg = types.ModuleType("megatron.core.transformer")
+        transformer_module_mod = types.ModuleType("megatron.core.transformer.module")
+
+        class FakeFloat16Module:
+            pass
+
+        class FakeMegatronModule(torch.nn.Module):
+            def __init__(self, config=None):
+                super().__init__()
+
+        transformer_module_mod.Float16Module = FakeFloat16Module
+        transformer_module_mod.MegatronModule = FakeMegatronModule
+        transformer_pkg.module = transformer_module_mod
+        monkeypatch.setitem(
+            sys.modules,
+            "megatron.core.transformer",
+            transformer_pkg,
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "megatron.core.transformer.module",
+            transformer_module_mod,
+        )
+        sys.modules["megatron.core"].transformer = transformer_pkg
+
+        patch_skip_float16_module(ctx)
+
+        import megatron.training.training as training_mod
+
+        assert training_mod.Float16Module is not FakeFloat16Module
+        assert training_mod.Float16Module.__name__ == "_FSDP2PassthroughModule"
+
+    def test_passthrough_module_preserves_fp32_weights(self, monkeypatch):
+        """Verify _FSDP2PassthroughModule does NOT convert parameters to BF16
+        and that forward() passes through correctly.
+
+        This is the core contract: Float16Module converts to BF16, but the
+        passthrough replacement must keep FP32 so FSDP2 MixedPrecisionPolicy
+        can handle the casting.
+        """
+        from primus.backends.megatron.patches.build_model_patches import (
+            patch_skip_float16_module,
+        )
+
+        backend_args = SimpleNamespace(
+            use_fsdp2_fp32_param_optimizer=True,
+            use_torch_fsdp2=True,
+            bf16=True,
+        )
+        ctx = _build_patch_context(backend_args)
+
+        monkeypatch.setattr(
+            "primus.backends.megatron.patches.build_model_patches.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        _install_fake_megatron_modules(monkeypatch)
+
+        transformer_pkg = types.ModuleType("megatron.core.transformer")
+        transformer_module_mod = types.ModuleType("megatron.core.transformer.module")
+
+        class FakeMegatronModule(torch.nn.Module):
+            def __init__(self, config=None):
+                super().__init__()
+
+        class FakeFloat16Module:
+            pass
+
+        transformer_module_mod.Float16Module = FakeFloat16Module
+        transformer_module_mod.MegatronModule = FakeMegatronModule
+        transformer_pkg.module = transformer_module_mod
+        monkeypatch.setitem(
+            sys.modules,
+            "megatron.core.transformer",
+            transformer_pkg,
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "megatron.core.transformer.module",
+            transformer_module_mod,
+        )
+        sys.modules["megatron.core"].transformer = transformer_pkg
+
+        patch_skip_float16_module(ctx)
+
+        import megatron.training.training as training_mod
+
+        PassthroughCls = training_mod.Float16Module
+
+        inner_model = torch.nn.Linear(4, 4, bias=True).to(dtype=torch.float32)
+        config = SimpleNamespace(virtual_pipeline_model_parallel_size=None)
+        wrapper = PassthroughCls(config, inner_model)
+
+        # Parameters must remain FP32
+        for name, p in wrapper.named_parameters():
+            assert (
+                p.dtype == torch.float32
+            ), f"Parameter '{name}' was converted to {p.dtype}, expected float32"
+
+        # wrapper.module must be the original model
+        assert wrapper.module is inner_model
+
+        # Forward must pass through correctly
+        x = torch.randn(2, 4, dtype=torch.float32)
+        expected = inner_model(x)
+        actual = wrapper(x)
+        torch.testing.assert_close(actual, expected)
+
+    @pytest.mark.parametrize(
+        "backend_args",
+        [
+            SimpleNamespace(use_fsdp2_fp32_param_optimizer=False, use_torch_fsdp2=True, bf16=True),
+            SimpleNamespace(use_fsdp2_fp32_param_optimizer=True, use_torch_fsdp2=False, bf16=True),
+            SimpleNamespace(use_fsdp2_fp32_param_optimizer=True, use_torch_fsdp2=True, bf16=False),
+        ],
+    )
+    def test_patch_skipped_when_conditions_not_met(self, monkeypatch, backend_args):
+        import primus.backends.megatron.patches.build_model_patches  # noqa: F401
+
+        monkeypatch.setattr(
+            "primus.core.patches.patch_runner.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "primus.core.patches.patch_runner.error_rank_0",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "primus.core.patches.patch.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        count = run_patches(
+            backend="megatron",
+            phase="before_train",
+            extra={"module_config": SimpleNamespace(params=backend_args)},
+            enabled_ids=["megatron.training.training.skip_float16_module"],
+        )
+
+        assert count == 0
+
+
+class TestFSDP2BF16MasterWeightOptimizerPatch:
+    """Tests for the FSDP2 BF16 master weight optimizer patch."""
+
+    def test_patch_applies_when_all_conditions_met(self, monkeypatch):
+        from primus.backends.megatron.patches.optimizer_patches import (
+            patch_fsdp2_bf16_master_weight_optimizer,
+        )
+
+        backend_args = SimpleNamespace(
+            use_fsdp2_bf16_master_weight_optimizer=True,
+            use_torch_fsdp2=True,
+            bf16=True,
+        )
+        ctx = _build_patch_context(backend_args)
+
+        training_mod, optimizer_mod = _install_fake_megatron_modules(monkeypatch)
+        original = lambda *args, **kwargs: Mock()
+        training_mod.get_megatron_optimizer = original
+        optimizer_mod.get_megatron_optimizer = original
+
+        mock_optimizer = Mock()
+        bf16_mw_stub = types.ModuleType(
+            "primus.backends.megatron.core.optimizer.fsdp2_bf16_master_weight_optimizer"
+        )
+        bf16_mw_stub.get_fsdp2_bf16_master_weight_optimizer = lambda *args, **kwargs: mock_optimizer
+        monkeypatch.setitem(
+            sys.modules,
+            "primus.backends.megatron.core.optimizer.fsdp2_bf16_master_weight_optimizer",
+            bf16_mw_stub,
+        )
+
+        monkeypatch.setattr(
+            "primus.backends.megatron.patches.optimizer_patches.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        patch_fsdp2_bf16_master_weight_optimizer(ctx)
+
+        assert training_mod.get_megatron_optimizer is not original
+        assert optimizer_mod.get_megatron_optimizer is not original
+
+        result = training_mod.get_megatron_optimizer(Mock(), [Mock()])
+        assert result is mock_optimizer
+
+    @pytest.mark.parametrize(
+        "backend_args",
+        [
+            SimpleNamespace(
+                use_fsdp2_bf16_master_weight_optimizer=False,
+                use_torch_fsdp2=True,
+                bf16=True,
+            ),
+            SimpleNamespace(
+                use_fsdp2_bf16_master_weight_optimizer=True,
+                use_torch_fsdp2=False,
+                bf16=True,
+            ),
+            SimpleNamespace(
+                use_fsdp2_bf16_master_weight_optimizer=True,
+                use_torch_fsdp2=True,
+                bf16=False,
+            ),
+        ],
+    )
+    def test_patch_skipped_when_any_condition_false(self, monkeypatch, backend_args):
+        import primus.backends.megatron.patches.optimizer_patches  # noqa: F401
+
+        monkeypatch.setattr(
+            "primus.core.patches.patch_runner.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "primus.core.patches.patch_runner.error_rank_0",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "primus.core.patches.patch.log_rank_0",
+            lambda *args, **kwargs: None,
+        )
+
+        training_mod, optimizer_mod = _install_fake_megatron_modules(monkeypatch)
+        original = lambda *args, **kwargs: Mock()
+        training_mod.get_megatron_optimizer = original
+        optimizer_mod.get_megatron_optimizer = original
+
+        count = run_patches(
+            backend="megatron",
+            phase="before_train",
+            extra={"module_config": SimpleNamespace(params=backend_args)},
+            enabled_ids=["megatron.optimizer.fsdp2_bf16_master_weight"],
+        )
+
+        assert count == 0
+        assert training_mod.get_megatron_optimizer is original
+
+
+class TestOptimizerPatchMutualExclusivity:
+    """Tests for mutual exclusivity of the FSDP2 custom optimizer patches."""
+
+    def test_two_conflicting_optimizer_flags_raise(self):
+        """Two FSDP2 custom optimizer flags set must fail loudly: the flags all
+        patch get_megatron_optimizer at the same priority, so enabling more than
+        one is ambiguous. validate_fsdp2_optimizer_exclusivity enforces this at
+        arg-validation time."""
+        from primus.modules.trainer.megatron.utils import (
+            validate_fsdp2_optimizer_exclusivity,
+        )
+
+        args = SimpleNamespace(
+            use_fsdp2_fp32_param_optimizer=True,
+            use_fsdp2_bf16_master_weight_optimizer=True,
+        )
+
+        with pytest.raises(ValueError, match="Conflicting FSDP2 optimizer selection"):
+            validate_fsdp2_optimizer_exclusivity(args)
+
+    def test_single_optimizer_flag_is_allowed(self):
+        """Exactly one FSDP2 optimizer flag is the supported case (no raise)."""
+        from primus.modules.trainer.megatron.utils import (
+            validate_fsdp2_optimizer_exclusivity,
+        )
+
+        for flag in (
+            "use_fsdp2_fp32_param_optimizer",
+            "use_fsdp2_bf16_master_weight_optimizer",
+        ):
+            args = SimpleNamespace(**{flag: True})
+            # Should not raise.
+            validate_fsdp2_optimizer_exclusivity(args)
+
+    def test_no_optimizer_flag_is_allowed(self):
+        """No FSDP2 optimizer flag set (default Megatron optimizer) must not raise."""
+        from primus.modules.trainer.megatron.utils import (
+            validate_fsdp2_optimizer_exclusivity,
+        )
+
+        validate_fsdp2_optimizer_exclusivity(SimpleNamespace())


### PR DESCRIPTION
Part of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Targets `feat/flux/core` — review after it. The diff here is only this layer.

## What this changes
The FSDP2 optimization layer used by Flux training: fp32 and bf16-master-weight optimizer variants, incremental grad-norm, the FSDP2 fp8 all-gather path, and the related torch-FSDP2 / fp8-cache / optimizer-registration patches.

## Dependencies
Sequenced after the CI-pins PR (`feat/flux/ci-env`); builds on `feat/flux/core`. It is the parent of the turbo layer, whose float8 extension lazily imports this layer's fp8 all-gather.

## Test plan
`pytest tests/unit_tests/optimizer tests/unit_tests/backends/megatron/diffusion/distributed`. Validated locally on an AMD GPU container: 87 passed.

## Files
14 (FSDP2 optimizers, fp8 all-gather, optimizer/FSDP2 patches + tests).
