### PR TITLE
feat(flux): Primus-Turbo float8 + local-spec extensions

### DIFF
--- a/primus/backends/megatron/core/extensions/fp8_cast_kernels_triton.py
+++ b/primus/backends/megatron/core/extensions/fp8_cast_kernels_triton.py
@@ -1,0 +1,343 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Fused FP8 cast Triton kernels (vendored into Primus).
+
+Two self-contained @triton_op kernels used by the FP8 local-spec path:
+
+  - ``cast_fp8_triton``           : fused FP8 cast + amax (no transpose), for the
+                                    native NN/TN arm. Single quantize + amax HBM
+                                    pass, no [N, M] transpose write.
+  - ``cast_transpose_fp8_triton`` : fused FP8 cast + transpose + amax, for the
+                                    forced-NT / delayed-scaling arm. One kernel
+                                    replaces a quantize kernel + .t().contiguous()
+                                    copy.
+
+Both follow TE's _cast_transpose_triton pattern with 2D grouped tiling.
+
+Vendored from Primus-Turbo ``integration/fp8-native-main`` @ 022f2b2b
+(``primus_turbo/pytorch/kernels/quantization/cast_fp8.py`` and
+``cast_transpose_fp8.py``). They are kept in Primus so the FP8 local-spec path
+builds against stock public Primus-Turbo ``main``, which never carried these
+kernels. The op namespaces were renamed ``primus_turbo::`` -> ``primus::`` to
+match the other Primus ``@triton_op``s.
+
+Registered as @triton_ops so that:
+  - torch.compile / Inductor can see through the op
+  - Output tensors are standard torch.empty (no triton.reinterpret metadata)
+  - register_fake provides correct shapes/strides for compile-time validation
+"""
+
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch.library import triton_op, wrap_triton
+
+
+def _fp8_max(dtype: torch.dtype) -> float:
+    return torch.finfo(dtype).max
+
+
+# ---------------------------------------------------------------------------
+# Cast + transpose + amax
+# ---------------------------------------------------------------------------
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64, "GROUP_M": 1}, num_warps=4),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64, "GROUP_M": 8}, num_warps=4),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128, "GROUP_M": 8}, num_warps=8),
+    ],
+    key=["M", "N"],
+)
+@triton.jit
+def _cast_transpose_amax_kernel(
+    X_ptr,
+    C_ptr,
+    T_ptr,
+    stride_xm,
+    stride_xn,
+    stride_cm,
+    stride_cn,
+    stride_tm,
+    stride_tn,
+    M,
+    N,
+    scale_ptr,
+    amax_ptr,
+    scale_inv_ptr,
+    max_fp8: tl.constexpr,
+    COMPUTE_AMAX: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    GROUP_M: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    scale = tl.load(scale_ptr)
+
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    rm = pid_m.to(tl.int64) * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n.to(tl.int64) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+
+    x_ptrs = X_ptr + rm[:, None] * stride_xm + rn[None, :] * stride_xn
+    a = tl.load(x_ptrs, mask=mask)
+    val = a.to(tl.float32)
+
+    scaled = val * scale
+    scaled = tl.clamp(scaled, -max_fp8, max_fp8)
+    fp8_val = scaled.to(C_ptr.dtype.element_ty)
+
+    c_ptrs = C_ptr + rm[:, None] * stride_cm + rn[None, :] * stride_cn
+    tl.store(c_ptrs, fp8_val, mask=mask)
+
+    # Transpose the tile so the store to T is coalesced (stride-1 in the fast dim).
+    # Without this, the transpose store scatters with stride=M which kills
+    # write throughput on MI355X under memory pressure.
+    fp8_val_t = tl.trans(fp8_val)
+    rn2 = pid_n.to(tl.int64) * BLOCK_N + tl.arange(0, BLOCK_N)
+    rm2 = pid_m.to(tl.int64) * BLOCK_M + tl.arange(0, BLOCK_M)
+    mask_t = (rn2 < N)[:, None] & (rm2 < M)[None, :]
+    t_ptrs = T_ptr + rn2[:, None] * stride_tm + rm2[None, :] * stride_tn
+    tl.store(t_ptrs, fp8_val_t, mask=mask_t)
+
+    if COMPUTE_AMAX:
+        tile_amax = tl.max(tl.abs(val))
+        tl.atomic_max(amax_ptr, tile_amax, sem="relaxed")
+
+    if pid == 0:
+        tl.store(scale_inv_ptr, tl.fdiv(1.0, scale))
+
+
+@triton_op("primus::cast_transpose_fp8_triton", mutates_args=())
+def cast_transpose_fp8_triton(
+    x: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    scale: torch.Tensor,
+    amax_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused FP8 cast + transpose + optional amax.
+
+    Args:
+        x: 2D input tensor [M, N] (bf16 or f16), must be contiguous.
+        fp8_dtype: Target FP8 dtype (e.g. torch.float8_e4m3fn).
+        scale: Scalar float32 tensor with the quantization scale.
+        amax_out: Optional scalar float32 tensor. If provided, the kernel
+                  writes the abs-max of x into it (atomically reduced).
+
+    Returns:
+        (cast_out, transpose_out, scale_inv) where:
+          cast_out:      [M, N] FP8 tensor (same layout as input)
+          transpose_out: [N, M] FP8 tensor (contiguous transpose)
+          scale_inv:     scalar float32, 1/scale
+    """
+    if x.ndim != 2:
+        raise ValueError(f"Expected 2D input, got {x.ndim}D")
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    M, N = x.shape
+    max_fp8 = _fp8_max(fp8_dtype)
+
+    cast_out = torch.empty((M, N), dtype=fp8_dtype, device=x.device)
+    transpose_out = torch.empty((N, M), dtype=fp8_dtype, device=x.device)
+    scale_inv = torch.empty((), dtype=torch.float32, device=x.device)
+
+    compute_amax = amax_out is not None
+    if not compute_amax:
+        amax_out = torch.empty((), dtype=torch.float32, device=x.device)
+    else:
+        amax_out.zero_()
+
+    grid = lambda META: (triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),)
+
+    wrap_triton(_cast_transpose_amax_kernel)[grid](
+        x,
+        cast_out,
+        transpose_out,
+        x.stride(0),
+        x.stride(1),
+        cast_out.stride(0),
+        cast_out.stride(1),
+        transpose_out.stride(0),
+        transpose_out.stride(1),
+        M,
+        N,
+        scale,
+        amax_out,
+        scale_inv,
+        max_fp8,
+        compute_amax,
+    )
+
+    return cast_out, transpose_out, scale_inv
+
+
+@cast_transpose_fp8_triton.register_fake
+def _cast_transpose_fp8_triton_meta(
+    x: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    scale: torch.Tensor,
+    amax_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    M, N = x.shape
+    return (
+        torch.empty((M, N), dtype=fp8_dtype, device=x.device),
+        torch.empty((N, M), dtype=fp8_dtype, device=x.device),
+        torch.empty((), dtype=torch.float32, device=x.device),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cast + amax (no transpose)
+# ---------------------------------------------------------------------------
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64, "GROUP_M": 1}, num_warps=4),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64, "GROUP_M": 8}, num_warps=4),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128, "GROUP_M": 8}, num_warps=8),
+    ],
+    key=["M", "N"],
+)
+@triton.jit
+def _cast_amax_kernel(
+    X_ptr,
+    C_ptr,
+    stride_xm,
+    stride_xn,
+    stride_cm,
+    stride_cn,
+    M,
+    N,
+    scale_ptr,
+    amax_ptr,
+    scale_inv_ptr,
+    max_fp8: tl.constexpr,
+    COMPUTE_AMAX: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    GROUP_M: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    scale = tl.load(scale_ptr)
+
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+
+    rm = pid_m.to(tl.int64) * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n.to(tl.int64) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+
+    x_ptrs = X_ptr + rm[:, None] * stride_xm + rn[None, :] * stride_xn
+    a = tl.load(x_ptrs, mask=mask)
+    val = a.to(tl.float32)
+
+    scaled = val * scale
+    scaled = tl.clamp(scaled, -max_fp8, max_fp8)
+    fp8_val = scaled.to(C_ptr.dtype.element_ty)
+
+    c_ptrs = C_ptr + rm[:, None] * stride_cm + rn[None, :] * stride_cn
+    tl.store(c_ptrs, fp8_val, mask=mask)
+
+    if COMPUTE_AMAX:
+        tile_amax = tl.max(tl.abs(val))
+        tl.atomic_max(amax_ptr, tile_amax, sem="relaxed")
+
+    if pid == 0:
+        tl.store(scale_inv_ptr, tl.fdiv(1.0, scale))
+
+
+@triton_op("primus::cast_fp8_triton", mutates_args=())
+def cast_fp8_triton(
+    x: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    scale: torch.Tensor,
+    amax_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused FP8 cast + optional amax (no transpose).
+
+    Args:
+        x: 2D input tensor [M, N] (bf16 or f16), must be contiguous.
+        fp8_dtype: Target FP8 dtype (e.g. torch.float8_e4m3fn).
+        scale: Scalar float32 tensor with the quantization scale.
+        amax_out: Optional scalar float32 tensor. If provided, the kernel
+                  writes the abs-max of the *unscaled* x into it (atomically).
+
+    Returns:
+        (cast_out, scale_inv) where:
+          cast_out:  [M, N] FP8 tensor (same layout as input)
+          scale_inv: scalar float32, 1 / scale
+    """
+    if x.ndim != 2:
+        raise ValueError(f"Expected 2D input, got {x.ndim}D")
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    M, N = x.shape
+    max_fp8 = _fp8_max(fp8_dtype)
+
+    cast_out = torch.empty((M, N), dtype=fp8_dtype, device=x.device)
+    scale_inv = torch.empty((), dtype=torch.float32, device=x.device)
+
+    compute_amax = amax_out is not None
+    if not compute_amax:
+        amax_out = torch.empty((), dtype=torch.float32, device=x.device)
+    else:
+        amax_out.zero_()
+
+    grid = lambda META: (triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),)
+
+    wrap_triton(_cast_amax_kernel)[grid](
+        x,
+        cast_out,
+        x.stride(0),
+        x.stride(1),
+        cast_out.stride(0),
+        cast_out.stride(1),
+        M,
+        N,
+        scale,
+        amax_out,
+        scale_inv,
+        max_fp8,
+        compute_amax,
+    )
+
+    return cast_out, scale_inv
+
+
+@cast_fp8_triton.register_fake
+def _cast_fp8_triton_meta(
+    x: torch.Tensor,
+    fp8_dtype: torch.dtype,
+    scale: torch.Tensor,
+    amax_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    M, N = x.shape
+    return (
+        torch.empty((M, N), dtype=fp8_dtype, device=x.device),
+        torch.empty((), dtype=torch.float32, device=x.device),
+    )

--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -77,8 +77,11 @@ from primus_turbo.pytorch.core.low_precision import (
     float8_e4m3,
 )
 from torch import Tensor
+
+# Imported from .constants (not .fp8) for TransformerEngine >= 2.12 compat;
+# the symbol moved out of transformer_engine.pytorch.fp8 in that release.
 from transformer_engine.pytorch.constants import dist_group_type
-from transformer_engine.pytorch.fp8 import DelayedScaling, FP8GlobalStateManager, Recipe
+from transformer_engine.pytorch.fp8 import FP8GlobalStateManager, Recipe
 
 from primus.core.pipeline_parallel.handler.offload_handler import OFFLOAD_BUFFER
 
@@ -310,6 +313,7 @@ class PrimusTurboQuantConfig:
         strategy: ScalingStrategy = ScalingStrategy.DYNAMIC,
         scale_dtype: ScaleDtype = ScaleDtype.FP32,
         block_size: int = None,
+        use_gradient_sr: bool = True,
     ):
         self._is_fp4 = False
         self._is_fp8 = False
@@ -321,6 +325,7 @@ class PrimusTurboQuantConfig:
                 strategy=strategy,
                 scale_dtype=scale_dtype,
                 block_size=block_size,
+                use_gradient_sr=use_gradient_sr,
             )
             self._is_fp4 = True
         else:
@@ -440,7 +445,7 @@ class PrimusTurboLowPrecisionGlobalStateManager(FP8GlobalStateManager):
     @classmethod
     def get_fp8_autocast_state(
         cls,
-    ) -> Tuple[bool, bool, Recipe, dist_group_type, bool, bool, PrimusTurboQuantConfig]:
+    ) -> Tuple[bool, bool, Recipe, dist_group_type, bool, bool, bool, bool, PrimusTurboQuantConfig]:
         """FP8 autocast state getter"""
         return (
             FP8GlobalStateManager.FP8_ENABLED,
@@ -457,7 +462,7 @@ class PrimusTurboLowPrecisionGlobalStateManager(FP8GlobalStateManager):
     @classmethod
     def set_fp8_autocast_state(
         cls,
-        fp8_state: Tuple[bool, bool, DelayedScaling, dist_group_type, bool, bool, PrimusTurboQuantConfig],
+        fp8_state: Tuple[bool, bool, Recipe, dist_group_type, bool, bool, bool, bool, PrimusTurboQuantConfig],
     ) -> None:
         """FP8 autocast state setter"""
         (
@@ -1828,7 +1833,7 @@ class PrimusTurboDeepEPTokenDispatcher(MoETokenDispatcher):
         pg_collection: Optional[ProcessGroupCollection] = None,
     ):
         """
-        Initialize the Flex token dispatcher.
+        Initialize the DeepEP token dispatcher.
 
         Args:
             num_local_experts (int): Number of local experts on the current device.
@@ -1838,13 +1843,14 @@ class PrimusTurboDeepEPTokenDispatcher(MoETokenDispatcher):
         """
         super().__init__(config=config, pg_collection=pg_collection)
 
-        assert self.tp_size * self.ep_size > 1, "Flex token dispatcher requires TPxEP > 1"
+        if self.tp_size * self.ep_size <= 1:
+            raise ValueError("DeepEP token dispatcher requires TPxEP > 1")
         assert (
             self.config.moe_enable_deepep
         ), "DeepEP is not enabled. Please set --moe-enable-deepep to use DeepEP backend."
         assert (
             self.config.moe_pad_expert_input_to_capacity is False
-        ), "Flex token dispatcher does not support --moe-pad-expert-input-to-capacity"
+        ), "DeepEP token dispatcher does not support --moe-pad-expert-input-to-capacity"
 
         args = get_args()
 

--- a/primus/backends/megatron/core/extensions/primus_turbo_float8_local.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_float8_local.py
@@ -1,0 +1,1703 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Compile-friendly FP8 linear layers for Megatron local spec.
+
+Self-contained autograd Functions that call Primus Turbo's low-level building
+blocks (quantize_fp8 + gemm_fp8_impl) directly, bypassing the higher-level
+pt.ops.gemm_fp8 wrappers entirely.
+
+Key properties:
+- Tensorwise uses the setup_context pattern with primitive-only args so
+  torch.compile can trace through without graph breaks. FP8 weight data is
+  extracted by the caller (Float8*ParallelLinear._forward_impl) to avoid
+  tensor subclass tracing inside the autograd.Function.
+- Rowwise and blockwise still use @allow_in_graph (separate feasibility work).
+- gemm_fp8_impl is already a torch.library.custom_op with register_fake
+- Zero TransformerEngine dependencies
+- Builds against stock public Primus-Turbo main: the only kernels not on main
+  (the fused FP8 cast / cast+transpose Triton ops) are vendored locally in
+  fp8_cast_kernels_triton.py; everything else still comes from Turbo main.
+- Requires tensor_model_parallel_size=1, no GAF, no sequence_parallel
+"""
+
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+from megatron.core.enums import Fp8Recipe
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from primus_turbo.pytorch.core.backend import BackendType
+from primus_turbo.pytorch.core.low_precision import (
+    Float8QuantConfig,
+    Format,
+    ScaleDtype,
+    ScalingGranularity,
+    float8_e4m3,
+    float8_e5m2,
+)
+from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
+from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
+    quant_fp8_blockwise_for_weight_impl,
+    quant_fp8_blockwise_impl,
+)
+from primus_turbo.pytorch.ops.quantization import quantize_fp8
+
+from primus.backends.megatron.core.fp8_utils import (
+    MXFP8_SCALING_BLOCK_SIZE,
+    SCALING_BLOCK_SIZE,
+)
+
+# ---------------------------------------------------------------------------
+# torch.compile-friendly wrappers for C++ quantization ops.
+#
+# The raw C++ ops (primus_turbo_cpp_extension::quantize_fp8_tensorwise etc.)
+# lack an Autograd dispatch key, which triggers warnings and can break
+# torch.compile graph tracing. Wrapping them with @torch.library.custom_op
+# (the same pattern used by gemm_fp8_impl) automatically handles Autograd
+# dispatch and provides register_fake for shape inference during tracing.
+# ---------------------------------------------------------------------------
+
+_custom_op = torch.library.custom_op
+
+
+@_custom_op("primus::quantize_fp8_tensorwise", mutates_args=(), device_types="cuda")
+def _quantize_fp8_tensorwise_op(
+    x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(x, out_dtype, scale)
+
+
+@_quantize_fp8_tensorwise_op.register_fake
+def _quantize_fp8_tensorwise_fake(
+    x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    x_fp8 = torch.empty_like(x, dtype=out_dtype)
+    scale_inv = torch.empty((), dtype=torch.float32, device=x.device)
+    return x_fp8, scale_inv
+
+
+def _quantize_fp8_tensorwise_setup_context(ctx, inputs, output):
+    pass
+
+
+def _quantize_fp8_tensorwise_backward(ctx, grad_x_fp8, grad_scale_inv):
+    return None, None, None
+
+
+_quantize_fp8_tensorwise_op.register_autograd(
+    _quantize_fp8_tensorwise_backward,
+    setup_context=_quantize_fp8_tensorwise_setup_context,
+)
+
+
+def _cast_transpose_fp8_fused_with_amax(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    scale: torch.Tensor,
+    amax_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused FP8 quantize + transpose + optional amax via the Triton @triton_op.
+
+    Returns (fp8_out, fp8_transpose, scale_inv). Inductor-transparent.
+
+    Uses the cast+transpose Triton kernel vendored in Primus
+    (fp8_cast_kernels_triton), so this arm builds against stock Turbo main.
+    """
+    from primus.backends.megatron.core.extensions.fp8_cast_kernels_triton import (
+        cast_transpose_fp8_triton,
+    )
+
+    return cast_transpose_fp8_triton(x, out_dtype, scale, amax_out)
+
+
+def _cast_fp8_fused_with_amax(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    scale: torch.Tensor,
+    amax_out: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Native-layout fused FP8 quantize (no transpose) + optional amax.
+
+    Analog of _cast_transpose_fp8_fused_with_amax for the natural NN/TN arm:
+    applies the delayed scale and captures the current abs-max in a single HBM
+    pass, with no [N, M] transpose write. Returns (fp8_out, scale_inv).
+
+    Uses the no-transpose cast Triton kernel vendored in Primus
+    (fp8_cast_kernels_triton), so this arm builds against stock Turbo main.
+    """
+    from primus.backends.megatron.core.extensions.fp8_cast_kernels_triton import (
+        cast_fp8_triton,
+    )
+
+    return cast_fp8_triton(x, out_dtype, scale, amax_out)
+
+
+def _quantize_fp8_tw(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Dispatch tensorwise FP8 quantize via the standard C++ @custom_op."""
+    return _quantize_fp8_tensorwise_op(x, out_dtype)
+
+
+def _get_fp8_dtype(format: Format, is_fwd: bool):
+    if format == Format.E4M3:
+        return float8_e4m3
+    elif format == Format.E5M2:
+        return float8_e5m2
+    elif format == Format.HYBRID:
+        return float8_e4m3 if is_fwd else float8_e5m2
+    else:
+        raise ValueError(f"Unsupported FP8 format: {format}")
+
+
+def _build_fp8_config(config):
+    """Build Float8QuantConfig from TransformerConfig without TE dependency."""
+    FORMAT_MAP = {"e4m3": Format.E4M3, "hybrid": Format.HYBRID}
+    fmt = FORMAT_MAP[config.fp8]
+
+    if config.fp8_recipe in (Fp8Recipe.tensorwise, Fp8Recipe.delayed):
+        # Fp8Recipe.delayed is accepted as a TE-compatible alias: it implies
+        # tensorwise granularity (the only granularity that makes sense with
+        # delayed/amax-history scaling).  The actual delayed-vs-dynamic
+        # strategy is resolved separately via fp8_scaling_strategy or the
+        # recipe itself (see Float8*ParallelLinear._use_delayed_scaling).
+        return Float8QuantConfig(format=fmt, granularity=ScalingGranularity.TENSORWISE)
+    elif config.fp8_recipe == Fp8Recipe.blockwise:
+        return Float8QuantConfig(
+            format=fmt,
+            granularity=ScalingGranularity.BLOCKWISE,
+            block_size=SCALING_BLOCK_SIZE,
+        )
+    elif config.fp8_recipe == Fp8Recipe.mxfp8:
+        return Float8QuantConfig(
+            format=fmt,
+            granularity=ScalingGranularity.MX_BLOCKWISE,
+            block_size=MXFP8_SCALING_BLOCK_SIZE,
+            scale_dtype=ScaleDtype.E8M0,
+        )
+    else:
+        raise ValueError(
+            f"Float8 local spec does not support fp8_recipe={config.fp8_recipe}. "
+            f"Supported: tensorwise, delayed, blockwise, mxfp8."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Decomposed FP8 quantize — native aten ops for Inductor fusion
+# ---------------------------------------------------------------------------
+
+
+def _quantize_fp8_tensorwise(x, fp8_dtype, fp8_max):
+    """Tensorwise FP8 quantize using native aten ops (traceable by Inductor).
+
+    Scale is computed in FP32 for precision, then narrowed to x.dtype (BF16) so
+    the pointwise chain (mul, clamp, to_fp8) stays in BF16 registers inside the
+    fused Triton kernel.  scale_inv is derived from the FP32 scale before the
+    narrowing to preserve hipBLASLt's float32 precision requirement.
+    """
+    amax = x.abs().amax().float()
+    scale_f32 = fp8_max / amax.clamp(min=1e-12)
+    scale_inv = 1.0 / scale_f32
+    scale = scale_f32.clamp(max=torch.finfo(x.dtype).max).to(x.dtype)
+    x_fp8 = (x * scale).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+    return x_fp8, scale_inv
+
+
+# ---------------------------------------------------------------------------
+# Autograd Functions — one per FP8 scaling granularity.
+# ---------------------------------------------------------------------------
+
+
+class DecomposedFP8LinearTensorwiseFunction(torch.autograd.Function):
+    """FP8 linear (Y = X @ W^T) with tensorwise scaling, using decomposed
+    quantize for forward-pass Inductor fusion.
+
+    Experimental: designed to enable Inductor fusion of quantize with
+    surrounding kernels. Currently slower than OpaqueFP8LinearTensorwiseFunction
+    due to Inductor's internal FP32 promotion and amax reduction barriers.
+    Kept for future work (delayed scaling, Compiled Autograd).
+
+    Uses setup_context pattern with primitive-only arguments (no config objects)
+    for clean Dynamo tracing.
+    """
+
+    @staticmethod
+    def forward(
+        input, weight, fp8_fwd_dtype, fp8_bwd_dtype, fp8_fwd_max, fp8_bwd_max, gran_value, backend_value
+    ):
+        out_dtype = input.dtype
+        orig_shape = input.shape
+        input_2d = input.reshape(-1, input.shape[-1])
+
+        a_fp8, a_scale_inv = _quantize_fp8_tensorwise(input_2d, fp8_fwd_dtype, fp8_fwd_max)
+        b_fp8, b_scale_inv = _quantize_fp8_tensorwise(weight, fp8_fwd_dtype, fp8_fwd_max)
+
+        output = gemm_fp8_impl(
+            a_fp8,
+            a_scale_inv,
+            False,
+            b_fp8,
+            b_scale_inv,
+            True,
+            out_dtype,
+            False,
+            granularity=gran_value,
+            default_backend=backend_value,
+        )
+        output = output.reshape(*orig_shape[:-1], output.shape[-1])
+
+        return output, a_fp8, a_scale_inv, b_fp8, b_scale_inv
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        _, _, fp8_fwd_dtype, fp8_bwd_dtype, fp8_fwd_max, fp8_bwd_max, gran_value, backend_value = inputs
+        output_val, a_fp8, a_scale_inv, b_fp8, b_scale_inv = output
+
+        ctx.save_for_backward(a_fp8, a_scale_inv, b_fp8, b_scale_inv)
+        ctx.mark_non_differentiable(a_fp8, a_scale_inv, b_fp8, b_scale_inv)
+        ctx.out_dtype = inputs[0].dtype
+        ctx.orig_shape = inputs[0].shape
+        ctx.fp8_bwd_dtype = fp8_bwd_dtype
+        ctx.fp8_bwd_max = fp8_bwd_max
+        ctx.gran_value = gran_value
+        ctx.backend_value = backend_value
+
+    @staticmethod
+    def backward(ctx, grad_output, *_):
+        a_fp8, a_scale_inv, b_fp8, b_scale_inv = ctx.saved_tensors
+
+        grad_2d = grad_output.reshape(-1, grad_output.shape[-1])
+        if not grad_2d.is_contiguous():
+            grad_2d = grad_2d.contiguous()
+
+        grad_fp8, grad_scale_inv = _quantize_fp8_tensorwise(grad_2d, ctx.fp8_bwd_dtype, ctx.fp8_bwd_max)
+
+        grad_input = gemm_fp8_impl(
+            grad_fp8,
+            grad_scale_inv,
+            False,
+            b_fp8,
+            b_scale_inv,
+            False,
+            ctx.out_dtype,
+            False,
+            granularity=ctx.gran_value,
+            default_backend=ctx.backend_value,
+        )
+        grad_input = grad_input.reshape(ctx.orig_shape)
+
+        grad_weight = gemm_fp8_impl(
+            a_fp8,
+            a_scale_inv,
+            True,
+            grad_fp8,
+            grad_scale_inv,
+            False,
+            ctx.out_dtype,
+            True,
+            granularity=ctx.gran_value,
+            default_backend=ctx.backend_value,
+        )
+
+        return grad_input, grad_weight, None, None, None, None, None, None
+
+
+class OpaqueFP8LinearTensorwiseFunction(torch.autograd.Function):
+    """FP8 linear (Y = X @ W^T) with tensorwise scaling using Primus Turbo's
+    opaque C++ quantize_fp8 kernel.
+
+    Uses the setup_context pattern with primitive-only saved state so that
+    torch.compile / TorchDynamo can trace through without graph breaks.
+    The caller must pre-extract FP8 weight data (b_fp8, b_scale_inv) from
+    FP8UnshardedWeightTensor *before* calling .apply().
+
+    Default path for tensorwise -- faster than the decomposed variant due to
+    optimized C++ quantize kernels.
+
+    Backward GEMMs are normalized to NT layout (transA=F, transB=T, transC=F)
+    so that hipBLASLt always selects the fast TN Tensile kernel on MI355X.
+    Pre-transposed FP8 copies of input and weight are saved for this purpose.
+    """
+
+    @staticmethod
+    def forward(
+        input,
+        weight,
+        weight_fp8,
+        weight_scale_inv,
+        fp8_fwd_dtype,
+        fp8_bwd_dtype,
+        gran_value,
+        backend_value,
+        force_nt=True,
+    ):
+        out_dtype = input.dtype
+        orig_shape = input.shape
+        input_2d = input.reshape(-1, input.shape[-1])
+
+        a_fp8, a_scale_inv = _quantize_fp8_tw(input_2d, fp8_fwd_dtype)
+
+        output = gemm_fp8_impl(
+            a_fp8,
+            a_scale_inv,
+            False,
+            weight_fp8,
+            weight_scale_inv,
+            True,
+            out_dtype,
+            False,
+            granularity=gran_value,
+            default_backend=backend_value,
+        )
+
+        output = output.reshape(*orig_shape[:-1], output.shape[-1])
+
+        if force_nt:
+            # Pre-transpose so backward dgrad/wgrad both run as NT GEMMs.
+            a_t_fp8 = a_fp8.t().contiguous()
+            w_t_fp8 = weight_fp8.t().contiguous()
+            return (output, a_t_fp8, a_scale_inv, w_t_fp8)
+
+        # Native: keep operands in their natural layout (no transpose). weight_fp8
+        # is not returned -- setup_context saves it straight from inputs.
+        return (output, a_fp8, a_scale_inv)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        # Tolerant unpack: legacy 8-arg callers default to forced NT; only the
+        # 9th positional (force_nt) toggles the native arm.
+        force_nt = inputs[8] if len(inputs) > 8 else True
+        (
+            input,
+            weight,
+            weight_fp8,
+            weight_scale_inv,
+            fp8_fwd_dtype,
+            fp8_bwd_dtype,
+            gran_value,
+            backend_value,
+        ) = inputs[:8]
+
+        if force_nt:
+            output_val, a_t_fp8, a_scale_inv, w_t_fp8 = output
+            ctx.save_for_backward(a_t_fp8, a_scale_inv, w_t_fp8, weight_scale_inv)
+            ctx.mark_non_differentiable(a_t_fp8, a_scale_inv, w_t_fp8)
+        else:
+            output_val, a_fp8, a_scale_inv = output
+            ctx.save_for_backward(a_fp8, a_scale_inv, weight_fp8, weight_scale_inv)
+            ctx.mark_non_differentiable(a_fp8, a_scale_inv)
+
+        ctx.force_nt = force_nt
+        ctx.out_dtype = input.dtype
+        ctx.orig_shape = input.shape
+        ctx.fp8_bwd_dtype = fp8_bwd_dtype
+        ctx.gran_value = gran_value
+        ctx.backend_value = backend_value
+
+    @staticmethod
+    def backward(ctx, grad_output, *_):
+        if not grad_output.is_contiguous():
+            grad_output = grad_output.contiguous()
+
+        grad_2d = grad_output.reshape(-1, grad_output.shape[-1])
+        grad_fp8, grad_scale_inv = _quantize_fp8_tw(grad_2d, ctx.fp8_bwd_dtype)
+
+        if ctx.force_nt:
+            a_t_fp8, a_scale_inv, w_t_fp8, w_scale_inv = ctx.saved_tensors
+
+            grad_input = gemm_fp8_impl(
+                grad_fp8,
+                grad_scale_inv,
+                False,
+                w_t_fp8,
+                w_scale_inv,
+                True,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+            grad_input = grad_input.reshape(ctx.orig_shape)
+
+            grad_t_fp8 = grad_fp8.t().contiguous()
+            grad_weight = gemm_fp8_impl(
+                grad_t_fp8,
+                grad_scale_inv,
+                False,
+                a_t_fp8,
+                a_scale_inv,
+                True,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+        else:
+            a_fp8, a_scale_inv, w_fp8, w_scale_inv = ctx.saved_tensors
+
+            # dgrad NN: grad @ weight  (transA=F, transB=F)
+            grad_input = gemm_fp8_impl(
+                grad_fp8,
+                grad_scale_inv,
+                False,
+                w_fp8,
+                w_scale_inv,
+                False,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+            grad_input = grad_input.reshape(ctx.orig_shape)
+
+            # wgrad TN: grad^T @ a  (transA=T, transB=F)
+            grad_weight = gemm_fp8_impl(
+                grad_fp8,
+                grad_scale_inv,
+                True,
+                a_fp8,
+                a_scale_inv,
+                False,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+
+        return grad_input, grad_weight, None, None, None, None, None, None, None
+
+
+class DelayedFP8LinearTensorwiseFunction(torch.autograd.Function):
+    """FP8 linear with delayed tensorwise scaling -- 3 independent scale tracks.
+
+    Weight is quantized inline during the forward pass (inside the compiled
+    graph where Inductor eliminates CPU dispatcher overhead).  Input and
+    gradient quantization also happen inline with fused amax capture.
+    Backward GEMM layout follows ``force_nt`` (set from ``fp8_force_nt_layout``):
+    native by default (dgrad=NN, wgrad=TN, no transpose), or forced-NT (operands
+    pre-transposed so both backward GEMMs run as NT) when opted in.
+    """
+
+    @staticmethod
+    def forward(
+        input,
+        weight,
+        scale_input,
+        scale_weight,
+        scale_grad,
+        staged_input_amax,
+        staged_weight_amax,
+        staged_grad_amax,
+        fp8_fwd_dtype,
+        fp8_bwd_dtype,
+        gran_value,
+        backend_value,
+        force_nt=True,
+    ):
+        out_dtype = input.dtype
+        orig_shape = input.shape
+        input_2d = input.reshape(-1, input.shape[-1])
+
+        if force_nt:
+            a_fp8, a_t_fp8, a_scale_inv = _cast_transpose_fp8_fused_with_amax(
+                input_2d, fp8_fwd_dtype, scale_input, staged_input_amax
+            )
+            torch._assert(a_t_fp8.is_contiguous(), "cast_transpose must return contiguous transpose")
+
+            w_fp8, w_t_fp8, w_scale_inv = _cast_transpose_fp8_fused_with_amax(
+                weight, fp8_fwd_dtype, scale_weight, staged_weight_amax
+            )
+            torch._assert(w_t_fp8.is_contiguous(), "cast_transpose must return contiguous transpose")
+
+            output = gemm_fp8_impl(
+                a_fp8,
+                a_scale_inv,
+                False,
+                w_fp8,
+                w_scale_inv,
+                True,
+                out_dtype,
+                False,
+                granularity=gran_value,
+                default_backend=backend_value,
+            )
+            output = output.reshape(*orig_shape[:-1], output.shape[-1])
+
+            return (output, a_t_fp8, a_scale_inv, w_t_fp8, w_scale_inv)
+
+        # Native: apply the delayed scale and capture the current amax in a
+        # single fused pass via the no-transpose Triton kernel. No transpose;
+        # backward runs dgrad=NN / wgrad=TN (see backward).
+        a_fp8, a_scale_inv = _cast_fp8_fused_with_amax(
+            input_2d, fp8_fwd_dtype, scale_input, staged_input_amax
+        )
+
+        w_fp8, w_scale_inv = _cast_fp8_fused_with_amax(
+            weight, fp8_fwd_dtype, scale_weight, staged_weight_amax
+        )
+
+        output = gemm_fp8_impl(
+            a_fp8,
+            a_scale_inv,
+            False,
+            w_fp8,
+            w_scale_inv,
+            True,
+            out_dtype,
+            False,
+            granularity=gran_value,
+            default_backend=backend_value,
+        )
+        output = output.reshape(*orig_shape[:-1], output.shape[-1])
+
+        return (output, a_fp8, a_scale_inv, w_fp8, w_scale_inv)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        # Tolerant unpack: legacy 12-arg callers default to forced NT; only the
+        # 13th positional (force_nt) toggles the native arm.
+        force_nt = inputs[12] if len(inputs) > 12 else True
+        (
+            input,
+            weight,
+            scale_input,
+            scale_weight,
+            scale_grad,
+            staged_input_amax,
+            staged_weight_amax,
+            staged_grad_amax,
+            fp8_fwd_dtype,
+            fp8_bwd_dtype,
+            gran_value,
+            backend_value,
+        ) = inputs[:12]
+
+        if force_nt:
+            (output_val, a_t_fp8, a_scale_inv, w_t_fp8, w_scale_inv) = output
+            ctx.save_for_backward(a_t_fp8, a_scale_inv, w_t_fp8, w_scale_inv, scale_grad, staged_grad_amax)
+            ctx.mark_non_differentiable(a_t_fp8, a_scale_inv, w_t_fp8, w_scale_inv)
+        else:
+            (output_val, a_fp8, a_scale_inv, w_fp8, w_scale_inv) = output
+            ctx.save_for_backward(a_fp8, a_scale_inv, w_fp8, w_scale_inv, scale_grad, staged_grad_amax)
+            ctx.mark_non_differentiable(a_fp8, a_scale_inv, w_fp8, w_scale_inv)
+
+        ctx.force_nt = force_nt
+        ctx.out_dtype = input.dtype
+        ctx.orig_shape = input.shape
+        ctx.fp8_bwd_dtype = fp8_bwd_dtype
+        ctx.gran_value = gran_value
+        ctx.backend_value = backend_value
+
+    @staticmethod
+    def backward(ctx, grad_output, *_):
+        if not grad_output.is_contiguous():
+            grad_output = grad_output.contiguous()
+        op_a, a_scale_inv, op_w, w_scale_inv, scale_grad, staged_grad_amax = ctx.saved_tensors
+
+        grad_2d = grad_output.reshape(-1, grad_output.shape[-1])
+
+        if ctx.force_nt:
+            # op_a = a_t_fp8, op_w = w_t_fp8
+            grad_fp8, grad_t_fp8, grad_scale_inv = _cast_transpose_fp8_fused_with_amax(
+                grad_2d, ctx.fp8_bwd_dtype, scale_grad, staged_grad_amax
+            )
+            torch._assert(grad_t_fp8.is_contiguous(), "cast_transpose must return contiguous transpose")
+
+            grad_input = gemm_fp8_impl(
+                grad_fp8,
+                grad_scale_inv,
+                False,
+                op_w,
+                w_scale_inv,
+                True,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+            grad_input = grad_input.reshape(ctx.orig_shape)
+
+            grad_weight = gemm_fp8_impl(
+                grad_t_fp8,
+                grad_scale_inv,
+                False,
+                op_a,
+                a_scale_inv,
+                True,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+        else:
+            # Native: op_a = a_fp8, op_w = w_fp8. Fused quantize + amax, no transpose.
+            grad_fp8, grad_scale_inv = _cast_fp8_fused_with_amax(
+                grad_2d, ctx.fp8_bwd_dtype, scale_grad, staged_grad_amax
+            )
+
+            # dgrad NN: grad @ weight  (transA=F, transB=F)
+            grad_input = gemm_fp8_impl(
+                grad_fp8,
+                grad_scale_inv,
+                False,
+                op_w,
+                w_scale_inv,
+                False,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+            grad_input = grad_input.reshape(ctx.orig_shape)
+
+            # wgrad TN: grad^T @ a  (transA=T, transB=F)
+            grad_weight = gemm_fp8_impl(
+                grad_fp8,
+                grad_scale_inv,
+                True,
+                op_a,
+                a_scale_inv,
+                False,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.gran_value,
+                default_backend=ctx.backend_value,
+            )
+
+        # 13 inputs to forward -> 13 grads returned (2 real + 11 None).
+        return (
+            grad_input,
+            grad_weight,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+class DualFP8LinearTensorwiseFunction(torch.autograd.Function):
+    """Two independent FP8 linears in a single autograd node.
+
+    Y_a = X_a @ W_a^T,  Y_b = X_b @ W_b^T
+
+    Uses the setup_context pattern with primitive-only saved state so that
+    torch.compile can trace through without graph breaks. The caller must
+    pre-extract FP8 weight data before calling .apply().
+
+    Backward GEMMs are normalized to NT layout (transA=F, transB=T, transC=F)
+    so that hipBLASLt always selects the fast TN Tensile kernel on MI355X.
+    """
+
+    @staticmethod
+    def forward(
+        input_a,
+        weight_a,
+        weight_fp8_a,
+        weight_scale_a,
+        input_b,
+        weight_b,
+        weight_fp8_b,
+        weight_scale_b,
+        fp8_fwd_dtype,
+        fp8_bwd_dtype,
+        gran_value,
+        backend_value,
+    ):
+        out_dtype = input_a.dtype
+
+        orig_shape_a = input_a.shape
+        orig_shape_b = input_b.shape
+        input_a_2d = input_a.reshape(-1, input_a.shape[-1])
+        input_b_2d = input_b.reshape(-1, input_b.shape[-1])
+
+        a_fp8_a, a_scale_a = _quantize_fp8_tw(input_a_2d, fp8_fwd_dtype)
+        a_fp8_b, a_scale_b = _quantize_fp8_tw(input_b_2d, fp8_fwd_dtype)
+
+        output_a = gemm_fp8_impl(
+            a_fp8_a,
+            a_scale_a,
+            False,
+            weight_fp8_a,
+            weight_scale_a,
+            True,
+            out_dtype,
+            False,
+            granularity=gran_value,
+            default_backend=backend_value,
+        )
+        output_b = gemm_fp8_impl(
+            a_fp8_b,
+            a_scale_b,
+            False,
+            weight_fp8_b,
+            weight_scale_b,
+            True,
+            out_dtype,
+            False,
+            granularity=gran_value,
+            default_backend=backend_value,
+        )
+
+        output_a = output_a.reshape(*orig_shape_a[:-1], output_a.shape[-1])
+        output_b = output_b.reshape(*orig_shape_b[:-1], output_b.shape[-1])
+
+        a_t_fp8_a = a_fp8_a.t().contiguous()
+        w_t_fp8_a = weight_fp8_a.t().contiguous()
+        a_t_fp8_b = a_fp8_b.t().contiguous()
+        w_t_fp8_b = weight_fp8_b.t().contiguous()
+
+        return (output_a, output_b, a_t_fp8_a, a_scale_a, w_t_fp8_a, a_t_fp8_b, a_scale_b, w_t_fp8_b)
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        (
+            input_a,
+            weight_a,
+            weight_fp8_a,
+            weight_scale_a,
+            input_b,
+            weight_b,
+            weight_fp8_b,
+            weight_scale_b,
+            fp8_fwd_dtype,
+            fp8_bwd_dtype,
+            gran_value,
+            backend_value,
+        ) = inputs
+        (output_a, output_b, a_t_fp8_a, a_scale_a, w_t_fp8_a, a_t_fp8_b, a_scale_b, w_t_fp8_b) = output
+
+        ctx.save_for_backward(
+            a_t_fp8_a,
+            a_scale_a,
+            w_t_fp8_a,
+            weight_scale_a,
+            a_t_fp8_b,
+            a_scale_b,
+            w_t_fp8_b,
+            weight_scale_b,
+        )
+        ctx.mark_non_differentiable(
+            a_t_fp8_a,
+            a_scale_a,
+            w_t_fp8_a,
+            a_t_fp8_b,
+            a_scale_b,
+            w_t_fp8_b,
+        )
+        ctx.out_dtype = input_a.dtype
+        ctx.orig_shape_a = input_a.shape
+        ctx.orig_shape_b = input_b.shape
+        ctx.fp8_bwd_dtype = fp8_bwd_dtype
+        ctx.gran_value = gran_value
+        ctx.backend_value = backend_value
+
+    @staticmethod
+    def backward(ctx, grad_output_a, grad_output_b, *_):
+        if not grad_output_a.is_contiguous():
+            grad_output_a = grad_output_a.contiguous()
+        if not grad_output_b.is_contiguous():
+            grad_output_b = grad_output_b.contiguous()
+
+        (a_t_fp8_a, a_scale_a, w_t_fp8_a, w_scale_a, a_t_fp8_b, a_scale_b, w_t_fp8_b, w_scale_b) = (
+            ctx.saved_tensors
+        )
+
+        # --- Stream A ---
+        grad_a_2d = grad_output_a.reshape(-1, grad_output_a.shape[-1])
+        grad_fp8_a, grad_scale_a = _quantize_fp8_tw(grad_a_2d, ctx.fp8_bwd_dtype)
+
+        grad_input_a = gemm_fp8_impl(
+            grad_fp8_a,
+            grad_scale_a,
+            False,
+            w_t_fp8_a,
+            w_scale_a,
+            True,
+            ctx.out_dtype,
+            False,
+            granularity=ctx.gran_value,
+            default_backend=ctx.backend_value,
+        )
+        grad_input_a = grad_input_a.reshape(ctx.orig_shape_a)
+
+        grad_t_fp8_a = grad_fp8_a.t().contiguous()
+        grad_weight_a = gemm_fp8_impl(
+            grad_t_fp8_a,
+            grad_scale_a,
+            False,
+            a_t_fp8_a,
+            a_scale_a,
+            True,
+            ctx.out_dtype,
+            False,
+            granularity=ctx.gran_value,
+            default_backend=ctx.backend_value,
+        )
+
+        # --- Stream B ---
+        grad_b_2d = grad_output_b.reshape(-1, grad_output_b.shape[-1])
+        grad_fp8_b, grad_scale_b = _quantize_fp8_tw(grad_b_2d, ctx.fp8_bwd_dtype)
+
+        grad_input_b = gemm_fp8_impl(
+            grad_fp8_b,
+            grad_scale_b,
+            False,
+            w_t_fp8_b,
+            w_scale_b,
+            True,
+            ctx.out_dtype,
+            False,
+            granularity=ctx.gran_value,
+            default_backend=ctx.backend_value,
+        )
+        grad_input_b = grad_input_b.reshape(ctx.orig_shape_b)
+
+        grad_t_fp8_b = grad_fp8_b.t().contiguous()
+        grad_weight_b = gemm_fp8_impl(
+            grad_t_fp8_b,
+            grad_scale_b,
+            False,
+            a_t_fp8_b,
+            a_scale_b,
+            True,
+            ctx.out_dtype,
+            False,
+            granularity=ctx.gran_value,
+            default_backend=ctx.backend_value,
+        )
+
+        return (
+            grad_input_a,
+            grad_weight_a,
+            None,
+            None,
+            grad_input_b,
+            grad_weight_b,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+@torch._dynamo.allow_in_graph
+class FP8LinearRowwiseFunction(torch.autograd.Function):
+    """FP8 linear (Y = X @ W^T) with rowwise scaling. Compile-friendly."""
+
+    @staticmethod
+    def forward(ctx, input, weight, config):
+        a_dtype = _get_fp8_dtype(config.format, is_fwd=True)
+        b_dtype = _get_fp8_dtype(config.format, is_fwd=True)
+        out_dtype = input.dtype
+        gran = config.granularity
+
+        orig_shape = input.shape
+        input_2d = input.reshape(-1, input.shape[-1])
+
+        a_fp8_row, a_scale_inv_row = quantize_fp8(input_2d, a_dtype, gran, axis=-1)
+        b_fp8_row, b_scale_inv_row = quantize_fp8(weight, b_dtype, gran, axis=-1)
+
+        output = gemm_fp8_impl(
+            a_fp8_row,
+            a_scale_inv_row,
+            False,
+            b_fp8_row,
+            b_scale_inv_row,
+            True,
+            out_dtype,
+            False,
+            granularity=gran.value,
+            default_backend=BackendType.CK.value,
+        )
+        output = output.reshape(*orig_shape[:-1], output.shape[-1])
+
+        a_fp8_col, a_scale_inv_col = quantize_fp8(input_2d, a_dtype, gran, axis=-2)
+        b_fp8_col, b_scale_inv_col = quantize_fp8(weight, b_dtype, gran, axis=-2)
+
+        ctx.save_for_backward(a_fp8_col, a_scale_inv_col, b_fp8_col, b_scale_inv_col)
+        ctx.out_dtype = out_dtype
+        ctx.config = config
+        ctx.orig_shape = orig_shape
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        if not grad_output.is_contiguous():
+            grad_output = grad_output.contiguous()
+        a_fp8_col, a_scale_inv_col, b_fp8_col, b_scale_inv_col = ctx.saved_tensors
+        grad_dtype = _get_fp8_dtype(ctx.config.format, is_fwd=False)
+        gran = ctx.config.granularity
+
+        grad_2d = grad_output.reshape(-1, grad_output.shape[-1])
+
+        grad_fp8_row, grad_scale_inv_row = quantize_fp8(grad_2d, grad_dtype, gran, axis=-1)
+
+        grad_input = gemm_fp8_impl(
+            grad_fp8_row,
+            grad_scale_inv_row,
+            False,
+            b_fp8_col,
+            b_scale_inv_col,
+            False,
+            ctx.out_dtype,
+            False,
+            granularity=gran.value,
+            default_backend=BackendType.CK.value,
+        )
+        grad_input = grad_input.reshape(ctx.orig_shape)
+
+        grad_fp8_col, grad_scale_inv_col = quantize_fp8(grad_2d, grad_dtype, gran, axis=-2)
+
+        grad_weight = gemm_fp8_impl(
+            a_fp8_col,
+            a_scale_inv_col,
+            True,
+            grad_fp8_col,
+            grad_scale_inv_col,
+            False,
+            ctx.out_dtype,
+            True,
+            granularity=gran.value,
+            default_backend=BackendType.CK.value,
+        )
+
+        return grad_input, grad_weight, None
+
+
+@torch._dynamo.allow_in_graph
+class FP8LinearBlockwiseFunction(torch.autograd.Function):
+    """FP8 linear (Y = X @ W^T) with blockwise scaling. Compile-friendly.
+
+    Note: saves BF16 input AND BF16 weight for backward (must re-quantize
+    with different axis/dtype), so no activation memory savings compared to
+    BF16 baseline.
+
+    Forward uses CK backend (NT layout). Backward uses Triton backend for
+    NN (grad_input) and TN (grad_weight) layouts because CK's blockwise
+    GEMM produces NaN on these layouts.  To satisfy Triton's same-dtype
+    constraint, the weight is re-quantized to the backward dtype (E5M2 for
+    hybrid format) from the saved BF16 copy.
+    """
+
+    @staticmethod
+    def forward(ctx, input, weight, config):
+        a_dtype = _get_fp8_dtype(config.format, is_fwd=True)
+        b_dtype = _get_fp8_dtype(config.format, is_fwd=True)
+        out_dtype = input.dtype
+        gran = config.granularity
+        bs = config.block_size
+
+        orig_shape = input.shape
+        input_2d = input.reshape(-1, input.shape[-1])
+
+        a_fp8_row, a_scale_inv_row = quant_fp8_blockwise_impl(input_2d, a_dtype, axis=1, block_size=bs)
+        b_fp8, b_scale_inv = quant_fp8_blockwise_for_weight_impl(weight, b_dtype, block_size=bs)
+
+        output = gemm_fp8_impl(
+            a_fp8_row,
+            a_scale_inv_row,
+            False,
+            b_fp8,
+            b_scale_inv,
+            True,
+            out_dtype,
+            False,
+            granularity=gran.value,
+            default_backend=BackendType.CK.value,
+        )
+        output = output.reshape(*orig_shape[:-1], output.shape[-1])
+
+        ctx.save_for_backward(input_2d, weight)
+        ctx.out_dtype = out_dtype
+        ctx.config = config
+        ctx.orig_shape = orig_shape
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        if not grad_output.is_contiguous():
+            grad_output = grad_output.contiguous()
+        input_saved, weight_saved = ctx.saved_tensors
+        bwd_dtype = _get_fp8_dtype(ctx.config.format, is_fwd=False)
+        gran = ctx.config.granularity
+        bs = ctx.config.block_size
+
+        grad_2d = grad_output.reshape(-1, grad_output.shape[-1])
+
+        grad_fp8_row, grad_scale_inv_row = quant_fp8_blockwise_impl(
+            grad_2d, bwd_dtype, axis=-1, block_size=bs
+        )
+        grad_fp8_col, grad_scale_inv_col = quant_fp8_blockwise_impl(
+            grad_2d, bwd_dtype, axis=-2, block_size=bs
+        )
+        a_fp8_col, a_scale_inv_col = quant_fp8_blockwise_impl(input_saved, bwd_dtype, axis=0, block_size=bs)
+        b_fp8_bwd, b_scale_inv_bwd = quant_fp8_blockwise_for_weight_impl(
+            weight_saved, bwd_dtype, block_size=bs
+        )
+
+        grad_input = gemm_fp8_impl(
+            grad_fp8_row,
+            grad_scale_inv_row,
+            False,
+            b_fp8_bwd,
+            b_scale_inv_bwd,
+            False,
+            ctx.out_dtype,
+            False,
+            granularity=gran.value,
+            default_backend=BackendType.TRITON.value,
+        )
+        grad_input = grad_input.reshape(ctx.orig_shape)
+
+        grad_weight = gemm_fp8_impl(
+            a_fp8_col,
+            a_scale_inv_col,
+            True,
+            grad_fp8_col,
+            grad_scale_inv_col,
+            False,
+            ctx.out_dtype,
+            True,
+            granularity=gran.value,
+            default_backend=BackendType.TRITON.value,
+        )
+
+        return grad_input, grad_weight, None
+
+
+# ---------------------------------------------------------------------------
+# Delayed FP8 scaling helpers — shared by Float8ColumnParallelLinear and
+# Float8RowParallelLinear.
+# ---------------------------------------------------------------------------
+
+
+def _update_fp8_scale(scale_buf, scale_inv_buf, amax, fp8_max):
+    """TE-aligned scale computation with edge case handling."""
+    sf = fp8_max / amax.clamp(min=1e-12)
+    sf = torch.where(amax > 0.0, sf, scale_buf)
+    sf = torch.where(torch.isfinite(amax), sf, scale_buf)
+    sf = torch.where(
+        torch.isinf(sf),
+        torch.tensor(torch.finfo(torch.float32).max, device=sf.device),
+        sf,
+    )
+    scale_buf.fill_(sf)
+    if scale_inv_buf is not None:
+        scale_inv_buf.fill_(1.0 / sf)
+
+
+def _init_delayed_scaling_state(module):
+    """Initialize delayed FP8 scaling buffers on a Float8*ParallelLinear."""
+    config = module.config
+    history_len = getattr(config, "fp8_amax_history_len", 1)
+    fp8_fwd_max = torch.finfo(module._fp8_fwd_dtype).max
+    fp8_bwd_max = torch.finfo(module._fp8_bwd_dtype).max
+
+    for name in ["amax_history_input", "amax_history_weight", "amax_history_grad"]:
+        module.register_buffer(
+            name,
+            torch.zeros(history_len),
+            persistent=False,
+        )
+
+    for name in ["scale_input", "scale_weight", "scale_grad"]:
+        module.register_buffer(
+            name,
+            torch.tensor(1.0, dtype=torch.float32),
+            persistent=False,
+        )
+
+    for name in ["staged_input_amax", "staged_grad_amax", "staged_weight_amax"]:
+        module.register_buffer(
+            name,
+            torch.tensor(0.0),
+            persistent=False,
+        )
+
+    module._fp8_fwd_max = fp8_fwd_max
+    module._fp8_bwd_max = fp8_bwd_max
+    module._amax_compute_algo = getattr(
+        config,
+        "fp8_amax_compute_algo",
+        "most_recent",
+    )
+    module._history_idx = 0
+    module._first_delayed_step = True
+
+
+def _batch_compute_scales(amaxes, fp8_max, old_scales):
+    """Vectorized scale computation across all modules at once."""
+    sf = fp8_max / amaxes.clamp(min=1e-12)
+    sf = torch.where(amaxes > 0.0, sf, old_scales)
+    sf = torch.where(torch.isfinite(amaxes), sf, old_scales)
+    sf = torch.where(torch.isinf(sf), torch.finfo(torch.float32).max, sf)
+    return sf
+
+
+# ---------------------------------------------------------------------------
+# Fused Triton kernel: replaces Python-loop-based _batched_update per step
+# with a single GPU dispatch over all (module, track) pairs.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _fused_delayed_scale_update_kernel(
+    amax_history_ptr,
+    staged_amaxes_ptr,
+    scales_ptr,
+    fp8_maxes_ptr,
+    history_idx,
+    N: tl.constexpr,
+    H: tl.constexpr,
+    use_max_algo: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    FP32_MAX: tl.constexpr,
+    FILTER_ZEROS: tl.constexpr = False,
+):
+    track = tl.program_id(1)
+    mod = tl.program_id(0)
+
+    base = track * N * H + mod * H
+
+    new_amax = tl.load(staged_amaxes_ptr + track * N + mod)
+    tl.store(amax_history_ptr + base + history_idx, new_amax)
+
+    if use_max_algo:
+        amax = tl.zeros([], dtype=tl.float32)
+        has_nonzero = tl.zeros([], dtype=tl.int32)
+        for off in range(0, H, BLOCK_H):
+            h_idx = off + tl.arange(0, BLOCK_H)
+            mask = h_idx < H
+            vals = tl.load(amax_history_ptr + base + h_idx, mask=mask, other=0.0)
+            if FILTER_ZEROS:
+                nonzero_mask = vals > 0.0
+                has_nonzero = has_nonzero | tl.sum(nonzero_mask.to(tl.int32), axis=0)
+                filtered = tl.where(nonzero_mask, vals, 0.0)
+                amax = tl.maximum(amax, tl.max(filtered, axis=0))
+            else:
+                amax = tl.maximum(amax, tl.max(vals, axis=0))
+    else:
+        amax = new_amax
+        has_nonzero = tl.where(new_amax > 0.0, 1, 0).to(tl.int32)
+
+    fp8_max = tl.load(fp8_maxes_ptr + track)
+    old_scale = tl.load(scales_ptr + track * N + mod)
+    sf = fp8_max / tl.maximum(amax, 1e-12)
+    if FILTER_ZEROS:
+        sf = tl.where(has_nonzero > 0, sf, old_scale)
+    else:
+        sf = tl.where(amax > 0.0, sf, old_scale)
+    sf = tl.where(amax == amax, sf, old_scale)
+    sf = tl.minimum(sf, FP32_MAX)
+    tl.store(scales_ptr + track * N + mod, sf)
+
+
+# ---------------------------------------------------------------------------
+# Global registry: replaces per-module scalar buffers with views into
+# contiguous (N,) tensors to eliminate Python iteration in the preamble.
+# ---------------------------------------------------------------------------
+
+
+class _DelayedScalingRegistry:
+    __slots__ = (
+        "n",
+        "modules",
+        "fwd_max",
+        "bwd_max",
+        "algo",
+        "history_len",
+        "_first_step",
+        "amax_history",
+        "_history_idx",
+        "fp8_maxes",
+        "staged_amaxes_3n",
+        "scales_3n",
+        "reduce_amax",
+        "amax_reduce_group",
+        "skip_bootstrap",
+        "filter_zeros",
+    )
+
+    def __init__(self, modules):
+        self.n = len(modules)
+        self.modules = modules
+        m0 = modules[0]
+        self.fwd_max = m0._fp8_fwd_max
+        self.bwd_max = m0._fp8_bwd_max
+        self.algo = m0._amax_compute_algo
+        self.history_len = m0.amax_history_input.shape[0]
+        device = m0.weight.device
+
+        self._first_step = True
+
+        H = self.history_len
+        N = self.n
+
+        self.scales_3n = torch.ones(3, N, dtype=torch.float32, device=device)
+        self.staged_amaxes_3n = torch.zeros(3, N, dtype=torch.float32, device=device)
+
+        self.amax_history = torch.zeros(3, N, H, dtype=torch.float32, device=device)
+        self._history_idx = 0
+        self.fp8_maxes = torch.tensor(
+            [self.fwd_max, self.fwd_max, self.bwd_max],
+            dtype=torch.float32,
+            device=device,
+        )
+
+        _config = getattr(m0, "config", None)
+        self.reduce_amax = getattr(_config, "fp8_reduce_amax", False) if _config else False
+        self.skip_bootstrap = getattr(_config, "fp8_skip_first_step_bootstrap", False) if _config else False
+        self.filter_zeros = getattr(_config, "fp8_filter_zeros_in_history", False) if _config else False
+        self.amax_reduce_group = None
+        if self.reduce_amax:
+            from megatron.core import parallel_state
+
+            if parallel_state.model_parallel_is_initialized():
+                self.amax_reduce_group = parallel_state.get_amax_reduction_group(
+                    with_context_parallel=True,
+                    tp_only_amax_red=getattr(_config, "tp_only_amax_red", False),
+                )
+
+        for i, m in enumerate(modules):
+            m._buffers["scale_input"] = torch.ones((), dtype=torch.float32, device=device)
+            m._buffers["scale_weight"] = torch.ones((), dtype=torch.float32, device=device)
+            m._buffers["scale_grad"] = torch.ones((), dtype=torch.float32, device=device)
+            m._buffers["staged_input_amax"] = torch.zeros((), dtype=torch.float32, device=device)
+            m._buffers["staged_weight_amax"] = torch.zeros((), dtype=torch.float32, device=device)
+            m._buffers["staged_grad_amax"] = torch.zeros((), dtype=torch.float32, device=device)
+            m._buffers["amax_history_input"] = self.amax_history[0, i, :]
+            m._buffers["amax_history_weight"] = self.amax_history[1, i, :]
+            m._buffers["amax_history_grad"] = self.amax_history[2, i, :]
+
+
+@torch.no_grad()
+def _fast_update_scales(registry):
+    """Ultra-fast scale update for most_recent + history_len=1.
+
+    Gathers per-module scalar amaxes into batched tensors, computes scales,
+    then scatters back.  Each module has independent storage for its scale
+    and amax buffers so that torch.compile version tracking is correct.
+    """
+    r = registry
+
+    # Detect device migration AND per-module buffer pointer breakage (e.g.
+    # after _reset_fp8_local_spec during MLPerf warmup teardown). Mirrors the
+    # same check in _fast_update_scales_with_history so the warmup-reset
+    # docstring contract holds for history_len==1 configs too: a fresh
+    # registry.__init__(modules) call sets _first_step=True, which bootstraps
+    # weight amaxes from the restored (post-warmup) weights below.
+    if (
+        r.scales_3n.device != r.modules[0].weight.device
+        or r.amax_history.untyped_storage().data_ptr()
+        != r.modules[0].amax_history_input.untyped_storage().data_ptr()
+    ):
+        r.__init__(r.modules)
+
+    if r._first_step and not r.skip_bootstrap:
+        weights = [m.weight.data for m in r.modules]
+        try:
+            weight_amaxes = torch.stack(torch._foreach_norm(weights, ord=float("inf"))).float()
+        except (AttributeError, RuntimeError):
+            weight_amaxes = torch.stack([w.abs().amax().float() for w in weights])
+        for i, m in enumerate(r.modules):
+            m.staged_weight_amax.fill_(weight_amaxes[i].item())
+    if r._first_step:
+        r._first_step = False
+
+    staged_input = torch.stack([m.staged_input_amax for m in r.modules])
+    staged_weight = torch.stack([m.staged_weight_amax for m in r.modules])
+    staged_grad = torch.stack([m.staged_grad_amax for m in r.modules])
+
+    if r.reduce_amax and r.amax_reduce_group is not None:
+        amaxes_3n = torch.stack([staged_input, staged_weight, staged_grad])
+        torch.distributed.all_reduce(
+            amaxes_3n,
+            op=torch.distributed.ReduceOp.MAX,
+            group=r.amax_reduce_group,
+        )
+        staged_input, staged_weight, staged_grad = amaxes_3n[0], amaxes_3n[1], amaxes_3n[2]
+
+    scale_input = torch.stack([m.scale_input for m in r.modules])
+    scale_weight = torch.stack([m.scale_weight for m in r.modules])
+    scale_grad = torch.stack([m.scale_grad for m in r.modules])
+
+    new_input = _batch_compute_scales(staged_input, r.fwd_max, scale_input)
+    new_weight = _batch_compute_scales(staged_weight, r.fwd_max, scale_weight)
+    new_grad = _batch_compute_scales(staged_grad, r.bwd_max, scale_grad)
+
+    # Batched device-only scatter: unbinding a (N,) float32 tensor into N
+    # 0-d views and copying with torch._foreach_copy_ keeps the per-module
+    # scale_* buffers independent (required for torch.compile version
+    # tracking) without the 3*N .item() host syncs the loop version
+    # incurred.
+    #
+    # NOTE (perf): the per-module scalar layout was chosen so that
+    # torch.compile sees each module's scale_* as an independent buffer
+    # version. A shared (N,) buffer with module-level views would let us
+    # skip the unbind+foreach_copy entirely, at the cost of more frequent
+    # compile cache invalidation. Worth benchmarking once the compile
+    # convergence work settles.
+    torch._foreach_copy_(
+        [m.scale_input for m in r.modules],
+        list(new_input.unbind()),
+    )
+    torch._foreach_copy_(
+        [m.scale_weight for m in r.modules],
+        list(new_weight.unbind()),
+    )
+    torch._foreach_copy_(
+        [m.scale_grad for m in r.modules],
+        list(new_grad.unbind()),
+    )
+
+
+@torch.no_grad()
+def _fast_update_scales_with_history(registry):
+    """Fused scale update for delayed scaling with history_len > 1.
+
+    Single Triton kernel dispatch replaces the prior Python-loop-based
+    per-module scale update (~200+ tiny GPU ops) with one launch.
+    """
+    r = registry
+
+    if (
+        r.amax_history.device != r.modules[0].weight.device
+        or r.amax_history.untyped_storage().data_ptr()
+        != r.modules[0].amax_history_input.untyped_storage().data_ptr()
+    ):
+        r.__init__(r.modules)
+
+    if r._first_step and not r.skip_bootstrap:
+        weights = [m.weight.data for m in r.modules]
+        try:
+            weight_amaxes = torch.stack(torch._foreach_norm(weights, ord=float("inf"))).float()
+        except (AttributeError, RuntimeError):
+            weight_amaxes = torch.stack([w.abs().amax().float() for w in weights])
+        for i, m in enumerate(r.modules):
+            m.staged_weight_amax.fill_(weight_amaxes[i].item())
+    if r._first_step:
+        r._first_step = False
+
+    r.staged_amaxes_3n[0].copy_(torch.stack([m.staged_input_amax for m in r.modules]))
+    r.staged_amaxes_3n[1].copy_(torch.stack([m.staged_weight_amax for m in r.modules]))
+    r.staged_amaxes_3n[2].copy_(torch.stack([m.staged_grad_amax for m in r.modules]))
+
+    if r.reduce_amax and r.amax_reduce_group is not None:
+        torch.distributed.all_reduce(
+            r.staged_amaxes_3n,
+            op=torch.distributed.ReduceOp.MAX,
+            group=r.amax_reduce_group,
+        )
+
+    N = r.n
+    H = r.history_len
+    BLOCK_H = triton.next_power_of_2(H) if H <= 1024 else 1024
+
+    _fused_delayed_scale_update_kernel[(N, 3)](
+        r.amax_history,
+        r.staged_amaxes_3n,
+        r.scales_3n,
+        r.fp8_maxes,
+        r._history_idx,
+        N=N,
+        H=H,
+        use_max_algo=(r.algo == "max"),
+        BLOCK_H=BLOCK_H,
+        FP32_MAX=torch.finfo(torch.float32).max,
+        FILTER_ZEROS=r.filter_zeros,
+    )
+
+    # See _fast_update_scales for the rationale behind _foreach_copy_ +
+    # unbind here. r.scales_3n is the (3, N) registry-batched scale tensor
+    # produced by the Triton kernel; rows 0/1/2 = input/weight/grad.
+    torch._foreach_copy_(
+        [m.scale_input for m in r.modules],
+        list(r.scales_3n[0].unbind()),
+    )
+    torch._foreach_copy_(
+        [m.scale_weight for m in r.modules],
+        list(r.scales_3n[1].unbind()),
+    )
+    torch._foreach_copy_(
+        [m.scale_grad for m in r.modules],
+        list(r.scales_3n[2].unbind()),
+    )
+
+    r._history_idx = (r._history_idx + 1) % H
+    for m in r.modules:
+        m._history_idx = r._history_idx
+
+
+# ---------------------------------------------------------------------------
+# Async allreduce split: stage+launch / wait+compute
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def _stage_and_launch_async_allreduce(registry):
+    """Stage per-module amaxes into r.staged_amaxes_3n and launch async allreduce.
+
+    Returns the async work handle (or None if allreduce is not needed).
+    Must be called after backward completes so staged_*_amax buffers are
+    populated.
+    """
+    r = registry
+    r.staged_amaxes_3n[0].copy_(torch.stack([m.staged_input_amax for m in r.modules]))
+    r.staged_amaxes_3n[1].copy_(torch.stack([m.staged_weight_amax for m in r.modules]))
+    r.staged_amaxes_3n[2].copy_(torch.stack([m.staged_grad_amax for m in r.modules]))
+
+    if r.reduce_amax and r.amax_reduce_group is not None:
+        handle = torch.distributed.all_reduce(
+            r.staged_amaxes_3n,
+            op=torch.distributed.ReduceOp.MAX,
+            group=r.amax_reduce_group,
+            async_op=True,
+        )
+        return handle
+    return None
+
+
+@torch.no_grad()
+def _wait_and_compute_scales(registry, handle):
+    """Wait on async allreduce handle and compute new scales from reduced amaxes.
+
+    For most_recent + history_len=1, computes scales directly from
+    staged_amaxes_3n. For history-based, dispatches the fused Triton kernel.
+    Handles weight caching if enabled.
+    """
+    r = registry
+
+    if handle is not None:
+        handle.wait()
+
+    if r.algo == "most_recent" and r.history_len == 1:
+        staged_input = r.staged_amaxes_3n[0]
+        staged_weight = r.staged_amaxes_3n[1]
+        staged_grad = r.staged_amaxes_3n[2]
+
+        scale_input = torch.stack([m.scale_input for m in r.modules])
+        scale_weight = torch.stack([m.scale_weight for m in r.modules])
+        scale_grad = torch.stack([m.scale_grad for m in r.modules])
+
+        new_input = _batch_compute_scales(staged_input, r.fwd_max, scale_input)
+        new_weight = _batch_compute_scales(staged_weight, r.fwd_max, scale_weight)
+        new_grad = _batch_compute_scales(staged_grad, r.bwd_max, scale_grad)
+
+        for i, m in enumerate(r.modules):
+            m.scale_input.fill_(new_input[i].item())
+            m.scale_weight.fill_(new_weight[i].item())
+            m.scale_grad.fill_(new_grad[i].item())
+    else:
+        N = r.n
+        H = r.history_len
+        BLOCK_H = triton.next_power_of_2(H) if H <= 1024 else 1024
+
+        _fused_delayed_scale_update_kernel[(N, 3)](
+            r.amax_history,
+            r.staged_amaxes_3n,
+            r.scales_3n,
+            r.fp8_maxes,
+            r._history_idx,
+            N=N,
+            H=H,
+            use_max_algo=(r.algo == "max"),
+            BLOCK_H=BLOCK_H,
+            FP32_MAX=torch.finfo(torch.float32).max,
+            FILTER_ZEROS=r.filter_zeros,
+        )
+
+        for i, m in enumerate(r.modules):
+            m.scale_input.fill_(r.scales_3n[0, i].item())
+            m.scale_weight.fill_(r.scales_3n[1, i].item())
+            m.scale_grad.fill_(r.scales_3n[2, i].item())
+
+        r._history_idx = (r._history_idx + 1) % H
+        for m in r.modules:
+            m._history_idx = r._history_idx
+
+
+# ---------------------------------------------------------------------------
+# Weight extraction helper — called outside autograd.Function to avoid
+# tensor-subclass isinstance checks inside the compiled graph.
+# ---------------------------------------------------------------------------
+
+
+def _extract_fp8_weight(weight, fp8_dtype):
+    """Return (fp8_data, scale_inv) from weight, handling FP8UnshardedWeightTensor."""
+    from primus.backends.megatron.core.distributed.fsdp2_fp8_all_gather import (
+        FP8UnshardedWeightTensor,
+    )
+
+    if isinstance(weight, FP8UnshardedWeightTensor):
+        return weight.get_fp8_data_and_scale_inv()
+    return _quantize_fp8_tw(weight, fp8_dtype)
+
+
+# ---------------------------------------------------------------------------
+# Granularity -> Function dispatch map
+# ---------------------------------------------------------------------------
+
+_FP8_FN_MAP = {
+    ScalingGranularity.TENSORWISE: OpaqueFP8LinearTensorwiseFunction,
+    ScalingGranularity.ROWWISE: FP8LinearRowwiseFunction,
+    ScalingGranularity.BLOCKWISE: FP8LinearBlockwiseFunction,
+}
+
+# Public alias
+FP8LinearTensorwiseFunction = OpaqueFP8LinearTensorwiseFunction
+
+
+# ---------------------------------------------------------------------------
+# FP8-aware parallel linear layers
+# ---------------------------------------------------------------------------
+
+
+class _Float8LinearMixin:
+    """Shared per-module FP8 behavior for Float8{Column,Row}ParallelLinear.
+
+    This is a mixin (not an nn.Module). Each concrete class also inherits a
+    Megatron ``*ParallelLinear`` and MUST list this mixin FIRST in its bases so
+    the ``_apply`` / ``_forward_impl`` overrides below take precedence over the
+    Megatron base (otherwise FP8 would be silently disabled). The concrete
+    ``__init__`` calls ``self._init_fp8_state()`` after ``super().__init__()``.
+
+    Requires: tensor_model_parallel_size=1, gradient_accumulation_fusion=False,
+    sequence_parallel=False. Fails fast at construction if violated.
+
+    Tensorwise uses the setup_context autograd pattern with pre-extracted FP8
+    weight data for graph-break-free torch.compile tracing.
+    Rowwise and blockwise still use @allow_in_graph.
+    """
+
+    def _init_fp8_state(self):
+        cls = type(self).__name__
+        if self.config.tensor_model_parallel_size != 1:
+            raise ValueError(
+                f"{cls} requires tensor_model_parallel_size=1. "
+                f"Got {self.config.tensor_model_parallel_size}."
+            )
+        if self.gradient_accumulation_fusion:
+            raise ValueError(f"{cls} requires gradient_accumulation_fusion=False.")
+        if self.sequence_parallel:
+            raise ValueError(f"{cls} requires sequence_parallel=False.")
+        if self.config.fp8 is None:
+            raise ValueError(f"{cls} requires config.fp8 to be set (e.g. 'e4m3').")
+
+        self._fp8_config = _build_fp8_config(self.config)
+        self._fp8_fn = _FP8_FN_MAP[self._fp8_config.granularity]
+
+        if self._fp8_config.granularity == ScalingGranularity.TENSORWISE:
+            self._fp8_fwd_dtype = _get_fp8_dtype(self._fp8_config.format, is_fwd=True)
+            self._fp8_bwd_dtype = _get_fp8_dtype(self._fp8_config.format, is_fwd=False)
+            self._fp8_gran_value = ScalingGranularity.TENSORWISE.value
+            self._fp8_backend_value = BackendType.HIPBLASLT.value
+            # Native layout (NN/TN) by default; forced-NT is opt-in per config.
+            # Read once at layer init so it stays a compile-time constant.
+            self._force_nt = getattr(self.config, "fp8_force_nt_layout", False)
+            self._use_delayed_scaling = (
+                getattr(self.config, "fp8_scaling_strategy", "dynamic") == "delayed"
+                or self.config.fp8_recipe == Fp8Recipe.delayed
+            )
+            if self._use_delayed_scaling:
+                _init_delayed_scaling_state(self)
+
+    def _apply(self, fn, recurse=True):
+        result = super()._apply(fn, recurse)
+        if getattr(self, "_use_delayed_scaling", False):
+            for name in [
+                "scale_input",
+                "scale_weight",
+                "scale_grad",
+                "amax_history_input",
+                "amax_history_weight",
+                "amax_history_grad",
+                "staged_input_amax",
+                "staged_grad_amax",
+                "staged_weight_amax",
+            ]:
+                buf = getattr(self, name, None)
+                if buf is not None and buf.dtype != torch.float32:
+                    self._buffers[name] = buf.data.float()
+        return result
+
+    def _forward_impl(self, input, weight, *args, **kwargs):
+        bias = kwargs.get("bias", None)
+
+        if self._fp8_config.granularity == ScalingGranularity.TENSORWISE:
+            if self._use_delayed_scaling:
+                result = DelayedFP8LinearTensorwiseFunction.apply(
+                    input,
+                    weight,
+                    self.scale_input,
+                    self.scale_weight,
+                    self.scale_grad,
+                    self.staged_input_amax,
+                    self.staged_weight_amax,
+                    self.staged_grad_amax,
+                    self._fp8_fwd_dtype,
+                    self._fp8_bwd_dtype,
+                    self._fp8_gran_value,
+                    self._fp8_backend_value,
+                    self._force_nt,
+                )
+                output = result[0]
+            else:
+                weight_fp8, weight_scale_inv = _extract_fp8_weight(
+                    weight,
+                    self._fp8_fwd_dtype,
+                )
+                result = self._fp8_fn.apply(
+                    input,
+                    weight,
+                    weight_fp8,
+                    weight_scale_inv,
+                    self._fp8_fwd_dtype,
+                    self._fp8_bwd_dtype,
+                    self._fp8_gran_value,
+                    self._fp8_backend_value,
+                    self._force_nt,
+                )
+                output = result[0]
+        else:
+            output = self._fp8_fn.apply(input, weight, self._fp8_config)
+
+        if bias is not None:
+            output = output + bias
+        return output
+
+
+class Float8ColumnParallelLinear(_Float8LinearMixin, ColumnParallelLinear):
+    """ColumnParallelLinear with per-module FP8. torch.compile friendly.
+
+    Shared FP8 behavior lives in :class:`_Float8LinearMixin`, which is listed
+    first so its ``_apply`` / ``_forward_impl`` overrides take effect.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._init_fp8_state()
+
+
+class Float8RowParallelLinear(_Float8LinearMixin, RowParallelLinear):
+    """RowParallelLinear with per-module FP8. torch.compile friendly.
+
+    Shared FP8 behavior lives in :class:`_Float8LinearMixin`, which is listed
+    first so its ``_apply`` / ``_forward_impl`` overrides take effect.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._init_fp8_state()

--- a/primus/backends/megatron/core/extensions/primus_turbo_local_spec.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_local_spec.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Primus Turbo Local Spec Provider
+
+Clean implementation using native Megatron modules with Primus Turbo
+optimizations. NO TransformerEngine dependencies.
+
+Key Features:
+- PrimusTurboLocalAttention: New class, inherits from MegatronModule (not TE)
+- Native Megatron linear layers (ColumnParallelLinear, RowParallelLinear)
+- Native LayerNorm (WrappedTorchNorm or FusedLayerNorm)
+- Maximum torch.compile compatibility
+- 52ms attention advantage preserved via pt.ops.flash_attn_func
+
+Performance Target (vs Inductor baseline):
+- Attention: Same (52ms advantage over Inductor's flash_attn)
+- GEMM: -7ms (native PyTorch proven within 0.8% of TE)
+- Elementwise: -157ms (torch.compile fusion)
+- Reduce: -17ms (torch.compile fusion)
+- Framework: -107ms (no TE overhead)
+- Total: ~1,131ms vs Inductor's 1,415ms = 20% faster
+"""
+
+import math
+import os
+from typing import Optional
+
+import primus_turbo.pytorch as pt
+import torch
+from primus_turbo.pytorch.ops.attention.flash_attn_interface import AiterFlashAttnFunc
+
+torch._dynamo.allow_in_graph(AiterFlashAttnFunc)
+
+
+@torch._dynamo.disable
+def _advance_model_parallel_rng(batch_size: int, num_heads: int) -> None:
+    """Simulate TE's CUDA RNG consumption inside
+    PrimusTurboLocalAttention.
+
+    TEDotProductAttention is instantiated with
+    get_rng_state_tracker=get_cuda_rng_tracker, so TE's fused_attn_fwd kernel
+    call runs inside tracker.fork() (the 'model-parallel-rng' generator state).
+    The ASM kernel pulls a fresh philox state per call regardless of dropout,
+    advancing model-parallel-rng by counter_offset = B*H*warp_size each
+    attention call. Aiter's _ndropout path does not touch RNG, so PT and
+    aiter attention see different downstream RNG sequences and diverge.
+
+    This helper replays the same RNG advance. Decorated with @dynamo.disable
+    so AOTAutograd never tries to trace through the generator manipulation.
+    """
+    warp_size = 64
+    counter_offset = batch_size * num_heads * warp_size
+    dev_idx = torch.cuda.current_device()
+    gens = torch.cuda.default_generators
+    if dev_idx >= len(gens):
+        return
+    gen = gens[dev_idx]
+
+    def _advance_with(g):
+        try:
+            g.set_offset(g.get_offset() + counter_offset)
+        except AttributeError:
+            torch.empty(counter_offset, device="cuda", dtype=torch.int32).random_(generator=g)
+
+    try:
+        from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
+
+        tracker = get_cuda_rng_tracker()
+    except Exception:
+        tracker = None
+
+    if tracker is not None and getattr(tracker, "is_initialized", lambda: False)():
+        with tracker.fork():
+            _advance_with(gen)
+    else:
+        _advance_with(gen)
+
+
+from megatron.core.models.backends import LocalSpecProvider
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.parallel_state import (
+    get_context_parallel_group,
+    get_tensor_model_parallel_group,
+)
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.transformer_config import TransformerConfig
+from megatron.training.global_vars import get_args
+from torch import Tensor
+
+
+class PrimusTurboLocalAttention(MegatronModule):
+    """
+    Primus Turbo Flash Attention - Native Megatron Implementation.
+
+    This is a COMPLETELY NEW class with ZERO TransformerEngine dependencies.
+
+    Key differences from PrimusTurboAttention (in primus_turbo.py):
+    - Inherits from MegatronModule (NOT te.pytorch.DotProductAttention)
+    - No TE infrastructure or overhead
+    - torch.compile friendly (no @no_torch_dynamo decorator)
+    - Same 52ms performance advantage via pt.ops.flash_attn_func
+
+    Used exclusively by: PrimusTurboLocalSpecProvider
+
+    Performance:
+    - 52ms faster than Inductor's flash_attn implementation
+    - Same as existing PrimusTurboAttention but without TE overhead
+    - torch.compile compatible for surrounding operations
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        attention_type: str,
+        attention_dropout: Optional[float] = None,
+        softmax_scale: Optional[float] = None,
+        k_channels: Optional[int] = None,
+        v_channels: Optional[int] = None,
+        cp_comm_type: str = "p2p",
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ):
+        super().__init__(config=config)
+
+        self.config = config
+        self.layer_number = layer_number
+        self.attn_mask_type = attn_mask_type
+        self.attention_type = attention_type
+
+        # Calculate softmax scale
+        kv_channels = k_channels if k_channels is not None else config.kv_channels
+        self.softmax_scale = softmax_scale or (1.0 / math.sqrt(kv_channels))
+
+        # Setup process groups
+        if pg_collection is None:
+            pg_collection = ProcessGroupCollection(
+                tp=get_tensor_model_parallel_group(check_initialized=False),
+                cp=get_context_parallel_group(check_initialized=False),
+            )
+
+        # Select Primus Turbo flash attention variant
+        args = get_args()
+        if args.enable_turbo_attention_float8:
+            self.attn_func = (
+                pt.ops.flash_attn_fp8_usp_func
+                if config.context_parallel_size > 1
+                else pt.ops.flash_attn_fp8_func
+            )
+        else:
+            self.attn_func = (
+                pt.ops.flash_attn_usp_func if config.context_parallel_size > 1 else pt.ops.flash_attn_func
+            )
+
+        # The transpose in forward() produces a non-contiguous, SBHD-strided view.
+        # aiter's v3 flash-attention backward mishandles that strided layout on
+        # gfx942 (MI300X), corrupting gradients and causing grad-norm divergence
+        # ~step 31; gfx950 (MI355X) handles it correctly. Feed contiguous BSHD on
+        # gfx942 only, so gfx950 keeps the faster zero-copy strided path unchanged.
+        # Computed here (not in forward) so torch.compile sees a constant guard
+        # rather than a device query in the traced region.
+        self.force_contiguous_qkv = torch.cuda.get_device_capability() < (9, 5)
+
+        # Setup context parallel arguments
+        self.attn_kwargs = {}
+        if config.context_parallel_size > 1:
+            self.attn_kwargs["ulysses_group"] = pg_collection.cp
+
+        # Validate configuration
+        if config.window_size is not None:
+            raise ValueError("PrimusTurboLocalAttention does not support sliding window attention")
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Tensor,
+        attn_mask_type: AttnMaskType,
+        attention_bias: Optional[Tensor] = None,
+        packed_seq_params: Optional[PackedSeqParams] = None,
+    ) -> Tensor:
+        """
+        Forward pass using Primus Turbo flash attention.
+
+        Args:
+            query: Query tensor [seq_len, batch, num_heads, head_dim] (sbhd)
+            key: Key tensor [seq_len, batch, num_heads, head_dim] (sbhd)
+            value: Value tensor [seq_len, batch, num_heads, head_dim] (sbhd)
+            attention_mask: Attention mask (not used by flash attention)
+            attn_mask_type: Type of attention mask (causal, no_mask, etc.)
+            attention_bias: Attention bias (not used in this implementation)
+            packed_seq_params: Packed sequence parameters (optional)
+
+        Returns:
+            Attention output [seq_len, batch, num_heads * head_dim] (merged heads)
+        """
+        query, key, value = [x.transpose(0, 1) for x in (query, key, value)]
+
+        # gfx942: avoid aiter's broken strided-sbhd backward (see __init__).
+        if self.force_contiguous_qkv:
+            query, key, value = query.contiguous(), key.contiguous(), value.contiguous()
+
+        causal = attn_mask_type == AttnMaskType.causal
+
+        if os.environ.get("PRIMUS_PT_MIMIC_TE_RNG", "0") == "1":
+            B = query.size(0)
+            H = query.size(2)
+            _advance_model_parallel_rng(B, H)
+
+        output = self.attn_func(
+            query,
+            key,
+            value,
+            dropout_p=0.0,
+            softmax_scale=self.softmax_scale,
+            causal=causal,
+            window_size=(-1, -1),
+            bias=None,
+            alibi_slopes=None,
+            deterministic=False,
+            return_lse=False,
+            return_attn_probs=False,
+            **self.attn_kwargs,
+        )
+
+        # Transpose back to Megatron format (bshd -> sbhd) and merge heads
+        output = output.transpose(0, 1)
+        output = output.reshape(output.shape[0], output.shape[1], -1)
+
+        return output
+
+
+class PrimusTurboMXFP4LocalSpecProvider(LocalSpecProvider):
+    """
+    Compile-friendly MXFP4 spec: Primus Turbo attention + MXFP4 linear layers.
+    NO TransformerEngine. NO global FP4 state in forward path.
+    Requires tensor_model_parallel_size=1.
+    """
+
+    def column_parallel_linear(self) -> type:
+        from .primus_turbo_mxfp4_local import MXFP4ColumnParallelLinear
+
+        return MXFP4ColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        from .primus_turbo_mxfp4_local import MXFP4RowParallelLinear
+
+        return MXFP4RowParallelLinear
+
+    def core_attention(self) -> type:
+        return PrimusTurboLocalAttention
+
+
+class PrimusTurboFloat8LocalSpecProvider(LocalSpecProvider):
+    """
+    Compile-friendly FP8 spec: Primus Turbo attention + FP8 linear layers.
+    NO TransformerEngine. NO global FP8 state in forward path.
+    NO changes to Primus-Turbo repo. Requires tensor_model_parallel_size=1.
+    """
+
+    def column_parallel_linear(self) -> type:
+        from .primus_turbo_float8_local import Float8ColumnParallelLinear
+
+        return Float8ColumnParallelLinear
+
+    def row_parallel_linear(self) -> type:
+        from .primus_turbo_float8_local import Float8RowParallelLinear
+
+        return Float8RowParallelLinear
+
+    def core_attention(self) -> type:
+        return PrimusTurboLocalAttention
+
+
+class PrimusTurboLocalSpecProvider(LocalSpecProvider):
+    """
+    Spec provider that extends LocalSpecProvider with Primus Turbo attention.
+
+    Uses native Megatron modules everywhere except attention, where it uses
+    PrimusTurboLocalAttention for the 52ms performance advantage.
+
+    Key features:
+    - NO TransformerEngine dependencies
+    - Maximum torch.compile compatibility
+    - Minimal custom code (~120 lines total)
+    - Native PyTorch GEMM (proven within 0.8% of TE)
+    - Primus Turbo flash attention (52ms advantage)
+
+    Configuration:
+        config.use_primus_turbo_local_spec = True
+
+    Performance Target:
+    - Attention: -52ms (Primus Turbo advantage over Inductor)
+    - Operator fusion: -180ms (torch.compile)
+    - Framework overhead: -107ms (no TE)
+    - GEMM: ~same (native PyTorch excellent)
+    - Total: ~1,131ms vs Inductor's 1,415ms (20% faster)
+
+    vs Current TE implementation:
+    - Total: ~1,131ms vs 1,588ms (28.8% faster)
+    """
+
+    def core_attention(self) -> type:
+        """Return Primus Turbo local attention (NO TE dependency)"""
+        return PrimusTurboLocalAttention
+
+    # Everything else inherited from LocalSpecProvider:
+    # - column_parallel_linear() -> ColumnParallelLinear (native Megatron)
+    # - row_parallel_linear() -> RowParallelLinear (native Megatron)
+    # - layer_norm() -> WrappedTorchNorm/FusedLayerNorm (compile-friendly)
+    # - fuse_layernorm_and_linear() -> False (no fusion overhead)
+    # - grouped_mlp_modules() -> SequentialMLP (native modules)
+    # - activation_func() -> None (standard activation)

--- a/primus/backends/megatron/core/fp8_utils.py
+++ b/primus/backends/megatron/core/fp8_utils.py
@@ -73,14 +73,19 @@ if HAVE_TE and HAVE_TURBO:
         return format_mapping[te_format]
 
     def get_fp8_recipe(config: TransformerConfig):
-        """Return fp8 recipe.
+        """Return fp8 recipe (Primus Turbo + TE variant).
 
         Arguments:
             config (TransformerConfig): Configuration object.
 
         Returns:
-            FP8 recipe: Transformer Engine FP8 recipe.
-            FP8 None reason: reason why the fp8 recipe is None.
+            Tuple of (fp8_recipe, fp8_recipe_none_reason):
+                - fp8_recipe: Transformer Engine FP8 recipe, or None.
+                - fp8_recipe_none_reason: reason why the fp8 recipe is None.
+
+        Note:
+            This variant (HAVE_TE + HAVE_TURBO) returns a tuple. The TE-only
+            variant returns a single recipe value.
         """
         if config.fp8 == "e4m3":
             fp8_format = transformer_engine.common.recipe.Format.E4M3

--- a/primus/backends/megatron/core/utils.py
+++ b/primus/backends/megatron/core/utils.py
@@ -1,26 +1,40 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
 from functools import lru_cache
+from typing import Any, List
 
+import torch
 from megatron.core import parallel_state
-from primus_turbo.pytorch.ops.attention.attention_utils import (
-    All2AllAttentionSharder,
-    AttentionSharder,
-)
+
+from primus.modules.module_utils import log_rank_0
 
 
 @lru_cache
 def produce_attention_sharder(cp_comm_type: str):
+    # Import only when needed to avoid import errors if primus_turbo is not available
+    try:
+        from primus_turbo.pytorch.ops.attention.attention_utils import (
+            All2AllAttentionSharder,
+        )
+    except ImportError:
+        raise ImportError("All2AllAttentionSharder not available. Ensure primus_turbo is properly installed.")
+
     if cp_comm_type == "a2a":
         return All2AllAttentionSharder()
     else:
         raise ValueError(f"Unsupported cp_comm_type: {cp_comm_type}")
 
 
-def shard_batch_on_this_cp_rank(sharder: AttentionSharder, batch):
+def shard_batch_on_this_cp_rank(sharder, batch):
+    # Import only when needed to avoid import errors if primus_turbo is not available
+    try:
+        pass
+    except ImportError:
+        raise ImportError("AttentionSharder not available. Ensure primus_turbo is properly installed.")
+
     cp_size = parallel_state.get_context_parallel_world_size()
     cp_group = parallel_state.get_context_parallel_group()
     if cp_size > 1:
@@ -29,3 +43,118 @@ def shard_batch_on_this_cp_rank(sharder: AttentionSharder, batch):
                 seq_dim = 1 if key != "attention_mask" else 2
                 batch[key] = sharder.shard_cp_input([val], cp_group, seq_dim)[0]
     return batch
+
+
+def apply_torch_compile_if_enabled(model: List[Any], args: Any) -> None:
+    """
+    Apply torch.compile to model AFTER distributed wrapping and config setup.
+
+    This must be called:
+    1. AFTER get_model() completes (which does FSDP/DDP wrapping internally)
+    2. AFTER ddp_config is set on the wrapped model
+    3. BEFORE optimizer creation
+
+    Args:
+        model: List of model modules (already wrapped in DDP/FSDP)
+        args: Megatron args object
+
+    Raises:
+        Exception: If compilation fails, exception is raised (not caught)
+    """
+    from megatron.training.utils import unwrap_model
+
+    # Check if compilation is enabled
+    if not getattr(args, "enable_torch_compile", False):
+        return
+
+    log_rank_0("=" * 80)
+    log_rank_0("Applying torch.compile AFTER distributed wrapping...")
+    log_rank_0("=" * 80)
+
+    # Import torch_FSDP for type checking
+    try:
+        from primus.backends.megatron.core.distributed.torch_fully_sharded_data_parallel import (
+            PrimusTorchFullyShardedDataParallel as torch_FSDP,
+        )
+    except ImportError:
+        torch_FSDP = None
+
+    for idx, model_module in enumerate(model):
+        # Check what type of wrapper we have
+        wrapper_type = type(model_module).__name__
+        log_rank_0(f"  Model [{idx}] wrapper: {wrapper_type}")
+
+        # Check if wrapped with FSDP and has ddp_config
+        if torch_FSDP and isinstance(model_module, torch_FSDP):
+            has_config = hasattr(model_module, "ddp_config")
+            log_rank_0(f"  FSDP detected - has ddp_config: {has_config}")
+
+            # Check if FSDP wrapper has compile_model method
+            if hasattr(model_module, "compile_model"):
+                log_rank_0(f"  Calling compile_model on FSDP wrapper...")
+                model_module.compile_model()
+                log_rank_0(f"    ✓ FSDP wrapper compilation complete")
+                continue
+
+        # Unwrap to get the actual model (Flux, GPT, etc.)
+        unwrapped_models = unwrap_model([model_module])
+
+        for unwrapped in unwrapped_models:
+            model_type = type(unwrapped).__name__
+
+            # Check if the model has a compile_model method
+            if hasattr(unwrapped, "compile_model"):
+                log_rank_0(f"  Compiling {model_type}...")
+
+                # Apply compilation
+                unwrapped.compile_model()
+
+                log_rank_0(f"    ✓ {model_type} compilation complete")
+            else:
+                log_rank_0(f"  ℹ  {model_type} does not support torch.compile " f"(no compile_model method)")
+
+    log_rank_0("torch.compile application complete")
+    log_rank_0("=" * 80)
+
+
+def apply_torch_compile_to_optimizer_if_enabled(optimizer: Any, args: Any) -> None:
+    """
+    Apply torch.compile to the optimizer's step() when enable_torch_compile is True.
+    Replaces optimizer.step with a compiled version so the trainer needs no changes.
+    Uses fullgraph=False for the optimizer step (recommended; allows timers/conditionals).
+    """
+    if optimizer is None:
+        return
+    if not getattr(args, "enable_torch_compile", False):
+        return
+    if not getattr(args, "torch_compile_optimizer", False):
+        log_rank_0("  Optimizer compilation disabled (torch_compile_optimizer=False)")
+        return
+
+    backend = getattr(args, "torch_compile_backend", "inductor")
+    mode = getattr(args, "torch_compile_mode", "default")
+    fullgraph = False  # Optimizer step: allow graph breaks (timers, conditionals)
+
+    compile_kwargs = {
+        "backend": backend,
+        "mode": mode,
+        "fullgraph": fullgraph,
+    }
+
+    scope = getattr(args, "torch_compile_optimizer_scope", "full")
+    log_rank_0(f"Applying torch.compile to optimizer step (scope={scope})...")
+    log_rank_0(f"  backend={backend}, mode={mode}, fullgraph={fullgraph}")
+
+    if scope == "inner_only":
+        inner_opt = getattr(optimizer, "optimizer", None)
+        if inner_opt is None:
+            log_rank_0("  ⚠ No inner optimizer found, falling back to full scope")
+            scope = "full"
+        else:
+            inner_opt.step = torch.compile(inner_opt.step, **compile_kwargs)
+            log_rank_0("  ✓ Inner optimizer step compiled (clip_grad_norm/DTensor ops excluded)")
+
+    if scope == "full":
+        original_step = optimizer.step
+        optimizer.step = torch.compile(original_step, **compile_kwargs)
+        log_rank_0("  ✓ Optimizer step compiled (full scope)")

--- a/primus/backends/megatron/core/utils.py
+++ b/primus/backends/megatron/core/utils.py
@@ -29,12 +29,6 @@ def produce_attention_sharder(cp_comm_type: str):
 
 
 def shard_batch_on_this_cp_rank(sharder, batch):
-    # Import only when needed to avoid import errors if primus_turbo is not available
-    try:
-        pass
-    except ImportError:
-        raise ImportError("AttentionSharder not available. Ensure primus_turbo is properly installed.")
-
     cp_size = parallel_state.get_context_parallel_world_size()
     cp_group = parallel_state.get_context_parallel_group()
     if cp_size > 1:

--- a/tests/unit_tests/backends/megatron/test_native_fp8_layout.py
+++ b/tests/unit_tests/backends/megatron/test_native_fp8_layout.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""GPU-only tests for the native (NN/TN) FP8 backward layout.
+
+FP8 GEMMs require an AMD GPU (gfx950); the fused no-transpose cast+amax kernel
+is vendored in Primus (fp8_cast_kernels_triton), so every test here is skipped
+when CUDA is unavailable. Run on an AMD GPU (gfx950) with the FP8 toolchain available.
+
+Coverage:
+  - native (``fp8_force_nt_layout=False``) vs legacy forced-NT numerical
+    equivalence for both forward and backward,
+  - finiteness of the weight gradient (the wgrad-NaN regression that motivated
+    the native layout),
+  - backward gradient flow / return-count validation for both
+    ``OpaqueFP8LinearTensorwiseFunction`` (9 inputs) and the full delayed-scaling
+    layer (``DelayedFP8LinearTensorwiseFunction``, 13 inputs); a count mismatch
+    would make ``autograd`` raise, so a successful backward validates the arity.
+"""
+
+import functools
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+    Float8ColumnParallelLinear,
+    OpaqueFP8LinearTensorwiseFunction,
+)
+from tests.utils import PrimusUT
+
+requires_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Native FP8 layout exercises FP8 GEMMs, which require an AMD GPU",
+)
+
+
+def _init_method():
+    return functools.partial(torch.nn.init.xavier_uniform_)
+
+
+def _make_config(force_nt, recipe="tensorwise"):
+    """TransformerConfig for an FP8 linear, with the diffusion-only
+    fp8_force_nt_layout attribute attached (the layer reads it via getattr)."""
+    config = TransformerConfig(
+        hidden_size=64,
+        num_attention_heads=8,
+        num_layers=1,
+        params_dtype=torch.bfloat16,
+        fp8="e4m3",
+        fp8_recipe=recipe,
+    )
+    config.fp8_force_nt_layout = force_nt
+    return config
+
+
+def _build_linear(force_nt, recipe="tensorwise"):
+    return Float8ColumnParallelLinear(
+        input_size=64,
+        output_size=128,
+        config=_make_config(force_nt, recipe=recipe),
+        init_method=_init_method(),
+        bias=False,
+        gather_output=False,
+        skip_bias_add=False,
+        is_expert=False,
+    )
+
+
+def _forward_only(layer, x):
+    out = layer(x)
+    return out[0] if isinstance(out, tuple) else out
+
+
+class _GpuLinearBase(PrimusUT):
+    """Shared setup: parallel state + a minimal global-args stub for the layers."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state, monkeypatch):
+        dummy_args = SimpleNamespace(
+            rank=0,
+            world_size=1,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            offload=False,
+            offload_ops=[],
+            patch_primus_pipeline=False,
+            pp_algorithm=None,
+            patch_zero_bubble=False,
+            enable_zero_bubble=False,
+            rampup_batch_size=None,
+            global_batch_size=1,
+            micro_batch_size=1,
+            data_parallel_size=1,
+            decrease_batch_size_if_needed=False,
+        )
+        import megatron.training.global_vars as gvars
+
+        monkeypatch.setattr(gvars, "_GLOBAL_ARGS", dummy_args)
+
+        # Some deploy images bake PRIMUS_TURBO_GEMM_BACKEND="" which makes
+        # GlobalBackendManager raise KeyError('') on the native path. Unset it
+        # here, exactly as the docs require for native-layout production runs.
+        if os.environ.get("PRIMUS_TURBO_GEMM_BACKEND", None) == "":
+            monkeypatch.delenv("PRIMUS_TURBO_GEMM_BACKEND", raising=False)
+
+
+class TestNativeVsForcedNtLayer(_GpuLinearBase):
+    """End-to-end equivalence of the native and forced-NT layouts via the layer."""
+
+    @requires_gpu
+    def test_forward_backward_match_and_finite(self):
+        # NOTE: looped instead of @pytest.mark.parametrize because PrimusUT is a
+        # unittest.TestCase, where pytest does not inject parametrized args.
+        for recipe in ("tensorwise", "delayed"):
+            with self.subTest(recipe=recipe):
+                torch.manual_seed(0)
+
+                native = _build_linear(force_nt=False, recipe=recipe).cuda()
+                forced = _build_linear(force_nt=True, recipe=recipe).cuda()
+                # Identical weights so the only difference is the backward GEMM layout.
+                forced.load_state_dict(native.state_dict())
+
+                assert native._force_nt is False
+                assert forced._force_nt is True
+
+                x = torch.randn(8, 64, dtype=torch.bfloat16, device="cuda")
+                x_native = x.clone().requires_grad_(True)
+                x_forced = x.clone().requires_grad_(True)
+
+                out_native = _forward_only(native, x_native)
+                out_forced = _forward_only(forced, x_forced)
+
+                assert torch.isfinite(out_native).all(), "native forward produced non-finite output"
+                torch.testing.assert_close(out_native, out_forced, atol=2e-2, rtol=2e-2)
+
+                out_native.sum().backward()
+                out_forced.sum().backward()
+
+                # wgrad NaN regression guard + native/forced equivalence.
+                assert torch.isfinite(native.weight.grad).all(), "native wgrad is non-finite (NaN regression)"
+                assert torch.isfinite(x_native.grad).all(), "native dgrad is non-finite"
+                torch.testing.assert_close(native.weight.grad, forced.weight.grad, atol=3e-2, rtol=3e-2)
+                torch.testing.assert_close(x_native.grad, x_forced.grad, atol=3e-2, rtol=3e-2)
+
+
+class TestOpaqueFunctionBackward(_GpuLinearBase):
+    """Direct autograd-Function checks for OpaqueFP8LinearTensorwiseFunction."""
+
+    @requires_gpu
+    def test_native_backward_returns_grads_for_input_and_weight(self):
+        from primus_turbo.pytorch.core.backend import BackendType
+        from primus_turbo.pytorch.core.low_precision import (
+            ScalingGranularity,
+            float8_e4m3,
+            float8_e5m2,
+        )
+        from primus_turbo.pytorch.ops.quantization import quantize_fp8
+
+        gran = ScalingGranularity.TENSORWISE.value
+        backend = BackendType.HIPBLASLT.value
+
+        x = torch.randn(8, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        w = torch.randn(128, 64, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        w_fp8, w_scale = quantize_fp8(w, float8_e4m3, ScalingGranularity.TENSORWISE)
+
+        # force_nt=False exercises the native arm; backward must return exactly
+        # 9 grads (one per forward input) or autograd raises here.
+        out = OpaqueFP8LinearTensorwiseFunction.apply(
+            x, w, w_fp8, w_scale, float8_e4m3, float8_e5m2, gran, backend, False
+        )
+        output = out[0] if isinstance(out, tuple) else out
+        output.sum().backward()
+
+        assert x.grad is not None and torch.isfinite(x.grad).all()
+        assert w.grad is not None and torch.isfinite(w.grad).all()

--- a/tests/unit_tests/backends/megatron/test_primus_turbo_float8_local.py
+++ b/tests/unit_tests/backends/megatron/test_primus_turbo_float8_local.py
@@ -1,0 +1,431 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for compile-friendly FP8 linear layers (primus_turbo_float8_local).
+
+Tests _build_fp8_config mapping, Float8ColumnParallelLinear/Float8RowParallelLinear
+construction guards, init-time dispatch to the correct autograd Function,
+decomposed tensorwise quantize numerical equivalence, and torch.compile
+graph-break validation.
+"""
+
+import functools
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from megatron.core.enums import Fp8Recipe
+from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
+from megatron.core.transformer.transformer_config import TransformerConfig
+from primus_turbo.pytorch.core.low_precision import (
+    ScalingGranularity,
+    float8_e4m3,
+    float8_e5m2,
+)
+
+from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+    DecomposedFP8LinearTensorwiseFunction,
+    Float8ColumnParallelLinear,
+    Float8RowParallelLinear,
+    FP8LinearBlockwiseFunction,
+    OpaqueFP8LinearTensorwiseFunction,
+    _build_fp8_config,
+    _Float8LinearMixin,
+    _quantize_fp8_tensorwise,
+)
+from tests.utils import PrimusUT
+
+
+class TestFloat8MixinStructure:
+    """Structural guards for the shared _Float8LinearMixin (no construction).
+
+    These do not build modules, so they exercise the class layout rather than
+    FP8 numerics. They catch the load-bearing footgun where the mixin is not
+    listed first in the bases: in that case the Megatron base's ``_apply`` /
+    ``_forward_impl`` would win and FP8 would be silently disabled. The
+    init-time tests below would NOT catch that, because ``__init__`` calls
+    ``self._init_fp8_state()`` explicitly regardless of MRO order.
+
+    Note: this module imports primus_turbo (CUDA-at-import), so it is still
+    gated by the module-level skip_if_no_cuda() and runs in the GPU lane.
+    """
+
+    @pytest.mark.parametrize(
+        "cls, base",
+        [
+            (Float8ColumnParallelLinear, ColumnParallelLinear),
+            (Float8RowParallelLinear, RowParallelLinear),
+        ],
+    )
+    def test_mixin_precedes_base_in_mro(self, cls, base):
+        mro = cls.__mro__
+        assert _Float8LinearMixin in mro
+        assert base in mro
+        assert mro.index(_Float8LinearMixin) < mro.index(base), (
+            f"{cls.__name__}: _Float8LinearMixin must precede {base.__name__} in the MRO "
+            "or FP8 _apply/_forward_impl would be silently overridden by the base."
+        )
+
+    @pytest.mark.parametrize("cls", [Float8ColumnParallelLinear, Float8RowParallelLinear])
+    def test_fp8_overrides_resolve_to_mixin(self, cls):
+        assert cls._forward_impl is _Float8LinearMixin._forward_impl
+        assert cls._apply is _Float8LinearMixin._apply
+
+
+class TestBuildFP8Config:
+    """Tests for _build_fp8_config() — no GPU, no parallel state."""
+
+    def _make_config(self, fp8="e4m3", fp8_recipe=Fp8Recipe.tensorwise):
+        return SimpleNamespace(fp8=fp8, fp8_recipe=fp8_recipe)
+
+    def test_invalid_recipe_raises(self):
+        with pytest.raises(ValueError, match="does not support"):
+            _build_fp8_config(self._make_config(fp8_recipe=Fp8Recipe.custom))
+
+
+def _init_method():
+    return functools.partial(torch.nn.init.xavier_uniform_)
+
+
+def _make_fp8_transformer_config(**overrides):
+    """Build a TransformerConfig suitable for Float8 linear layers."""
+    defaults = dict(
+        hidden_size=64,
+        num_attention_heads=8,
+        num_layers=1,
+        params_dtype=torch.bfloat16,
+        fp8="e4m3",
+        fp8_recipe="tensorwise",
+    )
+    defaults.update(overrides)
+    return TransformerConfig(**defaults)
+
+
+class TestFloat8LinearGuards(PrimusUT):
+    """Tests that Float8 linear layers reject invalid configurations at init."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state, monkeypatch):
+        dummy_args = SimpleNamespace(
+            rank=0,
+            world_size=1,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            offload=False,
+            offload_ops=[],
+            patch_primus_pipeline=False,
+            pp_algorithm=None,
+            patch_zero_bubble=False,
+            enable_zero_bubble=False,
+            rampup_batch_size=None,
+            global_batch_size=1,
+            micro_batch_size=1,
+            data_parallel_size=1,
+            decrease_batch_size_if_needed=False,
+        )
+        import megatron.training.global_vars as gvars
+
+        monkeypatch.setattr(gvars, "_GLOBAL_ARGS", dummy_args)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_column_parallel_rejects_tp_gt_1(self):
+        config = _make_fp8_transformer_config(tensor_model_parallel_size=2)
+        with pytest.raises(ValueError, match="tensor_model_parallel_size=1"):
+            Float8ColumnParallelLinear(
+                input_size=64,
+                output_size=128,
+                config=config,
+                init_method=_init_method(),
+                bias=False,
+                gather_output=False,
+                skip_bias_add=False,
+                is_expert=False,
+            )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_column_parallel_rejects_gaf(self):
+        config = _make_fp8_transformer_config(gradient_accumulation_fusion=True)
+        with pytest.raises(ValueError, match="gradient_accumulation_fusion"):
+            Float8ColumnParallelLinear(
+                input_size=64,
+                output_size=128,
+                config=config,
+                init_method=_init_method(),
+                bias=False,
+                gather_output=False,
+                skip_bias_add=False,
+                is_expert=False,
+            )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_column_parallel_rejects_sequence_parallel(self):
+        # SP requires TP>1 at TransformerConfig level, so we set TP=2 to
+        # pass config validation and hit our Float8 guard instead.
+        config = _make_fp8_transformer_config(
+            sequence_parallel=True,
+            tensor_model_parallel_size=2,
+        )
+        with pytest.raises(ValueError, match="tensor_model_parallel_size=1"):
+            Float8ColumnParallelLinear(
+                input_size=64,
+                output_size=128,
+                config=config,
+                init_method=_init_method(),
+                bias=False,
+                gather_output=False,
+                skip_bias_add=False,
+                is_expert=False,
+            )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_column_parallel_rejects_fp8_none(self):
+        config = _make_fp8_transformer_config(fp8=None)
+        with pytest.raises(ValueError, match="config.fp8"):
+            Float8ColumnParallelLinear(
+                input_size=64,
+                output_size=128,
+                config=config,
+                init_method=_init_method(),
+                bias=False,
+                gather_output=False,
+                skip_bias_add=False,
+                is_expert=False,
+            )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_row_parallel_rejects_fp8_none(self):
+        config = _make_fp8_transformer_config(fp8=None)
+        with pytest.raises(ValueError, match="config.fp8"):
+            Float8RowParallelLinear(
+                input_size=64,
+                output_size=128,
+                config=config,
+                init_method=_init_method(),
+                bias=False,
+                input_is_parallel=True,
+                skip_bias_add=False,
+                is_expert=False,
+            )
+
+
+class TestFloat8LinearInit(PrimusUT):
+    """Tests successful construction and init-time dispatch."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state, monkeypatch):
+        dummy_args = SimpleNamespace(
+            rank=0,
+            world_size=1,
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+            offload=False,
+            offload_ops=[],
+            patch_primus_pipeline=False,
+            pp_algorithm=None,
+            patch_zero_bubble=False,
+            enable_zero_bubble=False,
+            rampup_batch_size=None,
+            global_batch_size=1,
+            micro_batch_size=1,
+            data_parallel_size=1,
+            decrease_batch_size_if_needed=False,
+        )
+        import megatron.training.global_vars as gvars
+
+        monkeypatch.setattr(gvars, "_GLOBAL_ARGS", dummy_args)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_column_parallel_dispatch_tensorwise_uses_opaque(self):
+        config = _make_fp8_transformer_config(fp8="e4m3", fp8_recipe="tensorwise")
+        layer = Float8ColumnParallelLinear(
+            input_size=64,
+            output_size=128,
+            config=config,
+            init_method=_init_method(),
+            bias=False,
+            gather_output=False,
+            skip_bias_add=False,
+            is_expert=False,
+        )
+        assert layer._fp8_fn is OpaqueFP8LinearTensorwiseFunction
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_column_parallel_dispatch_blockwise(self):
+        config = _make_fp8_transformer_config(fp8="e4m3", fp8_recipe="blockwise")
+        layer = Float8ColumnParallelLinear(
+            input_size=64,
+            output_size=128,
+            config=config,
+            init_method=_init_method(),
+            bias=False,
+            gather_output=False,
+            skip_bias_add=False,
+            is_expert=False,
+        )
+        assert layer._fp8_fn is FP8LinearBlockwiseFunction
+
+
+class TestQuantizeFP8Tensorwise(PrimusUT):
+    """Verify _quantize_fp8_tensorwise correctness and properties."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        pass
+
+    def _reference_quantize(self, x, fp8_dtype, fp8_max):
+        """Pure-PyTorch reference (known correct): compute in FP32."""
+        x_f32 = x.float()
+        amax = x_f32.abs().amax()
+        scale = fp8_max / amax.clamp(min=1e-12)
+        x_fp8 = (x_f32 * scale).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+        scale_inv = 1.0 / scale
+        return x_fp8, scale_inv
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_e4m3_correctness(self):
+        """BF16-scale quantize should match FP32 reference within a few percent
+        of elements (boundary rounding from BF16 scale precision)."""
+        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+        fp8_dtype = float8_e4m3
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        decomp_fp8, decomp_sinv = _quantize_fp8_tensorwise(x, fp8_dtype, fp8_max)
+        ref_fp8, ref_sinv = self._reference_quantize(x, fp8_dtype, fp8_max)
+
+        mismatch = (decomp_fp8.to(torch.float32) != ref_fp8.to(torch.float32)).float().mean()
+        assert mismatch < 0.05, f"More than 5% of elements differ: {mismatch:.4f}"
+        assert decomp_sinv.dtype == torch.float32
+        torch.testing.assert_close(decomp_sinv, ref_sinv, atol=0, rtol=0)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_e5m2_correctness(self):
+        """BF16-scale quantize should match FP32 reference within 1 FP8 ULP."""
+        x = torch.randn(64, 512, dtype=torch.bfloat16, device="cuda")
+        fp8_dtype = float8_e5m2
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        decomp_fp8, decomp_sinv = _quantize_fp8_tensorwise(x, fp8_dtype, fp8_max)
+        ref_fp8, ref_sinv = self._reference_quantize(x, fp8_dtype, fp8_max)
+
+        mismatch = (decomp_fp8.to(torch.float32) != ref_fp8.to(torch.float32)).float().mean()
+        assert mismatch < 0.02, f"More than 2% of elements differ: {mismatch:.4f}"
+        assert decomp_sinv.dtype == torch.float32
+        torch.testing.assert_close(decomp_sinv, ref_sinv, atol=0, rtol=0)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_dequant_roundtrip(self):
+        """Verify quantize -> dequantize preserves values within FP8 precision."""
+        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+        fp8_dtype = float8_e4m3
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        x_fp8, scale_inv = _quantize_fp8_tensorwise(x, fp8_dtype, fp8_max)
+        x_recon = x_fp8.float() * scale_inv
+
+        rel_err = ((x_recon - x.float()).abs() / x.float().abs().clamp(min=1e-12)).mean()
+        assert rel_err < 0.1, f"Mean relative error {rel_err:.4f} too high for e4m3"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_zero_tensor_no_nan(self):
+        x = torch.zeros(32, 64, dtype=torch.bfloat16, device="cuda")
+        fp8_dtype = float8_e4m3
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        fp8_out, sinv = _quantize_fp8_tensorwise(x, fp8_dtype, fp8_max)
+        assert not torch.isnan(sinv).any(), "scale_inv should not be NaN for zero input"
+        assert not torch.isinf(sinv).any(), "scale_inv should not be Inf for zero input"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_near_zero_no_nan(self):
+        """Tensors with very small amax should not produce NaN or Inf in output."""
+        x = torch.randn(32, 64, dtype=torch.bfloat16, device="cuda") * 1e-6
+        fp8_dtype = float8_e4m3
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        x_fp8, scale_inv = _quantize_fp8_tensorwise(x, fp8_dtype, fp8_max)
+        assert not torch.isnan(x_fp8.float()).any(), "FP8 output has NaN for near-zero input"
+        assert not torch.isinf(x_fp8.float()).any(), "FP8 output has Inf for near-zero input"
+        assert not torch.isnan(scale_inv).any(), "scale_inv has NaN for near-zero input"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_scale_bf16_overflow_guard(self):
+        """When amax is tiny, FP32 scale would overflow BF16.  Clamp must prevent it."""
+        x = torch.full((4, 4), 1e-8, dtype=torch.bfloat16, device="cuda")
+        fp8_dtype = float8_e4m3
+        fp8_max = torch.finfo(fp8_dtype).max
+
+        x_fp8, scale_inv = _quantize_fp8_tensorwise(x, fp8_dtype, fp8_max)
+        assert not torch.isnan(x_fp8.float()).any(), "BF16 overflow guard failed — NaN in output"
+        assert torch.isfinite(scale_inv), "scale_inv should be finite"
+
+
+class TestDecomposedTensorwiseCompile(PrimusUT):
+    """Verify DecomposedFP8LinearTensorwiseFunction works with torch.compile."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        pass
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_no_graph_break(self):
+        """torch._dynamo.explain should report zero graph breaks for the
+        decomposed quantize + gemm_fp8_impl forward."""
+        from primus_turbo.pytorch.core.backend import BackendType
+
+        fp8_fwd_dtype = float8_e4m3
+        fp8_bwd_dtype = float8_e5m2
+        fp8_fwd_max = torch.finfo(fp8_fwd_dtype).max
+        fp8_bwd_max = torch.finfo(fp8_bwd_dtype).max
+        gran_value = ScalingGranularity.TENSORWISE.value
+        backend_value = BackendType.HIPBLASLT.value
+
+        x = torch.randn(4, 64, dtype=torch.bfloat16, device="cuda")
+        w = torch.randn(128, 64, dtype=torch.bfloat16, device="cuda")
+
+        explanation = torch._dynamo.explain(
+            DecomposedFP8LinearTensorwiseFunction.apply,
+        )(x, w, fp8_fwd_dtype, fp8_bwd_dtype, fp8_fwd_max, fp8_bwd_max, gran_value, backend_value)
+        assert explanation.graph_break_count == 0, (
+            f"Expected 0 graph breaks, got {explanation.graph_break_count}. "
+            f"Reasons: {explanation.break_reasons}"
+        )
+
+
+class TestOpaqueTensorwiseCompile(PrimusUT):
+    """Verify the refactored OpaqueFP8LinearTensorwiseFunction has zero graph breaks."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        pass
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires GPU")
+    def test_no_graph_break(self):
+        """torch._dynamo.explain should report zero graph breaks for the
+        setup_context-based OpaqueFP8LinearTensorwiseFunction forward."""
+        from primus_turbo.pytorch.core.backend import BackendType
+        from primus_turbo.pytorch.ops.quantization import quantize_fp8
+
+        torch._dynamo.reset()
+
+        fp8_fwd_dtype = float8_e4m3
+        fp8_bwd_dtype = float8_e5m2
+        gran_value = ScalingGranularity.TENSORWISE.value
+        backend_value = BackendType.HIPBLASLT.value
+
+        x = torch.randn(4, 64, dtype=torch.bfloat16, device="cuda")
+        w = torch.randn(128, 64, dtype=torch.bfloat16, device="cuda")
+        w_fp8, w_scale = quantize_fp8(w, fp8_fwd_dtype, ScalingGranularity.TENSORWISE)
+
+        explanation = torch._dynamo.explain(
+            OpaqueFP8LinearTensorwiseFunction.apply,
+        )(x, w, w_fp8, w_scale, fp8_fwd_dtype, fp8_bwd_dtype, gran_value, backend_value)
+        assert explanation.graph_break_count == 0, (
+            f"Expected 0 graph breaks, got {explanation.graph_break_count}. "
+            f"Reasons: {explanation.break_reasons}"
+        )


### PR DESCRIPTION
Part of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Targets `feat/flux/opt` — review after it. Parent of the fp8/mxfp4/compile layers.

## What this changes
The Primus-Turbo integration layer: the float8 "local" extension, the turbo local-spec layer wiring, the Triton fp8-cast kernels, the native fp8 layout, and fp8 utilities.

## Why it's stacked here
The float8 extension lazily imports the FSDP2 fp8 all-gather added in `feat/flux/opt`, and a turbo test exercises that path — so it bases on `feat/flux/opt`, not `feat/flux/core`.

## Dependencies
Sequenced after the CI-pins PR (`feat/flux/ci-env`); its float8/fp8 unit tests are green on the current CI pin (no turbo-bump dependency). Builds on `feat/flux/opt`.

## Test plan
`pytest tests/unit_tests/backends/megatron/diffusion -k "turbo or native_fp8"`. Validated locally on an AMD GPU container: 22 passed.

## Files
8 (turbo float8 + local-spec extensions, Triton fp8-cast kernels, fp8 utils + tests).
