### PR TITLE
feat(flux): delayed fp8 scaling + TE DPA prologue patches

### DIFF
--- a/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
+++ b/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
@@ -29,7 +29,6 @@ Patch 2 -- Grad-zero stream overlap + data HtoD prefetch:
 """
 
 import torch
-from megatron.core.enums import Fp8Recipe
 
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.core.utils.module_utils import log_rank_0
@@ -100,6 +99,13 @@ def reset_prefetch_state():
 
 
 def _needs_delayed_scaling(ctx: PatchContext) -> bool:
+    # Imported lazily (not at module top-level) so that importing this patch
+    # module never depends on ``megatron`` being importable. A top-level
+    # ``from megatron...`` here can crash the patches package auto-import if
+    # megatron is momentarily unavailable (e.g. mid circular-import), which
+    # then leaves the package in a half-initialized state.
+    from megatron.core.enums import Fp8Recipe
+
     args = get_args(ctx)
     if args is None or not bool(getattr(args, "fp8", False)):
         return False

--- a/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
+++ b/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
@@ -1,0 +1,337 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron train_step patch for delayed FP8 scaling updates and preamble
+optimization.
+
+Patch 1 -- Delayed FP8 scale update:
+    Wraps train_step to call the scale update preamble on every FP8 delayed
+    module before the original train_step runs.  For most_recent +
+    history_len=1 (production config), a fast path stages per-module amaxes
+    into the registry-batched ``staged_amaxes_3n`` / ``scales_3n`` tensors,
+    computes new scales with a few fused ops, and scatters them back to the
+    per-module scalar ``m.scale_*`` buffers.  Per-module scalars (rather
+    than views into a shared ``(N,)`` tensor) are required so that each
+    module's buffer storage is independent for torch.compile version
+    tracking.
+
+Patch 2 -- Grad-zero stream overlap + data HtoD prefetch:
+    Dispatches DDP grad-buffer zeroing (grad_data.zero_()) on a secondary
+    CUDA stream so it overlaps with HtoD data transfer, saving ~4.6 ms/iter.
+    Additionally, prefetches the next data batch to GPU on a dedicated HtoD
+    stream.  The prefetch iterator is injected at the forward_backward_func
+    level (not by replacing data_iterator in train_step) to preserve
+    compatibility with Megatron's RerunDataIterator type assertion.
+"""
+
+import torch
+from megatron.core.enums import Fp8Recipe
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+# Module-level handle so the MLPerf warmup hook (or any external code) can
+# reach the CudaPrefetchIterator state owned by
+# ``patch_grad_zero_and_data_prefetch`` (which would otherwise live solely
+# in that patch's closure and be unreachable from outside).
+#
+# The warmup hook needs this so it can invalidate the cached prefetch
+# iterator at the end of the warmup epilogue.  Without that invalidation,
+# the prefetcher stays bound to the synthetic-data iterator that was passed
+# in for warmup step 1, and every subsequent real training step silently
+# reads from the cycling synthetic dataset (because
+# ``MegatronDataloaderWrapper`` is cyclic and never raises ``StopIteration``).
+_PREFETCH_HANDLE: dict = {"state": None}
+
+# Shared state for async amax allreduce between Patch 1 (scale update) and
+# Patch 2 (fwd/bwd wrapper).  Patch 2 launches the async allreduce after
+# forward_backward_func returns; Patch 1 waits on the handle at the start
+# of the next train_step before computing new scales.
+#
+# Realistic overlap window: the time between forward_backward_func returning
+# (in step N) and the Patch 1 wait/compute at the start of step N+1.  In
+# practice that's roughly ``optimizer.step + grad_zero`` -- not the full
+# train_step.  The overlap is still useful but smaller than the all-reduce
+# cost in most configs, so this is best-effort latency hiding rather than a
+# free win.
+_ASYNC_AMAX_HANDLE: dict = {"handle": None, "registry": None}
+
+
+def _reset_async_amax_state():
+    """Drop any pending async amax allreduce handle.
+
+    Idempotent best-effort cleanup invoked from both call sites in this
+    module (Patch 1's wait path and Patch 2's launch path).  Leaving a
+    stale handle in ``_ASYNC_AMAX_HANDLE["handle"]`` would cause the next
+    train_step to try to wait on an already-consumed or never-launched
+    work object and either deadlock or raise.
+    """
+    _ASYNC_AMAX_HANDLE["handle"] = None
+
+
+def get_prefetch_state():
+    """Return the closure-shared ``_prefetch_state`` dict, or ``None`` if
+    ``patch_grad_zero_and_data_prefetch`` has not been installed yet."""
+    return _PREFETCH_HANDLE.get("state")
+
+
+def reset_prefetch_state():
+    """Drop the cached ``CudaPrefetchIterator`` so the next ``train_step``
+    rebuilds it around its current ``data_iterator`` argument.
+
+    Required after MLPerf warmup, because warmup step 1 is the first call
+    into ``_patched_train_step``, so the prefetcher gets bound to the
+    synthetic iterator.  Without invalidation, every real training step
+    afterwards substitutes the cached prefetcher (still wrapping synthetic
+    data) for the real ``data_iterator`` argument inside the
+    ``_synced_prefetch_fwd_bwd`` wrapper.
+
+    Returns the evicted iterator (or ``None`` if no cache existed) so
+    callers can log what was dropped.
+    """
+    state = _PREFETCH_HANDLE.get("state")
+    if state is None:
+        return None
+    return state.pop("iter", None)
+
+
+def _needs_delayed_scaling(ctx: PatchContext) -> bool:
+    args = get_args(ctx)
+    if args is None or not bool(getattr(args, "fp8", False)):
+        return False
+    return (
+        getattr(args, "fp8_scaling_strategy", "dynamic") == "delayed"
+        or getattr(args, "fp8_recipe", None) == Fp8Recipe.delayed
+    ) and not getattr(args, "disable_delayed_scaling_patches", False)
+
+
+@register_patch(
+    "megatron.fp8.delayed_scaling_update",
+    backend="megatron",
+    phase="before_train",
+    description="Wrap train_step to update delayed FP8 scales before each step.",
+    priority=40,
+    condition=_needs_delayed_scaling,
+)
+def patch_delayed_fp8_update(ctx: PatchContext):
+    import megatron.training.training as megatron_training
+
+    from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+        _DelayedScalingRegistry,
+        _fast_update_scales,
+        _fast_update_scales_with_history,
+        _wait_and_compute_scales,
+    )
+    from primus.backends.megatron.patches._patch_guard import is_patched, mark_patched
+
+    _PATCH_KEY = "megatron.fp8.delayed_scaling_update"
+    if is_patched(megatron_training, _PATCH_KEY):
+        log_rank_0("[Patch:delayed_scaling_update] Already applied; skipping re-wrap.")
+        return
+
+    _original_train_step = megatron_training.train_step
+    _cached_delayed_modules = []
+    _registry = None
+
+    def _patched_train_step(
+        forward_step_func,
+        data_iterator,
+        model,
+        optimizer,
+        opt_param_scheduler,
+        config,
+        forward_backward_func,
+        iteration=None,
+    ):
+        nonlocal _registry
+        if not _cached_delayed_modules:
+            _cached_delayed_modules.extend(
+                m
+                for model_chunk in model
+                for m in model_chunk.modules()
+                if getattr(m, "_use_delayed_scaling", False)
+            )
+        if _cached_delayed_modules:
+            if _registry is None:
+                _registry = _DelayedScalingRegistry(_cached_delayed_modules)
+                _ASYNC_AMAX_HANDLE["registry"] = _registry
+
+            pending_handle = _ASYNC_AMAX_HANDLE.get("handle")
+            if pending_handle is not None:
+                try:
+                    _wait_and_compute_scales(_registry, pending_handle)
+                finally:
+                    # Always drop the handle, even if wait / compute raised:
+                    # leaving a consumed handle here would cause the next
+                    # train_step to try to wait on it again.
+                    _reset_async_amax_state()
+            else:
+                if _registry.algo == "most_recent" and _registry.history_len == 1:
+                    _fast_update_scales(_registry)
+                else:
+                    _fast_update_scales_with_history(_registry)
+        return _original_train_step(
+            forward_step_func,
+            data_iterator,
+            model,
+            optimizer,
+            opt_param_scheduler,
+            config,
+            forward_backward_func,
+            iteration=iteration,
+        )
+
+    megatron_training.train_step = _patched_train_step
+    mark_patched(megatron_training, _PATCH_KEY)
+    log_rank_0(
+        "[Patch:delayed_scaling_update] "
+        "Wrapped train_step with async amax allreduce support. "
+        "First step uses synchronous fallback; subsequent steps wait on "
+        "async handle launched by post-fwd_bwd hook."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch 2: Grad-zero stream overlap + data HtoD prefetch
+# ---------------------------------------------------------------------------
+
+
+@register_patch(
+    "megatron.grad_zero_and_data_prefetch",
+    backend="megatron",
+    phase="before_train",
+    description="Overlap grad buffer zeroing and data HtoD transfer via secondary CUDA streams.",
+    priority=41,
+    condition=_needs_delayed_scaling,
+)
+def patch_grad_zero_and_data_prefetch(ctx: PatchContext):
+    args = get_args(ctx)
+    if getattr(args, "reuse_grad_buf_for_mxfp8_param_ag", False):
+        log_rank_0(
+            "[Patch:grad_zero_and_data_prefetch] SKIPPED — "
+            "reuse_grad_buf_for_mxfp8_param_ag is set (shared param/grad buffer)."
+        )
+        return
+
+    import megatron.training.training as megatron_training
+    from megatron.core.distributed import DistributedDataParallel
+
+    from primus.backends.megatron.patches._patch_guard import is_patched, mark_patched
+
+    _PATCH_KEY = "megatron.grad_zero_and_data_prefetch"
+    if is_patched(megatron_training, _PATCH_KEY):
+        log_rank_0("[Patch:grad_zero_and_data_prefetch] Already applied; skipping re-wrap.")
+        return
+
+    tp_size = getattr(args, "tensor_model_parallel_size", 1)
+
+    _original_train_step = megatron_training.train_step
+    _original_zero_grad_buffer = DistributedDataParallel.zero_grad_buffer
+    _zero_stream = torch.cuda.Stream()
+    _prefetch_state: dict = {}
+    # Expose the closure-local prefetch state so the MLPerf warmup hook can
+    # invalidate the cached prefetch iterator at the end of warmup; see
+    # ``reset_prefetch_state`` above for the rationale.
+    _PREFETCH_HANDLE["state"] = _prefetch_state
+
+    def _stream_zero_grad_buffer(self):
+        """CPU metadata on main thread; GPU grad_data.zero_() on secondary stream."""
+        if getattr(self.config, "cuda_graph_impl", "none") != "transformer_engine":
+            for param in self.params_with_grad:
+                param.grad_added_to_main_grad = False
+        with torch.cuda.stream(_zero_stream):
+            for buffer in self.buffers + self.expert_parallel_buffers:
+                buffer.reset()
+        for bucket_group in self.bucket_groups + self.expert_parallel_bucket_groups:
+            bucket_group.reset()
+
+    DistributedDataParallel.zero_grad_buffer = _stream_zero_grad_buffer
+
+    def _patched_train_step(
+        forward_step_func,
+        data_iterator,
+        model,
+        optimizer,
+        opt_param_scheduler,
+        config,
+        forward_backward_func,
+        iteration=None,
+    ):
+        if "iter" not in _prefetch_state and tp_size == 1:
+            if isinstance(data_iterator, (list, tuple)):
+                # Virtual pipeline parallel passes a list of per-chunk iterators,
+                # which the single-stream prefetcher cannot wrap. Skip prefetch
+                # (a pure HtoD-overlap optimization) and let the original iterator
+                # flow through unchanged.
+                if not _prefetch_state.get("vpp_skip_logged"):
+                    log_rank_0(
+                        "[Patch:grad_zero_and_data_prefetch] "
+                        "Skipping CudaPrefetchIterator: data_iterator is a list "
+                        "(virtual pipeline parallel)."
+                    )
+                    _prefetch_state["vpp_skip_logged"] = True
+            else:
+                from primus.backends.megatron.data.cuda_prefetch import (
+                    CudaPrefetchIterator,
+                )
+
+                compute_dtype = torch.bfloat16 if getattr(args, "bf16", False) else torch.float16
+                _prefetch_state["iter"] = CudaPrefetchIterator(
+                    data_iterator,
+                    compute_dtype=compute_dtype,
+                )
+                log_rank_0(
+                    "[Patch:grad_zero_and_data_prefetch] "
+                    f"Created CudaPrefetchIterator (dtype={compute_dtype})."
+                )
+
+        _pf = _prefetch_state.get("iter")
+
+        def _synced_prefetch_fwd_bwd(*fwd_args, **fwd_kwargs):
+            torch.cuda.current_stream().wait_stream(_zero_stream)
+            if _pf is not None:
+                fwd_kwargs["data_iterator"] = _pf
+            result = forward_backward_func(*fwd_args, **fwd_kwargs)
+
+            registry = _ASYNC_AMAX_HANDLE.get("registry")
+            if registry is not None:
+                from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+                    _stage_and_launch_async_allreduce,
+                )
+
+                try:
+                    _ASYNC_AMAX_HANDLE["handle"] = _stage_and_launch_async_allreduce(registry)
+                except Exception:
+                    # Launch failed: clear so the next train_step takes the
+                    # synchronous fallback path instead of trying to wait on
+                    # a non-existent handle.
+                    _reset_async_amax_state()
+                    raise
+
+            return result
+
+        return _original_train_step(
+            forward_step_func,
+            data_iterator,
+            model,
+            optimizer,
+            opt_param_scheduler,
+            config,
+            _synced_prefetch_fwd_bwd,
+            iteration=iteration,
+        )
+
+    megatron_training.train_step = _patched_train_step
+    mark_patched(megatron_training, _PATCH_KEY)
+    log_rank_0(
+        "[Patch:grad_zero_and_data_prefetch] "
+        "DDP grad_data.zero_() on secondary stream; "
+        "data HtoD prefetch on secondary stream; "
+        "secondary streams synced before forward_backward_func; "
+        "async amax allreduce launched after forward_backward_func "
+        "(awaited at the start of the next train_step)."
+    )

--- a/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
+++ b/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
@@ -230,7 +230,6 @@ def patch_grad_zero_and_data_prefetch(ctx: PatchContext):
     tp_size = getattr(args, "tensor_model_parallel_size", 1)
 
     _original_train_step = megatron_training.train_step
-    _original_zero_grad_buffer = DistributedDataParallel.zero_grad_buffer
     _zero_stream = torch.cuda.Stream()
     _prefetch_state: dict = {}
     # Expose the closure-local prefetch state so the MLPerf warmup hook can

--- a/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
+++ b/primus/backends/megatron/patches/delayed_fp8_scaling_patches.py
@@ -32,7 +32,7 @@ import torch
 from megatron.core.enums import Fp8Recipe
 
 from primus.core.patches import PatchContext, get_args, register_patch
-from primus.modules.module_utils import log_rank_0
+from primus.core.utils.module_utils import log_rank_0
 
 # Module-level handle so the MLPerf warmup hook (or any external code) can
 # reach the CudaPrefetchIterator state owned by

--- a/primus/backends/megatron/patches/te_patches/dpa_consolidated_prologue_patches.py
+++ b/primus/backends/megatron/patches/te_patches/dpa_consolidated_prologue_patches.py
@@ -44,7 +44,7 @@ import torch
 from torch import Tensor
 
 from primus.core.patches import PatchContext, get_args, register_patch
-from primus.modules.module_utils import log_rank_0
+from primus.core.utils.module_utils import log_rank_0
 
 # Positional index of dropout_p inside FusedAttnFunc.forward's *args (i.e.
 # inside our captured _capture_tls.captured_args tuple, which excludes ctx).

--- a/primus/backends/megatron/patches/te_patches/dpa_consolidated_prologue_patches.py
+++ b/primus/backends/megatron/patches/te_patches/dpa_consolidated_prologue_patches.py
@@ -1,0 +1,305 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+DPA Consolidated Prologue Patch
+
+Separates the eager setup (FP8 metadata, backend selection, cu_seqlens, etc.)
+from the FusedAttnFunc kernel call in DotProductAttention, so that the kernel
+call can live inside a torch.compile compiled graph rather than running eagerly.
+
+Graph-break analysis (per DPA call):
+
+    Before:
+        [compiled A] --break--> [DPA runs fully eager, kernel included] --break--> [compiled B]
+
+    After (attention_dropout == 0, the Flux default - fast path):
+        [compiled A] --break--> [eager prologue] --break--> [compiled post-ops (kernel inside)]
+
+    After (attention_dropout > 0 - safe path):
+        [compiled A] --break--> [eager prologue] --break--> [eager fork + kernel] --break--> [compiled post-ops]
+
+Break counts: 2 for the fast path, 3 for the safe path.  The safe path runs
+the FusedAttn kernel inside the model-parallel-rng fork context so the
+kernel's philox state targets the correct generator.  In the fast path the
+kernel doesn't consume RNG (dropout is 0), so the fork wrapper is omitted
+and the kernel stays inside the compiled graph alongside the post-attention
+ops (output reshape, projection, skip connections).
+
+Mechanism:
+    FusedAttnFunc.forward is monkey-patched with a thread-local "capture mode".
+    When capture mode is active the patched forward stores its arguments in
+    thread-local storage and raises ``_CaptureComplete``, aborting the DPA
+    forward after all setup is done.  The captured args are then passed to the
+    *real* ``FusedAttnFunc.apply`` inside the compiled graph.
+"""
+
+import threading
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.modules.module_utils import log_rank_0
+
+# Positional index of dropout_p inside FusedAttnFunc.forward's *args (i.e.
+# inside our captured _capture_tls.captured_args tuple, which excludes ctx).
+# Verified against transformer_engine.pytorch.attention.dot_product_attention
+# .backends.FusedAttnFunc.forward as of TE 2.12. If a future TE upgrade
+# reshuffles the positional layout, _new_te_dpa_forward falls back to the
+# always-fork (safe) path rather than silently routing to the dropout=0 fast
+# path with the wrong field.
+_DROPOUT_P_IDX = 14
+
+# ---------------------------------------------------------------------------
+# Thread-local capture state
+# ---------------------------------------------------------------------------
+_capture_tls = threading.local()
+
+
+class _CaptureComplete(Exception):
+    """Raised inside the patched FusedAttnFunc.forward to abort after capture."""
+
+
+# ---------------------------------------------------------------------------
+# Patch registration
+# ---------------------------------------------------------------------------
+@register_patch(
+    "megatron.te.dpa_consolidated_prologue",
+    backend="megatron",
+    phase="before_train",
+    priority=55,
+    description=(
+        "Consolidated DPA prologue: separates eager attention setup from "
+        "FusedAttnFunc kernel call to reduce torch.compile graph breaks"
+    ),
+    condition=lambda ctx: (
+        (
+            (
+                getattr(get_args(ctx), "torch_compile", None) is not None
+                and getattr(get_args(ctx).torch_compile, "enable", False)
+            )
+            # Align with torch_compile_patches.py, which also honors the flat
+            # enable_torch_compile flag; otherwise this prologue optimization is
+            # silently skipped for configs that compile via enable_torch_compile.
+            or getattr(get_args(ctx), "enable_torch_compile", False)
+        )
+        and not getattr(get_args(ctx), "disable_dpa_prologue_patch", False)
+    ),
+)
+def patch_dpa_consolidated_prologue(ctx: PatchContext):
+    """Replace TEDotProductAttention.forward with a two-phase version.
+
+    Phase 1 – eager prologue (``@torch._dynamo.disable``):
+        Runs the full DPA + FusedAttention setup pipeline to compute all
+        arguments for ``FusedAttnFunc.apply``, without running the kernel.
+
+    Phase 2 – compiled kernel call:
+        ``FusedAttnFunc.apply`` (marked ``allow_in_graph``) runs inside the
+        torch.compile compiled graph, enabling fusion with pre/post-attention
+        operations.
+    """
+    from megatron.core.extensions.transformer_engine import TEDotProductAttention
+    from transformer_engine.pytorch.attention.dot_product_attention.backends import (
+        FusedAttnFunc,
+    )
+
+    # ---- Idempotency guard -----------------------------------------------
+    # Re-running this patch would capture the already-patched forward as
+    # "_orig_*", double-wrapping the capture logic. Guard against it.
+    if getattr(TEDotProductAttention, "_primus_dpa_prologue_patched", False):
+        log_rank_0("[Patch:megatron.te.dpa_consolidated_prologue] already applied; skipping re-patch")
+        return
+
+    # ---- TE version check ------------------------------------------------
+    # _DROPOUT_P_IDX (and the captured-args layout) is pinned to TE 2.12. On a
+    # different TE version the layout may drift; the fast-path detection
+    # already falls back to the always-fork safe path on mismatch, but warn so
+    # the perf regression is visible rather than silent.
+    try:
+        import transformer_engine
+
+        _te_version = getattr(transformer_engine, "__version__", None)
+    except Exception:
+        _te_version = None
+    if _te_version is not None and not str(_te_version).startswith("2.12"):
+        log_rank_0(
+            "[Patch:megatron.te.dpa_consolidated_prologue] WARNING: "
+            f"_DROPOUT_P_IDX={_DROPOUT_P_IDX} was verified against TE 2.12 but "
+            f"detected transformer_engine {_te_version}. The dropout=0 fast path "
+            "will conservatively fall back to the safe rng-fork path if the "
+            "captured-args layout differs."
+        )
+
+    # ---- Mark FusedAttnFunc as graph-safe --------------------------------
+    torch._dynamo.allow_in_graph(FusedAttnFunc)
+
+    # ---- Patch FusedAttnFunc.forward for capture mode --------------------
+    _orig_fused_attn_func_fwd = FusedAttnFunc.forward
+
+    @staticmethod
+    def _capturing_fused_attn_func_fwd(ctx, *args):  # noqa: N805 – autograd ctx
+        if getattr(_capture_tls, "capture_mode", False):
+            _capture_tls.captured_args = args
+            raise _CaptureComplete()
+        return _orig_fused_attn_func_fwd(ctx, *args)
+
+    FusedAttnFunc.forward = _capturing_fused_attn_func_fwd
+
+    # ---- Save original TEDotProductAttention.forward ---------------------
+    _orig_te_dpa_forward = TEDotProductAttention.forward
+
+    # ---- Eager prologue --------------------------------------------------
+    @torch._dynamo.disable
+    def _dpa_eager_prologue(
+        te_dpa,
+        query,
+        key,
+        value,
+        attention_mask,
+        attn_mask_type,
+        attention_bias,
+        packed_seq_params,
+        num_splits,
+    ):
+        """Run the full DPA + FusedAttention setup eagerly.
+
+        Returns
+        -------
+        captured_args : tuple | None
+            Arguments for ``FusedAttnFunc.apply`` if fused backend was chosen.
+        fallback_result : Tensor | None
+            Final output tensor if a non-fused backend ran to completion.
+        """
+        _capture_tls.capture_mode = True
+        _capture_tls.captured_args = None
+        fallback_result = None
+
+        try:
+            fallback_result = _orig_te_dpa_forward(
+                te_dpa,
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type=attn_mask_type,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+                num_splits=num_splits,
+            )
+        except _CaptureComplete:
+            pass  # expected – fused attention args captured
+        finally:
+            _capture_tls.capture_mode = False
+
+        return _capture_tls.captured_args, fallback_result
+
+    # ---- RNG-correct kernel execution ------------------------------------
+    from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
+
+    @torch._dynamo.disable
+    def _fused_attn_with_rng_fork(captured_args):
+        """Run FusedAttnFunc.apply inside the model-parallel-rng fork.
+
+        The eager prologue's _CaptureComplete exception unwinds TE's
+        internal fork context before the kernel runs, so rng_gen=None
+        causes the default CUDA generator to be advanced instead of
+        model-parallel-rng.  This wrapper re-enters the fork so the
+        kernel's philox_cuda_state call targets the correct generator.
+        """
+        tracker = get_cuda_rng_tracker()
+        if tracker.is_initialized():
+            states = tracker.get_states()
+            if "model-parallel-rng" in states:
+                with tracker.fork("model-parallel-rng"):
+                    return FusedAttnFunc.apply(*captured_args)
+        return FusedAttnFunc.apply(*captured_args)
+
+    # ---- Max-logit bookkeeping (qk_clip) ---------------------------------
+    @torch._dynamo.disable
+    def _update_max_logit_stats(te_dpa, batch_max_logit):
+        if hasattr(te_dpa, "current_max_attn_logits"):
+            if te_dpa.current_max_attn_logits is None:
+                te_dpa.current_max_attn_logits = batch_max_logit
+            else:
+                te_dpa.current_max_attn_logits = torch.max(te_dpa.current_max_attn_logits, batch_max_logit)
+
+    # ---- Replacement forward ---------------------------------------------
+    def _new_te_dpa_forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Optional[Tensor],
+        attn_mask_type=None,
+        attention_bias: Optional[Tensor] = None,
+        packed_seq_params=None,
+        num_splits: Optional[int] = None,
+    ) -> Tensor:
+        """TEDotProductAttention.forward with consolidated prologue.
+
+        The eager prologue handles all DPA setup (FP8 metadata, backend
+        selection, cu_seqlens computation, etc.).  Then ``FusedAttnFunc.apply``
+        runs inside the compiled graph.
+
+        For non-fused backends (flash / unfused), the original forward runs
+        fully inside the prologue and the result is returned directly.
+        """
+        captured_args, fallback_result = _dpa_eager_prologue(
+            self,
+            query,
+            key,
+            value,
+            attention_mask,
+            attn_mask_type,
+            attention_bias,
+            packed_seq_params,
+            num_splits,
+        )
+
+        if captured_args is not None:
+            # Fast path: when dropout_p == 0 the FusedAttn kernel doesn't
+            # consume RNG, so we can skip the eager rng-fork wrapper and
+            # call FusedAttnFunc.apply directly inside the compiled graph
+            # (it's already marked allow_in_graph above). This drops a
+            # graph break in the common Flux case (attention_dropout=0).
+            #
+            # Safe path: anything that isn't a clean numeric zero (including
+            # IndexError if a TE upgrade changes captured_args' layout, or
+            # an unexpected tensor / object at the dropout slot) falls back
+            # to the always-fork path so correctness is never compromised
+            # by a layout drift.
+            try:
+                _dropout_p = captured_args[_DROPOUT_P_IDX]
+                _use_fast_path = isinstance(_dropout_p, (int, float)) and _dropout_p == 0
+            except (IndexError, TypeError):
+                _use_fast_path = False
+
+            if _use_fast_path:
+                result = FusedAttnFunc.apply(*captured_args)
+            else:
+                result = _fused_attn_with_rng_fork(captured_args)
+            return_max_logit = captured_args[-1]
+
+            if return_max_logit:
+                core_attn_out = result[0].view(*result[0].shape[:-2], -1)
+                _update_max_logit_stats(self, result[1])
+                return core_attn_out
+
+            return result.view(*result.shape[:-2], -1)
+
+        return fallback_result
+
+    # ---- Apply the monkey-patch ------------------------------------------
+    TEDotProductAttention.forward = _new_te_dpa_forward
+    TEDotProductAttention._primus_dpa_prologue_patched = True
+
+    log_rank_0("[Patch:megatron.te.dpa_consolidated_prologue] " "Applied allow_in_graph to FusedAttnFunc")
+    log_rank_0(
+        "[Patch:megatron.te.dpa_consolidated_prologue] "
+        "Replaced TEDotProductAttention.forward with consolidated prologue"
+    )

--- a/primus/backends/megatron/patches/turbo/fp8_patches.py
+++ b/primus/backends/megatron/patches/turbo/fp8_patches.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -28,7 +28,9 @@ def _is_fp8_can_patch(ctx: PatchContext) -> bool:
     backend="megatron",
     phase="before_train",
     description="Override Megatron get_fp8_context to use Primus implementation when fp8 is enabled",
-    condition=_is_fp8_can_patch,
+    condition=lambda ctx: (
+        _is_fp8_can_patch(ctx) and not getattr(get_args(ctx), "disable_fp8_context_patches", False)
+    ),
 )
 def patch_fp8_context(ctx: PatchContext):
     """

--- a/tests/unit_tests/backends/megatron/diffusion/test_delayed_fp8_triton_op.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_delayed_fp8_triton_op.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Validate the @triton_op cast_transpose_fp8_triton kernel.
+
+Tests:
+  1. Correctness: FP8 cast + transpose + amax match reference
+  2. GEMM interaction: output feeds into torch._scaled_mm without regression
+  3. torch.compile: triton_op is traceable (no graph breaks)
+  4. Autograd: gradients flow through a minimal FP8 linear autograd.Function
+
+Run:
+    python -m pytest tests/unit_tests/backends/megatron/diffusion/test_delayed_fp8_triton_op.py -v
+or standalone:
+    python tests/unit_tests/backends/megatron/diffusion/test_delayed_fp8_triton_op.py
+"""
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus_turbo.pytorch.core.backend import BackendType
+from primus_turbo.pytorch.core.low_precision import (
+    ScalingGranularity,
+    float8_e4m3,
+    float8_e5m2,
+)
+
+from primus.backends.megatron.core.extensions.fp8_cast_kernels_triton import (
+    cast_transpose_fp8_triton,
+)
+from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+    DelayedFP8LinearTensorwiseFunction,
+)
+
+DEVICE = "cuda:0"
+DTYPE = torch.bfloat16
+FP8_DTYPE = float8_e4m3
+FP8_MAX = torch.finfo(FP8_DTYPE).max
+FP8_BWD_DTYPE = float8_e5m2
+FP8_BWD_MAX = torch.finfo(FP8_BWD_DTYPE).max
+
+
+# -----------------------------------------------------------------------
+# Test 1: Correctness
+# -----------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (4096, 3072),
+        (16384, 3072),
+        (8192, 8192),
+    ],
+)
+def test_correctness(shape):
+    M, N = shape
+    x = torch.randn(M, N, dtype=DTYPE, device=DEVICE)
+    scale = torch.tensor(FP8_MAX / x.abs().amax().item(), dtype=torch.float32, device=DEVICE)
+    amax_buf = torch.zeros((), dtype=torch.float32, device=DEVICE)
+
+    cast_out, trans_out, scale_inv = cast_transpose_fp8_triton(x, FP8_DTYPE, scale, amax_buf)
+
+    assert cast_out.shape == (M, N), f"Cast shape mismatch: {cast_out.shape}"
+    assert cast_out.dtype == FP8_DTYPE
+    assert trans_out.shape == (N, M), f"Trans shape mismatch: {trans_out.shape}"
+    assert trans_out.dtype == FP8_DTYPE
+    assert trans_out.is_contiguous(), "Transpose output must be contiguous"
+    assert scale_inv.shape == (), f"Scale inv shape mismatch: {scale_inv.shape}"
+
+    ref_scaled = (x.float() * scale.item()).clamp(-FP8_MAX, FP8_MAX)
+    ref_fp8 = ref_scaled.to(FP8_DTYPE)
+    assert torch.equal(cast_out, ref_fp8), f"Cast output mismatch for {shape}"
+
+    ref_trans = ref_fp8.t().contiguous()
+    assert torch.equal(trans_out, ref_trans), f"Transpose output mismatch for {shape}"
+
+    expected_scale_inv = 1.0 / scale.item()
+    assert (
+        abs(scale_inv.item() - expected_scale_inv) < 1e-5
+    ), f"scale_inv {scale_inv.item()} != {expected_scale_inv}"
+
+    expected_amax = x.float().abs().amax().item()
+    assert (
+        abs(amax_buf.item() - expected_amax) / max(expected_amax, 1e-8) < 1e-3
+    ), f"amax {amax_buf.item()} != {expected_amax}"
+
+
+# -----------------------------------------------------------------------
+# Test 2: GEMM interaction (the critical regression test)
+# -----------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (16384, 3072),
+        (4096, 12288),
+    ],
+)
+def test_gemm_interaction(shape):
+    M, N = shape
+    x = torch.randn(M, N, dtype=DTYPE, device=DEVICE)
+    scale = torch.tensor(FP8_MAX / x.abs().amax().item(), dtype=torch.float32, device=DEVICE)
+    amax_buf = torch.zeros((), dtype=torch.float32, device=DEVICE)
+
+    cast_out, _, scale_inv = cast_transpose_fp8_triton(x, FP8_DTYPE, scale, amax_buf)
+
+    w = torch.randn(N, N, dtype=DTYPE, device=DEVICE).to(FP8_DTYPE).t()
+    w_scale = torch.tensor(1.0, dtype=torch.float32, device=DEVICE)
+
+    result = torch._scaled_mm(cast_out, w, out_dtype=DTYPE, scale_a=scale_inv, scale_b=w_scale)
+    assert result.shape == (M, N)
+    assert result.dtype == DTYPE
+    assert not result.isnan().any(), "GEMM produced NaN"
+    assert not result.isinf().any(), "GEMM produced Inf"
+
+
+# -----------------------------------------------------------------------
+# Test 3: torch.compile traceability
+# -----------------------------------------------------------------------
+def test_torch_compile():
+    M, N = 4096, 3072
+    x = torch.randn(M, N, dtype=DTYPE, device=DEVICE)
+    scale = torch.tensor(FP8_MAX / x.abs().amax().item(), dtype=torch.float32, device=DEVICE)
+    amax_buf = torch.zeros((), dtype=torch.float32, device=DEVICE)
+
+    @torch.compile(fullgraph=True)
+    def fn(x, scale, amax_buf):
+        return cast_transpose_fp8_triton(x, FP8_DTYPE, scale, amax_buf)
+
+    cast_out, trans_out, scale_inv = fn(x, scale, amax_buf)
+
+    assert cast_out.shape == (M, N)
+    assert trans_out.shape == (N, M)
+    assert cast_out.dtype == FP8_DTYPE
+
+    # Verify match with eager
+    amax_eager = torch.zeros((), dtype=torch.float32, device=DEVICE)
+    cast_eager, trans_eager, si_eager = cast_transpose_fp8_triton(x, FP8_DTYPE, scale, amax_eager)
+    assert torch.equal(cast_out, cast_eager), "Compiled output != eager output"
+    assert torch.equal(trans_out, trans_eager), "Compiled transpose != eager transpose"
+
+
+# -----------------------------------------------------------------------
+# Test 4: Direct test of the *production* delayed-tensorwise FP8 autograd
+# Function (DelayedFP8LinearTensorwiseFunction), exercising both the native
+# (force_nt=False -> dgrad=NN/wgrad=TN) and forced-NT (force_nt=True) arms.
+#
+# This replaces the previous in-file ``_MinimalFP8Linear`` replica: it calls the
+# shipped Function directly so a regression in its quantization, GEMM layout, or
+# fused amax capture is actually caught.
+# -----------------------------------------------------------------------
+def _rel_err(actual: torch.Tensor, ref: torch.Tensor) -> float:
+    ref = ref.float()
+    return ((actual.float() - ref).norm() / ref.norm().clamp_min(1e-12)).item()
+
+
+@pytest.mark.parametrize("force_nt", [True, False])
+def test_delayed_fp8_linear_function(force_nt):
+    M, K, N = 256, 512, 256
+
+    torch.manual_seed(0)
+    inp = torch.randn(M, K, dtype=DTYPE, device=DEVICE, requires_grad=True)
+    weight = torch.randn(N, K, dtype=DTYPE, device=DEVICE, requires_grad=True)
+    grad_output = torch.randn(M, N, dtype=DTYPE, device=DEVICE)
+
+    # Delayed tensorwise scales (one scalar per track), chosen to fill the FP8
+    # range the way the production warmup staging would.
+    scale_input = torch.tensor(FP8_MAX / inp.detach().abs().amax().item(), dtype=torch.float32, device=DEVICE)
+    scale_weight = torch.tensor(
+        FP8_MAX / weight.detach().abs().amax().item(), dtype=torch.float32, device=DEVICE
+    )
+    scale_grad = torch.tensor(
+        FP8_BWD_MAX / grad_output.abs().amax().item(), dtype=torch.float32, device=DEVICE
+    )
+
+    staged_input_amax = torch.zeros((), dtype=torch.float32, device=DEVICE)
+    staged_weight_amax = torch.zeros((), dtype=torch.float32, device=DEVICE)
+    staged_grad_amax = torch.zeros((), dtype=torch.float32, device=DEVICE)
+
+    gran_value = ScalingGranularity.TENSORWISE.value
+    backend_value = BackendType.HIPBLASLT.value
+
+    result = DelayedFP8LinearTensorwiseFunction.apply(
+        inp,
+        weight,
+        scale_input,
+        scale_weight,
+        scale_grad,
+        staged_input_amax,
+        staged_weight_amax,
+        staged_grad_amax,
+        FP8_DTYPE,
+        FP8_BWD_DTYPE,
+        gran_value,
+        backend_value,
+        force_nt,
+    )
+    output = result[0]
+
+    # Forward: output ~= input @ weight.T (standard nn.Linear), FP8-tensorwise.
+    ref_out = inp.detach().float() @ weight.detach().float().t()
+    assert output.shape == (M, N)
+    assert torch.isfinite(output).all(), "FP8 forward produced non-finite values"
+    out_rel = _rel_err(output, ref_out)
+    assert out_rel < 0.1, f"FP8 forward too far from bf16 reference: rel_err={out_rel:.4f}"
+
+    # Fused amax capture (the delayed-scaling contract): the staged buffers must
+    # be written with the *current* tensor amaxes during forward.
+    assert staged_input_amax.item() > 0, "staged_input_amax not captured in forward"
+    assert staged_weight_amax.item() > 0, "staged_weight_amax not captured in forward"
+    in_amax_rel = abs(staged_input_amax.item() - inp.detach().float().abs().amax().item()) / max(
+        inp.detach().float().abs().amax().item(), 1e-8
+    )
+    w_amax_rel = abs(staged_weight_amax.item() - weight.detach().float().abs().amax().item()) / max(
+        weight.detach().float().abs().amax().item(), 1e-8
+    )
+    assert in_amax_rel < 1e-2, f"staged input amax mismatch: rel={in_amax_rel:.4f}"
+    assert w_amax_rel < 1e-2, f"staged weight amax mismatch: rel={w_amax_rel:.4f}"
+
+    # Backward through the production Function.
+    output.backward(grad_output)
+    assert inp.grad is not None and weight.grad is not None
+    assert torch.isfinite(inp.grad).all(), "grad_input non-finite"
+    assert torch.isfinite(weight.grad).all(), "grad_weight non-finite"
+
+    ref_grad_input = grad_output.float() @ weight.detach().float()
+    ref_grad_weight = grad_output.float().t() @ inp.detach().float()
+    # e5m2 backward has only 2 mantissa bits, so use a looser bound than forward.
+    gi_rel = _rel_err(inp.grad, ref_grad_input)
+    gw_rel = _rel_err(weight.grad, ref_grad_weight)
+    assert gi_rel < 0.2, f"grad_input too far from reference: rel_err={gi_rel:.4f}"
+    assert gw_rel < 0.2, f"grad_weight too far from reference: rel_err={gw_rel:.4f}"
+
+    assert staged_grad_amax.item() > 0, "staged_grad_amax not captured in backward"

--- a/tests/unit_tests/backends/megatron/diffusion/test_fused_delayed_scale_update.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_fused_delayed_scale_update.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Validate the fused Triton kernel for delayed FP8 scale update.
+
+Tests:
+  1. Correctness: fused kernel matches reference Python-loop implementation
+  2. Edge cases: zero amaxes, NaN amaxes, very small amaxes
+  3. History rollover: circular index wraps correctly
+  4. Algorithm variants: 'max' vs 'most_recent'
+
+Run:
+    python -m pytest tests/unit_tests/backends/megatron/diffusion/test_fused_delayed_scale_update.py -v
+or standalone:
+    python tests/unit_tests/backends/megatron/diffusion/test_fused_delayed_scale_update.py
+"""
+
+import pytest
+import torch
+
+triton = pytest.importorskip("triton")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU")
+
+DEVICE = "cuda:0"
+FP8_FWD_MAX = torch.finfo(torch.float8_e4m3fn).max  # 448.0
+FP8_BWD_MAX = torch.finfo(torch.float8_e5m2).max  # 57344.0
+FP32_MAX = torch.finfo(torch.float32).max
+
+
+def _reference_update(amax_history, staged_amaxes, scales, fp8_maxes, history_idx, use_max_algo):
+    """Pure-PyTorch reference matching the fused delayed-scale update logic."""
+    T, N, H = amax_history.shape
+    for t in range(T):
+        for m in range(N):
+            new_amax = staged_amaxes[t, m].item()
+            amax_history[t, m, history_idx] = new_amax
+
+            if use_max_algo:
+                amax = amax_history[t, m, :].max().item()
+            else:
+                amax = new_amax
+
+            fp8_max = fp8_maxes[t].item()
+            old_scale = scales[t, m].item()
+
+            if amax > 0.0 and amax == amax:  # positive and not NaN
+                sf = fp8_max / max(amax, 1e-12)
+                sf = min(sf, FP32_MAX)
+            else:
+                sf = old_scale
+
+            scales[t, m] = sf
+
+
+def _run_fused_kernel(amax_history, staged_amaxes, scales, fp8_maxes, history_idx, use_max_algo):
+    """Call the actual fused Triton kernel."""
+    from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+        _fused_delayed_scale_update_kernel,
+    )
+
+    _, N, H = amax_history.shape
+    BLOCK_H = triton.next_power_of_2(H) if H <= 1024 else 1024
+
+    _fused_delayed_scale_update_kernel[(N, 3)](
+        amax_history,
+        staged_amaxes,
+        scales,
+        fp8_maxes,
+        history_idx,
+        N=N,
+        H=H,
+        use_max_algo=use_max_algo,
+        BLOCK_H=BLOCK_H,
+        FP32_MAX=FP32_MAX,
+    )
+
+
+@pytest.mark.parametrize(
+    "N,H",
+    [
+        (1, 1),
+        (4, 16),
+        (57, 1024),
+        (10, 128),
+    ],
+)
+@pytest.mark.parametrize("algo", ["max", "most_recent"])
+def test_correctness(N, H, algo):
+    """Fused kernel must produce identical scales and history as reference."""
+    use_max_algo = algo == "max"
+    fp8_maxes = torch.tensor([FP8_FWD_MAX, FP8_FWD_MAX, FP8_BWD_MAX], dtype=torch.float32, device=DEVICE)
+
+    torch.manual_seed(42)
+    amax_history_ref = torch.rand(3, N, H, dtype=torch.float32, device=DEVICE) * 10.0
+    staged_amaxes = torch.rand(3, N, dtype=torch.float32, device=DEVICE) * 5.0
+    scales_ref = torch.ones(3, N, dtype=torch.float32, device=DEVICE)
+    history_idx = H // 3
+
+    amax_history_fused = amax_history_ref.clone()
+    scales_fused = scales_ref.clone()
+
+    _reference_update(amax_history_ref, staged_amaxes, scales_ref, fp8_maxes, history_idx, use_max_algo)
+    _run_fused_kernel(amax_history_fused, staged_amaxes, scales_fused, fp8_maxes, history_idx, use_max_algo)
+
+    torch.testing.assert_close(
+        amax_history_fused,
+        amax_history_ref,
+        atol=0,
+        rtol=0,
+        msg=f"amax_history mismatch for N={N}, H={H}, algo={algo}",
+    )
+    torch.testing.assert_close(
+        scales_fused, scales_ref, atol=1e-5, rtol=1e-5, msg=f"scales mismatch for N={N}, H={H}, algo={algo}"
+    )
+
+
+def test_zero_amaxes():
+    """When all staged amaxes are zero and history is zero, scales should stay at old_scale."""
+    N, H = 8, 16
+    fp8_maxes = torch.tensor([FP8_FWD_MAX, FP8_FWD_MAX, FP8_BWD_MAX], dtype=torch.float32, device=DEVICE)
+    amax_history = torch.zeros(3, N, H, dtype=torch.float32, device=DEVICE)
+    staged_amaxes = torch.zeros(3, N, dtype=torch.float32, device=DEVICE)
+    old_scales = torch.full((3, N), 42.0, dtype=torch.float32, device=DEVICE)
+    scales = old_scales.clone()
+
+    _run_fused_kernel(amax_history, staged_amaxes, scales, fp8_maxes, history_idx=0, use_max_algo=True)
+
+    torch.testing.assert_close(
+        scales, old_scales, atol=0, rtol=0, msg="Scales should be unchanged when all amaxes are zero"
+    )
+
+
+def test_nan_amaxes():
+    """NaN amaxes should leave scales unchanged (NaN guard)."""
+    N, H = 4, 8
+    fp8_maxes = torch.tensor([FP8_FWD_MAX, FP8_FWD_MAX, FP8_BWD_MAX], dtype=torch.float32, device=DEVICE)
+    amax_history = torch.zeros(3, N, H, dtype=torch.float32, device=DEVICE)
+    staged_amaxes = torch.full((3, N), float("nan"), dtype=torch.float32, device=DEVICE)
+    old_scales = torch.full((3, N), 7.0, dtype=torch.float32, device=DEVICE)
+    scales = old_scales.clone()
+
+    _run_fused_kernel(amax_history, staged_amaxes, scales, fp8_maxes, history_idx=0, use_max_algo=True)
+
+    torch.testing.assert_close(
+        scales, old_scales, atol=0, rtol=0, msg="Scales should be unchanged when amaxes are NaN"
+    )
+
+
+def test_very_small_amaxes():
+    """Very small amaxes should produce large scales clamped to FP32_MAX."""
+    N, H = 4, 8
+    fp8_maxes = torch.tensor([FP8_FWD_MAX, FP8_FWD_MAX, FP8_BWD_MAX], dtype=torch.float32, device=DEVICE)
+    amax_history = torch.zeros(3, N, H, dtype=torch.float32, device=DEVICE)
+    staged_amaxes = torch.full((3, N), 1e-40, dtype=torch.float32, device=DEVICE)
+    scales = torch.ones(3, N, dtype=torch.float32, device=DEVICE)
+
+    _run_fused_kernel(amax_history, staged_amaxes, scales, fp8_maxes, history_idx=0, use_max_algo=False)
+
+    assert not scales.isinf().any(), "Scales should not be inf (should be clamped)"
+    assert not scales.isnan().any(), "Scales should not be NaN"
+    assert (scales <= FP32_MAX).all(), "Scales should be <= FP32_MAX"
+
+
+@pytest.mark.parametrize("H", [4, 16, 64])
+def test_history_rollover(H):
+    """Circular index should write to correct position across multiple steps."""
+    N = 3
+    fp8_maxes = torch.tensor([FP8_FWD_MAX, FP8_FWD_MAX, FP8_BWD_MAX], dtype=torch.float32, device=DEVICE)
+    amax_history = torch.zeros(3, N, H, dtype=torch.float32, device=DEVICE)
+    scales = torch.ones(3, N, dtype=torch.float32, device=DEVICE)
+
+    for step in range(H + 5):
+        idx = step % H
+        staged = torch.full((3, N), float(step + 1), dtype=torch.float32, device=DEVICE)
+        _run_fused_kernel(amax_history, staged, scales, fp8_maxes, history_idx=idx, use_max_algo=True)
+
+        assert amax_history[0, 0, idx].item() == float(
+            step + 1
+        ), f"History not written at idx={idx} on step={step}"
+
+
+def test_multi_step_vs_reference():
+    """Run 50 steps of both fused and reference, verify they stay in sync."""
+    N, H = 10, 32
+    use_max_algo = True
+    fp8_maxes = torch.tensor([FP8_FWD_MAX, FP8_FWD_MAX, FP8_BWD_MAX], dtype=torch.float32, device=DEVICE)
+
+    torch.manual_seed(123)
+    amax_history_ref = torch.zeros(3, N, H, dtype=torch.float32, device=DEVICE)
+    amax_history_fused = torch.zeros(3, N, H, dtype=torch.float32, device=DEVICE)
+    scales_ref = torch.ones(3, N, dtype=torch.float32, device=DEVICE)
+    scales_fused = torch.ones(3, N, dtype=torch.float32, device=DEVICE)
+
+    for step in range(50):
+        idx = step % H
+        staged = torch.rand(3, N, dtype=torch.float32, device=DEVICE) * (10.0 + step)
+
+        _reference_update(amax_history_ref, staged, scales_ref, fp8_maxes, idx, use_max_algo)
+        _run_fused_kernel(amax_history_fused, staged, scales_fused, fp8_maxes, idx, use_max_algo)
+
+    torch.testing.assert_close(
+        amax_history_fused, amax_history_ref, atol=0, rtol=0, msg="amax_history diverged over 50 steps"
+    )
+    torch.testing.assert_close(
+        scales_fused, scales_ref, atol=1e-5, rtol=1e-5, msg="scales diverged over 50 steps"
+    )
+
+
+def test_registry_integration():
+    """Validate _fast_update_scales_with_history via _DelayedScalingRegistry."""
+    from primus.backends.megatron.core.extensions.primus_turbo_float8_local import (
+        _DelayedScalingRegistry,
+        _fast_update_scales_with_history,
+    )
+
+    N, H = 8, 16
+
+    class _FakeModule(torch.nn.Module):
+        """Minimal stand-in for Float8*ParallelLinear with real tensors."""
+
+        def __init__(self, weight_data):
+            super().__init__()
+            self._fp8_fwd_max = FP8_FWD_MAX
+            self._fp8_bwd_max = FP8_BWD_MAX
+            self._amax_compute_algo = "max"
+            self._use_delayed_scaling = True
+            self._first_delayed_step = True
+            self._history_idx = 0
+            self.weight = torch.nn.Parameter(weight_data)
+            self.register_buffer("amax_history_input", torch.zeros(H, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("amax_history_weight", torch.zeros(H, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("amax_history_grad", torch.zeros(H, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("scale_input", torch.tensor(1.0, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("scale_weight", torch.tensor(1.0, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("scale_grad", torch.tensor(1.0, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("staged_input_amax", torch.tensor(0.0, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("staged_weight_amax", torch.tensor(0.0, dtype=torch.float32, device=DEVICE))
+            self.register_buffer("staged_grad_amax", torch.tensor(0.0, dtype=torch.float32, device=DEVICE))
+
+    torch.manual_seed(99)
+    weights = [torch.randn(64, 64, dtype=torch.bfloat16, device=DEVICE) for _ in range(N)]
+    modules = [_FakeModule(weights[i]) for i in range(N)]
+
+    registry = _DelayedScalingRegistry(modules)
+
+    # Staging is now done per-module: each m owns scalar buffers m.staged_input_amax,
+    # m.staged_grad_amax. _fast_update_scales_with_history stacks them into
+    # registry.staged_amaxes_3n[0/2] before launching the Triton kernel; scales
+    # land in registry.scales_3n and are scattered back to m.scale_*.
+    # Parallel pure-Python reference, driven by the EXACT amaxes the kernel used.
+    fp8_maxes = torch.tensor([FP8_FWD_MAX, FP8_FWD_MAX, FP8_BWD_MAX], dtype=torch.float32, device=DEVICE)
+    amax_history_ref = torch.zeros(3, N, H, dtype=torch.float32, device=DEVICE)
+    scales_ref = torch.ones(3, N, dtype=torch.float32, device=DEVICE)
+    history_idx_ref = 0
+    use_max_algo = True  # _FakeModule sets _amax_compute_algo = "max"
+
+    torch.manual_seed(77)
+    for step in range(5):
+        for i in range(N):
+            modules[i].staged_input_amax.fill_(torch.rand(1, device=DEVICE).item() * 10)
+            modules[i].staged_grad_amax.fill_(torch.rand(1, device=DEVICE).item() * 5)
+
+        _fast_update_scales_with_history(registry)
+
+        # The fused kernel only reads registry.staged_amaxes_3n (rows input/weight/grad)
+        # and writes amax_history/scales, so reading it back yields the exact amaxes the
+        # kernel consumed -- including the first-step weight bootstrap from ||weight||_inf
+        # that is staged inside the call. Drive the reference with the same inputs and the
+        # same history index it used this step.
+        staged_used = registry.staged_amaxes_3n.clone()
+        _reference_update(amax_history_ref, staged_used, scales_ref, fp8_maxes, history_idx_ref, use_max_algo)
+        history_idx_ref = (history_idx_ref + 1) % H
+
+    # Registry results must match the reference: history bit-for-bit, scales within fp32 tol.
+    torch.testing.assert_close(
+        registry.amax_history,
+        amax_history_ref,
+        atol=0,
+        rtol=0,
+        msg="registry amax_history diverged from reference loop",
+    )
+    torch.testing.assert_close(
+        registry.scales_3n,
+        scales_ref,
+        atol=1e-5,
+        rtol=1e-5,
+        msg="registry scales diverged from reference loop",
+    )
+
+    # Per-module buffers must reflect the registry-batched results (rows input/weight/grad).
+    for i, m in enumerate(modules):
+        torch.testing.assert_close(m.scale_input, scales_ref[0, i], atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(m.scale_weight, scales_ref[1, i], atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(m.scale_grad, scales_ref[2, i], atol=1e-5, rtol=1e-5)
+        torch.testing.assert_close(m.amax_history_input, amax_history_ref[0, i], atol=0, rtol=0)
+        torch.testing.assert_close(m.amax_history_weight, amax_history_ref[1, i], atol=0, rtol=0)
+        torch.testing.assert_close(m.amax_history_grad, amax_history_ref[2, i], atol=0, rtol=0)
+
+    # Sanity: scales finite and positive.
+    assert not registry.scales_3n.isnan().any(), "scales have NaN"
+    assert not registry.scales_3n.isinf().any(), "scales have Inf"
+    assert (registry.scales_3n[0] > 0).all(), "scale_input should be positive"
+    assert (registry.scales_3n[1] > 0).all(), "scale_weight should be positive"
+
+    assert registry._history_idx == 5 % H, f"history_idx should be {5 % H}, got {registry._history_idx}"
+    for m in modules:
+        assert m._history_idx == registry._history_idx, "Per-module _history_idx not synced with registry"
+
+
+if __name__ == "__main__":
+    print("=== Test 1: Correctness (max, various sizes) ===")
+    for N, H in [(1, 1), (4, 16), (57, 1024), (10, 128)]:
+        for algo in ["max", "most_recent"]:
+            test_correctness(N, H, algo)
+            print(f"  N={N}, H={H}, algo={algo}: PASS")
+
+    print("\n=== Test 2: Zero amaxes ===")
+    test_zero_amaxes()
+    print("  PASS")
+
+    print("\n=== Test 3: NaN amaxes ===")
+    test_nan_amaxes()
+    print("  PASS")
+
+    print("\n=== Test 4: Very small amaxes ===")
+    test_very_small_amaxes()
+    print("  PASS")
+
+    print("\n=== Test 5: History rollover ===")
+    for H in [4, 16, 64]:
+        test_history_rollover(H)
+        print(f"  H={H}: PASS")
+
+    print("\n=== Test 6: Multi-step vs reference ===")
+    test_multi_step_vs_reference()
+    print("  PASS")
+
+    print("\n=== Test 7: Registry integration ===")
+    test_registry_integration()
+    print("  PASS")
+
+    print("\nAll tests passed!")


### PR DESCRIPTION
Part of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Targets `feat/flux/turbo` — review after it. One of the parents of the trainers PR.

## What this changes
The delayed-fp8-scaling patch set plus the consolidated Transformer-Engine dot-product-attention (DPA) prologue patch.

## Dependencies
Sequenced after the CI-pins PR (`feat/flux/ci-env`); its fp8 unit tests are green on the current CI pin (no turbo-bump dependency). Builds on `feat/flux/turbo`.

## Test plan
`pytest tests/unit_tests/backends/megatron/diffusion -k "delayed_fp8 or fused_delayed"`. Validated locally on an AMD GPU container: 24 passed.

## Files
5 (delayed-fp8 patches, TE DPA prologue patch + tests).
