### PR TITLE
feat(flux): diffusion data preprocessing pipelines + data CLI

### DIFF
--- a/primus/backends/megatron/data/diffusion/preprocessing/__init__.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Data preprocessing for diffusion models.
+
+Pipeline implementations live in the ``pipelines`` subpackage; shared helpers
+live in ``utils``. Import those submodules directly.
+"""

--- a/primus/backends/megatron/data/diffusion/preprocessing/auth.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/auth.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Authentication utilities for HuggingFace dataset access.
+
+Provides secure token loading from files with permission checks.
+"""
+
+import logging
+import os
+import stat
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class HFAuthError(Exception):
+    """Exception raised for HuggingFace authentication errors."""
+
+
+def check_file_permissions(file_path: Path) -> bool:
+    """
+    Check if file has secure permissions (600 or 400).
+
+    Args:
+        file_path: Path to token file
+
+    Returns:
+        True if permissions are secure, False otherwise
+    """
+    try:
+        file_stat = os.stat(file_path)
+        mode = stat.S_IMODE(file_stat.st_mode)
+
+        # Check if file is readable by others or group
+        if mode & (stat.S_IRGRP | stat.S_IROTH):
+            return False
+
+        # Check if file is writable by others or group
+        if mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return False
+
+        return True
+    except OSError as e:
+        logger.error(f"Failed to check file permissions: {e}")
+        return False
+
+
+def load_token_from_file(token_file: str) -> str:
+    """
+    Load HuggingFace token from file with security checks.
+
+    Args:
+        token_file: Path to file containing HuggingFace token
+
+    Returns:
+        Token string
+
+    Raises:
+        HFAuthError: If file has insecure permissions or cannot be read
+    """
+    token_path = Path(token_file).expanduser().resolve()
+
+    # Check if file exists
+    if not token_path.exists():
+        raise HFAuthError(
+            f"Token file not found: {token_path}\n" f"Please create the file or check the path."
+        )
+
+    # Check if it's a file (not directory)
+    if not token_path.is_file():
+        raise HFAuthError(f"Token path is not a file: {token_path}")
+
+    # Check file permissions
+    if not check_file_permissions(token_path):
+        raise HFAuthError(
+            f"Token file has insecure permissions: {token_path}\n"
+            f"Please set secure permissions:\n"
+            f"  chmod 600 {token_path}\n"
+            f"Current permissions allow read/write by group or others."
+        )
+
+    # Read token
+    try:
+        with open(token_path, "r") as f:
+            token = f.read().strip()
+
+        if not token:
+            raise HFAuthError(f"Token file is empty: {token_path}")
+
+        # Basic validation (HF tokens start with 'hf_')
+        if not token.startswith("hf_"):
+            logger.warning(
+                f"Token from {token_path} doesn't start with 'hf_' - "
+                f"this may not be a valid HuggingFace token"
+            )
+
+        logger.info(f"Loaded HuggingFace token from {token_path}")
+        return token
+
+    except IOError as e:
+        raise HFAuthError(f"Failed to read token file {token_path}: {e}")
+
+
+def setup_hf_authentication(token_file: Optional[str] = None, use_env: bool = True) -> Optional[str]:
+    """
+    Setup HuggingFace authentication with multiple fallback options.
+
+    Priority:
+    1. Token from file (if token_file provided)
+    2. Token from HF_TOKEN environment variable (if use_env=True)
+    3. Token from HF CLI login (~/.cache/huggingface/token)
+    4. No authentication (public datasets only)
+
+    Args:
+        token_file: Optional path to token file
+        use_env: Whether to check HF_TOKEN environment variable
+
+    Returns:
+        Token string if found, None otherwise
+
+    Side effects:
+        Sets HF_TOKEN environment variable if token is found
+    """
+    # Priority 1: Token file
+    if token_file:
+        try:
+            token = load_token_from_file(token_file)
+            os.environ["HF_TOKEN"] = token
+            logger.info("Using HuggingFace token from file")
+            return token
+        except HFAuthError as e:
+            logger.error(str(e))
+            raise
+
+    # Priority 2: Environment variable
+    if use_env and "HF_TOKEN" in os.environ:
+        token = os.environ["HF_TOKEN"]
+        if token:
+            logger.info("Using HuggingFace token from HF_TOKEN environment variable")
+            return token
+
+    # Priority 3: HF CLI login
+    hf_cache_token = Path.home() / ".cache" / "huggingface" / "token"
+    if hf_cache_token.exists():
+        if not check_file_permissions(hf_cache_token):
+            logger.warning(
+                f"HuggingFace CLI token file has insecure permissions: {hf_cache_token}. "
+                "Skipping it; run `chmod 600` on the file to use it."
+            )
+        else:
+            try:
+                with open(hf_cache_token, "r") as f:
+                    token = f.read().strip()
+                if token:
+                    os.environ["HF_TOKEN"] = token
+                    logger.info("Using HuggingFace token from CLI login (~/.cache/huggingface/token)")
+                    return token
+            except IOError as e:
+                logger.debug(f"Could not read HF CLI token: {e}")
+
+    # No authentication found
+    logger.info("No HuggingFace authentication found. " "Only public datasets will be accessible.")
+    return None
+
+
+__all__ = [
+    "HFAuthError",
+    "load_token_from_file",
+    "setup_hf_authentication",
+    "check_file_permissions",
+]

--- a/primus/backends/megatron/data/diffusion/preprocessing/download.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/download.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Reusable download utilities for dataset preparation pipelines.
+
+Provides HTTP download with exponential backoff, MD5 verification,
+and MLCommons R2 manifest resolution (.uri / .md5 protocol).
+Uses urllib.request (stdlib) -- no external HTTP dependencies needed.
+"""
+
+import hashlib
+import logging
+import random
+import shutil
+import time
+import urllib.error
+import urllib.request
+from http.client import HTTPResponse
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_DOWNLOAD_TIMEOUT = 300  # 5 min per file
+_MAX_RETRIES = 5
+_BASE_DELAY = 1.0
+_MAX_DELAY = 60.0
+_USER_AGENT = "Wget/1.21"
+
+
+class _MD5MismatchError(Exception):
+    """Raised when a downloaded file's MD5 doesn't match the expected value."""
+
+
+def _is_retryable(status_code: int) -> bool:
+    return status_code == 429 or 500 <= status_code < 600
+
+
+def download_with_backoff(
+    url: str,
+    dest: Path,
+    expected_md5: Optional[str] = None,
+    max_retries: int = _MAX_RETRIES,
+    base_delay: float = _BASE_DELAY,
+    timeout: int = _DOWNLOAD_TIMEOUT,
+) -> None:
+    """Download a file via HTTP with exponential backoff on 429/5xx.
+
+    Streams the response to disk to avoid holding large files in memory.
+    Verifies MD5 checksum if provided.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    last_error: Optional[Exception] = None
+    for attempt in range(max_retries + 1):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+            resp: HTTPResponse = urllib.request.urlopen(req, timeout=timeout)
+            with open(dest, "wb") as f:
+                shutil.copyfileobj(resp, f)
+
+            if expected_md5:
+                actual_md5 = hashlib.md5(dest.read_bytes()).hexdigest()
+                if actual_md5 != expected_md5:
+                    dest.unlink(missing_ok=True)
+                    raise _MD5MismatchError(
+                        f"MD5 mismatch for {dest.name}: " f"expected {expected_md5}, got {actual_md5}"
+                    )
+            return
+
+        except urllib.error.HTTPError as e:
+            last_error = e
+            if not _is_retryable(e.code) or attempt == max_retries:
+                dest.unlink(missing_ok=True)
+                raise RuntimeError(
+                    f"HTTP {e.code} downloading {url} " f"(attempt {attempt + 1}/{max_retries + 1})"
+                ) from e
+            delay = min(base_delay * (2**attempt) + random.uniform(0, 1), _MAX_DELAY)
+            logger.warning(f"  HTTP {e.code} on {url}, retry {attempt + 1}/{max_retries} " f"in {delay:.1f}s")
+            time.sleep(delay)
+
+        except (urllib.error.URLError, TimeoutError, OSError) as e:
+            last_error = e
+            if attempt == max_retries:
+                dest.unlink(missing_ok=True)
+                raise RuntimeError(f"Download failed for {url} after {max_retries + 1} attempts: {e}") from e
+            delay = min(base_delay * (2**attempt) + random.uniform(0, 1), _MAX_DELAY)
+            logger.warning(
+                f"  Network error on {url}: {e}, retry {attempt + 1}/{max_retries} " f"in {delay:.1f}s"
+            )
+            time.sleep(delay)
+
+        except _MD5MismatchError as e:
+            last_error = e
+            if attempt == max_retries:
+                dest.unlink(missing_ok=True)
+                raise RuntimeError(str(e)) from e
+            delay = min(base_delay * (2**attempt) + random.uniform(0, 1), _MAX_DELAY)
+            logger.warning(f"  {e}, retry {attempt + 1}/{max_retries} in {delay:.1f}s")
+            time.sleep(delay)
+
+    dest.unlink(missing_ok=True)
+    raise RuntimeError(f"Download failed for {url}: {last_error}")
+
+
+def fetch_url_text(url: str, timeout: int = 30) -> str:
+    """Fetch a small text resource (manifest, etc.) via HTTP."""
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    resp = urllib.request.urlopen(req, timeout=timeout)
+    return resp.read().decode("utf-8")
+
+
+def parse_md5_manifest(
+    manifest_text: str,
+    suffix_filter: Optional[str] = None,
+) -> List[Tuple[str, str]]:
+    """Parse an MLCommons .md5 manifest into (md5, filename) pairs.
+
+    Args:
+        manifest_text: Raw text content of the .md5 file.
+        suffix_filter: If provided, only include files ending with this
+            suffix (e.g. ".arrow"). None means include all files.
+
+    Returns:
+        Sorted list of (md5, filename) tuples, sorted by filename
+        for deterministic ordering.
+    """
+    entries = []
+    for line in manifest_text.strip().splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) != 2:
+            continue
+        md5, fname = parts
+        if suffix_filter is not None and not fname.endswith(suffix_filter):
+            continue
+        entries.append((md5, fname))
+    entries.sort(key=lambda x: x[1])
+    return entries
+
+
+def fetch_manifest(manifest_url: str) -> Tuple[str, List[Tuple[str, str]]]:
+    """Fetch .uri and .md5 manifests, return (base_url, [(md5, filename)]).
+
+    The manifest_url should end with '.uri' or '.md5'. The function derives
+    the complementary URL by replacing the suffix.
+    """
+    uri_url = manifest_url.replace(".md5", ".uri")
+    md5_url = manifest_url.replace(".uri", ".md5")
+
+    base_url = fetch_url_text(uri_url).strip()
+    md5_text = fetch_url_text(md5_url)
+    entries = parse_md5_manifest(md5_text)
+
+    logger.info(f"Manifest: {len(entries)} files, base URL: {base_url}")
+    return base_url, entries

--- a/primus/backends/megatron/data/diffusion/preprocessing/finalize.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/finalize.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Automatic Energon dataset finalization for Primus diffusion pipelines.
+
+This module automates the post-processing steps required after data preprocessing:
+1. Create .nv-meta/dataset.yaml with correct sample type configuration
+2. Run ``energon prepare`` non-interactively to index the dataset
+3. Verify the dataset is ready for training
+
+Supports two indexing strategies:
+- **Ratio-based** (default): splits shards by train/val/test ratio.
+  Works with both the programmatic ``BaseWebdatasetFactory`` API and
+  the ``energon prepare`` subprocess fallback.
+- **Pattern-based**: assigns shards to splits by regex patterns on
+  relative paths (e.g. ``"train/.*"``).  Requires the programmatic
+  API (``megatron-energon >= 7.x``).
+
+Usage:
+    from primus.backends.megatron.data.diffusion.preprocessing.finalize import finalize_energon_dataset
+
+    # Ratio-based (original behavior)
+    finalize_energon_dataset(
+        output_dir='/workspace/Primus/data/encoded_pokemon',
+        train_split=1.0,
+        encoding='preencoded',
+    )
+
+    # Pattern-based (MLPerf layout with separate train/ and val/ dirs)
+    finalize_energon_dataset(
+        output_dir='/workspace/Primus/data/mlperf_flux1',
+        encoding='preencoded_numpy',
+        split_parts_patterns=[("train", "train/.*"), ("val", "val/.*")],
+    )
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import List, Literal, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_ENCODING_TYPE = Literal["preencoded", "preencoded_numpy", "raw"]
+
+
+def _write_dataset_yaml(output_path: Path, encoding: str) -> Path:
+    """Write .nv-meta/dataset.yaml with the correct subflavor."""
+    meta_dir = output_path / ".nv-meta"
+    meta_dir.mkdir(exist_ok=True)
+
+    dataset_yaml_path = meta_dir / "dataset.yaml"
+    dataset_yaml_path.write_text(
+        f"__module__: megatron.energon\n"
+        f"__class__: CrudeWebdataset\n"
+        f"subflavors:\n"
+        f"  encoding: {encoding}\n"
+    )
+    logger.info(f"✓ Created {dataset_yaml_path}")
+    return dataset_yaml_path
+
+
+def _prepare_programmatic(
+    output_path: Path,
+    num_workers: int,
+    train_split: float,
+    split_parts_patterns: Optional[List[Tuple[str, str]]],
+) -> None:
+    """Index dataset using BaseWebdatasetFactory.prepare_dataset()."""
+    from megatron.energon import BaseWebdatasetFactory
+
+    shard_paths = sorted(str(p.relative_to(output_path)) for p in output_path.glob("**/*.tar"))
+    if not shard_paths:
+        raise FileNotFoundError(f"No .tar shards found under {output_path}")
+
+    kwargs: dict = {
+        "parent_path": str(output_path),
+        "paths": shard_paths,
+        "workers": num_workers,
+    }
+
+    if split_parts_patterns:
+        kwargs["split_parts_patterns"] = split_parts_patterns
+    else:
+        val_split = (1.0 - train_split) / 2
+        test_split = (1.0 - train_split) / 2
+        kwargs["split_parts_ratio"] = [
+            ("train", train_split),
+            ("val", val_split),
+            ("test", test_split),
+        ]
+
+    logger.info(f"  Indexing with BaseWebdatasetFactory ({len(shard_paths)} shards)")
+    BaseWebdatasetFactory.prepare_dataset(**kwargs)
+    logger.info("✓ Energon indexing complete (programmatic API)")
+
+
+def _prepare_subprocess(
+    output_path: Path,
+    num_workers: int,
+    train_split: float,
+    split_parts_patterns: Optional[List[Tuple[str, str]]],
+) -> None:
+    """Fallback: index dataset using ``energon prepare`` subprocess.
+
+    NOTE: The subprocess path only supports ratio-based splitting.
+    Pattern-based ``split_parts_patterns`` requires the programmatic API.
+    """
+    if split_parts_patterns:
+        raise RuntimeError(
+            "Pattern-based split_parts_patterns requires "
+            "megatron.energon.BaseWebdatasetFactory (programmatic API). "
+            "Install megatron-energon >= 7.x or use ratio-based splitting."
+        )
+
+    val_split = (1.0 - train_split) / 2
+    test_split = (1.0 - train_split) / 2
+    split_input = f"{train_split}, {val_split}, {test_split}\nn\n"
+
+    logger.info(f"  Split ratios: train={train_split:.2f}, " f"val={val_split:.2f}, test={test_split:.2f}")
+    logger.info("  Running energon prepare subprocess...")
+
+    try:
+        process = subprocess.Popen(
+            [
+                "energon",
+                "prepare",
+                str(output_path),
+                "--num-workers",
+                str(num_workers),
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        stdout, _ = process.communicate(input=split_input, timeout=300)
+
+        if process.returncode != 0:
+            logger.error("energon prepare failed:")
+            logger.error(stdout)
+            raise RuntimeError(f"energon prepare exited with code {process.returncode}")
+
+        for line in stdout.splitlines():
+            if any(skip in line for skip in ["libibverbs", "Warning:", "UserWarning"]):
+                continue
+            if any(key in line for key in ["Indexing", "Done", "Found", "samples", "shards"]):
+                logger.info(f"  {line.strip()}")
+
+        logger.info("✓ Energon indexing complete (subprocess)")
+
+    except subprocess.TimeoutExpired:
+        process.kill()
+        raise RuntimeError(
+            "energon prepare timed out after 5 minutes. "
+            "This may indicate a problem with the dataset or system resources."
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "energon command not found. Make sure megatron-energon is installed:\n"
+            "  pip install megatron-energon"
+        )
+
+
+def finalize_energon_dataset(
+    output_dir: str,
+    train_split: float = 1.0,
+    encoding: _ENCODING_TYPE = "preencoded",
+    num_workers: int = 8,
+    split_parts_patterns: Optional[List[Tuple[str, str]]] = None,
+) -> None:
+    """
+    Finalize Energon WebDataset by creating dataset.yaml and running energon prepare.
+
+    This automates the manual steps typically required after data preprocessing:
+    1. Create .nv-meta/dataset.yaml with correct subflavor configuration
+    2. Run energon indexing (programmatic API with subprocess fallback)
+    3. Verify the dataset is ready for training
+
+    Args:
+        output_dir: Path to dataset directory containing tar files.
+        train_split: Fraction for training (rest split evenly between
+            val/test). Ignored when split_parts_patterns is provided.
+        encoding: Dataset encoding mode.
+        num_workers: Number of workers for energon prepare (default: 8).
+        split_parts_patterns: List of (split_name, pattern) tuples for
+            pattern-based splitting, e.g.
+            ``[("train", "train/.*"), ("val", "val/.*")]``.
+            When provided, train_split is ignored.
+
+    Raises:
+        RuntimeError: If energon prepare fails or energon command not found
+        FileNotFoundError: If output_dir doesn't exist or has no tar files
+    """
+    output_path = Path(output_dir)
+
+    if not output_path.exists():
+        raise FileNotFoundError(f"Output directory not found: {output_dir}")
+
+    tar_files = list(output_path.glob("**/*.tar"))
+    if not tar_files:
+        raise FileNotFoundError(
+            f"No .tar files found in {output_dir}. " "Make sure data preprocessing completed successfully."
+        )
+
+    logger.info("=" * 80)
+    logger.info("Finalizing Energon dataset for training...")
+    logger.info("=" * 80)
+    logger.info(f"Found {len(tar_files)} shard(s) to index")
+
+    _write_dataset_yaml(output_path, encoding)
+
+    logger.info("Running energon prepare (this may take a few minutes)...")
+
+    try:
+        _prepare_programmatic(output_path, num_workers, train_split, split_parts_patterns)
+    except ImportError:
+        logger.info("BaseWebdatasetFactory not available, falling back to subprocess")
+        _prepare_subprocess(output_path, num_workers, train_split, split_parts_patterns)
+
+    from .validate import validate_energon_dataset
+
+    validate_energon_dataset(output_dir, encoding=encoding)
+
+    logger.info("=" * 80)
+    logger.info(f"✓ Dataset finalized: {output_dir}")
+    logger.info(f"  To use in training, set: dataset_path: {output_dir}")
+    logger.info("=" * 80)

--- a/primus/backends/megatron/data/diffusion/preprocessing/pipelines/__init__.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/pipelines/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Dataset preparation pipelines for Megatron diffusion models.
+
+Provides reusable pipeline classes for creating Energon WebDatasets
+from various input sources (HuggingFace, directories, WebDatasets).
+"""
+
+from .base import DatasetPipeline
+from .encoded import EncodedDatasetPipeline
+from .ingest import StreamingIngestPipeline
+from .raw import RawDatasetPipeline
+
+__all__ = [
+    "DatasetPipeline",
+    "RawDatasetPipeline",
+    "EncodedDatasetPipeline",
+    "StreamingIngestPipeline",
+]

--- a/primus/backends/megatron/data/diffusion/preprocessing/pipelines/base.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/pipelines/base.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Abstract base class for dataset preparation pipelines."""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+from ..utils import load_from_directory, load_from_huggingface, load_from_webdataset
+
+logger = logging.getLogger(__name__)
+
+
+class DatasetPipeline(ABC):
+    """Abstract base for all dataset preparation pipelines.
+
+    Subclasses implement run() which executes the full pipeline
+    and returns a dict of statistics (samples_processed, shards_written, etc.).
+    """
+
+    # Whether HuggingFace sources are loaded in streaming mode. Subclasses that
+    # need the full dataset materialized (e.g. for distributed total-count
+    # splitting) set this to False.
+    HF_STREAMING: bool = True
+
+    @abstractmethod
+    def run(self, **kwargs) -> Dict[str, Any]: ...
+
+    def load_data(self, **source_kwargs):
+        """Load data based on ``self.source_type``.
+
+        Args:
+            **source_kwargs: Source-specific arguments
+                - directory: input_dir
+                - huggingface: hf_dataset, hf_split, hf_data_files, image/caption keys
+                - webdataset: input_path
+
+        Returns:
+            Iterator over samples with 'image' and 'caption' keys.
+        """
+        if self.source_type == "directory":
+            logger.info(f"Loading from directory: {source_kwargs['input_dir']}")
+            return load_from_directory(source_kwargs["input_dir"])
+        elif self.source_type == "huggingface":
+            hf_split = source_kwargs.get("hf_split", "train")
+            hf_data_files = source_kwargs.get("hf_data_files")
+            if hf_data_files:
+                logger.info(
+                    f"Loading from HuggingFace: {source_kwargs['hf_dataset']} "
+                    f"(split: {hf_split}, data_files: {hf_data_files})"
+                )
+            else:
+                logger.info(f"Loading from HuggingFace: {source_kwargs['hf_dataset']} (split: {hf_split})")
+
+            return load_from_huggingface(
+                source_kwargs["hf_dataset"],
+                split=hf_split,
+                streaming=self.HF_STREAMING,
+                data_files=hf_data_files,
+                image_key=source_kwargs.get("image_key"),
+                caption_key=source_kwargs.get("caption_key"),
+                image_keys=source_kwargs.get("image_keys"),
+                caption_keys=source_kwargs.get("caption_keys"),
+            )
+        elif self.source_type == "webdataset":
+            logger.info(f"Loading from WebDataset: {source_kwargs['input_path']}")
+            return load_from_webdataset(source_kwargs["input_path"])
+        else:
+            raise ValueError(f"Unknown source type: {self.source_type}")

--- a/primus/backends/megatron/data/diffusion/preprocessing/pipelines/encoded.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/pipelines/encoded.py
@@ -1,0 +1,608 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Pre-encoded dataset preparation pipeline for Megatron diffusion models.
+
+Creates pre-encoded Energon WebDatasets with VAE/T5/CLIP encoded tensors
+for faster training (no on-the-fly encoding overhead).
+"""
+
+import logging
+import time
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from primus.backends.megatron.data.diffusion.encoders import get_encoder
+from primus.backends.megatron.data.diffusion.encoders.config import (
+    CLIPLConfig,
+    T5XXLConfig,
+    VAEConfig,
+)
+
+from ..utils import (
+    get_distributed_info,
+    preprocess_image,
+    save_to_webdataset,
+    split_work_for_rank,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def set_reproducibility(seed: int = 42) -> None:
+    """Set global seeds and cuDNN flags for reproducible encoding.
+
+    Called explicitly from the pipeline entry point rather than at import time,
+    so importing this module does not mutate global torch/cuDNN state for
+    unrelated callers.
+    """
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+from .base import DatasetPipeline
+
+
+class EncodedDatasetPipeline(DatasetPipeline):
+    """
+    Pipeline for creating pre-encoded Energon WebDataset with VAE/T5/CLIP tensors.
+
+    This pipeline pre-encodes images with VAE and text with T5/CLIP, creating larger
+    datasets that enable faster training (no encoding overhead).
+
+    Args:
+        source_type: Type of input source ('directory', 'huggingface', 'webdataset')
+        output_dir: Output directory for Energon WebDataset
+        model_path: Pretrained model path (HF or local, default: black-forest-labs/FLUX.1-dev)
+        vae_path: Custom VAE path (overrides model_path)
+        t5_path: Custom T5 path (overrides model_path)
+        clip_path: Custom CLIP path (overrides model_path)
+        precision: Model precision ('bf16', 'fp16', 'fp32', default: 'bf16')
+        device: Device for encoding (default: 'cuda')
+        batch_size: Encoding batch size (default: 8)
+        t5_max_length: T5 max sequence length (default: 512, use 256 for schnell)
+        image_size: Target image size (default: 1024)
+        variable_size: If True, resize to nearest multiple of 16 instead of fixed size (default: False)
+        center_crop: Whether to center crop images (default: True)
+        max_size: Maximum dimension when variable_size is True (default: 1024)
+        shard_size: Samples per shard (default: 1000)
+        max_samples: Maximum samples to process (default: None for all)
+        compress: Whether to compress tar files with gzip (default: False)
+        hf_token_file: Path to HuggingFace token file (default: None)
+        vae_latent_mode: 'presampled' stores only latents; 'resample' additionally
+            stores mean and logvar for training-time reparameterization (default: 'presampled')
+
+    Example:
+        >>> pipeline = EncodedDatasetPipeline(
+        ...     source_type='huggingface',
+        ...     output_dir='/data/encoded_pokemon',
+        ...     model_path='black-forest-labs/FLUX.1-dev',
+        ...     batch_size=8,
+        ...     image_size=1024,
+        ... )
+        >>> results = pipeline.run(
+        ...     hf_dataset='diffusers/pokemon-gpt4-captions',
+        ...     hf_split='train'
+        ... )
+        >>> print(f"Processed {results['samples_processed']} samples")
+    """
+
+    # Encoded pipeline materializes the full HF dataset (non-streaming) so the
+    # distributed loader can split by total count.
+    HF_STREAMING: bool = False
+
+    def __init__(
+        self,
+        source_type: str,
+        output_dir: str,
+        model_path: str = "black-forest-labs/FLUX.1-dev",
+        vae_path: Optional[str] = None,
+        t5_path: Optional[str] = None,
+        clip_path: Optional[str] = None,
+        precision: str = "bf16",
+        device: str = "cuda",
+        batch_size: int = 8,
+        t5_max_length: int = 512,
+        variable_size: bool = False,
+        image_size: int = 1024,
+        center_crop: bool = True,
+        max_size: int = 1024,
+        shard_size: int = 1000,
+        max_samples: Optional[int] = None,
+        compress: bool = False,
+        hf_token_file: Optional[str] = None,
+        vae_latent_mode: str = "presampled",
+    ):
+        if vae_latent_mode not in ("presampled", "resample"):
+            raise ValueError(f"vae_latent_mode must be 'presampled' or 'resample', got '{vae_latent_mode}'")
+
+        self.source_type = source_type
+        self.output_dir = Path(output_dir)
+        self.model_path = model_path
+        self.vae_path = vae_path
+        self.t5_path = t5_path
+        self.clip_path = clip_path
+        self.precision = precision
+        self.device = device
+        self.batch_size = batch_size
+        self.t5_max_length = t5_max_length
+        self.variable_size = variable_size
+        self.image_size = image_size
+        self.center_crop = center_crop
+        self.max_size = max_size
+        self.shard_size = shard_size
+        self.max_samples = max_samples
+        self.compress = compress
+        self.vae_latent_mode = vae_latent_mode
+
+        # Setup HF authentication if token file provided
+        if hf_token_file:
+            from ..auth import HFAuthError, setup_hf_authentication
+
+            try:
+                setup_hf_authentication(token_file=hf_token_file)
+            except HFAuthError as e:
+                raise ValueError(f"HuggingFace authentication failed: {e}")
+
+        # Get distributed info
+        self.rank, self.world_size = get_distributed_info()
+
+        logger.info(f"Initialized EncodedDatasetPipeline (rank {self.rank}/{self.world_size})")
+        logger.info(f"Model: {self.model_path}")
+        logger.info(f"Precision: {self.precision}")
+        logger.info(f"Batch size: {self.batch_size}")
+        logger.info(f"T5 max sequence length: {self.t5_max_length}")
+        logger.info(f"VAE latent mode: {self.vae_latent_mode}")
+
+        # Load encoders
+        self.vae, self.t5, self.clip = self._load_encoders()
+
+    @staticmethod
+    def _raise_encoder_auth_error(encoder_name: str, model_path: str, original_error: Exception):
+        """Raise a clear error when encoder download fails due to authentication."""
+        err_str = str(original_error).lower()
+        is_auth = any(
+            kw in err_str
+            for kw in [
+                "token",
+                "permission",
+                "private repository",
+                "gated",
+                "401",
+                "403",
+                "authentication",
+                "login",
+            ]
+        )
+        if is_auth:
+            raise RuntimeError(
+                f"Failed to download {encoder_name} encoder from '{model_path}'.\n"
+                f"This model likely requires HuggingFace authentication.\n\n"
+                f"To fix, provide a token using one of:\n"
+                f"  1. --hf-token-file /path/to/.hf_token\n"
+                f"  2. export HF_TOKEN=hf_xxx\n"
+                f"  3. huggingface-cli login\n"
+            ) from original_error
+        raise RuntimeError(
+            f"Failed to load {encoder_name} encoder from '{model_path}': {original_error}"
+        ) from original_error
+
+    def _load_encoders(self):
+        """Load VAE, T5, and CLIP encoders."""
+        logger.info("Loading encoders...")
+
+        # Determine if we're using FLUX model (needs subfolders)
+        vae_model_path = self.vae_path or self.model_path
+        t5_model_path = self.t5_path or self.model_path
+        clip_model_path = self.clip_path or self.model_path
+
+        is_flux = "FLUX" in self.model_path or "flux" in self.model_path.lower()
+
+        # Create encoder configs with subfolders for FLUX models
+        vae_config = VAEConfig(
+            type="autoencoder_kl",
+            model_path=vae_model_path,
+            subfolder="vae" if (is_flux and not self.vae_path) else None,
+            precision=self.precision,
+            device=self.device,
+        )
+
+        t5_config = T5XXLConfig(
+            type="t5_xxl",
+            model_path=t5_model_path,
+            subfolder="text_encoder_2" if (is_flux and not self.t5_path) else None,
+            tokenizer_subfolder="tokenizer_2" if (is_flux and not self.t5_path) else None,
+            max_length=self.t5_max_length,
+            precision=self.precision,
+            device=self.device,
+        )
+
+        clip_config = CLIPLConfig(
+            type="clip_l",
+            model_path=clip_model_path,
+            subfolder="text_encoder" if (is_flux and not self.clip_path) else None,
+            tokenizer_subfolder="tokenizer" if (is_flux and not self.clip_path) else None,
+            precision=self.precision,
+            device=self.device,
+        )
+
+        # Load encoders with clear error messages on failure
+        try:
+            vae = get_encoder(vae_config)
+        except Exception as e:
+            self._raise_encoder_auth_error("VAE", vae_config.model_path, e)
+        logger.info(f"Loaded VAE from {vae_config.model_path}")
+
+        try:
+            t5 = get_encoder(t5_config)
+        except Exception as e:
+            self._raise_encoder_auth_error("T5-XXL", t5_config.model_path, e)
+        logger.info(f"Loaded T5-XXL from {t5_config.model_path}")
+
+        try:
+            clip = get_encoder(clip_config)
+        except Exception as e:
+            self._raise_encoder_auth_error("CLIP-L", clip_config.model_path, e)
+        logger.info(f"Loaded CLIP-L from {clip_config.model_path}")
+
+        # Set to eval mode
+        vae.eval()
+        t5.eval()
+        clip.eval()
+
+        return vae, t5, clip
+
+    def load_data_distributed(self, **source_kwargs):
+        """
+        Load only the data needed for this rank (distributed-aware loading).
+
+        This method loads data more efficiently by having each rank load only
+        its assigned portion of the dataset, rather than loading everything
+        and then splitting.
+
+        Args:
+            **source_kwargs: Source-specific arguments
+                - For directory: input_dir
+                - For huggingface: hf_dataset, hf_split
+                - For webdataset: input_path
+
+        Returns:
+            List of samples assigned to this rank
+        """
+        if self.source_type == "directory":
+            # Get file list (cheap operation, all ranks do this)
+            from pathlib import Path
+
+            from PIL import Image
+
+            input_path = Path(source_kwargs["input_dir"])
+            images_dir = input_path / "images"
+            captions_dir = input_path / "captions"
+
+            if not images_dir.exists():
+                raise ValueError(f"Images directory not found: {images_dir}")
+            if not captions_dir.exists():
+                raise ValueError(f"Captions directory not found: {captions_dir}")
+
+            # Get all image files
+            image_extensions = [".jpg", ".jpeg", ".png", ".webp"]
+            all_image_files = []
+            for ext in image_extensions:
+                all_image_files.extend(sorted(images_dir.glob(f"*{ext}")))
+
+            total_files = len(all_image_files)
+            logger.info(f"Found {total_files} total images")
+
+            # Apply max_samples limit BEFORE splitting across ranks so that
+            # max_samples refers to the total number of samples, not per-rank.
+            if self.max_samples and total_files > self.max_samples:
+                logger.info(f"Limiting to {self.max_samples} total samples (before rank split)")
+                all_image_files = all_image_files[: self.max_samples]
+                total_files = self.max_samples
+
+            # Split file list across ranks (before loading!)
+            start_idx, end_idx = split_work_for_rank(total_files, self.rank, self.world_size)
+            my_files = all_image_files[start_idx:end_idx]
+
+            logger.info(f"Rank {self.rank}: Loading {len(my_files)} images (indices {start_idx}-{end_idx})")
+
+            # Now load only this rank's files
+            items = []
+            for img_path in my_files:
+                caption_path = captions_dir / f"{img_path.stem}.txt"
+                if not caption_path.exists():
+                    logger.warning(f"Caption not found for {img_path.name}, skipping")
+                    continue
+
+                try:
+                    image = Image.open(img_path).convert("RGB")
+                    with open(caption_path, "r", encoding="utf-8") as f:
+                        caption = f.read().strip()
+                    items.append({"image": image, "caption": caption})
+                except Exception as e:
+                    logger.warning(f"Failed to load {img_path.name}: {e}")
+
+            return items
+        else:
+            # For non-directory sources, fall back to loading all data
+            logger.warning(
+                f"Distributed loading not yet implemented for {self.source_type}, loading all data"
+            )
+            data_iter = self.load_data(**source_kwargs)
+            all_items = list(data_iter)
+            total_items = len(all_items)
+
+            # Apply max_samples limit BEFORE splitting across ranks so that
+            # max_samples refers to the total number of samples, not per-rank.
+            if self.max_samples and total_items > self.max_samples:
+                logger.info(f"Limiting to {self.max_samples} total samples (before rank split)")
+                all_items = all_items[: self.max_samples]
+                total_items = self.max_samples
+
+            # Split work across ranks
+            start_idx, end_idx = split_work_for_rank(total_items, self.rank, self.world_size)
+            return all_items[start_idx:end_idx]
+
+    def _preprocess_images_batch(self, images):
+        """
+        Preprocess batch of PIL images for VAE encoding.
+
+        Args:
+            images: List of PIL Images
+
+        Returns:
+            Tensor [B, C, H, W] in range [-1, 1]
+        """
+        tensors = []
+        for image in images:
+            # Ensure RGB mode
+            if image.mode != "RGB":
+                image = image.convert("RGB")
+
+            # Convert to numpy array and normalize to [-1, 1]
+            img_array = np.array(image).astype(np.float32) / 255.0
+            img_array = img_array * 2.0 - 1.0
+
+            # Convert to tensor (HWC -> CHW)
+            img_tensor = torch.from_numpy(np.transpose(img_array, (2, 0, 1)))
+            tensors.append(img_tensor)
+
+        return torch.stack(tensors)
+
+    def _encode_batch(self, images, captions):
+        """
+        Encode a batch of images and captions.
+
+        Position IDs are NOT generated during preprocessing - they will be
+        computed at runtime based on actual tensor shapes. This provides
+        flexibility for variable-resolution training.
+
+        Args:
+            images: List of PIL Images
+            captions: List of caption strings
+
+        Returns:
+            List of sample dicts with encoded tensors
+        """
+        with torch.no_grad():
+            # Preprocess images
+            images_tensor = self._preprocess_images_batch(images)
+            images_tensor = images_tensor.to(self.device)
+
+            # Encode images with VAE
+            if self.vae_latent_mode == "resample":
+                latents, mean, logvar = self.vae.encode_for_resample(images_tensor)
+            else:
+                latents = self.vae.encode(images_tensor)
+
+            # Encode text with T5
+            prompt_embeds = self.t5.encode(captions)
+
+            # Encode text with CLIP
+            _, pooled_prompt_embeds = self.clip.encode(captions)
+
+        # Move to CPU and create samples (NO position IDs)
+        samples = []
+        for i in range(len(images)):
+            sample = {
+                "latents.pth": latents[i].cpu(),
+                "prompt_embeds.pth": prompt_embeds[i].cpu(),
+                "pooled_prompt_embeds.pth": pooled_prompt_embeds[i].cpu(),
+            }
+            if self.vae_latent_mode == "resample":
+                sample["mean.pth"] = mean[i].cpu()
+                sample["logvar.pth"] = logvar[i].cpu()
+            samples.append(sample)
+
+        return samples
+
+    def run(self, **source_kwargs):
+        """
+        Execute the encoded dataset preparation pipeline.
+
+        Args:
+            **source_kwargs: Source-specific arguments (passed to load_data)
+
+        Returns:
+            Dictionary with processing statistics:
+                - samples_processed: Number of samples successfully processed
+                - samples_skipped: Number of samples that failed
+                - shards_written: Number of output shards created
+        """
+        import torch.distributed as dist
+
+        # Reproducible encoding: set seeds/cuDNN flags here (not at import time).
+        set_reproducibility()
+
+        start_time = time.time()
+        rank_prefix = f"[RANK {self.rank}]"
+
+        tqdm.write(f"{rank_prefix} Stage 1/4: Initialization")
+        tqdm.write(f"{rank_prefix} Source: {self.source_type}")
+        tqdm.write(
+            f"{rank_prefix} Image preprocessing: size={self.image_size}, crop={self.center_crop}, variable_size={self.variable_size}"
+        )
+
+        # Synchronization point: ensure all ranks start together
+        if dist.is_initialized():
+            dist.barrier()
+
+        # Load data using distributed-aware loading (each rank loads only its portion)
+        tqdm.write(f"{rank_prefix} Stage 2/4: Loading data")
+        items_to_process = self.load_data_distributed(**source_kwargs)
+        tqdm.write(f"{rank_prefix} Loaded {len(items_to_process)} items")
+
+        # Synchronization point: ensure all ranks finished loading
+        if dist.is_initialized():
+            dist.barrier()
+
+        # Sort items by dimensions AFTER splitting to ensure batches have uniform sizes
+        # This prevents tensor stacking errors while maintaining balanced workload across ranks
+        items_to_process = sorted(
+            items_to_process, key=lambda item: item["image"].size  # Returns (width, height)
+        )
+
+        total_to_process = len(items_to_process)
+
+        tqdm.write(f"{rank_prefix} Stage 3/4: Encoding samples")
+
+        # Process in batches
+        batch_images = []
+        batch_captions = []
+        encoded_samples = []
+        samples_processed = 0
+        samples_skipped = 0
+        shards_written = 0
+
+        pbar = tqdm(
+            total=total_to_process,
+            desc=f"{rank_prefix} Encoding",
+            unit="sample",
+            disable=(self.rank != 0 and self.world_size > 4),
+        )
+
+        def _flush_batch():
+            """Encode and accumulate the current batch, returning count."""
+            nonlocal batch_images, batch_captions, encoded_samples, samples_processed
+            nonlocal shards_written
+            batch_samples = self._encode_batch(batch_images, batch_captions)
+            encoded_samples.extend(batch_samples)
+            count = len(batch_samples)
+            samples_processed += count
+            pbar.update(count)
+            batch_images = []
+            batch_captions = []
+
+            if len(encoded_samples) >= self.shard_size:
+                shard_offset = shards_written * self.world_size + self.rank
+                num_shards = save_to_webdataset(
+                    encoded_samples,
+                    str(self.output_dir),
+                    self.shard_size,
+                    shard_offset=shard_offset,
+                    compress=self.compress,
+                )
+                shards_written += num_shards
+                encoded_samples = []
+
+        for idx, item in enumerate(items_to_process):
+            try:
+                image = item["image"]
+                if self.image_size or self.center_crop or self.variable_size:
+                    image = preprocess_image(
+                        image,
+                        variable_size=self.variable_size,
+                        size=self.image_size,
+                        center_crop=self.center_crop,
+                        max_size=self.max_size,
+                    )
+
+                current_size = image.size
+
+                if batch_images and batch_images[0].size != current_size:
+                    _flush_batch()
+
+                batch_images.append(image)
+                batch_captions.append(item["caption"])
+
+                if len(batch_images) >= self.batch_size:
+                    _flush_batch()
+
+            except Exception as e:
+                tqdm.write(f"{rank_prefix} Failed to encode sample {idx}: {e}")
+                logger.debug(f"Sample {idx} encoding error", exc_info=True)
+                samples_skipped += 1
+                batch_images = []
+                batch_captions = []
+                continue
+
+        # Process remaining batch
+        if batch_images:
+            try:
+                _flush_batch()
+            except Exception as e:
+                tqdm.write(f"{rank_prefix} Failed to encode final batch: {e}")
+
+        # Save remaining samples
+        if encoded_samples:
+            shard_offset = shards_written * self.world_size + self.rank
+            num_shards = save_to_webdataset(
+                encoded_samples,
+                str(self.output_dir),
+                self.shard_size,
+                shard_offset=shard_offset,
+                compress=self.compress,
+            )
+            shards_written += num_shards
+
+        pbar.close()
+
+        elapsed_time = time.time() - start_time
+        tqdm.write(f"{rank_prefix} Stage 4/4: Complete")
+        tqdm.write(
+            f"{rank_prefix} Finished in {elapsed_time:.1f}s — "
+            f"processed: {samples_processed}, skipped: {samples_skipped}, shards: {shards_written}"
+        )
+
+        # Generate empty encodings for CFG dropout (rank 0 only).
+        # Uses the same T5/CLIP models already loaded with the same t5_max_length,
+        # guaranteeing sequence length consistency with the encoded dataset.
+        if self.rank == 0:
+            self._generate_empty_encodings()
+
+        # Critical synchronization point: ensure all ranks finished encoding before returning
+        if dist.is_initialized():
+            dist.barrier()
+
+        return {
+            "samples_processed": samples_processed,
+            "samples_skipped": samples_skipped,
+            "shards_written": shards_written,
+        }
+
+    def _generate_empty_encodings(self):
+        """Generate and save T5/CLIP encodings for the empty string (rank 0 only)."""
+        empty_dir = self.output_dir / "empty_encodings"
+        empty_dir.mkdir(parents=True, exist_ok=True)
+
+        with torch.no_grad():
+            t5_empty = self.t5.encode([""])
+            _, clip_empty = self.clip.encode([""])
+
+        t5_np = t5_empty.cpu().float().numpy()
+        clip_np = clip_empty.cpu().float().numpy()
+
+        np.save(str(empty_dir / "t5_empty.npy"), t5_np)
+        np.save(str(empty_dir / "clip_empty.npy"), clip_np)
+
+        tqdm.write(
+            f"[RANK 0] Saved empty encodings to {empty_dir} " f"(t5={t5_np.shape}, clip={clip_np.shape})"
+        )

--- a/primus/backends/megatron/data/diffusion/preprocessing/pipelines/ingest.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/pipelines/ingest.py
@@ -1,0 +1,311 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Streaming Arrow-to-WebDataset pipeline for MLPerf Flux datasets.
+
+Downloads Apache Arrow IPC files from MLCommons R2 storage using a
+concurrent prefetch pool, converts numpy-serialized bfloat16 samples
+directly into WebDataset tar shards, then deletes each Arrow file to
+minimize peak disk usage.
+
+Reduces the 6 TB disk requirement to roughly the final dataset size
+(~1.2 TB for cc12m) plus a small prefetch buffer of Arrow files.
+"""
+
+import io
+import json
+import logging
+import queue
+import tarfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
+
+import pyarrow.ipc
+
+from ..download import download_with_backoff, fetch_manifest
+from .base import DatasetPipeline
+
+logger = logging.getLogger(__name__)
+
+ARROW_COLUMNS = ("t5_encodings", "clip_encodings", "mean", "logvar")
+WDS_KEYS = ("t5.bytes", "clip.bytes", "mean.bytes", "logvar.bytes")
+
+_SENTINEL = None
+
+
+def _arrow_to_tar(
+    arrow_path: Path,
+    tar_path: Path,
+    global_sample_offset: int,
+) -> int:
+    """Convert one Arrow IPC stream file into a WebDataset tar shard.
+
+    Reads the Arrow stream, writes each row as a set of compound-key
+    entries (e.g. ``00000000.t5.bytes``) into a tar archive. Uses the
+    ``__key__`` column from the Arrow file when available, otherwise
+    generates sequential keys.
+
+    Returns the number of samples written.
+    """
+    reader = pyarrow.ipc.open_stream(str(arrow_path))
+    table = reader.read_all()
+    num_rows = table.num_rows
+
+    has_key_col = "__key__" in table.schema.names
+
+    tar_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(str(tar_path), "w") as tar:
+        for row_idx in range(num_rows):
+            if has_key_col:
+                base_name = table.column("__key__")[row_idx].as_py()
+            else:
+                base_name = f"{global_sample_offset + row_idx:08d}"
+
+            for col_name, wds_key in zip(ARROW_COLUMNS, WDS_KEYS):
+                col = table.column(col_name)
+                raw_bytes = col[row_idx].as_py()
+                if raw_bytes is None:
+                    continue
+                data = bytes(raw_bytes)
+
+                entry_name = f"{base_name}.{wds_key}"
+                info = tarfile.TarInfo(name=entry_name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+            meta = json.dumps({"key": base_name}).encode("utf-8")
+            meta_info = tarfile.TarInfo(name=f"{base_name}.json")
+            meta_info.size = len(meta)
+            tar.addfile(meta_info, io.BytesIO(meta))
+
+    return num_rows
+
+
+class StreamingIngestPipeline(DatasetPipeline):
+    """Streaming pipeline: download Arrow files from R2 -> WebDataset tars.
+
+    Downloads are parallelized with a prefetch pool (``max_workers`` threads)
+    while conversion runs sequentially on the main thread, preserving
+    deterministic shard ordering.  A semaphore (``prefetch_depth``) limits
+    how many Arrow files are kept on disk at once.
+
+    Args:
+        manifest_url: URL to the .uri manifest on MLCommons R2.
+        input_dir: Local directory for temporary Arrow file storage.
+        output_dir: Output directory for WebDataset tar shards.
+        split_name: Subdirectory name for the split (e.g. 'train', 'val').
+        max_files: Maximum number of Arrow files to process (None = all).
+        max_workers: Number of concurrent download threads (default 4).
+        prefetch_depth: Max Arrow files buffered on disk ahead of
+            conversion (default 6).  Disk overhead ~ prefetch_depth x 200 MB.
+    """
+
+    def __init__(
+        self,
+        manifest_url: str,
+        input_dir: str,
+        output_dir: str,
+        split_name: str = "train",
+        max_files: Optional[int] = None,
+        max_workers: int = 4,
+        prefetch_depth: int = 6,
+    ):
+        self.manifest_url = manifest_url
+        self.input_dir = Path(input_dir)
+        self.output_dir = Path(output_dir) / split_name
+        self.split_name = split_name
+        self.max_files = max_files
+        self.max_workers = max_workers
+        self.prefetch_depth = prefetch_depth
+
+    def run(self, **kwargs) -> Dict[str, int]:
+        """Execute the streaming conversion pipeline.
+
+        Returns:
+            Dict with 'files_processed', 'samples_written', 'shards_created',
+            'shards_skipped', 'files_failed'.
+        """
+        base_url, entries = fetch_manifest(self.manifest_url)
+
+        if self.max_files is not None:
+            entries = entries[: self.max_files]
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.input_dir.mkdir(parents=True, exist_ok=True)
+
+        total_files = len(entries)
+
+        logger.info("=" * 80)
+        logger.info(f"Streaming Arrow->WebDataset conversion: {self.split_name}")
+        logger.info(f"  Arrow files to process: {total_files}")
+        logger.info(f"  Output: {self.output_dir}")
+        logger.info(f"  Download workers: {self.max_workers}, " f"prefetch depth: {self.prefetch_depth}")
+        logger.info("=" * 80)
+
+        prefetch_q: queue.Queue[Union[Tuple[int, str, Path], None]] = queue.Queue()
+        download_semaphore = threading.Semaphore(self.prefetch_depth)
+        producer_error: List[BaseException] = []
+        cancel_event = threading.Event()
+
+        failed_files: List[Dict] = []
+        failed_lock = threading.Lock()
+
+        def _download_one(file_idx: int, md5: str, fname: str) -> Tuple[int, str, Path]:
+            file_url = f"{base_url}/{fname}"
+            # fname comes from a remote manifest; never let it traverse outside
+            # input_dir (e.g. "../../etc/passwd"). Use the basename and verify
+            # the resolved path stays under input_dir before writing.
+            safe_name = Path(fname).name
+            base_dir = self.input_dir.resolve()
+            arrow_path = (base_dir / safe_name).resolve()
+            if not safe_name or arrow_path.parent != base_dir:
+                raise ValueError(f"Unsafe manifest filename rejected: {fname!r}")
+            logger.info(f"  [download {file_idx + 1}/{total_files}] {fname}")
+            download_with_backoff(file_url, arrow_path, expected_md5=md5)
+            return file_idx, fname, arrow_path
+
+        skipped_count = [0]
+
+        def _producer() -> None:
+            """Submit downloads and drain results concurrently.
+
+            A separate drain thread processes completed futures in submission
+            order and feeds the prefetch queue.  The semaphore acquire in the
+            submit loop blocks when ``prefetch_depth`` files are already
+            in-flight or queued, bounding temporary disk usage.
+            """
+            try:
+                with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
+                    futures_q: queue.Queue = queue.Queue()
+
+                    def _drain() -> None:
+                        while True:
+                            item = futures_q.get()
+                            if item is _SENTINEL:
+                                break
+                            fut, file_idx, fname = item
+                            if cancel_event.is_set():
+                                download_semaphore.release()
+                                continue
+                            try:
+                                result = fut.result()
+                                prefetch_q.put(result)
+                            except Exception as exc:
+                                download_semaphore.release()
+                                logger.warning(
+                                    f"  [FAILED download " f"{file_idx + 1}/{total_files}] " f"{fname}: {exc}"
+                                )
+                                with failed_lock:
+                                    failed_files.append(
+                                        {
+                                            "file_idx": file_idx,
+                                            "filename": fname,
+                                            "error": str(exc),
+                                            "stage": "download",
+                                        }
+                                    )
+
+                    drain_thread = threading.Thread(target=_drain, daemon=True)
+                    drain_thread.start()
+
+                    for file_idx, (md5, fname) in enumerate(entries):
+                        if cancel_event.is_set():
+                            break
+                        tar_path = self.output_dir / f"shard_{file_idx:06d}.tar"
+                        if tar_path.exists():
+                            skipped_count[0] += 1
+                            logger.info(f"  [skip {file_idx + 1}/{total_files}] " f"{fname} (shard exists)")
+                            continue
+                        download_semaphore.acquire()
+                        fut = pool.submit(_download_one, file_idx, md5, fname)
+                        futures_q.put((fut, file_idx, fname))
+
+                    futures_q.put(_SENTINEL)
+                    drain_thread.join()
+            except BaseException as exc:
+                producer_error.append(exc)
+            finally:
+                prefetch_q.put(_SENTINEL)
+
+        producer_thread = threading.Thread(target=_producer, daemon=True)
+        producer_thread.start()
+
+        global_sample_offset = 0
+        total_samples = 0
+        files_processed = 0
+
+        try:
+            while True:
+                item = prefetch_q.get()
+                if item is _SENTINEL:
+                    break
+
+                file_idx, fname, arrow_path = item
+
+                shard_name = f"shard_{file_idx:06d}.tar"
+                tar_path = self.output_dir / shard_name
+
+                try:
+                    num_samples = _arrow_to_tar(arrow_path, tar_path, global_sample_offset)
+                except Exception as exc:
+                    logger.warning(f"  [FAILED convert {file_idx + 1}/{total_files}] " f"{fname}: {exc}")
+                    tar_path.unlink(missing_ok=True)
+                    arrow_path.unlink(missing_ok=True)
+                    download_semaphore.release()
+                    with failed_lock:
+                        failed_files.append(
+                            {
+                                "file_idx": file_idx,
+                                "filename": fname,
+                                "error": str(exc),
+                                "stage": "conversion",
+                            }
+                        )
+                    continue
+
+                global_sample_offset += num_samples
+                total_samples += num_samples
+                files_processed += 1
+
+                arrow_path.unlink(missing_ok=True)
+                download_semaphore.release()
+
+                logger.info(
+                    f"[{files_processed}/{total_files}] {fname} -> {shard_name}: "
+                    f"{num_samples} samples (cumulative: {total_samples})"
+                )
+        except BaseException:
+            cancel_event.set()
+            raise
+        finally:
+            producer_thread.join(timeout=10)
+
+        if producer_error:
+            raise RuntimeError(f"Download failed: {producer_error[0]}") from producer_error[0]
+
+        if failed_files:
+            manifest_path = self.output_dir / "failed_files.json"
+            manifest_path.write_text(json.dumps(failed_files, indent=2))
+            logger.warning(f"{len(failed_files)} file(s) failed. " f"See {manifest_path}")
+
+        skipped = skipped_count[0]
+        failed = len(failed_files)
+        logger.info("=" * 80)
+        logger.info(
+            f"Done {self.split_name}: {files_processed} new + {skipped} skipped"
+            f"{f' + {failed} failed' if failed else ''}"
+            f" -> {files_processed + skipped} shards, "
+            f"{total_samples} new samples"
+        )
+        logger.info("=" * 80)
+
+        return {
+            "files_processed": files_processed,
+            "samples_written": total_samples,
+            "shards_created": files_processed + skipped,
+            "shards_skipped": skipped,
+            "files_failed": failed,
+        }

--- a/primus/backends/megatron/data/diffusion/preprocessing/pipelines/raw.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/pipelines/raw.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Raw dataset preparation pipeline for Megatron diffusion models.
+
+Creates raw Energon WebDatasets with images and captions for on-the-fly
+encoding during training.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from ..utils import (
+    encode_image_to_bytes,
+    get_distributed_info,
+    preprocess_image,
+    save_to_webdataset,
+)
+
+logger = logging.getLogger(__name__)
+
+
+from .base import DatasetPipeline
+
+
+class RawDatasetPipeline(DatasetPipeline):
+    """
+    Pipeline for creating raw Energon WebDataset with images and captions.
+
+    This pipeline creates smaller datasets where encoding (VAE/T5/CLIP) happens
+    on-the-fly during training. Suitable for experimentation and when storage
+    is limited.
+
+    Args:
+        source_type: Type of input source ('directory', 'huggingface', 'webdataset')
+        output_dir: Output directory for Energon WebDataset
+        image_size: Target image size (default: 1024)
+        center_crop: Whether to center crop images (default: True)
+        image_format: Output image format (default: 'JPEG')
+        image_quality: JPEG/WEBP quality 1-100 (default: 95)
+        shard_size: Samples per shard (default: 1000)
+        max_samples: Maximum samples to process (default: None for all)
+        compress: Whether to compress tar files with gzip (default: False)
+        hf_token_file: Path to HuggingFace token file (default: None)
+        variable_size: If True, resize to nearest multiple of 16 instead of fixed size (default: False)
+        max_size: Maximum dimension when variable_size is True (default: 1024)
+
+    Example:
+        >>> pipeline = RawDatasetPipeline(
+        ...     source_type='huggingface',
+        ...     output_dir='/data/raw_pokemon',
+        ...     image_size=1024,
+        ...     center_crop=True,
+        ... )
+        >>> results = pipeline.run(
+        ...     hf_dataset='diffusers/pokemon-gpt4-captions',
+        ...     hf_split='train'
+        ... )
+        >>> print(f"Processed {results['samples_processed']} samples")
+    """
+
+    def __init__(
+        self,
+        source_type: str,
+        output_dir: str,
+        variable_size: bool = False,
+        image_size: int = 1024,
+        center_crop: bool = True,
+        max_size: int = 1024,
+        image_format: str = "JPEG",
+        image_quality: int = 95,
+        shard_size: int = 1000,
+        max_samples: Optional[int] = None,
+        compress: bool = False,
+        hf_token_file: Optional[str] = None,
+    ):
+        self.source_type = source_type
+        self.output_dir = Path(output_dir)
+        self.variable_size = variable_size
+        self.image_size = image_size
+        self.center_crop = center_crop
+        self.max_size = max_size
+        self.image_format = image_format
+        self.image_quality = image_quality
+        self.shard_size = shard_size
+        self.max_samples = max_samples
+        self.compress = compress
+
+        # Setup HF authentication if token file provided
+        if hf_token_file:
+            from ..auth import HFAuthError, setup_hf_authentication
+
+            try:
+                setup_hf_authentication(token_file=hf_token_file)
+            except HFAuthError as e:
+                raise ValueError(f"HuggingFace authentication failed: {e}")
+
+        # Get distributed info
+        self.rank, self.world_size = get_distributed_info()
+
+        # Determine output format extension
+        self.format_ext = {
+            "JPEG": "jpg",
+            "PNG": "png",
+            "WEBP": "webp",
+        }[self.image_format]
+
+        logger.info(f"Initialized RawDatasetPipeline (rank {self.rank}/{self.world_size})")
+        logger.info(f"Output directory: {self.output_dir}")
+        logger.info(f"Image preprocessing: size={self.image_size}, crop={self.center_crop}")
+
+    def process_sample(self, item):
+        """
+        Process a single sample.
+
+        Args:
+            item: Sample dict with 'image' (PIL Image) and 'caption' (str)
+
+        Returns:
+            Sample dict with image bytes and caption text
+        """
+        # Preprocess image
+        image = preprocess_image(
+            item["image"],
+            variable_size=self.variable_size,
+            size=self.image_size,
+            center_crop=self.center_crop,
+            max_size=self.max_size,
+        )
+
+        # Encode to bytes
+        image_bytes = encode_image_to_bytes(image, format=self.image_format, quality=self.image_quality)
+
+        # Create sample with standard keys
+        return {
+            self.format_ext: image_bytes,
+            "txt": item["caption"],
+        }
+
+    def run(self, **source_kwargs):
+        """
+        Execute the raw dataset preparation pipeline.
+
+        Args:
+            **source_kwargs: Source-specific arguments (passed to load_data)
+
+        Returns:
+            Dictionary with processing statistics:
+                - samples_processed: Number of samples successfully processed
+                - samples_skipped: Number of samples that failed
+                - shards_written: Number of output shards created
+        """
+        logger.info(f"Starting raw dataset preparation (rank {self.rank}/{self.world_size})")
+        logger.info(f"Source: {self.source_type}")
+
+        # Load data as a lazy iterator (never materialized in full)
+        data_iter = self.load_data(**source_kwargs)
+
+        if self.world_size > 1:
+            logger.info(
+                f"Distributed mode: rank {self.rank}/{self.world_size} "
+                f"processing every {self.world_size}th item (round-robin by load index)"
+            )
+
+        # Process and accumulate samples
+        samples = []
+        samples_processed = 0
+        samples_skipped = 0
+        shards_written = 0
+
+        # Stream items and assign them to ranks round-robin by global load
+        # index, so the full dataset is never held in memory. max_samples caps
+        # the GLOBAL index (total across ranks, not per-rank), preserving the
+        # prior semantics; the rank split changes from contiguous ranges to
+        # round-robin (same overall dataset, more balanced load). The index is
+        # assigned at load time, before process_sample, so the rank assignment
+        # stays deterministic even when samples are skipped.
+        for global_idx, item in enumerate(data_iter):
+            # Truthy check (not `is not None`) mirrors the original semantics
+            # where max_samples=0 / None meant "no limit".
+            if self.max_samples and global_idx >= self.max_samples:
+                break
+            if global_idx % self.world_size != self.rank:
+                continue
+            try:
+                sample = self.process_sample(item)
+                samples.append(sample)
+                samples_processed += 1
+
+                # Log progress
+                if samples_processed % 100 == 0:
+                    logger.info(f"Processed {samples_processed} samples (skipped {samples_skipped})")
+
+                # Save shard when full
+                if len(samples) >= self.shard_size:
+                    # Use distributed-aware shard naming to prevent conflicts
+                    shard_offset = shards_written * self.world_size + self.rank
+                    if self.world_size > 1 and shards_written == 0:
+                        logger.info(f"Rank {self.rank}: First shard will be numbered {shard_offset:06d}.tar")
+
+                    num_shards = save_to_webdataset(
+                        samples,
+                        str(self.output_dir),
+                        self.shard_size,
+                        shard_offset=shard_offset,
+                        compress=self.compress,
+                    )
+                    shards_written += num_shards
+                    samples = []
+
+            except Exception as e:
+                logger.warning(f"Failed to process sample {global_idx}: {e}")
+                samples_skipped += 1
+                continue
+
+        # Save remaining samples
+        if samples:
+            shard_offset = shards_written * self.world_size + self.rank
+            num_shards = save_to_webdataset(
+                samples,
+                str(self.output_dir),
+                self.shard_size,
+                shard_offset=shard_offset,
+                compress=self.compress,
+            )
+            shards_written += num_shards
+
+        return {
+            "samples_processed": samples_processed,
+            "samples_skipped": samples_skipped,
+            "shards_written": shards_written,
+        }

--- a/primus/backends/megatron/data/diffusion/preprocessing/utils.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/utils.py
@@ -1,0 +1,546 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Common utilities for dataset preprocessing.
+
+This module provides shared functionality for creating WebDataset shards
+from various input sources (HuggingFace Hub, directories, existing WebDatasets).
+"""
+
+import io
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+
+import torch
+import webdataset as wds
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+def get_distributed_info() -> Tuple[int, int]:
+    """
+    Get distributed processing information (rank, world_size).
+
+    Returns:
+        Tuple of (rank, world_size). Returns (0, 1) if not in distributed mode.
+
+    Example:
+        >>> rank, world_size = get_distributed_info()
+        >>> if rank == 0:
+        ...     print("This is the master process")
+    """
+    try:
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            rank = torch.distributed.get_rank()
+            world_size = torch.distributed.get_world_size()
+            return rank, world_size
+    except (ImportError, AttributeError):
+        pass
+
+    # Fallback to environment variables
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    return rank, world_size
+
+
+def split_work_for_rank(total: int, rank: int, world_size: int) -> Tuple[int, int]:
+    """
+    Calculate start/end indices for this rank in distributed processing.
+
+    Args:
+        total: Total number of items to process
+        rank: Current process rank (0 to world_size-1)
+        world_size: Total number of processes
+
+    Returns:
+        Tuple of (start_idx, end_idx) for this rank
+
+    Example:
+        >>> start, end = split_work_for_rank(1000, 0, 4)
+        >>> print(f"Process 0 handles items {start} to {end}")
+        Process 0 handles items 0 to 250
+    """
+    items_per_rank = total // world_size
+    start_idx = rank * items_per_rank
+
+    if rank == world_size - 1:
+        # Last rank gets all remaining items (including remainder)
+        end_idx = total
+    else:
+        end_idx = start_idx + items_per_rank
+
+    return start_idx, end_idx
+
+
+def save_to_webdataset(
+    samples: List[Dict[str, Any]],
+    output_dir: str,
+    shard_size: int,
+    shard_offset: int = 0,
+    compress: bool = False,
+) -> int:
+    """
+    Save samples to WebDataset tar shards.
+
+    Args:
+        samples: List of sample dictionaries with keys as extensions
+            Example: {'images': image_bytes, 'txt': caption_text}
+        output_dir: Directory to save shards
+        shard_size: Number of samples per shard
+        shard_offset: Starting shard number (for distributed processing)
+        compress: Whether to compress tar files (gzip)
+
+    Returns:
+        Number of shards created
+
+    Example:
+        >>> samples = [
+        ...     {'images': image_bytes, 'txt': 'a cat'},
+        ...     {'images': image_bytes2, 'txt': 'a dog'},
+        ... ]
+        >>> num_shards = save_to_webdataset(samples, '/path/to/output', shard_size=1000)
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Calculate number of shards needed
+    num_shards = (len(samples) + shard_size - 1) // shard_size
+
+    for shard_idx in range(num_shards):
+        start_idx = shard_idx * shard_size
+        end_idx = min(start_idx + shard_size, len(samples))
+        shard_samples = samples[start_idx:end_idx]
+
+        # Create shard filename
+        shard_num = shard_offset + shard_idx
+        ext = ".tar.gz" if compress else ".tar"
+        shard_path = os.path.join(output_dir, f"{shard_num:06d}{ext}")
+
+        # Write shard
+        with wds.TarWriter(shard_path) as sink:
+            for sample_idx, sample in enumerate(shard_samples):
+                # Generate unique key for this sample
+                key = f"{shard_num:06d}_{sample_idx:06d}"
+
+                # Create WebDataset sample dict
+                wds_sample = {"__key__": key}
+
+                for ext, data in sample.items():
+                    if ext.startswith("__"):
+                        continue  # Skip special keys
+
+                    # Handle different data types
+                    if isinstance(data, bytes):
+                        wds_sample[ext] = data
+                    elif isinstance(data, str):
+                        wds_sample[ext] = data.encode("utf-8")
+                    elif isinstance(data, torch.Tensor):
+                        # Save tensor to bytes
+                        buffer = io.BytesIO()
+                        torch.save(data, buffer)
+                        wds_sample[ext] = buffer.getvalue()
+                    elif isinstance(data, Image.Image):
+                        # Save PIL image to bytes
+                        buffer = io.BytesIO()
+                        data.save(buffer, format="JPEG")
+                        wds_sample[ext] = buffer.getvalue()
+                    else:
+                        logger.warning(f"Unknown data type for key {ext}: {type(data)}")
+                        continue
+
+                sink.write(wds_sample)
+
+        logger.info(f"Created shard {shard_path} with {len(shard_samples)} samples")
+
+    return num_shards
+
+
+# Default keys to try when loading from HuggingFace if not specified in config
+DEFAULT_IMAGE_KEYS = ["image", "jpg", "jpeg", "png", "img", "photo"]
+DEFAULT_CAPTION_KEYS = ["caption", "text", "txt", "description", "prompt"]
+
+
+def _extract_field(item: dict, field_keys: List[str], idx: int, field_type: str) -> Any:
+    """
+    Extract field from item using list of possible keys.
+    Supports dot notation for JSON paths (e.g., 'json.caption').
+
+    Args:
+        item: Dataset sample dictionary
+        field_keys: List of keys to try (e.g., ['caption', 'json.caption'])
+        idx: Sample index (for logging)
+        field_type: 'image' or 'caption' (currently unused)
+
+    Returns:
+        Field value if found, None otherwise
+
+    Example:
+        >>> item = {'jpg': image_bytes, 'json': {'caption': 'a cat'}}
+        >>> _extract_field(item, ['caption', 'json.caption'], 0, 'caption')
+        'a cat'
+    """
+    for key in field_keys:
+        if "." in key:
+            # Handle JSON path (e.g., 'json.caption')
+            value = _extract_json_path(item, key, idx)
+            if value is not None:
+                return value
+        elif key in item:
+            return item[key]
+    return None
+
+
+def _extract_json_path(item: dict, path: str, idx: int) -> Any:
+    """
+    Extract value from nested JSON using dot notation.
+
+    Args:
+        item: Dataset sample dictionary
+        path: Dot-separated path (e.g., 'json.metadata.caption')
+        idx: Sample index (for logging)
+
+    Returns:
+        Extracted value if found, None otherwise
+
+    Example:
+        >>> item = {'json': b'{"caption": "a cat"}'}
+        >>> _extract_json_path(item, 'json.caption', 0)
+        'a cat'
+    """
+    import json as json_module
+
+    parts = path.split(".")
+    current = item
+
+    for i, part in enumerate(parts):
+        if part not in current:
+            return None
+
+        current = current[part]
+
+        # If we hit a JSON string/bytes at any level, parse it
+        if isinstance(current, (bytes, str)):
+            try:
+                if isinstance(current, bytes):
+                    current = json_module.loads(current.decode("utf-8"))
+                elif isinstance(current, str) and (current.startswith("{") or current.startswith("[")):
+                    current = json_module.loads(current)
+            except Exception as e:
+                logger.debug(f"Sample {idx} failed to parse JSON at '{part}': {e}")
+                return None
+
+    return current if isinstance(current, (str, int, float)) else None
+
+
+def load_from_huggingface(
+    dataset_name: str,
+    split: str = "train",
+    streaming: bool = True,
+    data_files: Optional[Union[str, List[str]]] = None,
+    image_key: Optional[str] = None,
+    caption_key: Optional[str] = None,
+    image_keys: Optional[List[str]] = None,
+    caption_keys: Optional[List[str]] = None,
+) -> Iterator[Dict[str, Any]]:
+    """
+    Load dataset from HuggingFace Hub with configurable field mappings.
+
+    Args:
+        dataset_name: HF dataset identifier (e.g., 'laion/laion400m')
+        split: Dataset split to load
+        streaming: Whether to stream the dataset (recommended for large datasets)
+        data_files: Specific files/paths to load from the dataset (e.g., 'data_1024_10K/*.tar')
+        image_key: Single image field name (e.g., 'jpg', 'image')
+        caption_key: Single caption field or JSON path (e.g., 'caption', 'json.caption')
+        image_keys: List of image field names to try (fallback to defaults if None)
+        caption_keys: List of caption fields/paths to try (fallback to defaults if None)
+
+    Yields:
+        Dicts with 'image' (PIL Image) and 'caption' (str) keys
+
+    Example:
+        >>> # Load with auto-detection (uses defaults)
+        >>> for item in load_from_huggingface('diffusers/pokemon-gpt4-captions'):
+        ...     print(f"Caption: {item['caption']}")
+
+        >>> # Load with specific field mappings
+        >>> for item in load_from_huggingface(
+        ...     'jackyhate/text-to-image-2M',
+        ...     image_key='jpg',
+        ...     caption_key='json.caption',
+        ...     data_files='data_1024_10K/*.tar'
+        ... ):
+        ...     print(f"Caption: {item['caption']}")
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        raise ImportError(
+            "The 'datasets' package is required for HuggingFace dataset loading. "
+            "Install with: pip install datasets"
+        )
+
+    if data_files:
+        logger.info(f"Loading HuggingFace dataset: {dataset_name} (split: {split}, data_files: {data_files})")
+    else:
+        logger.info(f"Loading HuggingFace dataset: {dataset_name} (split: {split})")
+
+    dataset = load_dataset(dataset_name, split=split, streaming=streaming, data_files=data_files)
+
+    # Determine which keys to try
+    if image_keys is None:
+        image_keys = [image_key] if image_key else DEFAULT_IMAGE_KEYS
+    if caption_keys is None:
+        caption_keys = [caption_key] if caption_key else DEFAULT_CAPTION_KEYS
+
+    for idx, item in enumerate(dataset):
+        # Try to extract image using configured keys
+        image = _extract_field(item, image_keys, idx, "image")
+
+        # Try to extract caption using configured keys (supports JSON paths)
+        caption = _extract_field(item, caption_keys, idx, "caption")
+
+        if isinstance(caption, list):
+            caption = caption[0] if caption else None
+
+        if image is None or caption is None:
+            logger.warning(f"Sample {idx} missing image or caption, skipping. Keys: {item.keys()}")
+            continue
+
+        # Ensure image is PIL Image
+        if not isinstance(image, Image.Image):
+            try:
+                if isinstance(image, bytes):
+                    image = Image.open(io.BytesIO(image))
+                else:
+                    logger.warning(f"Sample {idx} has unexpected image type: {type(image)}")
+                    continue
+            except Exception as e:
+                logger.warning(f"Sample {idx} failed to load image: {e}")
+                continue
+
+        yield {
+            "image": image,
+            "caption": caption,
+        }
+
+
+def load_from_directory(input_dir: str) -> Iterator[Dict[str, Any]]:
+    """
+    Load dataset from directory structure.
+
+    Expected structure:
+        input_dir/
+            images/
+                0000000.jpg
+                0000001.jpg
+            captions/
+                0000000.txt
+                0000001.txt
+
+    Args:
+        input_dir: Root directory containing 'images' and 'captions' subdirectories
+
+    Yields:
+        Dicts with 'image' (PIL Image) and 'caption' (str) keys
+
+    Example:
+        >>> for item in load_from_directory('/path/to/dataset'):
+        ...     print(f"Caption: {item['caption']}")
+    """
+    input_path = Path(input_dir)
+    images_dir = input_path / "images"
+    captions_dir = input_path / "captions"
+
+    if not images_dir.exists():
+        raise ValueError(f"Images directory not found: {images_dir}")
+
+    if not captions_dir.exists():
+        raise ValueError(f"Captions directory not found: {captions_dir}")
+
+    logger.info(f"Loading dataset from directory: {input_dir}")
+
+    # Find all image files
+    image_extensions = [".jpg", ".jpeg", ".png", ".webp"]
+    image_files = []
+    for ext in image_extensions:
+        image_files.extend(sorted(images_dir.glob(f"*{ext}")))
+
+    logger.info(f"Found {len(image_files)} image files")
+
+    for img_path in image_files:
+        # Find corresponding caption file
+        caption_path = captions_dir / f"{img_path.stem}.txt"
+
+        if not caption_path.exists():
+            logger.warning(f"Caption not found for {img_path.name}, skipping")
+            continue
+
+        try:
+            # Load image
+            image = Image.open(img_path).convert("RGB")
+
+            # Load caption
+            with open(caption_path, "r", encoding="utf-8") as f:
+                caption = f.read().strip()
+
+            yield {
+                "image": image,
+                "caption": caption,
+            }
+
+        except Exception as e:
+            logger.warning(f"Failed to load {img_path.name}: {e}")
+            continue
+
+
+def load_from_webdataset(input_path: str) -> Iterator[Dict[str, Any]]:
+    """
+    Load existing WebDataset with non-standard keys.
+
+    Converts to standard format {'image': PIL Image, 'caption': str}
+
+    Args:
+        input_path: Path or glob pattern to WebDataset tar files
+            Examples: '/path/to/shards/*.tar', '/path/to/shard_000000.tar'
+
+    Yields:
+        Dicts with 'image' (PIL Image) and 'caption' (str) keys
+
+    Example:
+        >>> for item in load_from_webdataset('/path/to/dataset/*.tar'):
+        ...     print(f"Caption: {item['caption']}")
+    """
+    logger.info(f"Loading WebDataset from: {input_path}")
+
+    dataset = wds.WebDataset(input_path)
+
+    for sample in dataset:
+        try:
+            # Try to find image with various keys
+            image = None
+            for img_key in ["jpg", "png", "jpeg", "webp", "image"]:
+                if img_key in sample:
+                    img_data = sample[img_key]
+                    if isinstance(img_data, bytes):
+                        image = Image.open(io.BytesIO(img_data)).convert("RGB")
+                    elif isinstance(img_data, Image.Image):
+                        image = img_data.convert("RGB")
+                    else:
+                        continue
+                    break
+
+            # Try to find caption with various keys
+            caption = None
+            for cap_key in ["txt", "caption.txt", "text", "caption"]:
+                if cap_key in sample:
+                    cap_data = sample[cap_key]
+                    if isinstance(cap_data, bytes):
+                        caption = cap_data.decode("utf-8")
+                    elif isinstance(cap_data, str):
+                        caption = cap_data
+                    else:
+                        continue
+                    break
+
+            if image is None or caption is None:
+                logger.warning(f"Sample missing image or caption, skipping. Keys: {sample.keys()}")
+                continue
+
+            yield {
+                "image": image,
+                "caption": caption,
+            }
+
+        except Exception as e:
+            logger.warning(f"Failed to load sample: {e}")
+            continue
+
+
+def preprocess_image(
+    image: Image.Image,
+    variable_size: bool = True,  # if True, then image is resized to the nearest multiple of 16, otherwise it is resized to the given size
+    size: int = 1024,  # only used if variable_size is False, then this is applied
+    center_crop: bool = False,  # only used if variable_size is False, then this is applied
+    max_size: int = 1024,  # maximum dimension when variable_size is True
+) -> Image.Image:
+    """
+    Preprocess image (resize, crop).
+
+    Args:
+        image: PIL Image
+        variable_size: If True, resize to nearest multiple of 16 up to max_size
+        size: Target size (square) - only used if variable_size is False
+        center_crop: Whether to center crop before resize - only used if variable_size is False
+        max_size: Maximum dimension when variable_size is True (default: 1024)
+
+    Returns:
+        Preprocessed PIL Image
+
+    Example:
+        >>> image = Image.open('photo.jpg')
+        >>> processed = preprocess_image(image, variable_size=True, max_size=2048)
+    """
+    # Center crop if requested
+    if center_crop and variable_size is False:
+        width, height = image.size
+        crop_size = min(width, height)
+        left = (width - crop_size) // 2
+        top = (height - crop_size) // 2
+        right = left + crop_size
+        bottom = top + crop_size
+        image = image.crop((left, top, right, bottom))
+
+    # Resize
+    if variable_size is False:
+        image = image.resize((size, size), Image.Resampling.LANCZOS)
+    else:
+        width, height = image.size
+        if max(width, height) > max_size:
+            scale = max_size / float(max(width, height))
+            new_w = int(round(width * scale))
+            new_h = int(round(height * scale))
+            # High-quality downsampling
+            image = image.resize((new_w, new_h), resample=Image.Resampling.LANCZOS)
+
+        width, height = image.size
+        new_size = (round(width / 16) * 16, round(height / 16) * 16)
+        image = image.resize(new_size, Image.LANCZOS)
+
+    return image
+
+
+def encode_image_to_bytes(image: Image.Image, format: str = "JPEG", quality: int = 95) -> bytes:
+    """
+    Encode PIL Image to bytes.
+
+    Args:
+        image: PIL Image
+        format: Image format ('JPEG', 'PNG', 'WEBP')
+        quality: JPEG/WEBP quality (1-100)
+
+    Returns:
+        Image bytes
+
+    Example:
+        >>> image = Image.open('photo.jpg')
+        >>> image_bytes = encode_image_to_bytes(image, format='JPEG', quality=95)
+    """
+    buffer = io.BytesIO()
+    image.save(buffer, format=format, quality=quality)
+    return buffer.getvalue()
+
+
+__all__ = [
+    "get_distributed_info",
+    "split_work_for_rank",
+    "save_to_webdataset",
+    "load_from_huggingface",
+    "load_from_directory",
+    "load_from_webdataset",
+    "preprocess_image",
+    "encode_image_to_bytes",
+]

--- a/primus/backends/megatron/data/diffusion/preprocessing/validate.py
+++ b/primus/backends/megatron/data/diffusion/preprocessing/validate.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Energon dataset validation for Primus diffusion pipelines.
+
+Validates that a prepared Energon WebDataset is structurally correct and
+loadable by the training code. Replaces the broken ``energon info`` CLI
+tool which does not support CrudeWebdataset format.
+
+Standalone usage:
+    python -m primus.backends.megatron.data.diffusion.preprocessing.validate /path/to/dataset
+
+Programmatic usage:
+    from primus.backends.megatron.data.diffusion.preprocessing.validate import (
+        validate_energon_dataset,
+    )
+    validate_energon_dataset('/path/to/dataset', encoding='preencoded')
+"""
+
+import json
+import logging
+import tarfile
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+import torch
+import yaml
+
+logger = logging.getLogger(__name__)
+
+EXPECTED_KEYS_PREENCODED = {"latents.pth", "prompt_embeds.pth", "pooled_prompt_embeds.pth"}
+EXPECTED_KEYS_PREENCODED_NUMPY = {"t5.bytes", "clip.bytes", "mean.bytes", "logvar.bytes"}
+EXPECTED_KEYS_RAW_IMAGE = {"jpg", "jpeg", "png", "webp"}
+
+
+def _check_metadata(output_path: Path) -> Optional[Dict]:
+    """Check that .nv-meta files exist and are valid. Returns info dict or None."""
+    meta_dir = output_path / ".nv-meta"
+
+    info_path = meta_dir / ".info.json"
+    if not info_path.exists():
+        info_path_yaml = meta_dir / ".info.yaml"
+        if info_path_yaml.exists():
+            info_path = info_path_yaml
+        else:
+            logger.error(f"Missing metadata: neither .info.json nor .info.yaml in {meta_dir}")
+            return None
+
+    try:
+        with open(info_path) as f:
+            if info_path.suffix == ".json":
+                info = json.load(f)
+            else:
+                info = yaml.safe_load(f)
+    except Exception as e:
+        logger.error(f"Failed to parse {info_path}: {e}")
+        return None
+
+    if "shard_counts" not in info:
+        logger.error(f"Missing 'shard_counts' in {info_path}")
+        return None
+
+    split_path = meta_dir / "split.yaml"
+    if not split_path.exists():
+        split_path = meta_dir / "split.json"
+    if not split_path.exists():
+        logger.error(f"Missing split config in {meta_dir}")
+        return None
+
+    try:
+        with open(split_path) as f:
+            splits = yaml.safe_load(f) if split_path.suffix == ".yaml" else json.load(f)
+    except Exception as e:
+        logger.error(f"Failed to parse {split_path}: {e}")
+        return None
+
+    train_parts = splits.get("split_parts", {}).get("train", [])
+    if not train_parts:
+        logger.warning("Train split is empty")
+
+    dataset_yaml = meta_dir / "dataset.yaml"
+    if not dataset_yaml.exists():
+        logger.error(f"Missing {dataset_yaml}")
+        return None
+
+    missing_files: List[str] = []
+    for shard_name in info["shard_counts"]:
+        if not (output_path / shard_name).exists():
+            missing_files.append(shard_name)
+        idx_name = shard_name + ".idx"
+        if not (output_path / idx_name).exists():
+            missing_files.append(idx_name)
+
+    if missing_files:
+        logger.error(f"Missing files on disk: {missing_files[:10]}")
+        return None
+
+    info["_splits"] = splits
+    return info
+
+
+def _check_sample_counts(output_path: Path, info: Dict) -> bool:
+    """Spot-check that the first shard's entry count matches .info.json."""
+    shard_counts = info["shard_counts"]
+    first_shard = next(iter(shard_counts))
+    expected = shard_counts[first_shard]
+
+    tar_path = output_path / first_shard
+    try:
+        with tarfile.open(str(tar_path), "r") as tar:
+            members = tar.getmembers()
+            sample_keys = set()
+            for m in members:
+                key = m.name.split(".", 1)[0]
+                sample_keys.add(key)
+            actual = len(sample_keys)
+    except Exception as e:
+        logger.error(f"Failed to read {tar_path}: {e}")
+        return False
+
+    if actual != expected:
+        logger.error(
+            f"Sample count mismatch in {first_shard}: " f".info.json says {expected}, tar contains {actual}"
+        )
+        return False
+
+    return True
+
+
+def _check_sample_load(
+    output_path: Path,
+    encoding: str,
+) -> Optional[Dict[str, str]]:
+    """
+    Load one sample through energon's Python API (same path as training).
+    Returns a dict of {key: description} for the sample, or None on failure.
+    """
+    try:
+        from megatron.energon import StandardWebdatasetFactory
+        from megatron.energon.dataset_config import load_config
+        from megatron.energon.epathlib import EPath
+        from megatron.energon.flavors.webdataset.config import MAIN_FOLDER_NAME
+        from megatron.energon.loader import get_loader
+        from megatron.energon.worker import WorkerConfig
+    except ImportError as e:
+        logger.warning(f"Cannot import megatron.energon for sample validation: {e}")
+        return None
+
+    try:
+        ds_path = EPath(str(output_path))
+        worker_config = WorkerConfig(rank=0, world_size=1, num_workers=0)
+        dataset = load_config(
+            ds_path / MAIN_FOLDER_NAME / "dataset.yaml",
+            default_kwargs=dict(
+                path=ds_path,
+                split_part="train",
+                training=False,
+                worker_config=worker_config,
+            ),
+            default_type=StandardWebdatasetFactory,
+        )
+        sample = next(iter(get_loader(dataset.build())))
+    except Exception as e:
+        logger.error(f"Failed to load sample via energon API: {e}")
+        return None
+
+    data_keys = [k for k in sample.keys() if not k.startswith("_")]
+
+    if encoding == "preencoded":
+        missing = EXPECTED_KEYS_PREENCODED - set(data_keys)
+        if missing:
+            logger.error(f"Sample missing expected keys for preencoded data: {missing}")
+            return None
+    elif encoding == "preencoded_numpy":
+        missing = EXPECTED_KEYS_PREENCODED_NUMPY - set(data_keys)
+        if missing:
+            logger.error(f"Sample missing expected keys for preencoded_numpy data: {missing}")
+            return None
+    elif encoding == "raw":
+        has_image = any(k in EXPECTED_KEYS_RAW_IMAGE for k in data_keys)
+        has_text = "txt" in data_keys
+        if not has_image or not has_text:
+            logger.error(f"Raw sample missing image or text key. Got: {data_keys}")
+            return None
+
+    descriptions = {}
+    for key in sorted(data_keys):
+        val = sample[key]
+        if isinstance(val, torch.Tensor):
+            descriptions[key] = f"shape={tuple(val.shape)}, dtype={val.dtype}"
+        elif isinstance(val, bytes):
+            descriptions[key] = f"bytes, len={len(val)}"
+        else:
+            descriptions[key] = f"{type(val).__name__}"
+
+    return descriptions
+
+
+def validate_energon_dataset(
+    output_dir: str,
+    encoding: Literal["preencoded", "preencoded_numpy", "raw"] = "preencoded",
+) -> bool:
+    """
+    Validate a prepared Energon WebDataset.
+
+    Performs four checks:
+      1. Metadata files (.info.json, split.yaml, dataset.yaml) are present and valid
+      2. Sample count in .info.json matches actual tar contents (spot-check)
+      3. One sample loads successfully through energon's Python API
+      4. Prints a structured summary of the dataset
+
+    Args:
+        output_dir: Path to the dataset directory
+        encoding: Expected encoding ('preencoded', 'preencoded_numpy', or 'raw')
+
+    Returns:
+        True if all checks pass, False otherwise.
+    """
+    output_path = Path(output_dir)
+    passed = True
+
+    logger.info("Validating dataset...")
+
+    # --- Check 1: metadata ---
+    info = _check_metadata(output_path)
+    if info is None:
+        logger.error("  Metadata check FAILED")
+        return False
+    logger.info("  Metadata check passed")
+
+    # --- Check 2: sample counts ---
+    if not _check_sample_counts(output_path, info):
+        logger.error("  Sample count check FAILED")
+        passed = False
+    else:
+        logger.info("  Sample count check passed")
+
+    # --- Check 3: load one sample via energon API ---
+    descriptions = _check_sample_load(output_path, encoding)
+    if descriptions is None:
+        logger.error("  Sample load check FAILED")
+        passed = False
+    else:
+        logger.info("  Sample load check passed")
+
+    # --- Check 4: summary ---
+    shard_counts = info["shard_counts"]
+    total_samples = sum(shard_counts.values())
+    num_shards = len(shard_counts)
+
+    splits = info.get("_splits", {}).get("split_parts", {})
+    split_summary = ", ".join(
+        (
+            f"{name}={len(shards)}"
+            if isinstance(shards, list) and not any("{" in s for s in shards)
+            else f"{name}={'non-empty' if shards else 'empty'}"
+        )
+        for name, shards in splits.items()
+    )
+
+    total_bytes = sum(f.stat().st_size for f in output_path.glob("**/*.tar"))
+    size_gb = total_bytes / (1024**3)
+
+    logger.info("  " + "-" * 40)
+    logger.info(f"  Encoding:       {encoding}")
+    logger.info(f"  Total samples:  {total_samples} across {num_shards} shard(s)")
+    logger.info(f"  Splits:         {split_summary}")
+    if descriptions:
+        logger.info("  Spot check:")
+        for key, desc in descriptions.items():
+            logger.info(f"    {key}: {desc}")
+    logger.info(f"  Dataset size:   {size_gb:.2f} GB")
+
+    if passed:
+        logger.info("✓ Dataset verified and ready for training")
+    else:
+        logger.warning("Dataset has issues — see errors above")
+
+    return passed
+
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Validate a Primus Energon WebDataset",
+    )
+    parser.add_argument("dataset_path", help="Path to the dataset directory")
+    parser.add_argument(
+        "--encoding",
+        choices=["preencoded", "preencoded_numpy", "raw"],
+        default="preencoded",
+        help="Expected encoding type (default: preencoded)",
+    )
+    args = parser.parse_args()
+
+    ok = validate_energon_dataset(args.dataset_path, encoding=args.encoding)
+    sys.exit(0 if ok else 1)

--- a/primus/cli/main.py
+++ b/primus/cli/main.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -34,6 +34,7 @@ except ModuleNotFoundError:
 
 import argparse
 import importlib
+import logging
 import pkgutil
 import traceback
 from typing import Callable, Dict, Iterable, Optional, Set
@@ -148,6 +149,8 @@ def main():
       ...
     """
     _ensure_project_root_on_path()
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
+    logging.getLogger("primus").setLevel(logging.INFO)
     parser = argparse.ArgumentParser(
         prog="primus",
         description="Primus Unified CLI for Training & Utilities",

--- a/primus/cli/subcommands/data.py
+++ b/primus/cli/subcommands/data.py
@@ -1,0 +1,950 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Dataset preparation subcommands for Megatron backend diffusion training.
+
+Provides tools to prepare datasets in Energon WebDataset format specifically
+for diffusion models using the Megatron backend.
+
+Commands:
+    primus data diffusion-raw      - Prepare raw Energon WebDataset
+    primus data diffusion-encoded  - Prepare pre-encoded Energon WebDataset
+    primus data diffusion-ingest   - Stream pre-encoded Arrow data into WebDataset
+
+Supports torch.distributed for multi-GPU processing:
+    torchrun --nproc_per_node=8 primus data diffusion-raw ...
+"""
+
+import argparse
+import logging
+
+from primus.backends.megatron.data.diffusion.preprocessing.auth import (
+    HFAuthError,
+    setup_hf_authentication,
+)
+from primus.backends.megatron.data.diffusion.preprocessing.pipelines.encoded import (
+    EncodedDatasetPipeline,
+)
+from primus.backends.megatron.data.diffusion.preprocessing.pipelines.raw import (
+    RawDatasetPipeline,
+)
+from primus.tools.utils import finalize_distributed, init_distributed
+
+logger = logging.getLogger(__name__)
+
+
+def _add_common_args(parser):
+    """Add arguments common to all data preparation commands."""
+    # Source configuration
+    source_group = parser.add_argument_group("Source Configuration")
+    source_group.add_argument(
+        "--source-type",
+        required=False,
+        choices=["directory", "huggingface", "webdataset"],
+        help="Type of input data source (required, can be set via --config)",
+    )
+    source_group.add_argument("--input-dir", type=str, help="Input directory (for directory source)")
+    source_group.add_argument("--hf-dataset", type=str, help="HuggingFace dataset name (for HF source)")
+    source_group.add_argument(
+        "--hf-split", type=str, default="train", help="HuggingFace dataset split (default: train)"
+    )
+    source_group.add_argument(
+        "--hf-data-files",
+        type=str,
+        default=None,
+        help='Specific files/paths within HF dataset (e.g., "data_1024_10K/*.tar")',
+    )
+    source_group.add_argument("--input-path", type=str, help="WebDataset path/glob (for webdataset source)")
+
+    # Output configuration (Energon format)
+    output_group = parser.add_argument_group("Output Configuration (Energon WebDataset)")
+    output_group.add_argument(
+        "--output-dir",
+        required=False,
+        help="Output directory for Energon WebDataset (required, can be set via --config)",
+    )
+    output_group.add_argument(
+        "--shard-size", type=int, default=1000, help="Samples per shard (default: 1000)"
+    )
+    output_group.add_argument(
+        "--max-samples", type=int, default=None, help="Maximum samples to process (default: all)"
+    )
+    output_group.add_argument("--compress", action="store_true", help="Compress tar files with gzip")
+
+    # Image preprocessing
+    image_group = parser.add_argument_group("Image Preprocessing")
+    image_group.add_argument(
+        "--variable-size",
+        action="store_true",
+        help="Resize images to the nearest multiple of 16 instead of fixed size",
+    )
+    image_group.add_argument(
+        "--image-size",
+        type=int,
+        default=1024,
+        help="Resize images to this size (default: 1024) when variable_size is disabled",
+    )
+    image_group.add_argument(
+        "--center-crop", action="store_false", help="Disable center cropping of images before resize"
+    )
+    image_group.add_argument(
+        "--max-size",
+        type=int,
+        default=1024,
+        help="Maximum image dimension for variable size mode (default: 1024)",
+    )
+
+    # HuggingFace Authentication
+    auth_group = parser.add_argument_group("HuggingFace Authentication")
+    auth_group.add_argument(
+        "--hf-token-file",
+        type=str,
+        default=None,
+        help=(
+            "Path to file containing HuggingFace token. "
+            "File must have secure permissions (600 or 400). "
+            "If not provided, falls back to HF_TOKEN env variable "
+            "or HF CLI login (~/.cache/huggingface/token)."
+        ),
+    )
+
+    return parser
+
+
+def _validate_source_args(args):
+    """Validate that required source arguments are provided."""
+    if args.source_type == "directory" and not args.input_dir:
+        raise ValueError("--input-dir required for directory source")
+    if args.source_type == "huggingface" and not args.hf_dataset:
+        raise ValueError("--hf-dataset required for huggingface source")
+    if args.source_type == "webdataset" and not args.input_path:
+        raise ValueError("--input-path required for webdataset source")
+
+
+def _prepare_raw(args):
+    """Prepare raw Energon WebDataset for on-the-fly encoding during training."""
+    # Initialize torch.distributed if launched with torchrun
+    init_distributed()
+
+    try:
+        _validate_source_args(args)
+
+        # Setup HF authentication
+        try:
+            setup_hf_authentication(token_file=getattr(args, "hf_token_file", None))
+        except HFAuthError as e:
+            logger.error(f"Authentication failed: {e}")
+            raise
+
+        logger.info("=" * 80)
+        logger.info("Megatron Diffusion: Raw Energon WebDataset Preparation")
+        logger.info("=" * 80)
+
+        pipeline = RawDatasetPipeline(
+            source_type=args.source_type,
+            output_dir=args.output_dir,
+            variable_size=args.variable_size,
+            image_size=args.image_size,
+            center_crop=args.center_crop,
+            max_size=args.max_size,
+            image_format=getattr(args, "image_format", "JPEG"),
+            image_quality=getattr(args, "image_quality", 95),
+            shard_size=args.shard_size,
+            max_samples=args.max_samples,
+            compress=args.compress,
+        )
+
+        source_kwargs = {}
+        if args.source_type == "directory":
+            source_kwargs["input_dir"] = args.input_dir
+        elif args.source_type == "huggingface":
+            source_kwargs["hf_dataset"] = args.hf_dataset
+            source_kwargs["hf_split"] = args.hf_split
+            source_kwargs["hf_data_files"] = getattr(args, "hf_data_files", None)
+            # Add data format configuration
+            source_kwargs["image_key"] = getattr(args, "image_key", None)
+            source_kwargs["caption_key"] = getattr(args, "caption_key", None)
+            source_kwargs["image_keys"] = getattr(args, "image_keys", None)
+            source_kwargs["caption_keys"] = getattr(args, "caption_keys", None)
+        elif args.source_type == "webdataset":
+            source_kwargs["input_path"] = args.input_path
+
+        results = pipeline.run(**source_kwargs)
+
+        logger.info("=" * 80)
+        logger.info("✓ Raw Energon WebDataset preparation complete!")
+        logger.info(f"  Samples processed: {results['samples_processed']}")
+        logger.info(f"  Samples skipped: {results['samples_skipped']}")
+        logger.info(f"  Shards created: {results['shards_written']}")
+        logger.info(f"  Output: {args.output_dir}")
+        logger.info(f"  Format: Raw Energon WebDataset (images + captions)")
+        logger.info(f"  Note: Encoding will be done on-the-fly during training")
+        logger.info("=" * 80)
+
+        # Finalize dataset unless --no-finalize was passed
+        if not getattr(args, "no_finalize", False):
+            # Import distributed utilities
+            import torch.distributed as dist
+
+            # Wait for all ranks to complete data preparation
+            if dist.is_initialized():
+                logger.info("Waiting for all ranks to complete...")
+                dist.barrier()
+
+            # Only rank 0 runs finalization
+            should_finalize = not dist.is_initialized() or dist.get_rank() == 0
+
+            if should_finalize:
+                from primus.backends.megatron.data.diffusion.preprocessing.finalize import (
+                    finalize_energon_dataset,
+                )
+
+                try:
+                    finalize_energon_dataset(
+                        output_dir=args.output_dir,
+                        train_split=getattr(args, "train_split", 1.0),
+                        encoding="raw",
+                        num_workers=8,
+                    )
+                except Exception as e:
+                    logger.error(f"Finalization failed: {e}")
+                    raise
+
+            # Wait again so all ranks exit together
+            if dist.is_initialized():
+                dist.barrier()
+
+    finally:
+        # Clean up distributed
+        finalize_distributed()
+
+
+def _flatten_preprocessing_config(config_dict: dict) -> dict:
+    """
+    Flatten nested YAML config to match CLI argument structure.
+
+    Transforms hierarchical YAML structure into flat dict matching argparse namespace.
+
+    Args:
+        config_dict: Nested config from YAML file
+
+    Returns:
+        Flattened dict with CLI argument names as keys
+
+    Example:
+        >>> config = {
+        ...     'source': {'type': 'huggingface', 'hf_dataset': 'pokemon'},
+        ...     'model': {'batch_size': 8}
+        ... }
+        >>> flat = _flatten_preprocessing_config(config)
+        >>> flat['source_type'], flat['batch_size']
+        ('huggingface', 8)
+    """
+    flat = {}
+
+    # Source configuration
+    if "source" in config_dict:
+        source = config_dict["source"]
+        flat["source_type"] = source.get("type")
+        flat["hf_dataset"] = source.get("hf_dataset")
+        flat["hf_split"] = source.get("hf_split", "train")
+        flat["hf_data_files"] = source.get("hf_data_files")
+        flat["input_dir"] = source.get("input_dir")
+        flat["input_path"] = source.get("input_path")
+
+    # Data format configuration (field mappings for image/caption extraction)
+    if "data_format" in config_dict:
+        data_format = config_dict["data_format"]
+        flat["image_key"] = data_format.get("image_key")
+        flat["caption_key"] = data_format.get("caption_key")
+        flat["image_keys"] = data_format.get("image_keys")
+        flat["caption_keys"] = data_format.get("caption_keys")
+
+    # Output configuration
+    if "output" in config_dict:
+        output = config_dict["output"]
+        flat["output_dir"] = output.get("output_dir")
+        flat["shard_size"] = output.get("shard_size", 1000)
+        flat["max_samples"] = output.get("max_samples")
+        flat["compress"] = output.get("compress", False)
+
+    # Model configuration
+    if "model" in config_dict:
+        model = config_dict["model"]
+        flat["model_path"] = model.get("model_path", "black-forest-labs/FLUX.1-dev")
+        flat["vae_path"] = model.get("vae_path")
+        flat["t5_path"] = model.get("t5_path")
+        flat["clip_path"] = model.get("clip_path")
+        flat["precision"] = model.get("precision", "bf16")
+        flat["device"] = model.get("device", "cuda")
+        flat["batch_size"] = model.get("batch_size", 8)
+        flat["t5_max_length"] = model.get("t5_max_length", 512)
+        flat["vae_latent_mode"] = model.get("vae_latent_mode", "presampled")
+
+    # Image preprocessing
+    if "image" in config_dict:
+        image = config_dict["image"]
+        flat["image_size"] = image.get("image_size", 1024)
+        flat["variable_size"] = image.get("variable_size", False)
+        flat["center_crop"] = image.get("center_crop", True)
+        flat["max_size"] = image.get("max_size", 1024)
+
+    # Authentication
+    if "auth" in config_dict:
+        auth = config_dict["auth"]
+        flat["hf_token_file"] = auth.get("hf_token_file")
+
+    return flat
+
+
+def _get_encoded_parser_defaults() -> dict:
+    """
+    Get default values from encoded parser for override detection.
+
+    Returns dict of argument name -> default value to detect which CLI
+    arguments were explicitly set vs using defaults.
+    """
+    return {
+        "config": None,
+        "source_type": None,
+        "hf_dataset": None,
+        "hf_split": "train",
+        "hf_data_files": None,
+        "input_dir": None,
+        "input_path": None,
+        "image_key": None,
+        "caption_key": None,
+        "image_keys": None,
+        "caption_keys": None,
+        "output_dir": None,
+        "shard_size": 1000,
+        "max_samples": None,
+        "compress": False,
+        "model_path": "black-forest-labs/FLUX.1-dev",
+        "vae_path": None,
+        "t5_path": None,
+        "clip_path": None,
+        "precision": "bf16",
+        "device": "cuda",
+        "batch_size": 8,
+        "t5_max_length": 512,
+        "image_size": 1024,
+        "variable_size": False,
+        "center_crop": True,
+        "max_size": 1024,
+        "hf_token_file": None,
+        "vae_latent_mode": "presampled",
+    }
+
+
+def _load_config_with_cli_overrides(args: "argparse.Namespace") -> "argparse.Namespace":
+    """
+    Load YAML config and merge with CLI arguments.
+
+    Priority order (highest to lowest):
+    1. Explicitly provided CLI arguments
+    2. YAML config values
+    3. CLI default values
+
+    Args:
+        args: Parsed CLI arguments
+
+    Returns:
+        Merged namespace with final configuration
+
+    Example:
+        >>> # With config file specifying batch_size: 8
+        >>> # And CLI arg --batch-size 16
+        >>> # Result: batch_size = 16 (CLI wins)
+    """
+    import argparse
+
+    # If no config file, return args as-is
+    if not getattr(args, "config", None):
+        return args
+
+    from primus.core.utils import yaml_utils
+
+    logger.info(f"Loading config from: {args.config}")
+
+    # Load and flatten YAML config
+    config_dict = yaml_utils.parse_yaml(args.config)
+    flat_config = _flatten_preprocessing_config(config_dict)
+
+    # Start with config values
+    merged_dict = flat_config.copy()
+
+    # Override with explicitly provided CLI arguments
+    parser_defaults = _get_encoded_parser_defaults()
+    cli_args = vars(args)
+
+    for key, cli_value in cli_args.items():
+        if key == "config":
+            # Keep config path for reference
+            merged_dict["config"] = cli_value
+            continue
+
+        # If CLI value differs from default, it was explicitly set
+        default_value = parser_defaults.get(key)
+        if cli_value != default_value:
+            merged_dict[key] = cli_value
+            logger.debug(f"CLI override: {key} = {cli_value}")
+
+    logger.info("Configuration merged (CLI args override YAML)")
+    return argparse.Namespace(**merged_dict)
+
+
+def _validate_preprocessing_config(args: "argparse.Namespace") -> None:
+    """
+    Validate preprocessing configuration after merging.
+
+    Ensures all required parameters are present regardless of source
+    (CLI, YAML, or both).
+
+    Args:
+        args: Merged configuration namespace
+
+    Raises:
+        ValueError: If required arguments are missing or invalid
+
+    Example:
+        >>> args = argparse.Namespace(source_type='huggingface', output_dir=None)
+        >>> _validate_preprocessing_config(args)  # Raises ValueError
+    """
+    # Check required arguments
+    required = ["source_type", "output_dir"]
+    missing = [arg for arg in required if not getattr(args, arg, None)]
+
+    if missing:
+        raise ValueError(
+            f"Missing required arguments: {', '.join(missing)}. "
+            f"Provide via --config YAML or CLI arguments."
+        )
+
+    # Validate source-specific requirements
+    if args.source_type == "huggingface":
+        if not getattr(args, "hf_dataset", None):
+            raise ValueError(
+                "Missing --hf-dataset for source-type 'huggingface'. "
+                "Specify in config file (source.hf_dataset) or via CLI."
+            )
+    elif args.source_type == "directory":
+        if not getattr(args, "input_dir", None):
+            raise ValueError(
+                "Missing --input-dir for source-type 'directory'. "
+                "Specify in config file (source.input_dir) or via CLI."
+            )
+    elif args.source_type == "webdataset":
+        if not getattr(args, "input_path", None):
+            raise ValueError(
+                "Missing --input-path for source-type 'webdataset'. "
+                "Specify in config file (source.input_path) or via CLI."
+            )
+    else:
+        raise ValueError(
+            f"Invalid source-type: {args.source_type}. " f"Must be one of: huggingface, directory, webdataset"
+        )
+
+
+def _prepare_encoded(args):
+    """Prepare pre-encoded Energon WebDataset with VAE/T5/CLIP for fast training."""
+    # Load and merge config if provided
+    args = _load_config_with_cli_overrides(args)
+
+    # Validate merged configuration
+    _validate_preprocessing_config(args)
+
+    # Initialize torch.distributed if launched with torchrun
+    init_distributed()
+
+    try:
+        _validate_source_args(args)
+
+        # Setup HF authentication
+        try:
+            setup_hf_authentication(token_file=getattr(args, "hf_token_file", None))
+        except HFAuthError as e:
+            logger.error(f"Authentication failed: {e}")
+            raise
+
+        logger.info("=" * 80)
+        logger.info("Megatron Diffusion: Pre-encoded Energon WebDataset Preparation")
+        logger.info("=" * 80)
+
+        pipeline = EncodedDatasetPipeline(
+            source_type=args.source_type,
+            output_dir=args.output_dir,
+            model_path=args.model_path,
+            vae_path=args.vae_path,
+            t5_path=args.t5_path,
+            clip_path=args.clip_path,
+            precision=args.precision,
+            device=args.device,
+            batch_size=args.batch_size,
+            t5_max_length=args.t5_max_length,
+            variable_size=args.variable_size,
+            image_size=args.image_size,
+            center_crop=args.center_crop,
+            max_size=args.max_size,
+            shard_size=args.shard_size,
+            max_samples=args.max_samples,
+            compress=args.compress,
+            vae_latent_mode=getattr(args, "vae_latent_mode", "presampled"),
+        )
+
+        source_kwargs = {}
+        if args.source_type == "directory":
+            source_kwargs["input_dir"] = args.input_dir
+        elif args.source_type == "huggingface":
+            source_kwargs["hf_dataset"] = args.hf_dataset
+            source_kwargs["hf_split"] = args.hf_split
+            source_kwargs["hf_data_files"] = getattr(args, "hf_data_files", None)
+            # Add data format configuration
+            source_kwargs["image_key"] = getattr(args, "image_key", None)
+            source_kwargs["caption_key"] = getattr(args, "caption_key", None)
+            source_kwargs["image_keys"] = getattr(args, "image_keys", None)
+            source_kwargs["caption_keys"] = getattr(args, "caption_keys", None)
+
+        elif args.source_type == "webdataset":
+            source_kwargs["input_path"] = args.input_path
+
+        results = pipeline.run(**source_kwargs)
+
+        logger.info("=" * 80)
+        logger.info("✓ Pre-encoded Energon WebDataset preparation complete!")
+        logger.info(f"  Samples processed: {results['samples_processed']}")
+        logger.info(f"  Samples skipped: {results['samples_skipped']}")
+        logger.info(f"  Shards created: {results['shards_written']}")
+        logger.info(f"  Output: {args.output_dir}")
+        logger.info(f"  Format: Pre-encoded Energon WebDataset (VAE/T5/CLIP tensors)")
+        logger.info(f"  Note: Training will be faster (no on-the-fly encoding)")
+        logger.info("=" * 80)
+
+        # Finalize dataset unless --no-finalize was passed
+        if not getattr(args, "no_finalize", False):
+            # Import distributed utilities
+            import torch.distributed as dist
+
+            # Wait for all ranks to complete data preparation
+            if dist.is_initialized():
+                logger.info("Waiting for all ranks to complete...")
+                dist.barrier()
+
+            # Only rank 0 runs finalization
+            should_finalize = not dist.is_initialized() or dist.get_rank() == 0
+
+            if should_finalize:
+                from primus.backends.megatron.data.diffusion.preprocessing.finalize import (
+                    finalize_energon_dataset,
+                )
+
+                try:
+                    finalize_energon_dataset(
+                        output_dir=args.output_dir,
+                        train_split=getattr(args, "train_split", 1.0),
+                        encoding="preencoded",
+                        num_workers=8,
+                    )
+                except Exception as e:
+                    logger.error(f"Finalization failed: {e}")
+                    raise
+
+            # Wait again so all ranks exit together
+            if dist.is_initialized():
+                dist.barrier()
+
+    finally:
+        # Clean up distributed
+        finalize_distributed()
+
+
+def _load_ingest_config(args):
+    """Load ingest YAML config and merge with CLI overrides.
+
+    Returns a flat dict consumed by _prepare_ingest.
+    """
+    from primus.core.utils import yaml_utils
+
+    config_path = args.config
+    if not config_path:
+        raise ValueError("--config is required for diffusion-ingest")
+
+    raw = yaml_utils.parse_yaml(config_path)
+
+    config = {
+        "datasets": raw.get("datasets", []),
+        "output_dir": raw.get("output", {}).get("output_dir"),
+        "max_workers": raw.get("pipeline", {}).get("max_workers", 4),
+        "prefetch_depth": raw.get("pipeline", {}).get("prefetch_depth", 6),
+        "max_files": raw.get("pipeline", {}).get("max_files"),
+        "no_finalize": False,
+    }
+
+    if raw.get("empty_encodings"):
+        config["empty_encodings"] = raw["empty_encodings"]
+
+    # CLI overrides
+    if getattr(args, "output_dir", None):
+        config["output_dir"] = args.output_dir
+    if getattr(args, "input_dir", None):
+        config["input_dir"] = args.input_dir
+    if getattr(args, "max_workers", None) is not None:
+        config["max_workers"] = args.max_workers
+    if getattr(args, "prefetch_depth", None) is not None:
+        config["prefetch_depth"] = args.prefetch_depth
+    if getattr(args, "max_files", None) is not None:
+        config["max_files"] = args.max_files
+    if getattr(args, "no_finalize", False):
+        config["no_finalize"] = True
+
+    if not config.get("output_dir"):
+        raise ValueError("output_dir is required. Set in config (output.output_dir) " "or via --output-dir.")
+
+    # Default input_dir
+    if "input_dir" not in config:
+        from pathlib import Path
+
+        config["input_dir"] = str(Path(config["output_dir"]) / "_arrow_tmp")
+
+    return config
+
+
+def _download_empty_encodings(config):
+    """Download empty_encodings files (small .npy files for CFG dropout)."""
+    from pathlib import Path
+
+    from primus.backends.megatron.data.diffusion.preprocessing.download import (
+        download_with_backoff,
+        fetch_manifest,
+    )
+
+    enc_cfg = config["empty_encodings"]
+    output_dir = Path(config["output_dir"]) / enc_cfg.get("output_subdir", "empty_encodings")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    base_url, entries = fetch_manifest(enc_cfg["manifest_url"])
+
+    for md5, fname in entries:
+        dest = output_dir / fname
+        if dest.exists():
+            logger.info(f"  [skip] {fname} (exists)")
+            continue
+        file_url = f"{base_url}/{fname}"
+        logger.info(f"  [download] {fname}")
+        download_with_backoff(file_url, dest, expected_md5=md5)
+
+    logger.info(f"Empty encodings downloaded to {output_dir}")
+
+
+def _prepare_ingest(args):
+    """Download and convert pre-encoded Arrow data into Energon WebDataset."""
+    from primus.backends.megatron.data.diffusion.preprocessing.pipelines.ingest import (
+        StreamingIngestPipeline,
+    )
+
+    config = _load_ingest_config(args)
+
+    logger.info("=" * 80)
+    logger.info("Megatron Diffusion: Streaming Ingest Pipeline")
+    logger.info("=" * 80)
+
+    total_failed = 0
+    for ds in config["datasets"]:
+        logger.info(f"Processing dataset: {ds['name']} (split: {ds['split_name']})")
+        pipeline = StreamingIngestPipeline(
+            manifest_url=ds["manifest_url"],
+            input_dir=config["input_dir"],
+            output_dir=config["output_dir"],
+            split_name=ds["split_name"],
+            max_files=config.get("max_files"),
+            max_workers=config["max_workers"],
+            prefetch_depth=config["prefetch_depth"],
+        )
+        result = pipeline.run()
+        total_failed += result.get("files_failed", 0)
+
+    if "empty_encodings" in config:
+        logger.info("Downloading empty encodings...")
+        _download_empty_encodings(config)
+
+    if not config.get("no_finalize"):
+        from primus.backends.megatron.data.diffusion.preprocessing.finalize import (
+            finalize_energon_dataset,
+        )
+
+        try:
+            finalize_energon_dataset(
+                output_dir=config["output_dir"],
+                encoding="preencoded_numpy",
+                split_parts_patterns=[("train", "train/.*"), ("val", "val/.*")],
+            )
+        except Exception as e:
+            logger.error(f"Finalization failed: {e}")
+            raise
+
+    logger.info("=" * 80)
+    logger.info("Ingest complete!")
+    logger.info(f"  Output: {config['output_dir']}")
+    if total_failed:
+        logger.warning(
+            f"  {total_failed} file(s) failed across all datasets. "
+            f"Check failed_files.json in each split directory."
+        )
+    logger.info("=" * 80)
+
+
+def register_subcommand(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    """
+    Register 'primus data' subcommand for Megatron diffusion dataset preparation.
+
+    Provides dataset preparation utilities specifically for diffusion models
+    using the Megatron backend, outputting Energon WebDataset format.
+    """
+    parser = subparsers.add_parser(
+        "data",
+        help="Dataset preparation tools (Megatron diffusion, Energon format)",
+        description=(
+            "Data preparation utilities for Megatron-backend diffusion models.\n"
+            "Creates datasets in Energon WebDataset format.\n\n"
+            "Supported modes:\n"
+            "  - diffusion-raw: Raw WebDataset (smaller, on-the-fly encoding)\n"
+            "  - diffusion-encoded: Pre-encoded WebDataset (larger, faster training)\n"
+            "  - diffusion-ingest: Stream pre-encoded Arrow data into WebDataset\n\n"
+            "Multi-GPU support via torch.distributed:\n"
+            "  torchrun --nproc_per_node=8 primus data diffusion-raw ...\n"
+            "  torchrun --nproc_per_node=8 primus data diffusion-encoded ..."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    data_subparsers = parser.add_subparsers(dest="data_command", required=True, help="Data preparation mode")
+
+    # ===== primus data diffusion-raw =====
+    raw_parser = data_subparsers.add_parser(
+        "diffusion-raw",
+        help="Prepare raw Energon WebDataset (Megatron diffusion: images + captions)",
+        description=(
+            "Prepare raw Energon WebDataset for Megatron diffusion training.\n\n"
+            "Creates smaller datasets with raw images and captions.\n"
+            "Encoding (VAE/T5/CLIP) happens on-the-fly during training.\n\n"
+            "Output format: Energon WebDataset (tar shards)\n\n"
+            "Use this when:\n"
+            "  - Storage is limited\n"
+            "  - Experimenting with different encoders\n"
+            "  - Rapid prototyping\n\n"
+            "Example:\n"
+            "  primus data diffusion-raw \\\n"
+            "    --source-type huggingface \\\n"
+            "    --hf-dataset diffusers/pokemon-gpt4-captions \\\n"
+            "    --output-dir /data/raw_pokemon \\\n"
+            "    --image-size 1024 --center-crop\n\n"
+            "Multi-GPU:\n"
+            "  torchrun --nproc_per_node=8 primus data diffusion-raw ..."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    _add_common_args(raw_parser)
+
+    # Raw-specific arguments
+    raw_specific = raw_parser.add_argument_group("Raw Dataset Options")
+    raw_specific.add_argument(
+        "--image-format",
+        choices=["JPEG", "PNG", "WEBP"],
+        default="JPEG",
+        help="Output image format (default: JPEG)",
+    )
+    raw_specific.add_argument(
+        "--image-quality", type=int, default=95, help="JPEG/WEBP quality 1-100 (default: 95)"
+    )
+
+    # Finalization arguments
+    raw_finalize = raw_parser.add_argument_group("Dataset Finalization")
+    raw_finalize.add_argument(
+        "--no-finalize",
+        action="store_true",
+        dest="no_finalize",
+        help="Skip automatic dataset.yaml creation and energon prepare (default: finalize is ON)",
+    )
+    raw_finalize.add_argument(
+        "--train-split",
+        type=float,
+        default=1.0,
+        help="Training split ratio for finalization (default: 1.0 = 100%% train, 0%% val/test)",
+    )
+
+    raw_parser.set_defaults(func=lambda args, unknown: _prepare_raw(args))
+
+    # ===== primus data diffusion-encoded =====
+    encoded_parser = data_subparsers.add_parser(
+        "diffusion-encoded",
+        help="Prepare pre-encoded Energon WebDataset (Megatron diffusion: VAE/T5/CLIP)",
+        description=(
+            "Prepare pre-encoded Energon WebDataset for Megatron diffusion training.\n\n"
+            "Pre-encodes images with VAE and text with T5/CLIP, creating larger\n"
+            "datasets that enable faster training (no encoding overhead).\n\n"
+            "Output format: Energon WebDataset with pre-encoded tensors\n\n"
+            "Use this when:\n"
+            "  - Training on production datasets\n"
+            "  - Maximum training speed is needed\n"
+            "  - Storage space is available\n\n"
+            "Example:\n"
+            "  primus data diffusion-encoded \\\n"
+            "    --source-type huggingface \\\n"
+            "    --hf-dataset diffusers/pokemon-gpt4-captions \\\n"
+            "    --output-dir /data/encoded_pokemon \\\n"
+            "    --model-path black-forest-labs/FLUX.1-dev \\\n"
+            "    --batch-size 8 --precision bf16\n\n"
+            "Config file:\n"
+            "  primus data diffusion-encoded --config preprocessing.yaml\n\n"
+            "Multi-GPU:\n"
+            "  torchrun --nproc_per_node=8 primus data diffusion-encoded ..."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # Config file support (optional, CLI args override config values)
+    encoded_parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Path to YAML config file (optional, CLI args override config values)",
+    )
+
+    _add_common_args(encoded_parser)
+
+    # Encoded-specific arguments
+    model_group = encoded_parser.add_argument_group("Model Configuration")
+    model_group.add_argument(
+        "--model-path",
+        default="black-forest-labs/FLUX.1-dev",
+        help="Pretrained model path (HF or local). Default: black-forest-labs/FLUX.1-dev "
+        "(requires HF authentication -- see --hf-token-file)",
+    )
+    model_group.add_argument("--vae-path", default=None, help="Custom VAE path (overrides --model-path)")
+    model_group.add_argument("--t5-path", default=None, help="Custom T5 path (overrides --model-path)")
+    model_group.add_argument("--clip-path", default=None, help="Custom CLIP path (overrides --model-path)")
+    model_group.add_argument(
+        "--precision",
+        choices=["bf16", "fp16", "fp32"],
+        default="bf16",
+        help="Model precision (default: bf16)",
+    )
+    model_group.add_argument("--device", default="cuda", help="Device for encoding (default: cuda)")
+    model_group.add_argument("--batch-size", type=int, default=8, help="Encoding batch size (default: 8)")
+    model_group.add_argument(
+        "--t5-max-length",
+        type=int,
+        default=512,
+        help="T5 max sequence length (default: 512, use 256 for FLUX.1-schnell)",
+    )
+    model_group.add_argument(
+        "--vae-latent-mode",
+        choices=["presampled", "resample"],
+        default="presampled",
+        help=(
+            "VAE latent storage mode (default: presampled). "
+            "'presampled' stores a single sampled latent per image. "
+            "'resample' additionally stores mean and logvar so the training "
+            "loop can re-draw latents via reparameterization at every step."
+        ),
+    )
+
+    # Finalization arguments
+    encoded_finalize = encoded_parser.add_argument_group("Dataset Finalization")
+    encoded_finalize.add_argument(
+        "--no-finalize",
+        action="store_true",
+        dest="no_finalize",
+        help="Skip automatic dataset.yaml creation and energon prepare (default: finalize is ON)",
+    )
+    encoded_finalize.add_argument(
+        "--train-split",
+        type=float,
+        default=1.0,
+        help="Training split ratio for finalization (default: 1.0 = 100%% train, 0%% val/test)",
+    )
+
+    encoded_parser.set_defaults(func=lambda args, unknown: _prepare_encoded(args))
+
+    # ===== primus data diffusion-ingest =====
+    ingest_parser = data_subparsers.add_parser(
+        "diffusion-ingest",
+        help="Stream pre-encoded Arrow data into Energon WebDataset",
+        description=(
+            "Stream pre-encoded Arrow data into Energon WebDataset.\n\n"
+            "Downloads Apache Arrow IPC files from MLCommons R2 (or similar),\n"
+            "converts them to WebDataset tar shards in a single pass using a\n"
+            "producer-consumer prefetch architecture. Minimizes disk usage by\n"
+            "deleting each Arrow file after conversion.\n\n"
+            "Requires a YAML config file specifying datasets and parameters.\n\n"
+            "Example:\n"
+            "  primus data diffusion-ingest \\\n"
+            "    --config primus/configs/data/megatron/diffusion/"
+            "preprocessing/mlperf_flux1.yaml\n\n"
+            "Override output:\n"
+            "  primus data diffusion-ingest \\\n"
+            "    --config .../mlperf_flux1.yaml \\\n"
+            "    --output-dir /custom/path --max-files 5"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    ingest_parser.add_argument(
+        "--config",
+        type=str,
+        required=True,
+        help="Path to YAML config file with datasets list and pipeline settings",
+    )
+
+    ingest_output = ingest_parser.add_argument_group("Output Configuration")
+    ingest_output.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Output directory (overrides config output.output_dir)",
+    )
+    ingest_output.add_argument(
+        "--input-dir",
+        type=str,
+        default=None,
+        help="Temp directory for Arrow downloads (default: <output-dir>/_arrow_tmp)",
+    )
+
+    ingest_pipeline = ingest_parser.add_argument_group("Pipeline Configuration")
+    ingest_pipeline.add_argument(
+        "--max-files",
+        type=int,
+        default=None,
+        help="Limit Arrow files per dataset (for testing)",
+    )
+    ingest_pipeline.add_argument(
+        "--max-workers",
+        type=int,
+        default=None,
+        help="Concurrent download threads (overrides config, default: 4)",
+    )
+    ingest_pipeline.add_argument(
+        "--prefetch-depth",
+        type=int,
+        default=None,
+        help="Max Arrow files buffered on disk (overrides config, default: 6)",
+    )
+
+    ingest_finalize = ingest_parser.add_argument_group("Dataset Finalization")
+    ingest_finalize.add_argument(
+        "--no-finalize",
+        action="store_true",
+        dest="no_finalize",
+        help="Skip automatic Energon finalization (default: finalize is ON)",
+    )
+
+    ingest_parser.set_defaults(func=lambda args, unknown: _prepare_ingest(args))
+
+    # Set default for parent parser (required by CLI framework, but never called due to required=True on subparsers)
+    parser.set_defaults(func=lambda args, unknown: None)
+
+    return parser

--- a/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/__init__.py
+++ b/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.

--- a/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_download.py
+++ b/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_download.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Tests for download utilities (download.py).
+
+Covers:
+- parse_md5_manifest: parsing, filtering, sorting
+- download_with_backoff: retry logic, MD5 verification, timeout handling
+- fetch_url_text: basic HTTP text fetch
+"""
+
+import hashlib
+import io
+import tempfile
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from primus.backends.megatron.data.diffusion.preprocessing.download import (
+    download_with_backoff,
+    fetch_url_text,
+    parse_md5_manifest,
+)
+
+_DOWNLOAD_MODULE = "primus.backends.megatron.data.diffusion.preprocessing.download"
+
+
+class TestParseMd5Manifest:
+    def test_basic_parsing(self):
+        text = "abc123 data-00000.arrow\ndef456 data-00001.arrow\n"
+        entries = parse_md5_manifest(text)
+        assert entries == [("abc123", "data-00000.arrow"), ("def456", "data-00001.arrow")]
+
+    def test_suffix_filter(self):
+        text = "abc123 data-00000.arrow\ndef456 readme.txt\n"
+        entries = parse_md5_manifest(text, suffix_filter=".arrow")
+        assert len(entries) == 1
+        assert entries[0][1] == "data-00000.arrow"
+
+    def test_no_filter_returns_all(self):
+        text = "abc123 data-00000.arrow\ndef456 readme.txt\n"
+        entries = parse_md5_manifest(text)
+        assert len(entries) == 2
+
+    def test_sorts_by_filename(self):
+        text = "bbb data-00002.arrow\naaa data-00001.arrow\nccc data-00000.arrow\n"
+        entries = parse_md5_manifest(text)
+        assert [e[1] for e in entries] == [
+            "data-00000.arrow",
+            "data-00001.arrow",
+            "data-00002.arrow",
+        ]
+
+    def test_skips_malformed_lines(self):
+        text = "abc123 data-00000.arrow\nbadline\n\n  \n"
+        entries = parse_md5_manifest(text)
+        assert len(entries) == 1
+
+
+class TestDownloadWithBackoff:
+    """Tests for download_with_backoff with mocked HTTP."""
+
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_success_on_first_try(self, mock_urlopen):
+        content = b"hello world"
+        mock_resp = MagicMock()
+        mock_resp.read.side_effect = [content, b""]
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            download_with_backoff("http://example.com/test.bin", dest, max_retries=0)
+            assert dest.exists()
+
+    @patch(f"{_DOWNLOAD_MODULE}.time.sleep")
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_retries_on_429(self, mock_urlopen, mock_sleep):
+        content = b"success data"
+        mock_resp_ok = MagicMock()
+        mock_resp_ok.read.side_effect = [content, b""]
+        mock_resp_ok.__enter__ = MagicMock(return_value=mock_resp_ok)
+        mock_resp_ok.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [
+            urllib.error.HTTPError("http://x", 429, "Too Many Requests", {}, io.BytesIO(b"")),
+            urllib.error.HTTPError("http://x", 429, "Too Many Requests", {}, io.BytesIO(b"")),
+            mock_resp_ok,
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            download_with_backoff("http://example.com/test.bin", dest, max_retries=3, base_delay=0.01)
+            assert dest.exists()
+            assert mock_urlopen.call_count == 3
+            assert mock_sleep.call_count == 2
+
+    @patch(f"{_DOWNLOAD_MODULE}.time.sleep")
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_retries_on_503(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            "http://x", 503, "Service Unavailable", {}, io.BytesIO(b"")
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            with pytest.raises(RuntimeError, match="HTTP 503"):
+                download_with_backoff("http://example.com/test.bin", dest, max_retries=2, base_delay=0.01)
+            assert mock_urlopen.call_count == 3  # initial + 2 retries
+
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_no_retry_on_404(self, mock_urlopen):
+        mock_urlopen.side_effect = urllib.error.HTTPError("http://x", 404, "Not Found", {}, io.BytesIO(b""))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            with pytest.raises(RuntimeError, match="HTTP 404"):
+                download_with_backoff("http://example.com/test.bin", dest, max_retries=3, base_delay=0.01)
+            assert mock_urlopen.call_count == 1
+
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_md5_verification_pass(self, mock_urlopen):
+        content = b"test content"
+        expected_md5 = hashlib.md5(content).hexdigest()
+
+        mock_resp = MagicMock()
+        mock_resp.read.side_effect = [content, b""]
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            download_with_backoff("http://example.com/test.bin", dest, expected_md5=expected_md5)
+            assert dest.exists()
+
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_md5_verification_fail(self, mock_urlopen):
+        content = b"test content"
+
+        mock_resp = MagicMock()
+        mock_resp.read.side_effect = [content, b""]
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            with pytest.raises(RuntimeError, match="MD5 mismatch"):
+                download_with_backoff(
+                    "http://example.com/test.bin",
+                    dest,
+                    expected_md5="bad_md5",
+                    max_retries=0,
+                )
+            assert not dest.exists()
+
+    @patch(f"{_DOWNLOAD_MODULE}.time.sleep")
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_retries_on_network_error(self, mock_urlopen, mock_sleep):
+        content = b"ok"
+        mock_resp_ok = MagicMock()
+        mock_resp_ok.read.side_effect = [content, b""]
+        mock_resp_ok.__enter__ = MagicMock(return_value=mock_resp_ok)
+        mock_resp_ok.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [
+            urllib.error.URLError("Connection refused"),
+            mock_resp_ok,
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            download_with_backoff("http://example.com/test.bin", dest, max_retries=2, base_delay=0.01)
+            assert dest.exists()
+            assert mock_urlopen.call_count == 2
+
+    @patch(f"{_DOWNLOAD_MODULE}.time.sleep")
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_retries_on_md5_mismatch_then_succeeds(self, mock_urlopen, mock_sleep):
+        good_content = b"correct data"
+        bad_content = b"corrupted data"
+        expected_md5 = hashlib.md5(good_content).hexdigest()
+
+        mock_resp_bad = MagicMock()
+        mock_resp_bad.read.side_effect = [bad_content, b""]
+        mock_resp_bad.__enter__ = MagicMock(return_value=mock_resp_bad)
+        mock_resp_bad.__exit__ = MagicMock(return_value=False)
+
+        mock_resp_good = MagicMock()
+        mock_resp_good.read.side_effect = [good_content, b""]
+        mock_resp_good.__enter__ = MagicMock(return_value=mock_resp_good)
+        mock_resp_good.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [mock_resp_bad, mock_resp_good]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            download_with_backoff(
+                "http://example.com/test.bin",
+                dest,
+                expected_md5=expected_md5,
+                max_retries=3,
+                base_delay=0.01,
+            )
+            assert dest.exists()
+            assert dest.read_bytes() == good_content
+            assert mock_urlopen.call_count == 2
+            assert mock_sleep.call_count == 1
+
+    @patch(f"{_DOWNLOAD_MODULE}.time.sleep")
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_md5_mismatch_exhausts_retries(self, mock_urlopen, mock_sleep):
+        bad_content = b"always bad"
+        expected_md5 = "0000000000000000"
+
+        def make_bad_resp(*args, **kwargs):
+            resp = MagicMock()
+            resp.read.side_effect = [bad_content, b""]
+            resp.__enter__ = MagicMock(return_value=resp)
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        mock_urlopen.side_effect = make_bad_resp
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "test.bin"
+            with pytest.raises(RuntimeError, match="MD5 mismatch"):
+                download_with_backoff(
+                    "http://example.com/test.bin",
+                    dest,
+                    expected_md5=expected_md5,
+                    max_retries=2,
+                    base_delay=0.01,
+                )
+            assert mock_urlopen.call_count == 3  # initial + 2 retries
+
+
+class TestFetchUrlText:
+    @patch(f"{_DOWNLOAD_MODULE}.urllib.request.urlopen")
+    def test_returns_decoded_text(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"https://example.com/base"
+        mock_urlopen.return_value = mock_resp
+
+        result = fetch_url_text("http://example.com/manifest.uri")
+        assert result == "https://example.com/base"

--- a/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_finalize.py
+++ b/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_finalize.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Tests for dataset finalization and encoder auth error detection.
+
+Tests finalize_energon_dataset from finalize.py and
+_raise_encoder_auth_error from encoded.py.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from primus.backends.megatron.data.diffusion.preprocessing.finalize import (
+    finalize_energon_dataset,
+)
+from primus.backends.megatron.data.diffusion.preprocessing.pipelines.encoded import (
+    EncodedDatasetPipeline,
+)
+from tests.utils import PrimusUT
+
+
+def _create_dummy_tar(directory: Path, name: str = "000000.tar") -> None:
+    """Create an empty .tar file for testing."""
+    (directory / name).write_bytes(b"")
+
+
+class TestDatasetYamlContent(PrimusUT):
+    """Tests that finalize_energon_dataset writes correct dataset.yaml."""
+
+    @patch(
+        "primus.backends.megatron.data.diffusion.preprocessing.finalize._prepare_programmatic",
+        side_effect=ImportError("forced: exercise subprocess fallback path"),
+    )
+    @patch("primus.backends.megatron.data.diffusion.preprocessing.validate.validate_energon_dataset")
+    @patch("subprocess.Popen")
+    def test_preencoded_yaml(self, mock_popen, mock_validate, mock_programmatic):
+        """dataset.yaml contains CrudeWebdataset with encoding: preencoded."""
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ("Done\n", None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _create_dummy_tar(Path(tmpdir))
+            finalize_energon_dataset(output_dir=tmpdir, train_split=1.0, encoding="preencoded")
+
+            dataset_yaml = Path(tmpdir) / ".nv-meta" / "dataset.yaml"
+            assert dataset_yaml.exists()
+            content = dataset_yaml.read_text()
+            assert "__class__: CrudeWebdataset" in content
+            assert "encoding: preencoded" in content
+
+            # Verify split_input passed to subprocess stdin
+            mock_process.communicate.assert_called_once_with(input="1.0, 0.0, 0.0\nn\n", timeout=300)
+
+    @patch(
+        "primus.backends.megatron.data.diffusion.preprocessing.finalize._prepare_programmatic",
+        side_effect=ImportError("forced: exercise subprocess fallback path"),
+    )
+    @patch("primus.backends.megatron.data.diffusion.preprocessing.validate.validate_energon_dataset")
+    @patch("subprocess.Popen")
+    def test_raw_yaml_and_split_format(self, mock_popen, mock_validate, mock_programmatic):
+        """dataset.yaml contains encoding: raw; split ratios are formatted correctly."""
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = ("Done\n", None)
+        mock_process.returncode = 0
+        mock_popen.return_value = mock_process
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _create_dummy_tar(Path(tmpdir))
+            finalize_energon_dataset(output_dir=tmpdir, train_split=0.8, encoding="raw")
+
+            content = (Path(tmpdir) / ".nv-meta" / "dataset.yaml").read_text()
+            assert "encoding: raw" in content
+
+            call_kwargs = mock_process.communicate.call_args
+            split_input = call_kwargs.kwargs.get("input") or call_kwargs[1].get("input")
+            assert split_input.startswith("0.8, ")
+            assert split_input.endswith("\nn\n")
+            parts = split_input.split("\n")[0].split(", ")
+            self.assertAlmostEqual(float(parts[0]), 0.8)
+            self.assertAlmostEqual(float(parts[1]), 0.1)
+            self.assertAlmostEqual(float(parts[2]), 0.1)
+
+
+class TestRaiseEncoderAuthError(PrimusUT):
+    """Tests for EncodedDatasetPipeline._raise_encoder_auth_error."""
+
+    def test_401_error_gives_auth_hint(self):
+        """Exception containing '401' raises RuntimeError with auth hint."""
+        original = Exception("HTTP 401 Unauthorized")
+        with self.assertRaises(RuntimeError) as ctx:
+            EncodedDatasetPipeline._raise_encoder_auth_error("VAE", "my-model", original)
+        assert "HuggingFace authentication" in str(ctx.exception)
+        assert "VAE" in str(ctx.exception)
+
+    def test_token_error_gives_auth_hint(self):
+        """Exception containing 'token' raises RuntimeError with auth hint."""
+        original = Exception("Please pass a valid token")
+        with self.assertRaises(RuntimeError) as ctx:
+            EncodedDatasetPipeline._raise_encoder_auth_error("T5-XXL", "my-model", original)
+        assert "HuggingFace authentication" in str(ctx.exception)
+        assert "T5-XXL" in str(ctx.exception)
+
+    def test_non_auth_error_preserves_message(self):
+        """Non-auth exception re-raises with original message intact."""
+        original = Exception("CUDA out of memory")
+        with self.assertRaises(RuntimeError) as ctx:
+            EncodedDatasetPipeline._raise_encoder_auth_error("CLIP-L", "my-model", original)
+        msg = str(ctx.exception)
+        assert "CUDA out of memory" in msg
+        assert "CLIP-L" in msg
+        assert "HuggingFace authentication" not in msg
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_ingest.py
+++ b/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_ingest.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Tests for the streaming ingest pipeline (pipelines/ingest.py).
+
+Covers:
+- StreamingIngestPipeline: parallel download + sequential conversion
+- Resume functionality (existing shards are skipped)
+- max_files parameter
+- Sample offset accumulation
+- Arrow file cleanup after conversion
+- Skip-and-log for failed downloads and conversions
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from primus.backends.megatron.data.diffusion.preprocessing.pipelines.ingest import (
+    StreamingIngestPipeline,
+)
+
+_INGEST_MODULE = "primus.backends.megatron.data.diffusion.preprocessing.pipelines.ingest"
+
+
+class TestStreamingIngestPipeline:
+    """Tests for the StreamingIngestPipeline with mocked I/O."""
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_processes_all_files(self, mock_manifest, mock_download, mock_convert):
+        """Pipeline processes all entries, creates correct number of shards."""
+        entries = [
+            ("md5_0", "data-00000.arrow"),
+            ("md5_1", "data-00001.arrow"),
+            ("md5_2", "data-00002.arrow"),
+        ]
+        mock_manifest.return_value = ("https://base.url", entries)
+        mock_convert.return_value = 100
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=f"{tmp}/arrows",
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_workers=2,
+                prefetch_depth=2,
+            )
+
+            def fake_download(url, dest, **kwargs):
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(b"fake")
+
+            mock_download.side_effect = fake_download
+
+            results = pipeline.run()
+
+        assert results["files_processed"] == 3
+        assert results["samples_written"] == 300
+        assert results["shards_created"] == 3
+        assert mock_download.call_count == 3
+        assert mock_convert.call_count == 3
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_max_files_limits_processing(self, mock_manifest, mock_download, mock_convert):
+        """max_files parameter limits how many files are processed."""
+        entries = [(f"md5_{i}", f"data-{i:05d}.arrow") for i in range(10)]
+        mock_manifest.return_value = ("https://base.url", entries)
+        mock_convert.return_value = 50
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=f"{tmp}/arrows",
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_files=3,
+                max_workers=2,
+                prefetch_depth=2,
+            )
+
+            def fake_download(url, dest, **kwargs):
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(b"fake")
+
+            mock_download.side_effect = fake_download
+
+            results = pipeline.run()
+
+        assert results["files_processed"] == 3
+        assert mock_download.call_count == 3
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_download_error_skips_file(self, mock_manifest, mock_download, mock_convert):
+        """A failed download is skipped; the pipeline continues with remaining files."""
+        entries = [("md5_0", "data-00000.arrow"), ("md5_1", "data-00001.arrow")]
+        mock_manifest.return_value = ("https://base.url", entries)
+        mock_convert.return_value = 100
+
+        call_count = [0]
+
+        def selective_download(url, dest, **kwargs):
+            call_count[0] += 1
+            if "data-00000" in url:
+                raise RuntimeError("Download failed: HTTP 500")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"fake")
+
+        mock_download.side_effect = selective_download
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=f"{tmp}/arrows",
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_workers=1,
+                prefetch_depth=2,
+            )
+
+            results = pipeline.run()
+
+            assert results["files_processed"] == 1
+            assert results["files_failed"] == 1
+            assert results["samples_written"] == 100
+            assert mock_convert.call_count == 1
+
+            failed_manifest = Path(tmp) / "output" / "train" / "failed_files.json"
+            assert failed_manifest.exists()
+            failures = json.loads(failed_manifest.read_text())
+            assert len(failures) == 1
+            assert failures[0]["stage"] == "download"
+            assert failures[0]["filename"] == "data-00000.arrow"
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_all_downloads_fail(self, mock_manifest, mock_download, mock_convert):
+        """If all downloads fail, the pipeline completes with zero processed."""
+        entries = [("md5_0", "data-00000.arrow"), ("md5_1", "data-00001.arrow")]
+        mock_manifest.return_value = ("https://base.url", entries)
+        mock_download.side_effect = RuntimeError("Download failed: HTTP 500")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=f"{tmp}/arrows",
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_workers=1,
+                prefetch_depth=2,
+            )
+
+            results = pipeline.run()
+
+        assert results["files_processed"] == 0
+        assert results["files_failed"] == 2
+        assert results["samples_written"] == 0
+        assert mock_convert.call_count == 0
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_conversion_error_skips_file(self, mock_manifest, mock_download, mock_convert):
+        """A failed conversion is skipped; partial tar is cleaned up."""
+        entries = [
+            ("md5_0", "data-00000.arrow"),
+            ("md5_1", "data-00001.arrow"),
+        ]
+        mock_manifest.return_value = ("https://base.url", entries)
+
+        def selective_convert(arrow_path, tar_path, offset):
+            if "data-00000" in str(arrow_path):
+                raise RuntimeError("Corrupt Arrow file")
+            return 100
+
+        mock_convert.side_effect = selective_convert
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=f"{tmp}/arrows",
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_workers=1,
+                prefetch_depth=2,
+            )
+
+            def fake_download(url, dest, **kwargs):
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(b"fake")
+
+            mock_download.side_effect = fake_download
+
+            results = pipeline.run()
+
+            assert results["files_processed"] == 1
+            assert results["files_failed"] == 1
+            assert results["samples_written"] == 100
+
+            output_train = Path(tmp) / "output" / "train"
+            assert not (output_train / "shard_000000.tar").exists()
+            assert (output_train / "failed_files.json").exists()
+            failures = json.loads((output_train / "failed_files.json").read_text())
+            assert len(failures) == 1
+            assert failures[0]["stage"] == "conversion"
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_arrow_files_deleted_after_conversion(self, mock_manifest, mock_download, mock_convert):
+        """Arrow files are cleaned up after conversion to tar."""
+        entries = [("md5_0", "data-00000.arrow")]
+        mock_manifest.return_value = ("https://base.url", entries)
+        mock_convert.return_value = 10
+
+        with tempfile.TemporaryDirectory() as tmp:
+            arrow_dir = Path(tmp) / "arrows"
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=str(arrow_dir),
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_workers=1,
+                prefetch_depth=2,
+            )
+
+            created_files = []
+
+            def fake_download(url, dest, **kwargs):
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(b"fake arrow data")
+                created_files.append(dest)
+
+            mock_download.side_effect = fake_download
+
+            pipeline.run()
+
+            for f in created_files:
+                assert not f.exists(), f"Arrow file should have been deleted: {f}"
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_sample_offset_accumulates(self, mock_manifest, mock_download, mock_convert):
+        """Global sample offset is passed correctly across shards."""
+        entries = [
+            ("md5_0", "data-00000.arrow"),
+            ("md5_1", "data-00001.arrow"),
+            ("md5_2", "data-00002.arrow"),
+        ]
+        mock_manifest.return_value = ("https://base.url", entries)
+
+        sample_counts = [100, 200, 150]
+        mock_convert.side_effect = sample_counts
+
+        with tempfile.TemporaryDirectory() as tmp:
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=f"{tmp}/arrows",
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_workers=1,
+                prefetch_depth=2,
+            )
+
+            def fake_download(url, dest, **kwargs):
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(b"fake")
+
+            mock_download.side_effect = fake_download
+
+            results = pipeline.run()
+
+        offsets = [c.args[2] for c in mock_convert.call_args_list]
+        assert offsets == [0, 100, 300]
+        assert results["samples_written"] == 450
+
+    @patch(f"{_INGEST_MODULE}._arrow_to_tar")
+    @patch(f"{_INGEST_MODULE}.download_with_backoff")
+    @patch(f"{_INGEST_MODULE}.fetch_manifest")
+    def test_resume_skips_existing_shards(self, mock_manifest, mock_download, mock_convert):
+        """Pre-existing shard tars are skipped; only missing shards are downloaded."""
+        entries = [
+            ("md5_0", "data-00000.arrow"),
+            ("md5_1", "data-00001.arrow"),
+            ("md5_2", "data-00002.arrow"),
+            ("md5_3", "data-00003.arrow"),
+        ]
+        mock_manifest.return_value = ("https://base.url", entries)
+        mock_convert.return_value = 100
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_train = Path(tmp) / "output" / "train"
+            output_train.mkdir(parents=True)
+
+            (output_train / "shard_000000.tar").write_bytes(b"existing")
+            (output_train / "shard_000002.tar").write_bytes(b"existing")
+
+            pipeline = StreamingIngestPipeline(
+                manifest_url="http://manifest.uri",
+                input_dir=f"{tmp}/arrows",
+                output_dir=f"{tmp}/output",
+                split_name="train",
+                max_workers=1,
+                prefetch_depth=2,
+            )
+
+            def fake_download(url, dest, **kwargs):
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(b"fake")
+
+            mock_download.side_effect = fake_download
+
+            results = pipeline.run()
+
+        assert results["files_processed"] == 2
+        assert results["shards_skipped"] == 2
+        assert results["shards_created"] == 4  # 2 new + 2 skipped
+        assert results["samples_written"] == 200  # only from the 2 new shards
+        assert mock_download.call_count == 2
+        assert mock_convert.call_count == 2

--- a/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_utils.py
+++ b/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_utils.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Tests for preprocessing utility functions.
+
+Tests distributed processing utilities and work splitting logic.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from primus.backends.megatron.data.diffusion.preprocessing.utils import (
+    get_distributed_info,
+    split_work_for_rank,
+)
+from tests.utils import PrimusUT
+
+
+class TestGetDistributedInfo(PrimusUT):
+    """Tests for get_distributed_info utility."""
+
+    @patch("torch.distributed.is_initialized")
+    @patch("torch.distributed.is_available")
+    def test_not_distributed(self, mock_is_available, mock_is_initialized):
+        """Test get_distributed_info when not in distributed mode."""
+        mock_is_available.return_value = True
+        mock_is_initialized.return_value = False
+
+        rank, world_size = get_distributed_info()
+
+        assert rank == 0
+        assert world_size == 1
+
+    @patch("torch.distributed.get_world_size")
+    @patch("torch.distributed.get_rank")
+    @patch("torch.distributed.is_initialized")
+    @patch("torch.distributed.is_available")
+    def test_distributed_mode(
+        self, mock_is_available, mock_is_initialized, mock_get_rank, mock_get_world_size
+    ):
+        """Test get_distributed_info in distributed mode."""
+        mock_is_available.return_value = True
+        mock_is_initialized.return_value = True
+        mock_get_rank.return_value = 2
+        mock_get_world_size.return_value = 8
+
+        rank, world_size = get_distributed_info()
+
+        assert rank == 2
+        assert world_size == 8
+
+
+class TestSplitWorkForRank(PrimusUT):
+    """Tests for split_work_for_rank utility."""
+
+    def test_multiple_ranks_evenly_divisible(self):
+        """Test work splitting when items divide evenly."""
+        world_size = 4
+        total_items = 100
+
+        expected_splits = [
+            (0, 25),  # rank 0
+            (25, 50),  # rank 1
+            (50, 75),  # rank 2
+            (75, 100),  # rank 3 (last rank gets remainder)
+        ]
+
+        for rank, (expected_start, expected_end) in enumerate(expected_splits):
+            start, end = split_work_for_rank(total_items, rank, world_size)
+            assert start == expected_start
+            assert end == expected_end
+
+    def test_multiple_ranks_with_remainder(self):
+        """Test work splitting when items don't divide evenly."""
+        world_size = 3
+        total_items = 100
+
+        expected_splits = [
+            (0, 33),  # rank 0: 33 items
+            (33, 66),  # rank 1: 33 items
+            (66, 100),  # rank 2: 34 items (gets remainder)
+        ]
+
+        for rank, (expected_start, expected_end) in enumerate(expected_splits):
+            start, end = split_work_for_rank(total_items, rank, world_size)
+            assert start == expected_start
+            assert end == expected_end
+
+    def test_last_rank_gets_remainder(self):
+        """Test that last rank gets any remaining items."""
+        total_items = 107
+        world_size = 8
+        items_per_rank = total_items // world_size  # 13
+
+        # Last rank should get remainder
+        start, end = split_work_for_rank(total_items, rank=7, world_size=world_size)
+
+        assert start == 7 * items_per_rank  # 91
+        assert end == total_items  # 107 (gets all remaining)
+
+    def test_covers_all_items(self):
+        """Test that all ranks together cover all items."""
+        total_items = 137
+        world_size = 7
+
+        all_indices = set()
+        for rank in range(world_size):
+            start, end = split_work_for_rank(total_items, rank, world_size)
+            rank_indices = set(range(start, end))
+            # No overlap
+            assert len(all_indices & rank_indices) == 0
+            all_indices.update(rank_indices)
+
+        # All items covered
+        assert all_indices == set(range(total_items))
+
+    def test_fewer_items_than_ranks(self):
+        """Test work splitting when items < ranks."""
+        total_items = 5
+        world_size = 10
+
+        # First 5 ranks get 0 items each (5 // 10 = 0)
+        # Last rank gets all items
+        for rank in range(world_size - 1):
+            start, end = split_work_for_rank(total_items, rank, world_size)
+            # Each rank gets 0 items except last
+            assert start == 0
+            assert end == 0
+
+        # Last rank gets all
+        start, end = split_work_for_rank(total_items, rank=world_size - 1, world_size=world_size)
+        assert end == total_items
+
+
+class TestWorkSplittingEdgeCases(PrimusUT):
+    """Test edge cases for work splitting."""
+
+    def test_empty_work(self):
+        """Test with zero items."""
+        start, end = split_work_for_rank(total=0, rank=0, world_size=4)
+
+        assert start == 0
+        assert end == 0
+
+    def test_one_item(self):
+        """Test with single item."""
+        world_size = 4
+
+        # Ranks 0-2 get 0 items (1 // 4 = 0)
+        for rank in range(world_size - 1):
+            start, end = split_work_for_rank(1, rank, world_size)
+            assert start == 0
+            assert end == 0
+
+        # Last rank gets the 1 item
+        start, end = split_work_for_rank(1, rank=world_size - 1, world_size=world_size)
+        assert start == 0
+        assert end == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_validate.py
+++ b/tests/unit_tests/backends/megatron/diffusion/data/preprocessing/test_validate.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Tests for Energon dataset validation module.
+
+Tests _check_metadata, _check_sample_counts, and validate_energon_dataset
+using synthetic dataset directories.
+"""
+
+import json
+import tarfile
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from primus.backends.megatron.data.diffusion.preprocessing.validate import (
+    _check_metadata,
+    _check_sample_counts,
+    validate_energon_dataset,
+)
+from tests.utils import PrimusUT
+
+
+def _build_valid_dataset(base: Path, num_samples: int = 3) -> None:
+    """Helper: build a minimal valid dataset directory on disk."""
+    meta_dir = base / ".nv-meta"
+    meta_dir.mkdir(parents=True)
+
+    shard_name = "000000.tar"
+    idx_name = shard_name + ".idx"
+
+    # Write .info.json
+    info = {"shard_counts": {shard_name: num_samples}}
+    (meta_dir / ".info.json").write_text(json.dumps(info))
+
+    # Write split.yaml
+    split = {"split_parts": {"train": [shard_name]}}
+    (meta_dir / "split.yaml").write_text(yaml.dump(split))
+
+    # Write dataset.yaml
+    (meta_dir / "dataset.yaml").write_text("__module__: megatron.energon\n__class__: CrudeWebdataset\n")
+
+    # Write shard tar with correct number of samples
+    tar_path = base / shard_name
+    with tarfile.open(str(tar_path), "w") as tar:
+        for i in range(num_samples):
+            key = f"000000_{i:06d}"
+            for ext in ("jpg", "txt"):
+                member_name = f"{key}.{ext}"
+                data = b"test"
+                info_obj = tarfile.TarInfo(name=member_name)
+                info_obj.size = len(data)
+                import io
+
+                tar.addfile(info_obj, io.BytesIO(data))
+
+    # Write .idx stub
+    (base / idx_name).write_text("")
+
+
+class TestCheckMetadata(PrimusUT):
+    """Tests for _check_metadata."""
+
+    def test_valid_metadata(self):
+        """Valid .nv-meta with all files returns info dict."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base)
+            info = _check_metadata(base)
+
+            assert info is not None
+            assert "shard_counts" in info
+            assert "_splits" in info
+
+    def test_missing_info_json(self):
+        """Missing .info.json returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base)
+            (base / ".nv-meta" / ".info.json").unlink()
+
+            assert _check_metadata(base) is None
+
+    def test_missing_shard_counts_key(self):
+        """Info file without shard_counts key returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base)
+            (base / ".nv-meta" / ".info.json").write_text(json.dumps({"other": 1}))
+
+            assert _check_metadata(base) is None
+
+    def test_missing_split_yaml(self):
+        """Missing split.yaml returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base)
+            (base / ".nv-meta" / "split.yaml").unlink()
+
+            assert _check_metadata(base) is None
+
+    def test_missing_dataset_yaml(self):
+        """Missing dataset.yaml returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base)
+            (base / ".nv-meta" / "dataset.yaml").unlink()
+
+            assert _check_metadata(base) is None
+
+    def test_missing_shard_file(self):
+        """Referenced shard file missing on disk returns None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base)
+            (base / "000000.tar").unlink()
+
+            assert _check_metadata(base) is None
+
+
+class TestCheckSampleCounts(PrimusUT):
+    """Tests for _check_sample_counts."""
+
+    def test_matching_counts(self):
+        """Tar with correct sample count returns True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base, num_samples=3)
+
+            info = _check_metadata(base)
+            assert info is not None
+            assert _check_sample_counts(base, info) is True
+
+    def test_mismatched_counts(self):
+        """Mismatch between .info.json and tar content returns False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            _build_valid_dataset(base, num_samples=3)
+
+            # Overwrite .info.json with wrong count
+            wrong_info = {"shard_counts": {"000000.tar": 99}}
+            (base / ".nv-meta" / ".info.json").write_text(json.dumps(wrong_info))
+
+            info = _check_metadata(base)
+            assert info is not None
+            assert _check_sample_counts(base, info) is False
+
+
+class TestValidateEnergonDataset(PrimusUT):
+    """Tests for validate_energon_dataset orchestration."""
+
+    @patch(
+        "primus.backends.megatron.data.diffusion.preprocessing.validate._check_sample_load",
+        return_value={"jpg": "bytes, len=100", "txt": "str"},
+    )
+    def test_full_pass(self, mock_load):
+        """Complete valid dataset returns True."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _build_valid_dataset(Path(tmpdir), num_samples=3)
+            assert validate_energon_dataset(tmpdir, encoding="raw") is True
+
+    @patch(
+        "primus.backends.megatron.data.diffusion.preprocessing.validate._check_sample_load",
+        return_value={"jpg": "bytes, len=100", "txt": "str"},
+    )
+    def test_metadata_failure_returns_false(self, mock_load):
+        """Metadata failure returns False immediately (early exit)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Empty dir has no .nv-meta at all
+            assert validate_energon_dataset(tmpdir, encoding="raw") is False
+            mock_load.assert_not_called()
+
+    @patch(
+        "primus.backends.megatron.data.diffusion.preprocessing.validate._check_sample_load",
+        return_value={"jpg": "bytes, len=100", "txt": "str"},
+    )
+    def test_count_mismatch_returns_false(self, mock_load):
+        """Count mismatch returns False but still prints summary."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _build_valid_dataset(Path(tmpdir), num_samples=3)
+
+            # Corrupt the count
+            wrong_info = {"shard_counts": {"000000.tar": 99}}
+            (Path(tmpdir) / ".nv-meta" / ".info.json").write_text(json.dumps(wrong_info))
+
+            assert validate_energon_dataset(tmpdir, encoding="raw") is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit_tests/cli/test_data_config.py
+++ b/tests/unit_tests/cli/test_data_config.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Tests for data preprocessing config parsing, validation, and authentication.
+
+Tests the YAML-to-CLI mapping in data.py and the auth priority chain in auth.py.
+"""
+
+import argparse
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from primus.backends.megatron.data.diffusion.preprocessing.auth import (
+    setup_hf_authentication,
+)
+from primus.cli.subcommands.data import (
+    _flatten_preprocessing_config,
+    _get_encoded_parser_defaults,
+    _load_config_with_cli_overrides,
+    _validate_preprocessing_config,
+)
+from tests.utils import PrimusUT
+
+
+class TestFlattenPreprocessingConfig(PrimusUT):
+    """Tests for _flatten_preprocessing_config YAML-to-flat-dict mapping."""
+
+    def test_all_sections_mapped(self):
+        """All 6 YAML sections produce correct flat keys."""
+        config = {
+            "source": {
+                "type": "huggingface",
+                "hf_dataset": "diffusers/pokemon",
+                "hf_split": "train",
+            },
+            "data_format": {
+                "image_key": "jpg",
+                "caption_key": "json.caption",
+            },
+            "output": {
+                "output_dir": "/data/out",
+                "shard_size": 500,
+            },
+            "model": {
+                "model_path": "my-model",
+                "batch_size": 4,
+                "precision": "fp16",
+            },
+            "image": {
+                "image_size": 512,
+                "variable_size": True,
+                "center_crop": False,
+            },
+            "auth": {
+                "hf_token_file": "/path/to/token",
+            },
+        }
+        flat = _flatten_preprocessing_config(config)
+
+        assert flat["source_type"] == "huggingface"
+        assert flat["hf_dataset"] == "diffusers/pokemon"
+        assert flat["image_key"] == "jpg"
+        assert flat["caption_key"] == "json.caption"
+        assert flat["output_dir"] == "/data/out"
+        assert flat["shard_size"] == 500
+        assert flat["model_path"] == "my-model"
+        assert flat["batch_size"] == 4
+        assert flat["precision"] == "fp16"
+        assert flat["image_size"] == 512
+        assert flat["variable_size"] is True
+        assert flat["center_crop"] is False
+        assert flat["hf_token_file"] == "/path/to/token"
+
+    def test_partial_config(self):
+        """Partial config with only source + output produces only those keys."""
+        config = {
+            "source": {"type": "directory", "input_dir": "/data/images"},
+            "output": {"output_dir": "/data/out"},
+        }
+        flat = _flatten_preprocessing_config(config)
+
+        assert flat["source_type"] == "directory"
+        assert flat["input_dir"] == "/data/images"
+        assert flat["output_dir"] == "/data/out"
+        assert "model_path" not in flat
+        assert "image_size" not in flat
+
+    def test_model_defaults(self):
+        """Model section injects correct defaults when keys are absent."""
+        config = {"model": {}}
+        flat = _flatten_preprocessing_config(config)
+
+        assert flat["model_path"] == "black-forest-labs/FLUX.1-dev"
+        assert flat["batch_size"] == 8
+        assert flat["precision"] == "bf16"
+        assert flat["device"] == "cuda"
+        assert flat["t5_max_length"] == 512
+
+    def test_image_defaults(self):
+        """Image section injects correct defaults when keys are absent."""
+        config = {"image": {}}
+        flat = _flatten_preprocessing_config(config)
+
+        assert flat["image_size"] == 1024
+        assert flat["variable_size"] is False
+        assert flat["center_crop"] is True
+        assert flat["max_size"] == 1024
+
+
+class TestValidatePreprocessingConfig(PrimusUT):
+    """Tests for _validate_preprocessing_config."""
+
+    def _make_args(self, **kwargs):
+        defaults = {
+            "source_type": "huggingface",
+            "output_dir": "/data/out",
+            "hf_dataset": "test/dataset",
+            "input_dir": None,
+            "input_path": None,
+        }
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_missing_source_type_raises(self):
+        """Missing source_type raises ValueError."""
+        args = self._make_args(source_type=None)
+        with self.assertRaises(ValueError, msg="source_type"):
+            _validate_preprocessing_config(args)
+
+    def test_missing_output_dir_raises(self):
+        """Missing output_dir raises ValueError."""
+        args = self._make_args(output_dir=None)
+        with self.assertRaises(ValueError, msg="output_dir"):
+            _validate_preprocessing_config(args)
+
+    def test_huggingface_without_hf_dataset_raises(self):
+        """HuggingFace source without hf_dataset raises ValueError."""
+        args = self._make_args(source_type="huggingface", hf_dataset=None)
+        with self.assertRaises(ValueError, msg="hf-dataset"):
+            _validate_preprocessing_config(args)
+
+    def test_directory_without_input_dir_raises(self):
+        """Directory source without input_dir raises ValueError."""
+        args = self._make_args(source_type="directory", input_dir=None)
+        with self.assertRaises(ValueError, msg="input-dir"):
+            _validate_preprocessing_config(args)
+
+    def test_valid_config_passes(self):
+        """Valid config raises no errors."""
+        args = self._make_args()
+        _validate_preprocessing_config(args)
+
+
+class TestLoadConfigWithCliOverrides(PrimusUT):
+    """Tests for _load_config_with_cli_overrides merge logic."""
+
+    @patch("primus.core.utils.yaml_utils.parse_yaml")
+    def test_cli_overrides_yaml(self, mock_parse_yaml):
+        """Explicitly set CLI args override YAML config values."""
+        mock_parse_yaml.return_value = {
+            "source": {"type": "huggingface", "hf_dataset": "yaml-dataset"},
+            "model": {"batch_size": 4},
+        }
+        defaults = _get_encoded_parser_defaults()
+        args = argparse.Namespace(
+            config="test.yaml",
+            batch_size=16,
+            **{k: v for k, v in defaults.items() if k not in ("config", "batch_size")},
+        )
+
+        result = _load_config_with_cli_overrides(args)
+
+        assert result.batch_size == 16
+        assert result.hf_dataset == "yaml-dataset"
+
+    @patch("primus.core.utils.yaml_utils.parse_yaml")
+    def test_yaml_used_when_cli_is_default(self, mock_parse_yaml):
+        """YAML values used when CLI arg equals its default."""
+        mock_parse_yaml.return_value = {
+            "model": {"batch_size": 4},
+        }
+        defaults = _get_encoded_parser_defaults()
+        args = argparse.Namespace(config="test.yaml", **{k: v for k, v in defaults.items() if k != "config"})
+
+        result = _load_config_with_cli_overrides(args)
+
+        assert result.batch_size == 4
+
+    def test_no_config_passthrough(self):
+        """No config file returns args unchanged."""
+        original = argparse.Namespace(config=None, batch_size=8)
+        result = _load_config_with_cli_overrides(original)
+        assert result is original
+
+
+class TestSetupHfAuthenticationPriority(PrimusUT):
+    """Tests for setup_hf_authentication priority chain."""
+
+    def test_file_takes_priority_over_env(self):
+        """Token file takes priority over HF_TOKEN env var."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".token", delete=False) as f:
+            f.write("hf_file_token_123")
+            token_path = f.name
+        try:
+            os.chmod(token_path, 0o600)
+            old_env = os.environ.get("HF_TOKEN")
+            os.environ["HF_TOKEN"] = "hf_env_token_456"
+            try:
+                token = setup_hf_authentication(token_file=token_path, use_env=True)
+                assert token == "hf_file_token_123"
+            finally:
+                if old_env is None:
+                    os.environ.pop("HF_TOKEN", None)
+                else:
+                    os.environ["HF_TOKEN"] = old_env
+        finally:
+            os.unlink(token_path)
+
+    def test_env_takes_priority_over_cache(self):
+        """HF_TOKEN env var is used when no file is provided."""
+        old_env = os.environ.get("HF_TOKEN")
+        os.environ["HF_TOKEN"] = "hf_env_token_789"
+        try:
+            token = setup_hf_authentication(token_file=None, use_env=True)
+            assert token == "hf_env_token_789"
+        finally:
+            if old_env is None:
+                os.environ.pop("HF_TOKEN", None)
+            else:
+                os.environ["HF_TOKEN"] = old_env
+
+    def test_no_auth_returns_none(self):
+        """No auth sources returns None."""
+        old_env = os.environ.pop("HF_TOKEN", None)
+        try:
+            with patch.object(
+                type(__import__("pathlib").Path()),
+                "exists",
+                return_value=False,
+            ):
+                token = setup_hf_authentication(token_file=None, use_env=True)
+                assert token is None
+        finally:
+            if old_env is not None:
+                os.environ["HF_TOKEN"] = old_env
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Part of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Targets `feat/flux/data` — review after it.

## What this changes
The offline data-preprocessing layer (auth / download / finalize / validate plus the raw/ingest/encoded pipeline stages), wired into a new `primus data` CLI subcommand.

## Dependencies
Sequenced after the CI-pins PR (`feat/flux/ci-env`); builds on `feat/flux/data` (uses its providers and inherits the energon/webdataset deps).

## Test plan
`pytest tests/unit_tests/backends/megatron/diffusion/data/preprocessing tests/unit_tests/cli/test_data_config.py`. Validated locally on an AMD GPU container: 63 passed.

## Files
20 (preprocessing pipelines, data CLI subcommand + tests).
