### PR TITLE
feat(flux): Flux HF->Primus checkpoint conversion tools

### DIFF
--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_checkpoint_converter.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_checkpoint_converter.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for Flux checkpoint converter.
+
+Tests QKV fusion, key mapping, and checkpoint conversion logic.
+"""
+
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus.backends.megatron.core.models.diffusion.flux import FluxConfig
+from tests.utils import PrimusUT
+
+# Note: We use lazy imports for checkpoint_converter functions to avoid
+# triggering parent package imports that require Megatron. Functions are
+# imported inside test methods when needed.
+
+
+class TestQKVWeightFusion(PrimusUT):
+    """Test QKV weight fusion for GQA."""
+
+    def test_qkv_weight_fusion_shape(self):
+        """Test that QKV fusion produces correct output shape."""
+        # Lazy import to avoid parent package Megatron dependency
+        from primus.backends.megatron.core.models.diffusion.flux.checkpoint_converter import (
+            _fuse_qkv_weights,
+        )
+
+        # Use Flux 12B config: hidden_size=3072, num_heads=24, head_size=128
+        config = FluxConfig.flux_12b()
+
+        hidden_size = config.hidden_size
+        q_weight = torch.randn(hidden_size, hidden_size)
+        k_weight = torch.randn(hidden_size, hidden_size)
+        v_weight = torch.randn(hidden_size, hidden_size)
+
+        # Fuse
+        qkv_weight = _fuse_qkv_weights(config, q_weight, k_weight, v_weight)
+
+        # Expected shape: [head_size * (num_heads + 2*num_query_groups), hidden_size]
+        # For Flux: num_query_groups = num_heads = 24
+        # So: [128 * (24 + 2*24), 3072] = [128 * 72, 3072] = [9216, 3072]
+        num_heads = config.num_attention_heads
+        num_query_groups = getattr(config, "num_query_groups", num_heads)
+        head_size = hidden_size // num_heads
+        expected_shape = (head_size * (num_heads + 2 * num_query_groups), hidden_size)
+
+        assert qkv_weight.shape == expected_shape, f"Expected {expected_shape}, got {qkv_weight.shape}"
+
+    def test_qkv_weight_fusion_interleaving(self):
+        """Test that QKV weights are interleaved correctly per group."""
+        # Lazy import to avoid parent package Megatron dependency
+        from primus.backends.megatron.core.models.diffusion.flux.checkpoint_converter import (
+            _fuse_qkv_weights,
+        )
+
+        # Use Flux 535M config with simple values for easier validation
+        # Note: Flux 535M has hidden_size=3072, num_heads=24, but we adjust expectations
+        # for the interleaving test which needs smaller values
+        config = FluxConfig.flux_535m()
+        # Override for test simplicity - fusion algorithm works with any config
+        config.hidden_size = 64
+        config.num_attention_heads = 4
+        config.num_query_groups = 4
+
+        hidden_size = 64
+        head_size = 16
+
+        # Create identifiable weights
+        q_weight = torch.ones(hidden_size, hidden_size) * 1.0
+        k_weight = torch.ones(hidden_size, hidden_size) * 2.0
+        v_weight = torch.ones(hidden_size, hidden_size) * 3.0
+
+        qkv_weight = _fuse_qkv_weights(config, q_weight, k_weight, v_weight)
+
+        # Reshape to verify interleaving: [heads_per_group + 2, num_groups, head_size, hidden_size]
+        # For this config: heads_per_group=1, num_groups=4
+        # So we expect pattern: [Q0, K0, V0, Q1, K1, V1, Q2, K2, V2, Q3, K3, V3]
+        qkv_reshaped = qkv_weight.reshape(4, 3, head_size, hidden_size)
+
+        # Check first group
+        assert torch.allclose(qkv_reshaped[0, 0], torch.ones(head_size, hidden_size) * 1.0), "Q0 mismatch"
+        assert torch.allclose(qkv_reshaped[0, 1], torch.ones(head_size, hidden_size) * 2.0), "K0 mismatch"
+        assert torch.allclose(qkv_reshaped[0, 2], torch.ones(head_size, hidden_size) * 3.0), "V0 mismatch"
+
+
+class TestQKVBiasFusion(PrimusUT):
+    """Test QKV bias fusion for GQA."""
+
+    def test_qkv_bias_fusion_shape(self):
+        """Test that QKV bias fusion produces correct output shape."""
+        # Lazy import to avoid parent package Megatron dependency
+        from primus.backends.megatron.core.models.diffusion.flux.checkpoint_converter import (
+            _fuse_qkv_bias,
+        )
+
+        # Use Flux 12B config
+        config = FluxConfig.flux_12b()
+
+        hidden_size = config.hidden_size
+        q_bias = torch.randn(hidden_size)
+        k_bias = torch.randn(hidden_size)
+        v_bias = torch.randn(hidden_size)
+
+        qkv_bias = _fuse_qkv_bias(config, q_bias, k_bias, v_bias)
+
+        # Expected shape: [head_size * (num_heads + 2*num_query_groups)]
+        num_heads = config.num_attention_heads
+        num_query_groups = getattr(config, "num_query_groups", num_heads)
+        head_size = hidden_size // num_heads
+        expected_shape = (head_size * (num_heads + 2 * num_query_groups),)
+
+        assert qkv_bias.shape == expected_shape, f"Expected {expected_shape}, got {qkv_bias.shape}"
+
+    def test_qkv_bias_fusion_interleaving(self):
+        """Test that QKV biases are interleaved correctly."""
+        # Lazy import to avoid parent package Megatron dependency
+        from primus.backends.megatron.core.models.diffusion.flux.checkpoint_converter import (
+            _fuse_qkv_bias,
+        )
+
+        # Use Flux 535M config with simple values for easier validation
+        config = FluxConfig.flux_535m()
+        # Override for test simplicity - fusion algorithm works with any config
+        config.hidden_size = 64
+        config.num_attention_heads = 4
+        config.num_query_groups = 4
+
+        # Create identifiable biases
+        q_bias = torch.ones(64) * 1.0
+        k_bias = torch.ones(64) * 2.0
+        v_bias = torch.ones(64) * 3.0
+
+        qkv_bias = _fuse_qkv_bias(config, q_bias, k_bias, v_bias)
+
+        # Reshape to verify: [num_groups, heads_per_group + 2, head_size]
+        qkv_reshaped = qkv_bias.reshape(4, 3, 16)
+
+        # Check first group
+        assert torch.allclose(qkv_reshaped[0, 0], torch.ones(16) * 1.0)
+        assert torch.allclose(qkv_reshaped[0, 1], torch.ones(16) * 2.0)
+        assert torch.allclose(qkv_reshaped[0, 2], torch.ones(16) * 3.0)
+
+
+class TestCheckpointConversion:
+    """Test end-to-end checkpoint conversion (with mock data)."""
+
+    def test_mock_conversion(self, tmp_path):
+        """Test conversion with mock HF checkpoint."""
+        from safetensors.torch import save_file as save_safetensors
+
+        from primus.backends.megatron.core.models.diffusion.flux.checkpoint_converter import (
+            convert_hf_checkpoint,
+        )
+
+        # Create minimal mock HF checkpoint for Flux 535M (1 joint + 1 single layer)
+        config = FluxConfig.flux_535m()
+        hidden_size = config.hidden_size
+
+        mock_state_dict = {}
+
+        # Double block 0
+        mock_state_dict["transformer_blocks.0.norm1.linear.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.norm1.linear.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_q.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_q.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_k.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_k.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_v.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_v.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_out.0.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_out.0.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.norm_q.weight"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.norm_k.weight"] = torch.randn(hidden_size)
+
+        # Added attention
+        mock_state_dict["transformer_blocks.0.attn.add_q_proj.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.add_q_proj.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.add_k_proj.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.add_k_proj.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.add_v_proj.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.add_v_proj.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_add_out.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.to_add_out.bias"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.norm_added_q.weight"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.attn.norm_added_k.weight"] = torch.randn(hidden_size)
+        mock_state_dict["transformer_blocks.0.norm1_context.linear.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["transformer_blocks.0.norm1_context.linear.bias"] = torch.randn(hidden_size)
+
+        # MLP
+        mock_state_dict["transformer_blocks.0.ff.net.0.proj.weight"] = torch.randn(
+            hidden_size * 4, hidden_size
+        )
+        mock_state_dict["transformer_blocks.0.ff.net.0.proj.bias"] = torch.randn(hidden_size * 4)
+        mock_state_dict["transformer_blocks.0.ff.net.2.weight"] = torch.randn(hidden_size, hidden_size * 4)
+        mock_state_dict["transformer_blocks.0.ff.net.2.bias"] = torch.randn(hidden_size)
+
+        # Context MLP
+        mock_state_dict["transformer_blocks.0.ff_context.net.0.proj.weight"] = torch.randn(
+            hidden_size * 4, hidden_size
+        )
+        mock_state_dict["transformer_blocks.0.ff_context.net.0.proj.bias"] = torch.randn(hidden_size * 4)
+        mock_state_dict["transformer_blocks.0.ff_context.net.2.weight"] = torch.randn(
+            hidden_size, hidden_size * 4
+        )
+        mock_state_dict["transformer_blocks.0.ff_context.net.2.bias"] = torch.randn(hidden_size)
+
+        # Single block 0
+        mock_state_dict["single_transformer_blocks.0.norm.linear.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["single_transformer_blocks.0.norm.linear.bias"] = torch.randn(hidden_size)
+        mock_state_dict["single_transformer_blocks.0.attn.to_q.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["single_transformer_blocks.0.attn.to_q.bias"] = torch.randn(hidden_size)
+        mock_state_dict["single_transformer_blocks.0.attn.to_k.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["single_transformer_blocks.0.attn.to_k.bias"] = torch.randn(hidden_size)
+        mock_state_dict["single_transformer_blocks.0.attn.to_v.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["single_transformer_blocks.0.attn.to_v.bias"] = torch.randn(hidden_size)
+        mock_state_dict["single_transformer_blocks.0.attn.norm_q.weight"] = torch.randn(hidden_size)
+        mock_state_dict["single_transformer_blocks.0.attn.norm_k.weight"] = torch.randn(hidden_size)
+        mock_state_dict["single_transformer_blocks.0.proj_mlp.weight"] = torch.randn(
+            hidden_size * 4, hidden_size
+        )
+        mock_state_dict["single_transformer_blocks.0.proj_mlp.bias"] = torch.randn(hidden_size * 4)
+        mock_state_dict["single_transformer_blocks.0.proj_out.weight"] = torch.randn(
+            hidden_size, hidden_size * 2
+        )
+        mock_state_dict["single_transformer_blocks.0.proj_out.bias"] = torch.randn(hidden_size)
+
+        # Root level
+        mock_state_dict["x_embedder.weight"] = torch.randn(hidden_size, 64)
+        mock_state_dict["x_embedder.bias"] = torch.randn(hidden_size)
+        mock_state_dict["context_embedder.weight"] = torch.randn(hidden_size, 4096)
+        mock_state_dict["context_embedder.bias"] = torch.randn(hidden_size)
+        mock_state_dict["time_text_embed.timestep_embedder.linear_1.weight"] = torch.randn(hidden_size, 256)
+        mock_state_dict["time_text_embed.timestep_embedder.linear_1.bias"] = torch.randn(hidden_size)
+        mock_state_dict["time_text_embed.timestep_embedder.linear_2.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["time_text_embed.timestep_embedder.linear_2.bias"] = torch.randn(hidden_size)
+        mock_state_dict["time_text_embed.text_embedder.linear_1.weight"] = torch.randn(hidden_size, 768)
+        mock_state_dict["time_text_embed.text_embedder.linear_1.bias"] = torch.randn(hidden_size)
+        mock_state_dict["time_text_embed.text_embedder.linear_2.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["time_text_embed.text_embedder.linear_2.bias"] = torch.randn(hidden_size)
+        mock_state_dict["time_text_embed.guidance_embedder.linear_1.weight"] = torch.randn(hidden_size, 256)
+        mock_state_dict["time_text_embed.guidance_embedder.linear_1.bias"] = torch.randn(hidden_size)
+        mock_state_dict["time_text_embed.guidance_embedder.linear_2.weight"] = torch.randn(
+            hidden_size, hidden_size
+        )
+        mock_state_dict["time_text_embed.guidance_embedder.linear_2.bias"] = torch.randn(hidden_size)
+        mock_state_dict["norm_out.linear.weight"] = torch.randn(hidden_size, hidden_size)
+        mock_state_dict["norm_out.linear.bias"] = torch.randn(hidden_size)
+        mock_state_dict["proj_out.weight"] = torch.randn(64, hidden_size)
+        mock_state_dict["proj_out.bias"] = torch.randn(64)
+
+        # Save mock checkpoint
+        checkpoint_path = tmp_path / "mock_flux.safetensors"
+        save_safetensors(mock_state_dict, str(checkpoint_path))
+
+        # Convert
+        primus_state_dict = convert_hf_checkpoint(
+            checkpoint_path,
+            flux_config=config,
+            save_to=None,
+        )
+
+        # Verify conversion
+        assert len(primus_state_dict) > 0, "Converted state dict is empty"
+
+        # Check that QKV was fused (with new TransformerBlock naming)
+        assert "transformer.layers.0.self_attention.linear_qkv.weight" in primus_state_dict
+        assert "transformer.layers.0.self_attention.linear_qkv.bias" in primus_state_dict
+        assert "transformer.layers.1.self_attention.linear_qkv.weight" in primus_state_dict
+
+        # Check that proj_out was split for single blocks
+        assert "transformer.layers.1.self_attention.linear_proj.weight" in primus_state_dict
+        assert "transformer.layers.1.mlp.linear_fc2.weight" in primus_state_dict
+
+        # Verify key mapping worked (with new TransformerBlock naming)
+        assert "transformer.layers.0.adaln.adaLN_modulation.1.weight" in primus_state_dict
+        # Note: Layer 1 is FluxSingleTransformerBlock which has different adaln structure
+
+        # norm_out scale/shift swap (the converter's only non-trivial root-level
+        # math): HF Diffusers stores the modulation as [SCALE; SHIFT] but
+        # Primus/BFL native expects [SHIFT; SCALE], so the two halves must be
+        # swapped along dim 0 -- a plain key-rename/passthrough would be a bug.
+        orig_w = mock_state_dict["norm_out.linear.weight"]
+        orig_b = mock_state_dict["norm_out.linear.bias"]
+        half_w = orig_w.shape[0] // 2
+        half_b = orig_b.shape[0] // 2
+        expected_w = torch.cat([orig_w[half_w:, :], orig_w[:half_w, :]], dim=0)
+        expected_b = torch.cat([orig_b[half_b:], orig_b[:half_b]], dim=0)
+
+        conv_w = primus_state_dict["norm_out.adaLN_modulation.1.weight"]
+        conv_b = primus_state_dict["norm_out.adaLN_modulation.1.bias"]
+        assert torch.equal(conv_w, expected_w), "norm_out weight halves were not swapped"
+        assert torch.equal(conv_b, expected_b), "norm_out bias halves were not swapped"
+        # Positive control: the swap must actually reorder, not pass through.
+        assert not torch.equal(conv_w, orig_w), "norm_out weight passed through without the scale/shift swap"
+        assert not torch.equal(conv_b, orig_b), "norm_out bias passed through without the scale/shift swap"

--- a/tools/checkpoint_conversion/convert_flux_hf_to_primus.py
+++ b/tools/checkpoint_conversion/convert_flux_hf_to_primus.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Convert HuggingFace Flux checkpoint to Primus format.
+
+This tool converts HuggingFace Diffusers Flux transformer checkpoints to
+Primus/Megatron-Core compatible format. It handles:
+- QKV weight fusion for grouped-query attention (GQA)
+- Key mapping from HF to Primus naming conventions
+- Single block proj_out splitting
+- Multi-file safetensors loading
+
+Usage:
+    # Convert FLUX.1-dev checkpoint
+    python tools/checkpoint_conversion/convert_flux_hf_to_primus.py \\
+        --input black-forest-labs/FLUX.1-dev \\
+        --output checkpoints/primus_flux_12b.safetensors \\
+        --variant flux_12b
+
+    # Convert with custom architecture
+    python tools/checkpoint_conversion/convert_flux_hf_to_primus.py \\
+        --input path/to/checkpoint \\
+        --output checkpoints/primus_custom.safetensors \\
+        --variant custom \\
+        --num-joint-layers 10 \\
+        --num-single-layers 20
+
+Example:
+    $ python tools/checkpoint_conversion/convert_flux_hf_to_primus.py \\
+        --input black-forest-labs/FLUX.1-dev \\
+        --output checkpoints/primus_flux_12b.safetensors \\
+        --variant flux_12b
+
+    Converting flux_12b checkpoint
+      Input: black-forest-labs/FLUX.1-dev
+      Output: checkpoints/primus_flux_12b.safetensors
+      Architecture: 19 joint + 38 single layers
+    Loading HuggingFace checkpoint from: black-forest-labs/FLUX.1-dev
+    ...
+    Conversion complete!
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add primus to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from primus.backends.megatron.core.models.diffusion.flux import (
+    FluxConfig,
+    convert_hf_checkpoint,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert HuggingFace Flux checkpoint to Primus format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Convert FLUX.1-dev (12B parameters)
+  %(prog)s --input black-forest-labs/FLUX.1-dev \\
+           --output checkpoints/primus_flux_12b.safetensors \\
+           --variant flux_12b
+
+  # Convert local checkpoint directory
+  %(prog)s --input /path/to/flux/checkpoint \\
+           --output primus_flux.safetensors \\
+           --variant flux_12b
+
+  # Convert with custom architecture
+  %(prog)s --input /path/to/checkpoint \\
+           --output primus_custom.safetensors \\
+           --variant custom \\
+           --num-joint-layers 10 \\
+           --num-single-layers 20
+        """,
+    )
+
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to HF checkpoint (file, directory, or HF model ID like 'black-forest-labs/FLUX.1-dev')",
+    )
+    parser.add_argument("--output", required=True, help="Output path for Primus checkpoint (.safetensors)")
+    parser.add_argument(
+        "--variant",
+        choices=["flux_535m", "flux_12b", "custom"],
+        default="flux_12b",
+        help="Flux variant (determines architecture). Default: flux_12b",
+    )
+    parser.add_argument(
+        "--num-joint-layers", type=int, help="Number of joint layers (only with --variant custom)"
+    )
+    parser.add_argument(
+        "--num-single-layers", type=int, help="Number of single layers (only with --variant custom)"
+    )
+
+    args = parser.parse_args()
+
+    # Validate custom variant arguments
+    if args.variant == "custom":
+        if not args.num_joint_layers or not args.num_single_layers:
+            parser.error("--num-joint-layers and --num-single-layers are required with --variant custom")
+    else:
+        if args.num_joint_layers or args.num_single_layers:
+            parser.error("--num-joint-layers and --num-single-layers can only be used with --variant custom")
+
+    # Create config based on variant
+    if args.variant == "flux_535m":
+        config = FluxConfig.flux_535m()
+    elif args.variant == "flux_12b":
+        config = FluxConfig.flux_12b()
+    else:  # custom
+        config = FluxConfig(num_joint_layers=args.num_joint_layers, num_single_layers=args.num_single_layers)
+
+    # Print conversion info
+    print("=" * 80)
+    print(f"Converting {args.variant} checkpoint")
+    print(f"  Input:  {args.input}")
+    print(f"  Output: {args.output}")
+    print(f"  Architecture: {config.num_joint_layers} joint + {config.num_single_layers} single layers")
+    print("=" * 80)
+    print()
+
+    # Convert checkpoint
+    try:
+        convert_hf_checkpoint(
+            checkpoint_path=args.input,
+            flux_config=config,
+            save_to=args.output,
+        )
+
+        print()
+        print("=" * 80)
+        print("✓ Conversion complete!")
+        print(f"Primus checkpoint saved to: {args.output}")
+        print("=" * 80)
+
+        return 0
+
+    except Exception as e:
+        print()
+        print("=" * 80)
+        print(f"✗ Conversion failed: {e}")
+        print("=" * 80)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/generate_empty_encodings.py
+++ b/tools/generate_empty_encodings.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Generate empty T5 and CLIP encodings for CFG dropout.
+
+Runs T5-XXL and CLIP-L on the empty string ("") and saves the resulting
+embeddings as .npy files. These are loaded by FluxPretrainTrainer at init
+to replace text embeddings during classifier-free guidance dropout.
+
+Using real model outputs (instead of torch.randn) is critical for training
+convergence — see NVIDIA MLPerf Training v5.1 reference.
+
+Usage:
+    python tools/generate_empty_encodings.py \
+        --output_dir /path/to/empty_encodings \
+        --t5_model google/t5-v1_1-xxl \
+        --clip_model openai/clip-vit-large-patch14 \
+        --t5_max_length 256
+
+Output files:
+    t5_empty.npy   - shape (1, seq_len, 4096)
+    clip_empty.npy - shape (1, 768)
+"""
+
+import argparse
+import os
+
+import numpy as np
+import torch
+
+
+def generate_t5_empty(model_name: str, max_length: int, device: str) -> np.ndarray:
+    """Generate T5-XXL encoding for empty string."""
+    from transformers import T5EncoderModel, T5Tokenizer
+
+    print(f"Loading T5 tokenizer: {model_name}")
+    tokenizer = T5Tokenizer.from_pretrained(model_name)
+
+    print(f"Loading T5 model: {model_name}")
+    model = T5EncoderModel.from_pretrained(model_name, torch_dtype=torch.float32)
+    model = model.to(device).eval()
+
+    with torch.no_grad():
+        inputs = tokenizer(
+            "",
+            max_length=max_length,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
+        ).to(device)
+
+        outputs = model(**inputs)
+        # outputs.last_hidden_state: (1, seq_len, 4096)
+        embeddings = outputs.last_hidden_state.cpu().numpy()
+
+    print(f"T5 empty encoding shape: {embeddings.shape}")
+    del model
+    torch.cuda.empty_cache()
+    return embeddings
+
+
+def generate_clip_empty(model_name: str, device: str) -> np.ndarray:
+    """Generate CLIP-L pooled encoding for empty string."""
+    from transformers import CLIPTextModel, CLIPTokenizer
+
+    print(f"Loading CLIP tokenizer: {model_name}")
+    tokenizer = CLIPTokenizer.from_pretrained(model_name)
+
+    print(f"Loading CLIP model: {model_name}")
+    model = CLIPTextModel.from_pretrained(model_name, torch_dtype=torch.float32)
+    model = model.to(device).eval()
+
+    with torch.no_grad():
+        inputs = tokenizer(
+            "",
+            max_length=tokenizer.model_max_length,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
+        ).to(device)
+
+        outputs = model(**inputs)
+        # outputs.pooler_output: (1, 768)
+        pooled = outputs.pooler_output.cpu().numpy()
+
+    print(f"CLIP empty encoding shape: {pooled.shape}")
+    del model
+    torch.cuda.empty_cache()
+    return pooled
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate empty T5/CLIP encodings for CFG dropout")
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        required=True,
+        help="Directory to save t5_empty.npy and clip_empty.npy",
+    )
+    parser.add_argument(
+        "--t5_model",
+        type=str,
+        default="google/t5-v1_1-xxl",
+        help="T5 model name or path (default: google/t5-v1_1-xxl)",
+    )
+    parser.add_argument(
+        "--clip_model",
+        type=str,
+        default="openai/clip-vit-large-patch14",
+        help="CLIP model name or path (default: openai/clip-vit-large-patch14)",
+    )
+    parser.add_argument(
+        "--t5_max_length",
+        type=int,
+        default=256,
+        help="Max sequence length for T5 encoding (default: 256 for schnell)",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Device to run models on (default: cuda if available)",
+    )
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    t5_path = os.path.join(args.output_dir, "t5_empty.npy")
+    clip_path = os.path.join(args.output_dir, "clip_empty.npy")
+
+    t5_embeddings = generate_t5_empty(args.t5_model, args.t5_max_length, args.device)
+    np.save(t5_path, t5_embeddings)
+    print(f"Saved T5 empty encodings to: {t5_path}")
+
+    clip_embeddings = generate_clip_empty(args.clip_model, args.device)
+    np.save(clip_path, clip_embeddings)
+    print(f"Saved CLIP empty encodings to: {clip_path}")
+
+    print("\nDone! Add to your YAML config:")
+    print(f"  empty_encodings_path: {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Targets `feat/flux/flux` — review after it.

## What this changes
Standalone tooling — the HF→Primus Flux checkpoint converter and the empty-encoding generator, plus the converter test. The converter module itself ships in the Flux model PR; this PR is just the CLI tools that use it.

## Dependencies
Sequenced after the CI-pins PR (`feat/flux/ci-env`); builds on `feat/flux/flux`.

## Test plan
`pytest tests/unit_tests/backends/megatron/diffusion/test_flux_checkpoint_converter.py`. Validated locally on an AMD GPU container: 5 passed.

## Files
3 (checkpoint converter tool, empty-encoding generator + test).
