### PR TITLE
feat(flux): diffusion + Flux pretrain trainers

### DIFF
--- a/primus/backends/megatron/core/models/diffusion/flux/config.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/config.py
@@ -20,6 +20,18 @@ import torch.nn as nn
 
 from ..common.config import BaseDiffusionConfig
 
+# Try to import erf_gelu from megatron, fallback to custom implementation
+try:
+    from megatron.core.transformer.utils import erf_gelu
+except ImportError:
+    # Fallback used when Megatron's erf_gelu is unavailable
+    def erf_gelu(x):
+        """GELU activation using error function approximation."""
+        return 0.5 * x * (1.0 + torch.erf(x / 1.4142135623730951))
+
+
+__all__ = ["FluxConfig", "openai_gelu_no_jit", "erf_gelu"]
+
 
 # Custom non-JIT compiled openai_gelu to avoid ROCm bugs
 def openai_gelu_no_jit(x):

--- a/primus/backends/megatron/diffusion_trainer.py
+++ b/primus/backends/megatron/diffusion_trainer.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn.functional as F
 
 from primus.backends.megatron.megatron_pretrain_trainer import MegatronPretrainTrainer
-from primus.modules.module_utils import log_rank_0
+from primus.core.utils.module_utils import log_rank_0
 
 
 class DiffusionPretrainTrainer(MegatronPretrainTrainer):

--- a/primus/backends/megatron/diffusion_trainer.py
+++ b/primus/backends/megatron/diffusion_trainer.py
@@ -1,0 +1,386 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Base diffusion trainer for Megatron-LM.
+
+This trainer provides a foundation for diffusion model training by overriding
+the forward step and dataset provider methods from MegatronPretrainTrainer.
+"""
+
+from abc import abstractmethod
+
+import torch
+import torch.nn.functional as F
+
+from primus.backends.megatron.megatron_pretrain_trainer import MegatronPretrainTrainer
+from primus.modules.module_utils import log_rank_0
+
+
+class DiffusionPretrainTrainer(MegatronPretrainTrainer):
+    """
+    Base trainer for diffusion models.
+
+    This trainer inherits from the backend's MegatronPretrainTrainer (which uses
+    MegatronBaseTrainer).
+
+    It overrides the forward step and dataset provider methods to support
+    diffusion-specific training. Subclasses should implement create_scheduler()
+    and may override create_model() if needed.
+
+    Configuration is accessed via backend_args (set by BaseTrainer.__init__()),
+    not via module_config.params, to avoid BaseModule dependency.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize diffusion trainer.
+
+        Args:
+            *args: Positional arguments passed to parent trainer
+            **kwargs: Keyword arguments passed to parent trainer
+                     (backend_args is extracted from kwargs by BaseTrainer)
+        """
+        super().__init__(*args, **kwargs)
+
+        self._scheduler = None
+        self._compiled_loss_fn = None
+        self._forward_step_count = 0
+        self._forward_step_count_initialized = False
+
+        # Composition pattern: avoids recreating the provider on each call
+        use_mock_data = getattr(self.backend_args, "mock_data", False)
+
+        if use_mock_data:
+            from primus.backends.megatron.data.synthetic_dataset_provider import (
+                SyntheticDatasetProvider,
+            )
+
+            # Get mock dataset configuration from YAML (if specified)
+            mock_dataset_config_ns = getattr(self.backend_args, "mock_dataset", None)
+            mock_dataset_config = self._convert_namespace_to_dict(mock_dataset_config_ns)
+
+            # Determine model type for default dataset selection
+            model_type_raw = getattr(self.backend_args, "model_type", None)
+            model_type = (
+                model_type_raw
+                if (isinstance(model_type_raw, str) and model_type_raw != "diffusion_model")
+                else "flux"
+            )
+
+            self.data_provider = SyntheticDatasetProvider(
+                dataset_config=mock_dataset_config, model_type=model_type
+            )
+            log_rank_0("Created SyntheticDatasetProvider for mock data")
+        else:
+            from primus.backends.megatron.data.energon_dataset_provider import (
+                EnergonDatasetProvider,
+            )
+
+            self.data_provider = EnergonDatasetProvider(task_encoder_factory=lambda: self.get_task_encoder())
+            log_rank_0("Created EnergonDatasetProvider for real data")
+
+        log_rank_0(f"{self.__class__.__name__} initialized")
+        log_rank_0(f"Data provider: {type(self.data_provider).__name__}")
+
+    def _convert_namespace_to_dict(self, ns_obj):
+        """
+        Convert SimpleNamespace (or nested SimpleNamespace) to dict.
+
+        Handles nested namespaces by recursively converting them.
+
+        Args:
+            ns_obj: SimpleNamespace, dict, or None
+
+        Returns:
+            dict, original input (if already a dict or primitive), or None
+        """
+        if ns_obj is None:
+            return None
+
+        if not hasattr(ns_obj, "__dict__"):
+            return ns_obj  # Already a dict or other type
+
+        result = vars(ns_obj)
+
+        # Recursively convert nested namespaces
+        if "params" in result and hasattr(result["params"], "__dict__"):
+            result["params"] = vars(result["params"])
+
+        return result
+
+    def setup(self):
+        """
+        Override setup() to inject diffusion model_provider.
+
+        MegatronBaseTrainer.setup() handles Megatron path, global vars, and parse_args patching.
+        We only need to set the model_provider here.
+        """
+        # Ensure data_parallel_size is set before parent setup() calls set_primus_global_variables()
+        # This is required by set_primus_global_variables()
+        if not hasattr(self.backend_args, "data_parallel_size"):
+            world_size = getattr(self.backend_args, "world_size", 1)
+            tensor_model_parallel_size = getattr(self.backend_args, "tensor_model_parallel_size", 1)
+            pipeline_model_parallel_size = getattr(self.backend_args, "pipeline_model_parallel_size", 1)
+            context_parallel_size = getattr(self.backend_args, "context_parallel_size", 1)
+            data_parallel_size = world_size // (
+                tensor_model_parallel_size * pipeline_model_parallel_size * context_parallel_size
+            )
+            setattr(self.backend_args, "data_parallel_size", data_parallel_size)
+            log_rank_0(
+                f"Computed data_parallel_size={data_parallel_size} from world_size={world_size}, tp={tensor_model_parallel_size}, pp={pipeline_model_parallel_size}, cp={context_parallel_size}"
+            )
+
+        # Create and set diffusion model provider
+        def _diffusion_model_provider(
+            pre_process=True, post_process=True, vp_stage=None, config=None, pg_collection=None
+        ):
+            """
+            Model provider wrapper for diffusion models.
+
+            This matches Megatron's model_provider signature but calls
+            our diffusion-specific create_model() instead of gpt_builder.
+
+            Note: vp_stage, config, and pg_collection are accepted for interface
+            compatibility with Megatron's model_provider signature but are not
+            used by diffusion models.
+            """
+            return self.create_model(pre_process=pre_process, post_process=post_process)
+
+        self.model_provider = _diffusion_model_provider
+        log_rank_0("=" * 80)
+        log_rank_0("Overridden model_provider to use diffusion model builder")
+        log_rank_0("=" * 80)
+
+        # Call parent's setup() which handles Megatron initialization
+        super().setup()
+
+    @abstractmethod
+    def create_model(self, pre_process=True, post_process=True):
+        """
+        Create diffusion model instance.
+
+        Returns:
+            Model instance (e.g., Flux)
+
+        Example:
+            from primus.backends.megatron.core.models.diffusion.flux import Flux
+            return Flux(config=self.model_config)
+        """
+        raise NotImplementedError("Subclasses must implement create_model()")
+
+    def _get_loss_fn(self):
+        """Return the loss function, optionally compiled.
+
+        When torch.compile is enabled for the model, the loss function is also
+        compiled as a standalone region.  This fuses the ~10 eager ATen ops
+        (sub, float casts, mse_loss, mean) into 1-2 kernels and gives the
+        autograd engine a single CompiledFunctionBackward node instead of
+        multiple eager backward nodes.
+
+        The compiled function is created lazily on first call and cached.
+        """
+        if self._compiled_loss_fn is not None:
+            return self._compiled_loss_fn
+
+        from primus.backends.megatron.training.diffusion.loss_computation import (
+            compute_flow_matching_loss,
+        )
+
+        try:
+            from megatron.training import get_args
+
+            args = get_args()
+            compile_enabled = getattr(args, "enable_torch_compile", False)
+        except Exception:
+            compile_enabled = False
+
+        if compile_enabled:
+            import torch
+
+            self._compiled_loss_fn = torch.compile(
+                compute_flow_matching_loss,
+                backend="inductor",
+                fullgraph=False,
+            )
+            log_rank_0("[DiffusionPretrainTrainer] Loss function compiled with torch.compile")
+        else:
+            self._compiled_loss_fn = compute_flow_matching_loss
+
+        return self._compiled_loss_fn
+
+    def forward_step(self, data_iterator, model, return_schedule_plan=False):
+        """
+        Forward training step for diffusion models.
+
+        Args:
+            data_iterator: Data iterator
+            model: Diffusion model (Flux)
+            return_schedule_plan: Whether to return schedule plan (for pipeline parallelism)
+
+        Returns:
+            Tuple of (noise_pred, loss_func_callable)
+        """
+        from primus.backends.megatron.training.diffusion.forward_step import (
+            flux_forward_step_func,
+        )
+
+        # Skip counter advance in eval. Advancing _forward_step_count on
+        # validation steps would shift the next training step's per-step seed
+        # by eval_iters * num_microbatches per --eval-interval window,
+        # defeating the goal of isolating training RNG from unrelated forward
+        # passes. Eval forward passes reuse the most recent training counter
+        # value, so the per-step CUDA reseed is a no-op replay during eval.
+        if model.training:
+            self._forward_step_count += 1
+
+        # Megatron's pattern: forward_step returns model output, loss_func computes loss
+        noise_pred, clean_latents, noise, loss_mask, metrics, is_validation = flux_forward_step_func(
+            data_iterator,
+            model,
+            scheduler=self.scheduler,
+            use_guidance_embed=getattr(self, "use_guidance_embed", False),
+            guidance_scale=getattr(self, "guidance_scale", None),
+            timestep_sampler=getattr(self, "timestep_sampler", None),
+            cfg_dropout_prob=getattr(self, "cfg_dropout_prob", 0.0),
+            empty_t5_encodings=getattr(self, "empty_t5_encodings", None),
+            empty_clip_encodings=getattr(self, "empty_clip_encodings", None),
+            vae_scale=getattr(self, "vae_scale", None),
+            vae_shift=getattr(self, "vae_shift", None),
+            vae_latent_mode=getattr(self, "vae_latent_mode", "presampled"),
+            per_step_rng_reseed=getattr(self, "per_step_rng_reseed", False),
+            step_count=self._forward_step_count,
+        )
+
+        # Store values needed for loss computation (will be used by loss function)
+        self._last_clean_latents = clean_latents
+        self._last_noise = noise
+        self._last_loss_mask = loss_mask
+
+        # Store metrics in runtime state
+        if hasattr(self, "runtime_state") and self.runtime_state:
+            self.runtime_state.update_metrics(metrics)
+        else:
+            log_rank_0("[DiffusionPretrainTrainer] WARNING: runtime_state not available, metrics not stored")
+
+        if is_validation:
+
+            def val_loss_func(output_tensor, non_loss_data=False):
+                if non_loss_data:
+                    return output_tensor
+                target = self._last_noise - self._last_clean_latents
+                loss = F.mse_loss(output_tensor.float(), target.float(), reduction="none")
+                loss_per_sample = loss.mean(dim=tuple(range(1, loss.ndim)))
+                loss_sum = loss_per_sample.sum()
+                sample_count = torch.tensor(
+                    loss_per_sample.numel(), dtype=loss_sum.dtype, device=loss_sum.device
+                )
+                return loss_sum, {"loss": (loss_sum.detach(), sample_count.detach())}
+
+            return noise_pred, val_loss_func
+
+        def diffusion_loss_func(output_tensor, non_loss_data=False):
+            if non_loss_data:
+                return output_tensor
+
+            loss = self._get_loss_fn()(
+                output_tensor, self._last_clean_latents, self._last_noise, self._last_loss_mask
+            )
+
+            reporting_metrics = {"reduced_train_loss": loss.detach().clone()}
+
+            return loss, reporting_metrics
+
+        return noise_pred, diffusion_loss_func
+
+    def get_forward_step(self):
+        """
+        Return forward step function for diffusion models.
+
+        Returns a function that wraps self.forward_step() to match
+        the interface expected by Megatron's pretrain() function.
+
+        On the first call, reconstructs the forward step counter from
+        checkpoint state (args.iteration * num_microbatches) so that
+        the per-step RNG seed sequence continues correctly after resume.
+        """
+
+        def diffusion_forward_step(data_iterator, model):
+            if not self._forward_step_count_initialized:
+                from megatron.core.num_microbatches_calculator import (
+                    get_num_microbatches,
+                )
+                from megatron.training import get_args
+
+                args = get_args()
+                # Reconstruct counter from checkpoint iteration. Assumes no
+                # iterations were skipped (iterations_to_skip is unused in
+                # diffusion training).
+                self._forward_step_count = args.iteration * get_num_microbatches()
+                self._forward_step_count_initialized = True
+
+            return self.forward_step(data_iterator, model, return_schedule_plan=False)
+
+        return diffusion_forward_step
+
+    def get_datasets_provider(self):
+        """
+        Return dataset provider function that delegates to self.data_provider.
+
+        This uses the composition pattern: the provider function delegates
+        to the injected data_provider instance, avoiding recreation on each call.
+        """
+
+        def diffusion_datasets_provider(train_val_test_num_samples, vp_stage=None):
+            """Delegate to injected data provider."""
+            from megatron.training import get_args
+
+            args = get_args()
+
+            return self.data_provider.create_dataloaders(
+                trainer_config=args, train_val_test_num_samples=train_val_test_num_samples, vp_stage=vp_stage
+            )
+
+        # Mark as distributed (required by Megatron)
+        diffusion_datasets_provider.is_distributed = self.data_provider.is_distributed
+
+        # Set __module__ to help with debugging (point to this module, not pretrain_gpt)
+        diffusion_datasets_provider.__module__ = __name__
+
+        log_rank_0(
+            f"[DiffusionPretrainTrainer] Created datasets provider: {type(self.data_provider).__name__}"
+        )
+        return diffusion_datasets_provider
+
+    @property
+    def scheduler(self):
+        """Lazily-initialized diffusion scheduler."""
+        if self._scheduler is None:
+            self._scheduler = self.create_scheduler()
+        return self._scheduler
+
+    @abstractmethod
+    def create_scheduler(self):
+        """
+        Create diffusion scheduler.
+
+        Returns:
+            Scheduler instance (e.g., FlowMatchEulerDiscreteScheduler)
+        """
+        raise NotImplementedError("Subclasses must implement create_scheduler()")
+
+    @abstractmethod
+    def get_task_encoder(self):
+        """
+        Get task encoder for Energon data pipeline.
+
+        Returns:
+            TaskEncoder instance (e.g., EncodedDiffusionTaskEncoder)
+
+        This method is called by EnergonDatasetProvider to create the task encoder
+        for processing WebDataset samples.
+        """
+        raise NotImplementedError("Subclasses must implement get_task_encoder()")

--- a/primus/backends/megatron/flux_pretrain_trainer.py
+++ b/primus/backends/megatron/flux_pretrain_trainer.py
@@ -26,7 +26,7 @@ from primus.backends.megatron.training.diffusion.schedulers import (
 from primus.backends.megatron.training.diffusion.timestep_sampling import (
     create_timestep_sampler,
 )
-from primus.modules.module_utils import log_rank_0
+from primus.core.utils.module_utils import log_rank_0
 
 
 def _restore_chimera_rng_state(args) -> None:

--- a/primus/backends/megatron/flux_pretrain_trainer.py
+++ b/primus/backends/megatron/flux_pretrain_trainer.py
@@ -1,0 +1,843 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Flux Pretrain Trainer for Primus-Megatron.
+
+This trainer implements Flux-specific training logic including:
+    - Flow matching scheduler with dynamic shifting
+    - Guidance embedding support
+    - Custom forward step function
+"""
+
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from primus.backends.megatron.diffusion_trainer import DiffusionPretrainTrainer
+from primus.backends.megatron.training.diffusion.schedulers import (
+    FlowMatchEulerDiscreteScheduler,
+)
+from primus.backends.megatron.training.diffusion.timestep_sampling import (
+    create_timestep_sampler,
+)
+from primus.modules.module_utils import log_rank_0
+
+
+def _restore_chimera_rng_state(args) -> None:
+    """Restore canonical RNG state after chimera model init.
+
+    Calls Megatron's `_set_random_seed` to restore CPU, CUDA default, and
+    model-parallel tracker generators to a canonical (per-rank-uniform) state.
+    Falls back to a manual restore if Megatron's signature changes.
+
+    Raises:
+        May propagate exceptions other than ImportError/TypeError from
+        _set_random_seed. The fallback handles ImportError (missing module)
+        and TypeError (API signature changes) gracefully.
+    """
+    try:
+        from megatron.training.initialize import _set_random_seed
+
+        _set_random_seed(
+            args.seed,
+            args.data_parallel_random_init,
+            args.te_rng_tracker,
+            args.inference_rng_tracker,
+            use_cudagraphable_rng=getattr(args, "enable_cuda_graph", False),
+        )
+    except (ImportError, TypeError) as e:
+        import logging
+
+        from megatron.core.tensor_parallel import random as tp_random
+
+        torch.manual_seed(args.seed)
+        torch.cuda.manual_seed(args.seed)
+        tp_random.model_parallel_cuda_manual_seed(args.seed)
+        logging.warning(
+            "[nemo_chimera_init] _set_random_seed API changed (%s). "
+            "Restored all RNG generators manually. Verify convergence "
+            "matches expected behavior.",
+            e,
+        )
+
+
+class FluxPretrainTrainer(DiffusionPretrainTrainer):
+    """
+    Trainer for Flux diffusion model pre-training.
+
+    Flux-specific features:
+        - Flow matching with Euler discrete scheduler
+        - Dynamic timestep shifting for variable resolution
+        - Optional guidance embedding for CFG
+
+    Config access via backend_args:
+        - Megatron args (guidance_embed, guidance_scale, etc.) via backend_args
+        - Primus-specific config (torch_compile) via backend_args (overrides section)
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize Flux pretrain trainer.
+
+        Args:
+            *args: Positional arguments passed to parent trainer
+            **kwargs: Keyword arguments passed to parent trainer
+                     (backend_args is extracted from kwargs by BaseTrainer.__init__())
+        """
+        super().__init__(*args, **kwargs)
+
+        self._training_rng_seeded = False
+
+        # backend_args is set by BaseTrainer.__init__()
+        params = self.backend_args
+
+        # Default False: per-step CUDA RNG reseed is an MLPerf-alignment
+        # feature; flipping it on globally changes the observable RNG
+        # sequence for every consumer of this trainer. MLPerf-aligned YAMLs
+        # opt in explicitly via per_step_rng_reseed: true.
+        self.per_step_rng_reseed = getattr(params, "per_step_rng_reseed", False)
+        self.nemo_chimera_init = getattr(params, "nemo_chimera_init", False)
+
+        # These come from the 'overrides' section in the YAML
+        self.use_guidance_embed = getattr(params, "guidance_embed", False)
+        self.guidance_scale = getattr(params, "guidance_scale", 3.5)
+
+        # Scheduler config
+        self.num_train_timesteps = getattr(params, "num_train_timesteps", 1000)
+        self.scheduler_shift = getattr(params, "scheduler_shift", 1.0)
+        self.use_dynamic_shifting = getattr(params, "use_dynamic_shifting", False)
+
+        # Timestep sampling strategy (MLPerf uses "direct_uniform")
+        timestep_strategy = getattr(params, "timestep_sampling_strategy", "logit_normal")
+        self.timestep_sampler = create_timestep_sampler(timestep_strategy)
+        log_rank_0(
+            f"Timestep sampling strategy: {timestep_strategy} -> {type(self.timestep_sampler).__name__}"
+        )
+
+        # CFG dropout: replace text embeddings with fixed empty encodings at this probability
+        self.cfg_dropout_prob = getattr(params, "cfg_dropout_prob", 0.0)
+        self.empty_t5_encodings = None
+        self.empty_clip_encodings = None
+
+        if self.cfg_dropout_prob > 0.0:
+            self._init_cfg_dropout(params)
+
+        # VAE latent normalization (matches NVIDIA MLPerf v5.1)
+        self.vae_scale = getattr(params, "vae_scale", None)
+        self.vae_shift = getattr(params, "vae_shift", None)
+        if self.vae_scale is not None:
+            log_rank_0(f"VAE normalization: scale={self.vae_scale}, shift={self.vae_shift}")
+
+        # VAE latent mode: "presampled" uses stored latents directly,
+        # "resample" re-draws from (mean, logvar) each step
+        self.vae_latent_mode = getattr(params, "vae_latent_mode", "presampled")
+        if self.vae_latent_mode not in ("presampled", "resample"):
+            raise ValueError(
+                f"vae_latent_mode must be 'presampled' or 'resample', " f"got '{self.vae_latent_mode}'"
+            )
+        if self.vae_latent_mode == "resample":
+            if self.vae_scale is None or self.vae_shift is None:
+                raise ValueError(
+                    "vae_latent_mode='resample' requires vae_scale and vae_shift "
+                    "to be set (e.g. vae_scale: 0.3611, vae_shift: 0.1159)"
+                )
+            log_rank_0(f"VAE latent mode: resample (reparameterization from mean+logvar each step)")
+        else:
+            log_rank_0(f"VAE latent mode: presampled (stored latents used directly)")
+
+        log_rank_0(f"Guidance embedding: {self.use_guidance_embed}")
+        log_rank_0(f"Scheduler shift: {self.scheduler_shift}")
+        log_rank_0(f"Dynamic shifting: {self.use_dynamic_shifting}")
+
+    def _init_cfg_dropout(self, params):
+        """
+        Initialize CFG dropout with real empty encodings.
+
+        Resolution order for empty encodings:
+        1. Explicit ``empty_encodings_path`` from config
+        2. ``{data_path}/empty_encodings/`` (generated by EncodedDatasetPipeline)
+        3. ``{data_path}/../empty_encodings/`` (MLPerf convention)
+
+        For mock_data runs, falls back to torch.randn().
+        For real data, raises FileNotFoundError if no encodings are found.
+        """
+        tp_size = getattr(params, "tensor_model_parallel_size", 1)
+        if tp_size != 1:
+            raise ValueError(
+                f"CFG dropout requires tensor_model_parallel_size=1 (got {tp_size}). "
+                "Different TP ranks would generate different dropout masks, causing divergent forward passes."
+            )
+
+        context_dim = getattr(params, "context_dim", 4096)
+        vec_in_dim = getattr(params, "vec_in_dim", 768)
+
+        encodings_dir = self._discover_empty_encodings(params)
+
+        if encodings_dir is not None:
+            t5_path = os.path.join(encodings_dir, "t5_empty.npy")
+            clip_path = os.path.join(encodings_dir, "clip_empty.npy")
+
+            self.empty_t5_encodings = torch.from_numpy(np.load(t5_path))[0].unsqueeze(1)
+            self.empty_clip_encodings = torch.from_numpy(np.load(clip_path))[0]
+
+            log_rank_0(
+                f"CFG dropout: loaded real empty encodings from {encodings_dir}, "
+                f"t5={self.empty_t5_encodings.shape}, clip={self.empty_clip_encodings.shape}"
+            )
+        elif getattr(params, "mock_data", False):
+            image_size = getattr(getattr(params, "mock_dataset", None), "params", None)
+            image_size = getattr(image_size, "image_size", 256) if image_size is not None else 256
+            image_tokens = (image_size // 8 // 2) ** 2
+            total_seq = getattr(params, "seq_length", 512)
+            t5_seq_len = total_seq - image_tokens
+
+            self.empty_t5_encodings = torch.randn(t5_seq_len, 1, context_dim)
+            self.empty_clip_encodings = torch.randn(vec_in_dim)
+            log_rank_0("CFG dropout: using torch.randn() empty encodings (mock_data mode)")
+        else:
+            data_path = getattr(params, "data_path", "<not set>")
+            if isinstance(data_path, list):
+                data_path = data_path[0] if data_path else "<not set>"
+            raise FileNotFoundError(
+                f"CFG dropout requires empty T5/CLIP encodings but none were found.\n"
+                f"Searched locations:\n"
+                f"  1. empty_encodings_path config key (not set)\n"
+                f"  2. {data_path}/empty_encodings/\n"
+                f"  3. {os.path.dirname(str(data_path))}/empty_encodings/\n\n"
+                f"To fix, either:\n"
+                f"  - Re-run dataset preparation with 'primus data diffusion-encoded' (auto-generates them)\n"
+                f"  - Run: python tools/generate_empty_encodings.py --output_dir <path>\n"
+                f"    and set empty_encodings_path in your YAML config"
+            )
+
+        log_rank_0(f"CFG dropout prob: {self.cfg_dropout_prob}")
+
+    @staticmethod
+    def _discover_empty_encodings(params) -> "str | None":
+        """Return the first valid empty_encodings directory, or None."""
+
+        def _has_files(dirpath):
+            return (
+                os.path.isdir(dirpath)
+                and os.path.isfile(os.path.join(dirpath, "t5_empty.npy"))
+                and os.path.isfile(os.path.join(dirpath, "clip_empty.npy"))
+            )
+
+        explicit = getattr(params, "empty_encodings_path", None)
+        if explicit and _has_files(str(explicit)):
+            return str(explicit)
+
+        data_path = getattr(params, "data_path", None)
+        if data_path is not None:
+            if isinstance(data_path, list):
+                data_path = data_path[0] if data_path else None
+            if data_path:
+                data_path = str(data_path)
+                inside = os.path.join(data_path, "empty_encodings")
+                if _has_files(inside):
+                    log_rank_0(f"CFG dropout: auto-discovered empty encodings at {inside}")
+                    return inside
+                alongside = os.path.join(os.path.dirname(data_path), "empty_encodings")
+                if _has_files(alongside):
+                    log_rank_0(f"CFG dropout: auto-discovered empty encodings at {alongside}")
+                    return alongside
+
+        return None
+
+    def forward_step(self, data_iterator, model, return_schedule_plan=False):
+        """
+        Forward step for Flux diffusion training.
+
+        Overrides base class to provide Flux forward step with scheduler and guidance config.
+        The base class implementation handles the new return signature correctly, so we just
+        call super() to use it.
+
+        On the first call, sets a per-DP-rank random seed so that each data-parallel
+        rank independently samples timesteps and noise (matching NeMo's approach).
+
+        Args:
+            data_iterator: Data iterator
+            model: Diffusion model (Flux)
+            return_schedule_plan: Whether to return schedule plan (for pipeline parallelism)
+
+        Returns:
+            Tuple of (output_tensor, loss_func_callable)
+        """
+        if not self._training_rng_seeded:
+            from megatron.core import parallel_state
+            from megatron.training import get_args
+
+            seed = get_args().seed
+            dp_rank = parallel_state.get_data_parallel_rank()
+            per_rank_seed = seed + 100 * dp_rank
+            torch.manual_seed(per_rank_seed)
+            torch.cuda.manual_seed(per_rank_seed)
+            self._training_rng_seeded = True
+            log_rank_0(f"Per-DP-rank training seed: {per_rank_seed} " f"(base={seed}, dp_rank={dp_rank})")
+
+        return super().forward_step(data_iterator, model, return_schedule_plan=return_schedule_plan)
+
+    def create_model(self, pre_process=True, post_process=True):
+        """
+        Create Flux model from YAML configuration.
+
+        Model architecture is loaded from YAML files:
+        - flux_12b.yaml / flux_535m.yaml for layer counts
+        - flux_base.yaml for common Flux architecture
+
+        Optionally loads checkpoint after model creation if configured.
+
+        Args:
+            pre_process: Not used (kept for Megatron model_provider interface compatibility)
+            post_process: Not used (kept for Megatron model_provider interface compatibility)
+
+        Returns:
+            Flux model instance
+        """
+        try:
+            log_rank_0("=" * 80)
+            log_rank_0(f"Creating Flux model from YAML config")
+
+            from megatron.training import get_args
+
+            from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+
+            config = self._build_flux_config_from_yaml()
+
+            # get_args() is safe here since create_model() is called after setup() completes
+            # setup() calls set_primus_global_variables() which initializes _GLOBAL_ARGS
+            args = get_args()
+            # Log complete FluxConfig at DEBUG level (matches Megatron's argument logging)
+            self._log_flux_config(config, args)
+
+            # Set torch_compile settings on args for trainer's apply_torch_compile_if_enabled method
+            # FluxConfig always has these attributes (defined as dataclass fields)
+            torch_compile_attrs = [
+                "enable_torch_compile",
+                "torch_compile_backend",
+                "torch_compile_mode",
+                "torch_compile_fullgraph",
+                "torch_compile_optimizer",
+                "torch_compile_optimizer_scope",
+            ]
+            for attr in torch_compile_attrs:
+                if not hasattr(args, attr):
+                    setattr(args, attr, getattr(config, attr))
+
+            # Backend selection is handled automatically by Flux model based on config.transformer_impl
+            # Pass backend=None to let get_flux_layer_spec() handle backend selection
+            backend = None
+
+            # Log which transformer implementation will be used
+            if config.transformer_impl == "local":
+                log_rank_0("Using local transformer implementation (NO TransformerEngine dependency)")
+            else:
+                log_rank_0("Using TransformerEngine implementation")
+            log_rank_0(
+                "Backend will be selected automatically by Flux model based on config.transformer_impl"
+            )
+
+            # Chimera init: replicate NeMo's per-rank seed contamination where
+            # each DP rank initializes non-parallel weights with a different seed.
+            # The distributed optimizer merges these into a chimera model.
+            if self.nemo_chimera_init:
+                import logging
+
+                from megatron.core import parallel_state
+
+                dp_rank = parallel_state.get_data_parallel_rank()
+                per_rank_seed = args.seed + 100 * dp_rank
+                torch.manual_seed(per_rank_seed)
+                torch.cuda.manual_seed(per_rank_seed)
+                logging.warning(
+                    "[nemo_chimera_init] WARNING: DP weight invariant intentionally broken. "
+                    "Each rank initializes non-parallel layers with a different seed. "
+                    "This replicates NeMo's per-rank seed contamination for convergence "
+                    "parity experiments only. dp_rank=%d, init_seed=%d (base=%d)",
+                    dp_rank,
+                    per_rank_seed,
+                    args.seed,
+                )
+
+            # Create Flux model (backend=None lets model select based on config.transformer_impl)
+            model = Flux(config=config, backend=backend)
+
+            if self.nemo_chimera_init:
+                _restore_chimera_rng_state(args)
+                log_rank_0(
+                    f"[nemo_chimera_init] Restored canonical RNG state (seed={args.seed}) after chimera model init"
+                )
+
+            # Calculate parameters for logging
+            total_params = sum(p.numel() for p in model.parameters())
+
+            log_rank_0(
+                f"Flux model created: {config.num_joint_layers} joint + {config.num_single_layers} single layers"
+            )
+            log_rank_0(f"Total parameters: {total_params / 1e6:.1f}M")
+
+            log_rank_0("=" * 80)
+
+            return model
+        except Exception as e:
+            log_rank_0(f"[ERROR] create_model() failed: {type(e).__name__}: {e}")
+            import traceback
+
+            log_rank_0(f"[ERROR] Traceback:\n{traceback.format_exc()}")
+            raise
+
+    def _build_flux_config_from_yaml(self):
+        """
+        Build FluxConfig from YAML configuration + training args.
+
+        All architectural parameters come from YAML files (merged into Megatron args):
+        - flux_535m.yaml or flux_12b.yaml specifies layer counts
+        - flux_base.yaml provides common architecture parameters
+
+        Training precision and recomputation settings come from backend_args.
+        Torch compile settings come from backend_args.torch_compile (Primus-specific, in overrides section, not in Megatron args).
+
+        Returns:
+            FluxConfig instance with all parameters
+        """
+        from functools import partial
+
+        import torch.nn.functional as F
+
+        from primus.backends.megatron.core.models.diffusion.flux.config import (
+            FluxConfig,
+            erf_gelu,
+        )
+
+        _openai_gelu_fused = partial(F.gelu, approximate="tanh")
+        _openai_gelu_fused.__name__ = "openai_gelu_fused"
+
+        # backend_args is set by BaseTrainer.__init__()
+        params = self.backend_args
+
+        # All architectural params from params (merged from YAML)
+        config_params = {
+            "num_joint_layers": getattr(params, "num_joint_layers", 19),
+            "num_single_layers": getattr(params, "num_single_layers", 38),
+            "hidden_size": getattr(params, "hidden_size", 3072),
+            "num_attention_heads": getattr(params, "num_attention_heads", 24),
+            "in_channels": getattr(params, "in_channels", 64),
+            "context_dim": getattr(params, "context_dim", 4096),
+            "vec_in_dim": getattr(params, "vec_in_dim", 768),
+            "model_channels": getattr(params, "model_channels", 256),
+            "guidance_embed": getattr(params, "guidance_embed", False),
+            # RoPE configuration
+            "apply_rope_fusion": getattr(params, "apply_rope_fusion", False),
+            "rotary_interleaved": getattr(params, "rotary_interleaved", True),
+            # Training hyperparameters stored on FluxConfig
+            "timestep_sampling_strategy": getattr(params, "timestep_sampling_strategy", "logit_normal"),
+            "cfg_dropout_prob": getattr(params, "cfg_dropout_prob", 0.0),
+            # Weight init for Megatron-managed layers (ColumnParallelLinear, RowParallelLinear).
+            # Xavier uniform matches NeMo's CustomFluxConfig (MLPerf v5.1).
+            "init_method": nn.init.xavier_uniform_,
+            "output_layer_init_method": nn.init.xavier_uniform_,
+        }
+
+        # Activation: YAML "openai_gelu" maps to fused F.gelu(approximate="tanh"); default in
+        # FluxConfig is the non-JIT Python GELU (ROCm-safe). Both match the tanh GELU approx.
+        activation_func_name = getattr(params, "activation_func", None)
+        if activation_func_name is not None:
+            activation_func_map = {
+                "erf_gelu": erf_gelu,
+                "openai_gelu": _openai_gelu_fused,
+            }
+            if activation_func_name not in activation_func_map:
+                raise ValueError(
+                    f"Unknown activation_func '{activation_func_name}'. "
+                    f"Choose from: {list(activation_func_map.keys())}"
+                )
+            func = activation_func_map[activation_func_name]
+            config_params["activation_func"] = func
+            log_rank_0(f"Activation function: {activation_func_name} -> {func.__name__}")
+
+        # Transformer implementation (standard TransformerConfig parameter)
+        # Read from backend_args (overrides section)
+        transformer_impl = getattr(params, "transformer_impl", "transformer_engine")
+        config_params["transformer_impl"] = transformer_impl
+
+        # Precision settings from params (not in model YAML)
+        config_params.update(
+            {
+                "bf16": getattr(params, "bf16", True),
+                "fp16": getattr(params, "fp16", False),
+                "params_dtype": getattr(params, "params_dtype", torch.float32),
+            }
+        )
+
+        # FP8 settings from params
+        config_params.update(
+            {
+                "fp8": getattr(params, "fp8", None),
+                "fp8_recipe": getattr(params, "fp8_recipe", "delayed"),
+                "fp8_margin": getattr(params, "fp8_margin", 0),
+                "fp8_amax_history_len": getattr(params, "fp8_amax_history_len", 1),
+                "fp8_amax_compute_algo": getattr(params, "fp8_amax_compute_algo", "most_recent"),
+                "fp8_wgrad": getattr(params, "fp8_wgrad", True),
+                "fp8_dot_product_attention": getattr(params, "fp8_dot_product_attention", False),
+                "fp8_multi_head_attention": getattr(params, "fp8_multi_head_attention", False),
+                "fp8_scaling_strategy": getattr(params, "fp8_scaling_strategy", "dynamic"),
+                "fp8_force_nt_layout": getattr(params, "fp8_force_nt_layout", False),
+                "fp8_reduce_amax": getattr(params, "fp8_reduce_amax", False),
+            }
+        )
+
+        # FP4/MXFP4 settings
+        fp4_enabled = getattr(params, "fp4", None)
+        fp4_recipe = getattr(params, "fp4_recipe", None)
+        if fp4_enabled and not fp4_recipe:
+            raise ValueError(
+                "fp4_recipe must be explicitly set in YAML when fp4 is enabled. "
+                "Use fp4_recipe: 'mxfp4' for AMD (native FP4 GEMM) or 'nvfp4' for NVIDIA."
+            )
+        config_params.update(
+            {
+                "fp4": fp4_enabled,
+                "fp4_recipe": fp4_recipe,
+                "mxfp4_backward_precision": getattr(params, "mxfp4_backward_precision", "mxfp4"),
+            }
+        )
+
+        # Sensitive layer configuration
+        config_params.update(
+            {
+                "sensitive_layers_enabled": getattr(params, "sensitive_layers_enabled", False),
+                "sensitive_layers_start": getattr(params, "sensitive_layers_start", 0),
+                "sensitive_layers_end": getattr(params, "sensitive_layers_end", 0),
+                "sensitive_layer_precision": getattr(params, "sensitive_layer_precision", "bf16"),
+                "mxfp4_gradient_stochastic_rounding": getattr(
+                    params, "mxfp4_gradient_stochastic_rounding", False
+                ),
+            }
+        )
+
+        config_params["use_dual_fp8_output_projection"] = getattr(
+            params,
+            "use_dual_fp8_output_projection",
+            False,
+        )
+
+        if (
+            config_params["use_dual_fp8_output_projection"]
+            and config_params.get("fp8_scaling_strategy") == "delayed"
+        ):
+            raise ValueError(
+                "use_dual_fp8_output_projection=True is incompatible with "
+                "fp8_scaling_strategy='delayed'. DualFP8LinearTensorwiseFunction "
+                "bypasses delayed-scaling staged amax buffers, causing stale/zero "
+                "values in the _DelayedScalingRegistry. Use "
+                "fp8_scaling_strategy='dynamic' or set "
+                "use_dual_fp8_output_projection=False."
+            )
+
+        config_params["use_triton_ops"] = getattr(
+            params,
+            "use_triton_ops",
+            False,
+        )
+        config_params["adaln_plain_ops"] = getattr(
+            params,
+            "adaln_plain_ops",
+            False,
+        )
+        config_params["adaln_always_jit_fuser"] = getattr(
+            params,
+            "adaln_always_jit_fuser",
+            False,
+        )
+        config_params["optimizer_foreach"] = getattr(
+            params,
+            "optimizer_foreach",
+            True,
+        )
+        config_params["overlap_grad_norm"] = getattr(
+            params,
+            "overlap_grad_norm",
+            False,
+        )
+        config_params["use_cpp_fp8_quantize"] = getattr(
+            params,
+            "use_cpp_fp8_quantize",
+            False,
+        )
+
+        # FSDP2 prefetch depth
+        fsdp_prefetch = getattr(params, "fsdp_prefetch_depth", None)
+        if fsdp_prefetch is not None:
+            config_params["fsdp_prefetch_depth"] = int(fsdp_prefetch)
+
+        # FSDP2 FP32 optimizer: initialize model in FP32, FSDP2 casts to BF16
+        if getattr(params, "use_fsdp2_fp32_param_optimizer", False):
+            config_params["params_dtype"] = torch.float32
+            config_params["pipeline_dtype"] = torch.bfloat16
+            log_rank_0("FSDP2 FP32 optimizer: params_dtype=FP32, pipeline=BF16")
+
+        # Recomputation settings from params
+        config_params.update(
+            {
+                "recompute_granularity": getattr(params, "recompute_granularity", None),
+                "recompute_method": getattr(params, "recompute_method", None),
+                "recompute_num_layers": getattr(params, "recompute_num_layers", None),
+                "recompute_modules": getattr(params, "recompute_modules", None),
+            }
+        )
+
+        # Torch compile settings from backend_args (overrides section)
+        # torch_compile is in overrides section in YAML, accessible via backend_args.torch_compile
+        torch_compile_config = getattr(self.backend_args, "torch_compile", None)
+
+        if torch_compile_config is not None:
+            compile_settings = {
+                "enable_torch_compile": getattr(torch_compile_config, "enable", False),
+                "torch_compile_backend": getattr(torch_compile_config, "backend", "inductor"),
+                "torch_compile_mode": getattr(torch_compile_config, "mode", "default"),
+                "torch_compile_fullgraph": getattr(torch_compile_config, "fullgraph", False),
+                "torch_compile_optimizer": getattr(torch_compile_config, "compile_optimizer", False),
+                "torch_compile_optimizer_scope": getattr(
+                    torch_compile_config, "compile_optimizer_scope", "full"
+                ),
+                "torch_compile_strategy": getattr(torch_compile_config, "strategy", "per_block"),
+                "torch_compile_replace_qk_rmsnorm": getattr(
+                    torch_compile_config, "replace_qk_rmsnorm", False
+                ),
+                "torch_compile_disable_inductor_cudagraphs": getattr(
+                    torch_compile_config, "disable_inductor_cudagraphs", True
+                ),
+                "torch_compile_emulate_precision_casts": getattr(
+                    torch_compile_config, "emulate_precision_casts", True
+                ),
+                "torch_compile_fused_ln_modulate": getattr(torch_compile_config, "fused_ln_modulate", True),
+            }
+        else:
+            # Default values if torch_compile section not present
+            compile_settings = {
+                "enable_torch_compile": False,
+                "torch_compile_backend": "inductor",
+                "torch_compile_mode": "default",
+                "torch_compile_fullgraph": False,
+                "torch_compile_optimizer": False,
+                "torch_compile_optimizer_scope": "full",
+                "torch_compile_strategy": "per_block",
+                "torch_compile_replace_qk_rmsnorm": False,
+                "torch_compile_disable_inductor_cudagraphs": True,
+                "torch_compile_emulate_precision_casts": True,
+                "torch_compile_fused_ln_modulate": True,
+            }
+
+        # Set on FluxConfig
+        config_params.update(compile_settings)
+
+        return FluxConfig(**config_params)
+
+    def _log_flux_config(self, config, args):
+        """Print FluxConfig fields (rank 0 only), similar to Megatron argument dumps."""
+        import dataclasses
+
+        # Only log on rank 0
+        if args.rank != 0:
+            return
+
+        # Accumulate the full dump into one multi-line message so the banner
+        # alignment is preserved (log_rank_0 stamps a caller prefix per call).
+        lines = []
+        lines.append("=" * 80)
+        lines.append("FluxConfig (Model Configuration)")
+        lines.append("=" * 80)
+
+        # Organize config parameters by category for better readability
+        categories = {
+            "Model Architecture": [
+                "model_type",
+                "num_joint_layers",
+                "num_single_layers",
+                "num_layers",
+                "hidden_size",
+                "num_attention_heads",
+                "ffn_hidden_size",
+            ],
+            "Input/Output Dimensions": [
+                "in_channels",
+                "out_channels",
+                "patch_size",
+                "context_dim",
+                "vec_in_dim",
+                "model_channels",
+            ],
+            "Position Embeddings (RoPE)": ["theta", "axes_dim", "rotary_interleaved", "apply_rope_fusion"],
+            "Guidance & Diffusion": [
+                "guidance_embed",
+                "guidance_scale",
+                "cfg_dropout_prob",
+                "timestep_sampling_strategy",
+            ],
+            "Attention & Layers": [
+                "add_qkv_bias",
+                "single_block_bias",
+                "attention_dropout",
+                "hidden_dropout",
+                "bias_dropout_fusion",
+            ],
+            "Normalization & Activation": ["activation_func", "layernorm_epsilon", "normalization"],
+            "Precision & Optimization": [
+                "bf16",
+                "fp16",
+                "fp32_residual_connection",
+                "gradient_accumulation_fusion",
+                "use_dual_fp8_output_projection",
+                "params_dtype",
+                "fp8",
+                "fp8_recipe",
+                "fp8_scaling_strategy",
+                "fp8_force_nt_layout",
+                "fp4",
+                "fp4_recipe",
+                "mxfp4_backward_precision",
+                "mxfp4_gradient_stochastic_rounding",
+                "sensitive_layers_enabled",
+                "sensitive_layers_start",
+                "sensitive_layers_end",
+                "sensitive_layer_precision",
+            ],
+            "Recomputation": [
+                "recompute_granularity",
+                "recompute_method",
+                "recompute_num_layers",
+                "recompute_modules",
+            ],
+            "Torch Compile": [
+                "enable_torch_compile",
+                "torch_compile_backend",
+                "torch_compile_mode",
+                "torch_compile_fullgraph",
+                "torch_compile_optimizer",
+                "torch_compile_optimizer_scope",
+                "torch_compile_strategy",
+                "torch_compile_replace_qk_rmsnorm",
+                "torch_compile_disable_inductor_cudagraphs",
+                "torch_compile_emulate_precision_casts",
+                "torch_compile_fused_ln_modulate",
+            ],
+            "Parallelism": [
+                "tensor_model_parallel_size",
+                "pipeline_model_parallel_size",
+                "sequence_parallel",
+                "expert_model_parallel_size",
+            ],
+            "CUDA Graph": ["enable_cuda_graph", "cuda_graph_scope", "cuda_graph_warmup_steps"],
+            "Transformer Engine": ["use_te_rng_tracker"],
+        }
+
+        # Get all dataclass fields
+        all_fields = {f.name for f in dataclasses.fields(config)}
+        categorized_fields = set()
+
+        # Print categorized fields
+        for category, field_names in categories.items():
+            # Check if any fields in this category exist
+            existing_fields = [f for f in field_names if f in all_fields]
+            if not existing_fields:
+                continue
+
+            lines.append(f"\n{category}:")
+            for field_name in existing_fields:
+                if hasattr(config, field_name):
+                    value = getattr(config, field_name)
+                    # Format value (handle callables specially)
+                    if callable(value) and not isinstance(value, type):
+                        value_str = getattr(value, "__name__", str(value))
+                    else:
+                        value_str = str(value)
+
+                    # Create dots for alignment (match Megatron's style: 48 chars)
+                    dots = "." * (48 - len(field_name))
+                    lines.append(f"  {field_name} {dots} {value_str}")
+                    categorized_fields.add(field_name)
+
+        # Print uncategorized fields (any fields not in our category lists)
+        uncategorized = all_fields - categorized_fields
+        if uncategorized:
+            lines.append("\nOther Configuration:")
+            for field_name in sorted(uncategorized):
+                if hasattr(config, field_name):
+                    value = getattr(config, field_name)
+                    if callable(value) and not isinstance(value, type):
+                        value_str = getattr(value, "__name__", str(value))
+                    else:
+                        value_str = str(value)
+                    dots = "." * (48 - len(field_name))
+                    lines.append(f"  {field_name} {dots} {value_str}")
+
+        # Add special note about apply_rope_fusion mismatch
+        if hasattr(config, "apply_rope_fusion") and hasattr(args, "apply_rope_fusion"):
+            if config.apply_rope_fusion != args.apply_rope_fusion:
+                lines.append("\n" + "!" * 80)
+                lines.append("IMPORTANT: FluxConfig vs Megatron Args Mismatch")
+                lines.append("!" * 80)
+                lines.append(f"  FluxConfig.apply_rope_fusion: {config.apply_rope_fusion}")
+                lines.append(f"  Megatron args.apply_rope_fusion: {args.apply_rope_fusion}")
+                lines.append(
+                    f'  → Flux uses FluxConfig value: RoPE fusion is {"ENABLED" if config.apply_rope_fusion else "DISABLED"}'
+                )
+                lines.append("  → Megatron args value is set by position_embedding_type validation")
+                lines.append(
+                    '  → (Megatron sets apply_rope_fusion=False when position_embedding_type != "rope")'
+                )
+                lines.append("!" * 80)
+
+        lines.append("=" * 80)
+        lines.append("End of FluxConfig")
+        lines.append("=" * 80)
+
+        log_rank_0("\n".join(lines))
+
+    def create_scheduler(self):
+        """
+        Create Flow Matching Euler Discrete Scheduler for Flux.
+
+        Returns:
+            FlowMatchEulerDiscreteScheduler instance
+        """
+        log_rank_0("Creating Flow Matching scheduler...")
+        log_rank_0(f"  num_train_timesteps: {self.num_train_timesteps}")
+        log_rank_0(f"  shift: {self.scheduler_shift}")
+        log_rank_0(f"  use_dynamic_shifting: {self.use_dynamic_shifting}")
+
+        scheduler = FlowMatchEulerDiscreteScheduler(
+            num_train_timesteps=self.num_train_timesteps,
+            shift=self.scheduler_shift,
+            use_dynamic_shifting=self.use_dynamic_shifting,
+            base_shift=0.5,  # Flux defaults
+            max_shift=1.15,
+            base_image_seq_len=256,
+            max_image_seq_len=4096,
+        )
+
+        return scheduler
+
+    def get_task_encoder(self):
+        """
+        Get Flux task encoder for Energon data pipeline.
+
+        Returns:
+            EncodedDiffusionTaskEncoder for pre-encoded data
+        """
+        from primus.backends.megatron.data.diffusion.task_encoders import (
+            EncodedDiffusionTaskEncoder,
+        )
+
+        # EnergonDatasetProvider will pass WorkerConfig to Energon directly
+        # TaskEncoder doesn't need WorkerConfig for pre-encoded data
+        task_encoder = EncodedDiffusionTaskEncoder(worker_config=None)
+
+        log_rank_0("Created EncodedDiffusionTaskEncoder for pre-encoded Flux data")
+        return task_encoder

--- a/primus/backends/megatron/training/evaluator.py
+++ b/primus/backends/megatron/training/evaluator.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -137,9 +137,21 @@ def primus_evaluate(
                     log_rank_0("Exiting during evaluation, timelimit reached")
                     return None, None, True
 
-        # Compute final average loss across all eval iterations
+        # DP all-reduce for tuple-path (validation) metrics so that every
+        # rank sees the same globally-averaged loss.  Scalar/legacy metrics
+        # are NOT all-reduced, matching upstream Megatron's evaluate().
         total_loss_dict = {}
         if is_pipeline_stage_containing_loss():
+            from megatron.core import mpu
+
+            dp_group = mpu.get_data_parallel_group(with_context_parallel=True)
+            for key in total_loss_numerators.keys():
+                num = total_loss_numerators[key]
+                den = total_loss_denominators[key]
+                if isinstance(num, torch.Tensor) and isinstance(den, torch.Tensor):
+                    torch.distributed.all_reduce(num, group=dp_group)
+                    torch.distributed.all_reduce(den, group=dp_group)
+
             for key in total_loss_numerators.keys():
                 # Reduce numerator/denominator across data-parallel ranks so the
                 # validation loss is a TRUE global average, identical on every rank.

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_diffusion_trainer.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_diffusion_trainer.py
@@ -1,0 +1,343 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Unit tests for DiffusionPretrainTrainer.
+
+Tests initialization, setup, data provider delegation, forward step,
+and scheduler lazy initialization.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from primus.backends.megatron.diffusion_trainer import DiffusionPretrainTrainer
+
+
+def _build_diffusion_trainer(monkeypatch: pytest.MonkeyPatch, backend_args=None, use_mock_data=True):
+    """Helper to build DiffusionPretrainTrainer with stubbed dependencies."""
+
+    # Create a concrete subclass for testing (DiffusionPretrainTrainer is abstract)
+    class ConcreteDiffusionTrainer(DiffusionPretrainTrainer):
+        def create_model(self, pre_process=True, post_process=True):
+            return Mock()
+
+        def create_scheduler(self):
+            return Mock()
+
+        def get_task_encoder(self):
+            return Mock()
+
+    # Stub out MegatronBaseTrainer.__init__ to avoid real Megatron imports
+    def dummy_base_init(self, backend_args=None, *args, **kwargs):
+        self.backend_args = backend_args
+        self.rank = 0
+        self.world_size = 1
+        self.local_rank = 0
+        self.master_addr = "localhost"
+        self.master_port = 12345
+
+    monkeypatch.setattr(
+        "primus.backends.megatron.megatron_base_trainer.MegatronBaseTrainer.__init__",
+        dummy_base_init,
+    )
+
+    # Silence logging
+    monkeypatch.setattr(
+        "primus.backends.megatron.diffusion_trainer.log_rank_0",
+        lambda *args, **kwargs: None,
+    )
+
+    if backend_args is None:
+        backend_args = SimpleNamespace(mock_data=use_mock_data)
+    else:
+        if not hasattr(backend_args, "mock_data"):
+            backend_args.mock_data = use_mock_data
+
+    return ConcreteDiffusionTrainer(backend_args=backend_args)
+
+
+class TestDiffusionPretrainTrainer:
+    """Tests for DiffusionPretrainTrainer."""
+
+    def test_init_with_mock_data_creates_synthetic_provider(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that initialization with mock_data=True creates SyntheticDatasetProvider."""
+        backend_args = SimpleNamespace(mock_data=True, model_type="flux")
+        trainer = _build_diffusion_trainer(monkeypatch, backend_args)
+
+        assert hasattr(trainer, "data_provider")
+        assert trainer.data_provider is not None
+        # Verify it's SyntheticDatasetProvider (check class name)
+        assert "Synthetic" in type(trainer.data_provider).__name__
+
+    def test_setup_calculates_data_parallel_size(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that setup() calculates data_parallel_size when not present."""
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            world_size=8,
+            tensor_model_parallel_size=2,
+            pipeline_model_parallel_size=1,
+            context_parallel_size=1,
+        )
+        trainer = _build_diffusion_trainer(monkeypatch, backend_args)
+
+        # Mock parent setup and other dependencies
+        setup_calls = []
+
+        def mock_parent_setup(self):
+            setup_calls.append("parent_setup")
+
+        monkeypatch.setattr(
+            "primus.backends.megatron.megatron_base_trainer.MegatronBaseTrainer.setup",
+            mock_parent_setup,
+        )
+
+        # Mock set_primus_global_variables
+        monkeypatch.setattr(
+            "primus.backends.megatron.training.global_vars.set_primus_global_variables",
+            lambda args: None,
+        )
+
+        trainer.setup()
+
+        # Verify data_parallel_size was calculated
+        assert hasattr(trainer.backend_args, "data_parallel_size")
+        assert trainer.backend_args.data_parallel_size == 4  # 8 / (2 * 1 * 1)
+        assert "parent_setup" in setup_calls
+
+    def test_setup_uses_existing_data_parallel_size(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that setup() uses existing data_parallel_size if present."""
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            data_parallel_size=16,
+            world_size=8,  # This would normally calculate to 4, but we have existing value
+        )
+        trainer = _build_diffusion_trainer(monkeypatch, backend_args)
+
+        # Mock parent setup
+        monkeypatch.setattr(
+            "primus.backends.megatron.megatron_base_trainer.MegatronBaseTrainer.setup",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            "primus.backends.megatron.training.global_vars.set_primus_global_variables",
+            lambda args: None,
+        )
+
+        trainer.setup()
+
+        # Verify existing data_parallel_size was not overwritten
+        assert trainer.backend_args.data_parallel_size == 16
+
+    def test_setup_sets_model_provider(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that setup() sets model_provider with correct signature."""
+        trainer = _build_diffusion_trainer(monkeypatch)
+
+        # Mock create_model
+        mock_model = Mock()
+        trainer.create_model = lambda pre_process=True, post_process=True: mock_model
+
+        # Mock parent setup
+        monkeypatch.setattr(
+            "primus.backends.megatron.megatron_base_trainer.MegatronBaseTrainer.setup",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            "primus.backends.megatron.training.global_vars.set_primus_global_variables",
+            lambda args: None,
+        )
+
+        trainer.setup()
+
+        # Verify model_provider was set
+        assert hasattr(trainer, "model_provider")
+        assert callable(trainer.model_provider)
+
+        # Verify model_provider signature matches Megatron's interface
+        result = trainer.model_provider(
+            pre_process=True,
+            post_process=True,
+            vp_stage=None,
+            config=None,
+            pg_collection=None,
+        )
+        assert result is mock_model
+
+    def test_get_datasets_provider_returns_delegating_function(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that get_datasets_provider() returns a function that delegates to data_provider."""
+        trainer = _build_diffusion_trainer(monkeypatch)
+
+        # Replace data_provider with a mock that has is_distributed as an attribute (not property)
+        mock_dataloaders = [Mock(), Mock(), Mock()]  # train, val, test
+
+        class MockDataProvider:
+            def __init__(self):
+                self.is_distributed = True
+                self.create_dataloaders = Mock(return_value=mock_dataloaders)
+
+        mock_data_provider = MockDataProvider()
+        trainer.data_provider = mock_data_provider
+
+        # Mock get_args
+        mock_args = SimpleNamespace()
+        training_mod = types.SimpleNamespace(get_args=lambda: mock_args)
+        monkeypatch.setitem(sys.modules, "megatron.training", training_mod)
+
+        provider_func = trainer.get_datasets_provider()
+
+        # Verify it's a function
+        assert callable(provider_func)
+
+        # Verify is_distributed flag is set
+        assert provider_func.is_distributed is True
+
+        # Call the provider function
+        train_val_test_num_samples = [100, 10, 10]
+        result = provider_func(train_val_test_num_samples, vp_stage=None)
+
+        # Verify data_provider.create_dataloaders was called
+        mock_data_provider.create_dataloaders.assert_called_once_with(
+            trainer_config=mock_args,
+            train_val_test_num_samples=train_val_test_num_samples,
+            vp_stage=None,
+        )
+
+        # Verify result matches what data_provider returned
+        assert result is mock_dataloaders
+
+    def test_forward_step_calls_flux_forward_step_func(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that forward_step() calls flux_forward_step_func and creates loss function."""
+        trainer = _build_diffusion_trainer(monkeypatch)
+
+        # Mock scheduler
+        mock_scheduler = Mock()
+        trainer._scheduler = mock_scheduler
+
+        # Mock flux_forward_step_func
+        mock_noise_pred = Mock()
+        mock_clean_latents = Mock()
+        mock_noise = Mock()
+        mock_loss_mask = Mock()
+        mock_metrics = {"test_metric": 1.0}
+
+        flux_forward_step_calls = []
+
+        def mock_flux_forward_step(
+            data_iterator,
+            model,
+            scheduler=None,
+            use_guidance_embed=False,
+            guidance_scale=None,
+            timestep_sampler=None,
+            cfg_dropout_prob=0.0,
+            empty_t5_encodings=None,
+            empty_clip_encodings=None,
+            **kwargs,
+        ):
+            flux_forward_step_calls.append(
+                (data_iterator, model, scheduler, use_guidance_embed, guidance_scale)
+            )
+            # 6-tuple per sibling commit 362ee36 (is_validation appended).
+            return (
+                mock_noise_pred,
+                mock_clean_latents,
+                mock_noise,
+                mock_loss_mask,
+                mock_metrics,
+                False,
+            )
+
+        # Patch at the import location (it's imported inside forward_step)
+        monkeypatch.setattr(
+            "primus.backends.megatron.training.diffusion.forward_step.flux_forward_step_func",
+            mock_flux_forward_step,
+        )
+
+        # Mock runtime_state
+        trainer.runtime_state = Mock()
+        trainer.runtime_state.update_metrics = Mock()
+
+        mock_data_iterator = Mock()
+        mock_model = Mock()
+
+        output, loss_func = trainer.forward_step(mock_data_iterator, mock_model)
+
+        # Verify flux_forward_step_func was called
+        assert len(flux_forward_step_calls) == 1
+        assert flux_forward_step_calls[0][0] is mock_data_iterator
+        assert flux_forward_step_calls[0][1] is mock_model
+        assert flux_forward_step_calls[0][2] is mock_scheduler
+
+        # Verify values were stored
+        assert trainer._last_clean_latents is mock_clean_latents
+        assert trainer._last_noise is mock_noise
+        assert trainer._last_loss_mask is mock_loss_mask
+
+        # Verify metrics were updated
+        trainer.runtime_state.update_metrics.assert_called_once_with(mock_metrics)
+
+        # Verify output is noise_pred
+        assert output is mock_noise_pred
+
+        # Verify loss_func is callable
+        assert callable(loss_func)
+
+        # Test loss function - mock compute_flow_matching_loss to avoid real computation
+        # It's imported inside the loss function, so patch at the import location
+        mock_loss = Mock()
+        mock_loss.detach.return_value = mock_loss
+        monkeypatch.setattr(
+            "primus.backends.megatron.training.diffusion.loss_computation.compute_flow_matching_loss",
+            lambda *args, **kwargs: mock_loss,
+        )
+
+        loss_result = loss_func(mock_noise_pred, non_loss_data=False)
+        assert len(loss_result) == 2  # (loss, metrics_dict)
+        # Verify the metrics dict has the expected key
+        assert "reduced_train_loss" in loss_result[1]
+
+    def test_forward_step_loss_func_with_non_loss_data(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that loss function returns output_tensor when non_loss_data=True."""
+        trainer = _build_diffusion_trainer(monkeypatch)
+
+        # Mock forward_step components
+        mock_scheduler = Mock()
+        trainer._scheduler = mock_scheduler
+
+        mock_noise_pred = Mock()
+        mock_clean_latents = Mock()
+        mock_noise = Mock()
+        mock_loss_mask = Mock()
+        mock_metrics = {}
+
+        # Patch at the import location (it's imported inside forward_step).
+        # 6-tuple per sibling commit 362ee36 (is_validation appended).
+        monkeypatch.setattr(
+            "primus.backends.megatron.training.diffusion.forward_step.flux_forward_step_func",
+            lambda *args, **kwargs: (
+                mock_noise_pred,
+                mock_clean_latents,
+                mock_noise,
+                mock_loss_mask,
+                mock_metrics,
+                False,
+            ),
+        )
+
+        trainer.runtime_state = Mock()
+        trainer.runtime_state.update_metrics = Mock()
+
+        output, loss_func = trainer.forward_step(Mock(), Mock())
+
+        # Test loss function with non_loss_data=True
+        result = loss_func(output, non_loss_data=True)
+
+        # Should return output_tensor directly
+        assert result is output

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_flux_forward_step_e2e.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_flux_forward_step_e2e.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+End-to-end tests for flux_forward_step_func.
+
+Tests the full forward step with a real Flux 535M model on CUDA,
+covering presampled, resample, validation, and CFG dropout paths.
+"""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+from primus.backends.megatron.training.diffusion.forward_step import (
+    flux_forward_step_func,
+)
+from primus.backends.megatron.training.diffusion.schedulers.flow_matching import (
+    FlowMatchEulerDiscreteScheduler,
+)
+from tests.unit_tests.backends.megatron.diffusion.constants import (
+    CLIP_L_EMBEDDING_DIM,
+    T5_XXL_EMBEDDING_DIM,
+    VAE_LATENT_CHANNELS,
+)
+
+
+def _patch_parallel_state():
+    """Return a stack of mock.patch context managers for parallel state."""
+    return [
+        patch(
+            "megatron.core.parallel_state.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "megatron.core.parallel_state.get_pipeline_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "megatron.core.parallel_state.get_data_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "megatron.core.parallel_state.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "megatron.training.get_args",
+            return_value=SimpleNamespace(seed=42),
+        ),
+    ]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+class TestFluxForwardStepE2E:
+    """End-to-end tests for flux_forward_step_func with real model."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        """Initialize parallel state for model tests."""
+
+    @pytest.fixture
+    def model(self):
+        config = FluxConfig.flux_535m()
+        m = Flux(config).cuda()
+        m.train()
+        return m
+
+    @pytest.fixture
+    def scheduler(self):
+        return FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000)
+
+    def _make_presampled_batch(self, batch_size=2, height=16, width=16):
+        return {
+            "latents": torch.randn(batch_size, VAE_LATENT_CHANNELS, height, width),
+            "prompt_embeds": torch.randn(batch_size, 32, T5_XXL_EMBEDDING_DIM),
+            "pooled_prompt_embeds": torch.randn(batch_size, CLIP_L_EMBEDDING_DIM),
+        }
+
+    def _make_resample_batch(self, batch_size=2, height=16, width=16):
+        return {
+            "mean": torch.randn(batch_size, VAE_LATENT_CHANNELS, height, width),
+            "logvar": torch.randn(batch_size, VAE_LATENT_CHANNELS, height, width),
+            "prompt_embeds": torch.randn(batch_size, 32, T5_XXL_EMBEDDING_DIM),
+            "pooled_prompt_embeds": torch.randn(batch_size, CLIP_L_EMBEDDING_DIM),
+        }
+
+    def test_presampled_path(self, model, scheduler):
+        """Test forward step with pre-encoded latents."""
+        batch = self._make_presampled_batch()
+        data_iterator = iter([batch])
+
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state():
+                stack.enter_context(p)
+            result = flux_forward_step_func(
+                data_iterator,
+                model,
+                scheduler=scheduler,
+                step_count=1,
+            )
+
+        noise_pred, clean_latents, noise, loss_mask, metrics, is_validation = result
+        assert noise_pred.shape == (2, VAE_LATENT_CHANNELS, 16, 16)
+        assert clean_latents.shape == noise_pred.shape
+        assert noise.shape == noise_pred.shape
+        assert loss_mask is None
+        assert not is_validation
+        assert metrics["batch_size"] == 2
+        assert metrics["latent_channels"] == VAE_LATENT_CHANNELS
+        assert metrics["image_height"] == 16 * 8
+        assert metrics["image_width"] == 16 * 8
+
+    def test_resample_path(self, model, scheduler):
+        """Test forward step with VAE resample mode."""
+        batch = self._make_resample_batch()
+        # Snapshot mean before the call (the forward step casts and moves it).
+        original_mean = batch["mean"].clone()
+        data_iterator = iter([batch])
+
+        vae_scale = 0.3611
+        vae_shift = 0.1159
+
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state():
+                stack.enter_context(p)
+            result = flux_forward_step_func(
+                data_iterator,
+                model,
+                scheduler=scheduler,
+                vae_latent_mode="resample",
+                vae_scale=vae_scale,
+                vae_shift=vae_shift,
+                step_count=1,
+            )
+
+        noise_pred, clean_latents, _, _, _, is_validation = result
+        assert noise_pred.shape == (2, VAE_LATENT_CHANNELS, 16, 16)
+        assert not is_validation
+
+        # Verify reparameterization actually fired: clean_latents must NOT
+        # equal the deterministic scale/shift on `mean` alone (which would
+        # be the result if vae_eps had been dropped or zeroed).
+        expected_no_eps = vae_scale * (original_mean.cuda() - vae_shift)
+        assert not torch.allclose(clean_latents.float(), expected_no_eps.float(), atol=1e-3), (
+            "clean_latents matches mean*(scale-shift) — reparameterization "
+            "noise term `eps * std` appears to have been dropped"
+        )
+
+    def test_validation_with_timestep_key(self, model, scheduler):
+        """Batch with 'timestep' key triggers validation mode."""
+        batch = self._make_presampled_batch()
+        batch["timestep"] = torch.arange(2)
+        data_iterator = iter([batch])
+
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state():
+                stack.enter_context(p)
+            result = flux_forward_step_func(
+                data_iterator,
+                model,
+                scheduler=scheduler,
+                step_count=1,
+            )
+
+        _, _, _, _, _, is_validation = result
+        assert is_validation is True
+        # The forward step writes derived timesteps (timestep / 8.0) into the batch.
+        assert "timesteps" in batch
+        assert torch.equal(
+            batch["timesteps"].float().cpu(),
+            torch.arange(2).float() / 8.0,
+        )
+
+    def test_validation_equidistant_injection(self, model, scheduler):
+        """model.eval() without timestep key injects equidistant timesteps."""
+        model.eval()
+        batch_size = 8
+        batch = self._make_presampled_batch(batch_size=batch_size)
+        data_iterator = iter([batch])
+
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state():
+                stack.enter_context(p)
+            result = flux_forward_step_func(
+                data_iterator,
+                model,
+                scheduler=scheduler,
+                step_count=1,
+            )
+
+        _, _, _, _, _, is_validation = result
+        assert is_validation is True
+        # Equidistant injection: batch["timestep"] = arange(B) % 8,
+        # batch["timesteps"] = that / 8.0.
+        assert "timestep" in batch
+        assert "timesteps" in batch
+        expected_timestep = torch.arange(batch_size, device="cuda") % 8
+        assert torch.equal(batch["timestep"], expected_timestep), (
+            f"batch['timestep'] expected {expected_timestep.tolist()}, " f"got {batch['timestep'].tolist()}"
+        )
+        assert torch.allclose(
+            batch["timesteps"].float(),
+            expected_timestep.float() / 8.0,
+        )
+
+    def test_cfg_dropout_full(self, model, scheduler):
+        """cfg_dropout_prob=1.0 replaces all text embeddings with empty encodings."""
+        batch_size = 2
+        seq_len = 32
+        batch = self._make_presampled_batch(batch_size=batch_size)
+        data_iterator = iter([batch])
+
+        # Use distinguishable empty encodings (not zeros) so we can verify
+        # the dropout actually substituted them rather than incidentally
+        # matching the original prompt_embeds.
+        empty_t5_value = 7.5
+        empty_clip_value = -3.25
+        empty_t5 = torch.full((seq_len, 1, T5_XXL_EMBEDDING_DIM), empty_t5_value, dtype=torch.float32)
+        empty_clip = torch.full((CLIP_L_EMBEDDING_DIM,), empty_clip_value, dtype=torch.float32)
+
+        # Capture the inputs the model receives by patching its forward.
+        captured = {}
+        original_forward = model.forward
+
+        def capturing_forward(*args, **kwargs):
+            captured["txt"] = kwargs.get("txt").detach().clone()
+            captured["y"] = kwargs.get("y").detach().clone()
+            return original_forward(*args, **kwargs)
+
+        model.forward = capturing_forward
+
+        try:
+            with contextlib.ExitStack() as stack:
+                for p in _patch_parallel_state():
+                    stack.enter_context(p)
+                result = flux_forward_step_func(
+                    data_iterator,
+                    model,
+                    scheduler=scheduler,
+                    cfg_dropout_prob=1.0,
+                    empty_t5_encodings=empty_t5,
+                    empty_clip_encodings=empty_clip,
+                    step_count=1,
+                )
+        finally:
+            model.forward = original_forward
+
+        noise_pred, _, _, _, _, is_validation = result
+        assert noise_pred.shape == (batch_size, VAE_LATENT_CHANNELS, 16, 16)
+        assert not is_validation
+
+        # txt is in (S, B, C) layout after the transpose.
+        # With prob=1.0 every row must be the empty encoding.
+        txt = captured["txt"].float()
+        assert torch.allclose(txt, torch.full_like(txt, empty_t5_value), atol=1e-2), (
+            f"prompt_embeds was not replaced by empty_t5 with cfg_dropout_prob=1.0; "
+            f"sample value={txt.flatten()[0].item():.3f}, expected {empty_t5_value}"
+        )
+
+        y = captured["y"].float()
+        assert torch.allclose(y, torch.full_like(y, empty_clip_value), atol=1e-2), (
+            f"pooled_prompt_embeds was not replaced by empty_clip with prob=1.0; "
+            f"sample value={y.flatten()[0].item():.3f}, expected {empty_clip_value}"
+        )

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_flux_model_creation.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_flux_model_creation.py
@@ -1,0 +1,288 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Unit tests for FluxPretrainTrainer model creation.
+
+Tests high-value Flux behavior in Primus:
+- backend_args -> FluxConfig mapping/defaults
+- model construction wiring
+- torch_compile settings propagation semantics
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus.backends.megatron.flux_pretrain_trainer import FluxPretrainTrainer
+
+
+def _build_flux_trainer(monkeypatch: pytest.MonkeyPatch, backend_args=None):
+    """Helper to build FluxPretrainTrainer with stubbed dependencies."""
+
+    # Stub out MegatronBaseTrainer.__init__ to avoid real Megatron imports
+    def dummy_base_init(self, backend_args=None, *args, **kwargs):
+        self.backend_args = backend_args
+        self.rank = 0
+        self.world_size = 1
+        self.local_rank = 0
+        self.master_addr = "localhost"
+        self.master_port = 12345
+
+    monkeypatch.setattr(
+        "primus.backends.megatron.megatron_base_trainer.MegatronBaseTrainer.__init__",
+        dummy_base_init,
+    )
+
+    # Stub out DiffusionPretrainTrainer.__init__
+    def dummy_diffusion_init(self, *args, **kwargs):
+        self.backend_args = kwargs.get("backend_args")
+        if self.backend_args is None and args:
+            self.backend_args = args[0]
+        if self.backend_args is None:
+            self.backend_args = SimpleNamespace()
+        self._scheduler = None
+        self.data_provider = Mock()
+
+    monkeypatch.setattr(
+        "primus.backends.megatron.diffusion_trainer.DiffusionPretrainTrainer.__init__",
+        dummy_diffusion_init,
+    )
+
+    # Silence logging
+    monkeypatch.setattr(
+        "primus.backends.megatron.flux_pretrain_trainer.log_rank_0",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "primus.backends.megatron.diffusion_trainer.log_rank_0",
+        lambda *args, **kwargs: None,
+    )
+
+    if backend_args is None:
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            guidance_embed=False,
+            guidance_scale=3.5,
+            num_train_timesteps=1000,
+            scheduler_shift=1.0,
+            use_dynamic_shifting=False,
+        )
+
+    return FluxPretrainTrainer(backend_args=backend_args)
+
+
+class TestFluxModelCreation:
+    """Tests for FluxPretrainTrainer model creation."""
+
+    def test_create_model_calls_build_flux_config(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that create_model() calls _build_flux_config_from_yaml()."""
+        trainer = _build_flux_trainer(monkeypatch)
+
+        build_config_calls = []
+        built_config = None
+
+        def tracked_build_config(self):
+            nonlocal built_config
+            build_config_calls.append(1)
+            from primus.backends.megatron.core.models.diffusion.flux.config import (
+                FluxConfig,
+            )
+
+            built_config = FluxConfig.flux_535m()
+            return built_config
+
+        trainer._build_flux_config_from_yaml = tracked_build_config.__get__(trainer, type(trainer))
+
+        # Mock Flux model
+        mock_flux_model = Mock()
+        mock_flux_model.parameters.return_value = []
+        flux_ctor = Mock(return_value=mock_flux_model)
+        monkeypatch.setattr(
+            "primus.backends.megatron.core.models.diffusion.flux.model.Flux",
+            flux_ctor,
+        )
+
+        # Mock get_args
+        mock_args = SimpleNamespace(rank=0)
+        training_mod = types.SimpleNamespace(get_args=lambda: mock_args)
+        monkeypatch.setitem(sys.modules, "megatron.training", training_mod)
+
+        result = trainer.create_model()
+
+        # Verify _build_flux_config_from_yaml was called
+        assert len(build_config_calls) == 1
+        flux_ctor.assert_called_once()
+        assert flux_ctor.call_args.kwargs["backend"] is None
+        assert flux_ctor.call_args.kwargs["config"] is built_config
+        assert result is mock_flux_model
+
+    def test_build_flux_config_from_yaml_extracts_parameters(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that _build_flux_config_from_yaml() extracts parameters from backend_args."""
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            # Model architecture params
+            num_joint_layers=24,
+            num_single_layers=8,
+            hidden_size=2048,
+            num_attention_heads=16,
+            ffn_hidden_size=8192,
+            # Precision
+            bf16=True,
+            fp16=False,
+            params_dtype=torch.bfloat16,
+            # Transformer impl
+            transformer_impl="local",
+        )
+
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+
+        config = trainer._build_flux_config_from_yaml()
+
+        # Verify config attributes were set
+        assert config.num_joint_layers == 24
+        assert config.num_single_layers == 8
+        assert config.hidden_size == 2048
+        assert config.num_attention_heads == 16
+        assert config.ffn_hidden_size == 8192
+        assert config.bf16 is True
+        assert config.fp16 is False
+        assert config.params_dtype == torch.bfloat16
+        assert config.transformer_impl == "local"
+
+    def test_build_flux_config_from_yaml_torch_compile_settings(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that torch_compile settings are extracted from backend_args."""
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            torch_compile=SimpleNamespace(
+                enable=True,
+                backend="inductor",
+                mode="reduce-overhead",
+                fullgraph=True,
+            ),
+        )
+
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+
+        config = trainer._build_flux_config_from_yaml()
+
+        # Verify torch_compile settings
+        assert config.enable_torch_compile is True
+        assert config.torch_compile_backend == "inductor"
+        assert config.torch_compile_mode == "reduce-overhead"
+        assert config.torch_compile_fullgraph is True
+
+    def test_create_model_sets_torch_compile_on_args(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that create_model() sets torch_compile attributes on args."""
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            torch_compile=SimpleNamespace(
+                enable=True,
+                backend="inductor",
+                mode="reduce-overhead",
+                fullgraph=True,
+            ),
+        )
+
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+
+        # Mock Flux model
+        mock_flux_model = Mock()
+        mock_flux_model.parameters.return_value = []
+        monkeypatch.setattr(
+            "primus.backends.megatron.core.models.diffusion.flux.model.Flux",
+            lambda *args, **kwargs: mock_flux_model,
+        )
+
+        # Mock get_args
+        mock_args = SimpleNamespace(rank=0)
+        training_mod = types.SimpleNamespace(get_args=lambda: mock_args)
+        monkeypatch.setitem(sys.modules, "megatron.training", training_mod)
+
+        trainer.create_model()
+
+        # Verify torch_compile attributes were set on args
+        assert mock_args.enable_torch_compile is True
+        assert mock_args.torch_compile_backend == "inductor"
+        assert mock_args.torch_compile_mode == "reduce-overhead"
+        assert mock_args.torch_compile_fullgraph is True
+
+    def test_build_flux_config_from_yaml_fp8_settings(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that FP8 fields are extracted from backend_args into FluxConfig."""
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            fp8="e4m3",
+            fp8_recipe="tensorwise",
+            fp8_margin=0,
+            fp8_amax_history_len=1,
+            fp8_amax_compute_algo="most_recent",
+            fp8_wgrad=True,
+            fp8_dot_product_attention=False,
+            fp8_multi_head_attention=False,
+        )
+
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+
+        config = trainer._build_flux_config_from_yaml()
+
+        assert config.fp8 == "e4m3"
+        assert config.fp8_recipe == "tensorwise"
+        assert config.fp8_margin == 0
+        assert config.fp8_amax_history_len == 1
+        assert config.fp8_amax_compute_algo == "most_recent"
+        assert config.fp8_wgrad is True
+        assert config.fp8_dot_product_attention is False
+        assert config.fp8_multi_head_attention is False
+
+    def test_create_model_does_not_overwrite_existing_torch_compile_attrs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Test that create_model() doesn't overwrite existing torch_compile attributes."""
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            torch_compile=SimpleNamespace(
+                enable=True,
+                backend="inductor",
+                mode="reduce-overhead",
+                fullgraph=True,
+            ),
+        )
+
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+
+        # Mock Flux model
+        mock_flux_model = Mock()
+        mock_flux_model.parameters.return_value = []
+        monkeypatch.setattr(
+            "primus.backends.megatron.core.models.diffusion.flux.model.Flux",
+            lambda *args, **kwargs: mock_flux_model,
+        )
+
+        # Mock get_args with existing attributes
+        mock_args = SimpleNamespace(
+            rank=0,
+            enable_torch_compile=False,  # Already set
+            torch_compile_backend="aot_eager",  # Already set
+        )
+        training_mod = types.SimpleNamespace(get_args=lambda: mock_args)
+        monkeypatch.setitem(sys.modules, "megatron.training", training_mod)
+
+        trainer.create_model()
+
+        # Verify existing attributes were NOT overwritten
+        assert mock_args.enable_torch_compile is False
+        assert mock_args.torch_compile_backend == "aot_eager"
+        # New attributes should still be set
+        assert mock_args.torch_compile_mode == "reduce-overhead"
+        assert mock_args.torch_compile_fullgraph is True

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_flux_trainer.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_flux_trainer.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for FluxPretrainTrainer.
+
+Tests initialization, configuration, method overrides, scheduler setup,
+and CFG dropout encoding discovery.
+"""
+
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus.backends.megatron.flux_pretrain_trainer import FluxPretrainTrainer
+
+
+def _build_flux_trainer(monkeypatch: pytest.MonkeyPatch, backend_args=None):
+    """Helper to build FluxPretrainTrainer with stubbed dependencies."""
+
+    # Stub out MegatronBaseTrainer.__init__ to avoid real Megatron imports
+    def dummy_init(self, backend_args: any = None):
+        self.backend_args = backend_args
+
+    monkeypatch.setattr(
+        "primus.backends.megatron.megatron_base_trainer.MegatronBaseTrainer.__init__",
+        dummy_init,
+    )
+
+    # Silence logging
+    monkeypatch.setattr(
+        "primus.backends.megatron.flux_pretrain_trainer.log_rank_0",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "primus.backends.megatron.diffusion_trainer.log_rank_0",
+        lambda *args, **kwargs: None,
+    )
+
+    if backend_args is None:
+        backend_args = SimpleNamespace(
+            guidance_embed=False,
+            guidance_scale=3.5,
+            num_train_timesteps=1000,
+            scheduler_shift=1.0,
+            use_dynamic_shifting=False,
+        )
+
+    return FluxPretrainTrainer(backend_args=backend_args)
+
+
+class TestFluxPretrainTrainer:
+    """Tests for FluxPretrainTrainer."""
+
+    def test_flux_trainer_scheduler_creation(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that scheduler is created correctly."""
+        backend_args = SimpleNamespace(
+            guidance_embed=False,
+            guidance_scale=3.5,
+            num_train_timesteps=1000,
+            scheduler_shift=1.0,
+            use_dynamic_shifting=False,
+        )
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+
+        # Create scheduler
+        scheduler = trainer.create_scheduler()
+
+        # Should be FlowMatchEulerDiscreteScheduler
+        from primus.backends.megatron.training.diffusion.schedulers import (
+            FlowMatchEulerDiscreteScheduler,
+        )
+
+        assert isinstance(scheduler, FlowMatchEulerDiscreteScheduler)
+        assert scheduler.num_train_timesteps == 1000
+        assert scheduler.shift == 1.0
+        assert scheduler.use_dynamic_shifting is False
+
+    def test_flux_trainer_scheduler_with_dynamic_shifting(self, monkeypatch: pytest.MonkeyPatch):
+        """Test scheduler creation with dynamic shifting enabled."""
+        backend_args = SimpleNamespace(
+            guidance_embed=False,
+            guidance_scale=3.5,
+            num_train_timesteps=1000,
+            scheduler_shift=1.0,
+            use_dynamic_shifting=True,
+            base_shift=0.5,
+            max_shift=1.15,
+        )
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+
+        scheduler = trainer.create_scheduler()
+
+        assert scheduler.use_dynamic_shifting is True
+        assert scheduler.base_shift == 0.5
+        assert scheduler.max_shift == 1.15
+
+    def test_flux_trainer_scheduler_lazy_initialization(self, monkeypatch: pytest.MonkeyPatch):
+        """Test that scheduler is lazily initialized via property."""
+        trainer = _build_flux_trainer(monkeypatch)
+
+        # Scheduler should not be created yet
+        assert trainer._scheduler is None
+
+        # Accessing scheduler property should create it
+        scheduler1 = trainer.scheduler
+        assert scheduler1 is not None
+        assert trainer._scheduler is scheduler1
+
+        # Accessing again should return same instance
+        scheduler2 = trainer.scheduler
+        assert scheduler2 is scheduler1
+
+
+def _create_encoding_files(directory):
+    """Create minimal t5_empty.npy and clip_empty.npy in a directory."""
+    os.makedirs(directory, exist_ok=True)
+    np.save(os.path.join(directory, "t5_empty.npy"), np.zeros((1, 256, 4096), dtype=np.float32))
+    np.save(os.path.join(directory, "clip_empty.npy"), np.zeros((1, 768), dtype=np.float32))
+
+
+class TestCFGDropoutDiscovery:
+    """Tests for CFG dropout empty encoding discovery and error handling."""
+
+    def test_discover_encodings_inside_data_path(self, monkeypatch, tmp_path):
+        """Auto-discovers encodings at {data_path}/empty_encodings/."""
+        monkeypatch.setattr(
+            "primus.backends.megatron.flux_pretrain_trainer.log_rank_0",
+            lambda *a, **kw: None,
+        )
+        enc_dir = tmp_path / "empty_encodings"
+        _create_encoding_files(str(enc_dir))
+
+        params = SimpleNamespace(data_path=str(tmp_path))
+        result = FluxPretrainTrainer._discover_empty_encodings(params)
+
+        assert result == str(enc_dir)
+
+    def test_discover_encodings_alongside_data_path(self, monkeypatch, tmp_path):
+        """Falls back to {data_path}/../empty_encodings/ when not inside."""
+        monkeypatch.setattr(
+            "primus.backends.megatron.flux_pretrain_trainer.log_rank_0",
+            lambda *a, **kw: None,
+        )
+        data_dir = tmp_path / "dataset"
+        data_dir.mkdir()
+        enc_dir = tmp_path / "empty_encodings"
+        _create_encoding_files(str(enc_dir))
+
+        params = SimpleNamespace(data_path=str(data_dir))
+        result = FluxPretrainTrainer._discover_empty_encodings(params)
+
+        assert result == str(enc_dir)
+
+    def test_discover_encodings_explicit_path(self, tmp_path):
+        """Explicit empty_encodings_path takes priority."""
+        explicit_dir = tmp_path / "custom_encodings"
+        _create_encoding_files(str(explicit_dir))
+
+        inside_dir = tmp_path / "data" / "empty_encodings"
+        _create_encoding_files(str(inside_dir))
+
+        params = SimpleNamespace(
+            data_path=str(tmp_path / "data"),
+            empty_encodings_path=str(explicit_dir),
+        )
+        result = FluxPretrainTrainer._discover_empty_encodings(params)
+
+        assert result == str(explicit_dir)
+
+    def test_discover_encodings_returns_none_when_missing(self, tmp_path):
+        """Returns None when no encoding files exist anywhere."""
+        params = SimpleNamespace(data_path=str(tmp_path))
+        result = FluxPretrainTrainer._discover_empty_encodings(params)
+
+        assert result is None
+
+    def test_discover_encodings_returns_none_for_partial_files(self, tmp_path):
+        """Returns None when only one of the two required files exists."""
+        enc_dir = tmp_path / "empty_encodings"
+        enc_dir.mkdir()
+        np.save(str(enc_dir / "t5_empty.npy"), np.zeros((1, 256, 4096), dtype=np.float32))
+
+        params = SimpleNamespace(data_path=str(tmp_path))
+        result = FluxPretrainTrainer._discover_empty_encodings(params)
+
+        assert result is None
+
+    def test_discover_encodings_handles_list_data_path(self, monkeypatch, tmp_path):
+        """Handles data_path passed as a list (takes first element)."""
+        monkeypatch.setattr(
+            "primus.backends.megatron.flux_pretrain_trainer.log_rank_0",
+            lambda *a, **kw: None,
+        )
+        enc_dir = tmp_path / "empty_encodings"
+        _create_encoding_files(str(enc_dir))
+
+        params = SimpleNamespace(data_path=[str(tmp_path), "/nonexistent"])
+        result = FluxPretrainTrainer._discover_empty_encodings(params)
+
+        assert result == str(enc_dir)
+
+    def test_cfg_dropout_raises_when_no_encodings_found(self, monkeypatch, tmp_path):
+        """Real data without encodings raises FileNotFoundError with instructions."""
+        backend_args = SimpleNamespace(
+            cfg_dropout_prob=0.1,
+            mock_data=False,
+            data_path=str(tmp_path),
+            tensor_model_parallel_size=1,
+        )
+
+        with pytest.raises(FileNotFoundError, match="primus data diffusion-encoded"):
+            _build_flux_trainer(monkeypatch, backend_args)

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_forward_step_count_gate.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_forward_step_count_gate.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for the model.training gate on DiffusionPretrainTrainer._forward_step_count.
+
+Contract under test: when ``model.training`` is False (the trainer is running
+an evaluation forward pass), the counter must NOT advance and the per-step
+CUDA RNG reseed must NOT fire. Otherwise validation steps shift the training
+RNG sequence by ``eval_iters * num_microbatches`` per ``--eval-interval``
+window, defeating the goal of isolating the training RNG from unrelated
+forward passes.
+
+These tests pair with
+``tests/unit_tests/backends/megatron/test_diffusion_trainer_forward_step_count.py``,
+which covers lazy initialization from checkpoint state and the
+``step_count`` flow into ``flux_forward_step_func``. This file is the
+single source of truth for the eval-skip contract — if the gate is reverted,
+the three ``TestForwardStepCountTrainingGate`` tests below must fail.
+"""
+
+from unittest.mock import Mock, patch
+
+import torch
+
+from primus.backends.megatron.diffusion_trainer import DiffusionPretrainTrainer
+
+
+class _ConcreteDiffusionTrainer(DiffusionPretrainTrainer):
+    """Minimal concrete subclass: abstract methods as no-ops."""
+
+    def create_model(self, *args, **kwargs):
+        return None
+
+    def create_scheduler(self, *args, **kwargs):
+        return None
+
+    def get_task_encoder(self, *args, **kwargs):
+        return None
+
+
+def _make_trainer():
+    """Construct a trainer with ``__init__`` bypassed.
+
+    Sets only the attributes ``forward_step`` reads. Lazy-init is forced to
+    "already initialized" because that surface is covered by
+    ``test_diffusion_trainer_forward_step_count.py::TestForwardStepCountLazyInit``.
+    """
+    trainer = _ConcreteDiffusionTrainer.__new__(_ConcreteDiffusionTrainer)
+    trainer._forward_step_count = 0
+    trainer._forward_step_count_initialized = True
+    trainer._scheduler = None
+
+    class _FakeRuntimeState:
+        def update_metrics(self, metrics):
+            pass
+
+    trainer.runtime_state = _FakeRuntimeState()
+    return trainer
+
+
+def _patch_flux_forward_step_func():
+    """Patch the real func with a recorder that captures ``step_count``."""
+    captured = []
+
+    def _recorder(*args, **kwargs):
+        captured.append(kwargs.get("step_count"))
+        t = torch.zeros(1)
+        return t, t, t, None, {}, False
+
+    return (
+        patch(
+            "primus.backends.megatron.training.diffusion.forward_step.flux_forward_step_func",
+            side_effect=_recorder,
+        ),
+        captured,
+    )
+
+
+class TestForwardStepCountTrainingGate:
+    """Direct coverage of the ``if model.training:`` gate on counter advance."""
+
+    def test_eval_does_not_advance_counter(self):
+        trainer = _make_trainer()
+        patcher, captured = _patch_flux_forward_step_func()
+        eval_model = Mock()
+        eval_model.training = False
+
+        with patcher:
+            trainer.forward_step(data_iterator=None, model=eval_model)
+
+        assert trainer._forward_step_count == 0
+        # Counter unchanged → step_count passed to the step func is the pre-call value.
+        assert captured == [0]
+
+    def test_train_advances_counter_by_one(self):
+        trainer = _make_trainer()
+        patcher, captured = _patch_flux_forward_step_func()
+        train_model = Mock()
+        train_model.training = True
+
+        with patcher:
+            trainer.forward_step(data_iterator=None, model=train_model)
+
+        assert trainer._forward_step_count == 1
+        assert captured == [1]
+
+    def test_eval_between_train_does_not_shift_sequence(self):
+        """Eval batches interleaved with training must NOT change the
+        ``step_count`` that subsequent training steps see."""
+        trainer = _make_trainer()
+        patcher, captured = _patch_flux_forward_step_func()
+
+        train_model = Mock()
+        train_model.training = True
+        eval_model = Mock()
+        eval_model.training = False
+
+        with patcher:
+            trainer.forward_step(data_iterator=None, model=train_model)  # 0 -> 1
+            trainer.forward_step(data_iterator=None, model=eval_model)  # stays 1
+            trainer.forward_step(data_iterator=None, model=eval_model)  # stays 1
+            trainer.forward_step(data_iterator=None, model=train_model)  # 1 -> 2
+
+        assert trainer._forward_step_count == 2
+        # Critical assertion: the 4th training step sees step_count=2, the
+        # same value it would see in the absence of the two eval calls. If
+        # the gate were missing, the sequence would be [1, 2, 3, 4].
+        assert captured == [1, 1, 1, 2]
+
+
+class TestPerStepReseedFormula:
+    """Positive control: when the counter advances, the per-step reseed
+    formula in ``flux_forward_step_func`` is computed correctly.
+
+    This is a focused regression test for the seed expression
+    ``(seed + 100 * dp_rank) * 10000 + step_count) % (2**63)``.
+    It deliberately reaches into the underlying step function rather than
+    going through the trainer so the formula is testable in isolation
+    from the gate logic."""
+
+    def test_reseed_uses_step_count_in_formula(self):
+        from primus.backends.megatron.training.diffusion import forward_step as fwd_mod
+
+        fake_args = Mock()
+        fake_args.seed = 7
+
+        train_model = Mock()
+        train_model.training = True
+
+        with patch.object(torch.cuda, "manual_seed") as mock_seed, patch(
+            "megatron.training.get_args", return_value=fake_args
+        ), patch("megatron.core.parallel_state.get_data_parallel_rank", return_value=3):
+            # flux_forward_step_func runs significant downstream logic that
+            # would require a full Megatron-Flux harness. We only need to
+            # verify the reseed call. Suppress the post-reseed failure so the
+            # mock.assert below still observes the manual_seed call.
+            try:
+                fwd_mod.flux_forward_step_func(
+                    data_iterator=None,
+                    model=train_model,
+                    scheduler=Mock(),
+                    per_step_rng_reseed=True,
+                    step_count=42,
+                )
+            except Exception:
+                # Expected: downstream code needs real data/model. The reseed
+                # call we care about happens before any of that — see the
+                # assert below.
+                pass
+
+        expected_seed = ((7 + 100 * 3) * 10000 + 42) % (2**63)
+        mock_seed.assert_called_once_with(expected_seed)

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_vae_resample_reproducibility.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_vae_resample_reproducibility.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for per-step RNG isolation reproducibility.
+
+Validates that:
+- Same step_count + same seed produces bitwise-identical outputs
+- Different step_count produces different outputs (RNG isolation works)
+"""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+from primus.backends.megatron.training.diffusion.forward_step import (
+    flux_forward_step_func,
+)
+from primus.backends.megatron.training.diffusion.schedulers.flow_matching import (
+    FlowMatchEulerDiscreteScheduler,
+)
+from tests.unit_tests.backends.megatron.diffusion.constants import (
+    CLIP_L_EMBEDDING_DIM,
+    T5_XXL_EMBEDDING_DIM,
+    VAE_LATENT_CHANNELS,
+)
+
+
+def _patch_parallel_state(seed=42):
+    """Return a list of mock.patch context managers for parallel state."""
+    return [
+        patch(
+            "megatron.core.parallel_state.get_tensor_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "megatron.core.parallel_state.get_pipeline_model_parallel_world_size",
+            return_value=1,
+        ),
+        patch(
+            "megatron.core.parallel_state.get_data_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "megatron.core.parallel_state.get_tensor_model_parallel_rank",
+            return_value=0,
+        ),
+        patch(
+            "megatron.training.get_args",
+            return_value=SimpleNamespace(seed=seed),
+        ),
+    ]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+class TestVaeResampleReproducibility:
+    """Tests per-step RNG isolation via observable output reproducibility."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        """Initialize parallel state for model tests."""
+
+    @pytest.fixture
+    def model(self):
+        config = FluxConfig.flux_535m()
+        m = Flux(config).cuda()
+        m.train()
+        return m
+
+    @pytest.fixture
+    def scheduler(self):
+        return FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000)
+
+    def _make_resample_batch(self, seed=99):
+        """Create a deterministic resample batch."""
+        g = torch.Generator().manual_seed(seed)
+        return {
+            "mean": torch.randn(2, VAE_LATENT_CHANNELS, 16, 16, generator=g),
+            "logvar": torch.randn(2, VAE_LATENT_CHANNELS, 16, 16, generator=g),
+            "prompt_embeds": torch.randn(2, 32, T5_XXL_EMBEDDING_DIM, generator=g),
+            "pooled_prompt_embeds": torch.randn(2, CLIP_L_EMBEDDING_DIM, generator=g),
+        }
+
+    def test_same_step_count_produces_identical_output(self, model, scheduler):
+        """Identical seed + step_count must produce bitwise-identical noise_pred."""
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state():
+                stack.enter_context(p)
+
+            batch1 = self._make_resample_batch(seed=99)
+            result1 = flux_forward_step_func(
+                iter([batch1]),
+                model,
+                scheduler=scheduler,
+                vae_latent_mode="resample",
+                vae_scale=0.3611,
+                vae_shift=0.1159,
+                step_count=5,
+            )
+            noise_pred_1 = result1[0].detach().clone()
+
+            batch2 = self._make_resample_batch(seed=99)
+            result2 = flux_forward_step_func(
+                iter([batch2]),
+                model,
+                scheduler=scheduler,
+                vae_latent_mode="resample",
+                vae_scale=0.3611,
+                vae_shift=0.1159,
+                step_count=5,
+            )
+            noise_pred_2 = result2[0].detach().clone()
+
+        assert torch.equal(noise_pred_1, noise_pred_2), (
+            "Same step_count should produce identical output "
+            f"(max diff: {(noise_pred_1 - noise_pred_2).abs().max().item():.2e})"
+        )
+
+    def test_different_step_count_produces_different_latents(self, model, scheduler):
+        """Different step_count values should produce different clean_latents.
+
+        Note: We compare clean_latents (index 1) rather than noise_pred (index 0)
+        because proj_out is zero-initialized (NeMo-aligned init), making noise_pred
+        always zero until training updates the projection layer.
+        """
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state():
+                stack.enter_context(p)
+
+            batch1 = self._make_resample_batch(seed=99)
+            result1 = flux_forward_step_func(
+                iter([batch1]),
+                model,
+                scheduler=scheduler,
+                vae_latent_mode="resample",
+                vae_scale=0.3611,
+                vae_shift=0.1159,
+                step_count=5,
+            )
+            latents_1 = result1[1].detach().clone()
+
+            batch2 = self._make_resample_batch(seed=99)
+            result2 = flux_forward_step_func(
+                iter([batch2]),
+                model,
+                scheduler=scheduler,
+                vae_latent_mode="resample",
+                vae_scale=0.3611,
+                vae_shift=0.1159,
+                step_count=6,
+            )
+            latents_2 = result2[1].detach().clone()
+
+        assert not torch.equal(latents_1, latents_2), (
+            "Different step_count values should produce different latents "
+            "(per-step RNG isolation not working)"
+        )
+
+    def test_different_base_seed_produces_different_output(self, model, scheduler):
+        """Different args.seed (same step_count) must produce different latents.
+
+        Validates the `_per_rank_seed = seed + 100*dp_rank` term in the step
+        seed formula at forward_step.py:237. A regression that drops `seed`
+        and uses only `step_count` would cause both runs to produce identical
+        output (since step_count is fixed at 5).
+        """
+        # Run 1: seed=42
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state(seed=42):
+                stack.enter_context(p)
+            batch1 = self._make_resample_batch(seed=99)
+            result1 = flux_forward_step_func(
+                iter([batch1]),
+                model,
+                scheduler=scheduler,
+                vae_latent_mode="resample",
+                vae_scale=0.3611,
+                vae_shift=0.1159,
+                step_count=5,
+            )
+            latents_42 = result1[1].detach().clone()
+
+        # Run 2: seed=43, identical step_count and identical batch contents.
+        with contextlib.ExitStack() as stack:
+            for p in _patch_parallel_state(seed=43):
+                stack.enter_context(p)
+            batch2 = self._make_resample_batch(seed=99)
+            result2 = flux_forward_step_func(
+                iter([batch2]),
+                model,
+                scheduler=scheduler,
+                vae_latent_mode="resample",
+                vae_scale=0.3611,
+                vae_shift=0.1159,
+                step_count=5,
+            )
+            latents_43 = result2[1].detach().clone()
+
+        assert not torch.equal(latents_42, latents_43), (
+            "Different args.seed values produced identical output — "
+            "the per-rank seed term appears to be missing from the step seed formula"
+        )

--- a/tests/unit_tests/backends/megatron/test_chimera_rng_restore.py
+++ b/tests/unit_tests/backends/megatron/test_chimera_rng_restore.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for `_restore_chimera_rng_state` defensive RNG restoration.
+
+Validates Fix 2: when Megatron's private `_set_random_seed` API drifts
+(signature change or removal), the helper falls back to a manual restore
+that covers all three RNG generators — CPU default, CUDA default, and the
+model-parallel tracker — so chimera training does not fail at startup.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus.backends.megatron.flux_pretrain_trainer import _restore_chimera_rng_state
+
+
+def _canonical_args(seed=42):
+    """Build the args namespace the helper reads."""
+    return SimpleNamespace(
+        seed=seed,
+        data_parallel_random_init=False,
+        te_rng_tracker=False,
+        inference_rng_tracker=False,
+        enable_cuda_graph=False,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+class TestChimeraRngRestoreFallback:
+    """The fallback path: when `_set_random_seed` raises TypeError or
+    ImportError, the helper must restore CPU, CUDA default, and the
+    model-parallel tracker generators manually so training continues."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        """Initialize parallel state — required because the fallback's
+        tp_random.model_parallel_cuda_manual_seed needs the tracker set up."""
+
+    def _verify_all_rngs_match_seed(self, seed):
+        """Sample from each generator and compare to a freshly-seeded
+        reference. If the helper's fallback fully restored the state,
+        the two samples must be bitwise identical for every generator."""
+        from megatron.core.tensor_parallel import random as tp_random
+
+        # CPU default generator.
+        cpu_after = torch.randn(8)
+        torch.manual_seed(seed)
+        cpu_ref = torch.randn(8)
+        assert torch.equal(cpu_after, cpu_ref), "CPU default generator was not restored to seed"
+
+        # CUDA default generator.
+        cuda_after = torch.randn(8, device="cuda")
+        torch.cuda.manual_seed(seed)
+        cuda_ref = torch.randn(8, device="cuda")
+        assert torch.equal(cuda_after, cuda_ref), "CUDA default generator was not restored to seed"
+
+        # Model-parallel tracker.
+        with tp_random.get_cuda_rng_tracker().fork():
+            tracker_after = torch.randn(8, device="cuda")
+        tp_random.model_parallel_cuda_manual_seed(seed)
+        with tp_random.get_cuda_rng_tracker().fork():
+            tracker_ref = torch.randn(8, device="cuda")
+        assert torch.equal(tracker_after, tracker_ref), "Model-parallel tracker was not restored to seed"
+
+    def _contaminate_rngs(self, contamination_seed):
+        """Set all three generators to a non-canonical seed so the test
+        observes the helper actively restoring rather than no-op-passing."""
+        from megatron.core.tensor_parallel import random as tp_random
+
+        torch.manual_seed(contamination_seed)
+        torch.cuda.manual_seed(contamination_seed)
+        tp_random.model_parallel_cuda_manual_seed(contamination_seed)
+
+    def test_typeerror_fallback_restores_all_rngs(self):
+        """Megatron signature drift (TypeError) must trigger manual restore."""
+        seed = 42
+        self._contaminate_rngs(contamination_seed=999)
+
+        args = _canonical_args(seed=seed)
+        with patch(
+            "megatron.training.initialize._set_random_seed",
+            side_effect=TypeError("signature changed"),
+        ):
+            _restore_chimera_rng_state(args)
+
+        self._verify_all_rngs_match_seed(seed)
+
+    def test_importerror_fallback_restores_all_rngs(self):
+        """Megatron module removal (ImportError) must trigger manual restore."""
+        seed = 42
+        self._contaminate_rngs(contamination_seed=999)
+
+        args = _canonical_args(seed=seed)
+        with patch(
+            "megatron.training.initialize._set_random_seed",
+            side_effect=ImportError("module gone"),
+        ):
+            _restore_chimera_rng_state(args)
+
+        self._verify_all_rngs_match_seed(seed)

--- a/tests/unit_tests/backends/megatron/test_diffusion_trainer_forward_step_count.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_trainer_forward_step_count.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for DiffusionPretrainTrainer's forward step count.
+
+Validates Fix 1: the `_forward_step_count` instance variable and its
+checkpoint-compatible lazy initialization from `args.iteration *
+get_num_microbatches()`. Also verifies the counter flows through to
+`flux_forward_step_func` as the `step_count` keyword argument.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from primus.backends.megatron.diffusion_trainer import DiffusionPretrainTrainer
+
+
+class _ConcreteDiffusionTrainer(DiffusionPretrainTrainer):
+    """Minimal concrete subclass: implements abstract methods as no-ops.
+
+    These methods are only required for instantiation; the tests never
+    invoke them.
+    """
+
+    def create_model(self, *args, **kwargs):
+        return None
+
+    def create_scheduler(self, *args, **kwargs):
+        return None
+
+    def get_task_encoder(self, *args, **kwargs):
+        return None
+
+
+def _make_trainer():
+    """Construct a DiffusionPretrainTrainer with __init__ bypassed.
+
+    Sets only the attributes required by `get_forward_step()` and
+    `forward_step()`. Other attributes are intentionally left unset so
+    that tests fail loudly if production code starts depending on them.
+    """
+    trainer = _ConcreteDiffusionTrainer.__new__(_ConcreteDiffusionTrainer)
+    trainer._forward_step_count = 0
+    trainer._forward_step_count_initialized = False
+    return trainer
+
+
+class TestForwardStepCountLazyInit:
+    """Tests for lazy initialization of _forward_step_count from checkpoint state."""
+
+    def test_lazy_init_from_checkpoint_iteration(self):
+        """First closure call must reconstruct counter as iteration * num_microbatches."""
+        trainer = _make_trainer()
+        trainer.forward_step = lambda data_iterator, model, return_schedule_plan=False: None
+
+        with patch(
+            "megatron.training.get_args",
+            return_value=SimpleNamespace(iteration=100),
+        ), patch(
+            "megatron.core.num_microbatches_calculator.get_num_microbatches",
+            return_value=4,
+        ):
+            closure = trainer.get_forward_step()
+            closure(data_iterator=None, model=None)
+
+        assert trainer._forward_step_count == 400
+        assert trainer._forward_step_count_initialized is True
+
+    def test_lazy_init_only_runs_once(self):
+        """Second call must not re-read args.iteration even if it changes."""
+        trainer = _make_trainer()
+        trainer.forward_step = lambda data_iterator, model, return_schedule_plan=False: None
+
+        args_state = SimpleNamespace(iteration=10)
+
+        with patch(
+            "megatron.training.get_args",
+            side_effect=lambda: args_state,
+        ), patch(
+            "megatron.core.num_microbatches_calculator.get_num_microbatches",
+            return_value=2,
+        ):
+            closure = trainer.get_forward_step()
+            closure(data_iterator=None, model=None)
+            assert trainer._forward_step_count == 20
+
+            args_state.iteration = 999
+            closure(data_iterator=None, model=None)
+
+        # Must remain 20: lazy init flag prevents a second reconstruction.
+        assert trainer._forward_step_count == 20
+        assert trainer._forward_step_count_initialized is True
+
+    def test_initial_iteration_zero(self):
+        """Fresh start (iteration=0) reconstructs counter to 0."""
+        trainer = _make_trainer()
+        trainer.forward_step = lambda data_iterator, model, return_schedule_plan=False: None
+
+        with patch(
+            "megatron.training.get_args",
+            return_value=SimpleNamespace(iteration=0),
+        ), patch(
+            "megatron.core.num_microbatches_calculator.get_num_microbatches",
+            return_value=8,
+        ):
+            closure = trainer.get_forward_step()
+            closure(data_iterator=None, model=None)
+
+        assert trainer._forward_step_count == 0
+        assert trainer._forward_step_count_initialized is True
+
+
+class TestCounterFlowsToForwardStepFunc:
+    """Integration test: trainer counter must pass through to flux_forward_step_func."""
+
+    def test_counter_flows_to_forward_step_func(self):
+        """forward_step must invoke flux_forward_step_func with step_count == counter."""
+        trainer = _make_trainer()
+        # _scheduler backs the `scheduler` lazy property; setting it pre-empts
+        # create_scheduler() which would otherwise raise abstract NotImplementedError.
+        trainer._scheduler = None
+
+        # Provide a fake runtime_state so forward_step doesn't fall into the
+        # log_rank_0 warning branch (which requires the Primus logger to be
+        # initialized — outside this test's scope).
+        class _FakeRuntimeState:
+            def update_metrics(self, metrics):
+                pass
+
+        trainer.runtime_state = _FakeRuntimeState()
+
+        recorded_kwargs = {}
+
+        def recording_func(*args, **kwargs):
+            recorded_kwargs.update(kwargs)
+            # Return shape matches: (noise_pred, clean_latents, noise, loss_mask, metrics, is_validation)
+            t = torch.zeros(1)
+            return t, t, t, None, {}, False
+
+        # Training model: `if model.training:` gate in forward_step requires
+        # a real attribute (None would AttributeError). Eval-skip behavior is
+        # covered in test_forward_step_count_gate.py.
+        train_model = Mock()
+        train_model.training = True
+
+        with patch(
+            "primus.backends.megatron.training.diffusion.forward_step.flux_forward_step_func",
+            side_effect=recording_func,
+        ):
+            # First forward step — counter increments from 0 to 1
+            trainer.forward_step(data_iterator=None, model=train_model)
+            assert recorded_kwargs["step_count"] == 1
+            assert trainer._forward_step_count == 1
+
+            # Second forward step — counter increments to 2
+            trainer.forward_step(data_iterator=None, model=train_model)
+            assert recorded_kwargs["step_count"] == 2
+            assert trainer._forward_step_count == 2


### PR DESCRIPTION
Part of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Targets `feat/flux/flux` and also merges `feat/flux/trainprim`, `feat/flux/fp8`, `feat/flux/data` — review after all four.

## What this changes
The trainers that tie the feature together: the generic diffusion trainer, the Flux pretrain trainer, and the validation-metric evaluator.

## Why it has several parents
The diffusion trainer lazily imports the data providers (`feat/flux/data`) and pulls in training primitives (`feat/flux/trainprim`) and fp8 (`feat/flux/fp8`); without the data parent its own tests fail with `ModuleNotFoundError: primus.backends.megatron.data`.

## Dependencies
Sequenced after the CI-pins PR (`feat/flux/ci-env`); its tests exercise no mxfp4/compile path and pass on the current CI pin (no turbo-bump dependency). Builds on `feat/flux/flux` + `feat/flux/trainprim` + `feat/flux/fp8` + `feat/flux/data`.

## Test plan
`pytest tests/unit_tests/backends/megatron/diffusion/training tests/unit_tests/backends/megatron/test_chimera_rng_restore.py`. Validated locally on an AMD GPU container: 41 passed.

## Files
11 (diffusion trainer, Flux pretrain trainer, evaluator + tests).
