### PR TITLE
chore: update GitHub org references from AMD-AIG-AIMA to AMD-AGI

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout Repo Primus-Turbo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: AMD-AIG-AIMA/Primus-Turbo
+          repository: AMD-AGI/Primus-Turbo
           submodules: "recursive"
           path: Primus-Turbo
           ref: ${{ env.PRIMUS_TURBO_COMMIT }}
@@ -240,7 +240,7 @@ jobs:
       - name: Checkout Repo Primus-Turbo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: AMD-AIG-AIMA/Primus-Turbo
+          repository: AMD-AGI/Primus-Turbo
           submodules: "recursive"
           path: Primus-Turbo
           ref: ${{ env.PRIMUS_TURBO_COMMIT }}
@@ -403,7 +403,7 @@ jobs:
       - name: Checkout Repo Primus-Turbo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: AMD-AIG-AIMA/Primus-Turbo
+          repository: AMD-AGI/Primus-Turbo
           submodules: "recursive"
           path: Primus-Turbo
           ref: ${{ env.PRIMUS_TURBO_COMMIT }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,7 +230,7 @@ jobs:
       - name: Checkout Repo Primus-Turbo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: AMD-AIG-AIMA/Primus-Turbo
+          repository: AMD-AGI/Primus-Turbo
           submodules: "recursive"
           path: Primus-Turbo
           ref: ${{ env.PRIMUS_TURBO_COMMIT }}
@@ -443,7 +443,7 @@ jobs:
       - name: Checkout Repo Primus-Turbo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          repository: AMD-AIG-AIMA/Primus-Turbo
+          repository: AMD-AGI/Primus-Turbo
           path: Primus-Turbo
           ref: ${{ env.PRIMUS_TURBO_COMMIT }}
       - name: Init Primus-Turbo submodules (full clone)

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,4 +67,4 @@ Get help and find answers:
 
 ---
 
-**Need help?** Check the [FAQ](./faq.md) or open an issue on [GitHub](https://github.com/AMD-AIG-AIMA/Primus/issues).
+**Need help?** Check the [FAQ](./faq.md) or open an issue on [GitHub](https://github.com/AMD-AGI/Primus/issues).

--- a/docs/posttraining.md
+++ b/docs/posttraining.md
@@ -447,6 +447,6 @@ recompute_num_layers: 1       # Number of layers to recompute
 
 ---
 
-**Need help?** Open an issue on [GitHub](https://github.com/AMD-AIG-AIMA/Primus/issues).
+**Need help?** Open an issue on [GitHub](https://github.com/AMD-AGI/Primus/issues).
 
 **Start fine-tuning with Primus! 🚀**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,7 +24,7 @@ rocm-smi && docker --version
 docker pull docker.io/rocm/primus:v26.3
 
 # Clone repository
-git clone --recurse-submodules https://github.com/AMD-AIG-AIMA/Primus.git
+git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
 cd Primus
 ```
 
@@ -93,7 +93,7 @@ primus-cli [options] <mode> [mode-args] -- [command]
 
 **Need Help?**
 - [FAQ](./faq.md) - Common questions
-- [GitHub Issues](https://github.com/AMD-AIG-AIMA/Primus/issues) - Report bugs
+- [GitHub Issues](https://github.com/AMD-AGI/Primus/issues) - Report bugs
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -61,7 +61,7 @@ Clone the repository and install dependencies:
 ```bash
 # Clone with submodules
 cd /workspace
-git clone --recurse-submodules git@github.com:AMD-AIG-AIMA/Primus.git
+git clone --recurse-submodules git@github.com:AMD-AGI/Primus.git
 
 # Or initialize submodules if already cloned
 git submodule update --init --recursive
@@ -164,7 +164,7 @@ NNODES=1 bash ./examples/run_slurm_pretrain.sh
 
 ### Stage 2: Tune GEMM Kernel
 
-This stage performs kernel tuning based on the dumped GEMM shapes using the [offline_tune tool](https://github.com/AMD-AIG-AIMA/Primus/tree/main/examples/offline_tune).
+This stage performs kernel tuning based on the dumped GEMM shapes using the [offline_tune tool](https://github.com/AMD-AGI/Primus/tree/main/examples/offline_tune).
 It typically takes 10–30 minutes depending on model size and shape complexity.
 
 
@@ -195,18 +195,18 @@ The following models are supported out of the box via provided configuration fil
 
 | Model            | Huggingface Config | Megatron Config | TorchTitan Config |
 | ---------------- | ------------------ | --------------- | ----------------- |
-| llama2_7B        | [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf)         | [llama2_7B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml)               | |
-| llama2_70B       | [meta-llama/Llama-2-70b-hf](https://huggingface.co/meta-llama/Llama-2-70b-hf)       | [llama2_70B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/llama2_70B-BF16-pretrain.yaml)             | |
-| llama3_8B        | [meta-llama/Meta-Llama-3-8B](https://huggingface.co/meta-llama/Meta-Llama-3-8B)     | [llama3_8B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/llama3_8B-BF16-pretrain.yaml)               | |
-| llama3_70B       | [meta-llama/Meta-Llama-3-70B](https://huggingface.co/meta-llama/Meta-Llama-3-70B)   | [llama3_70B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/llama3_70B-BF16-pretrain.yaml)             | |
-| llama3.1_8B      | [meta-llama/Llama-3.1-8B](https://huggingface.co/meta-llama/Llama-3.1-8B)           | [llama3.1_8B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml)           | [llama3.1_8B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/torchtitan/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml)|
-| llama3.1_70B     | [meta-llama/Llama-3.1-70B](https://huggingface.co/meta-llama/Llama-3.1-70B)         | [llama3.1_70B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/llama3.1_70B-BF16-pretrain.yaml)         | [llama3.1_70B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/torchtitan/configs/MI300X/llama3.1_70B-BF16-pretrain.yaml)|
-| llama3.1_405B     | [meta-llama/Llama-3.1-405B](https://huggingface.co/meta-llama/Llama-3.1-405B)         | [llama3.1_405B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/llama3.1_405B-BF16-pretrain.yaml)         | [llama3.1_405B-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/torchtitan/configs/MI300X/llama3.1_405B-BF16-pretrain.yaml)|
-| deepseek_v2_lite | [deepseek-ai/DeepSeek-V2-Lite](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite) | [deepseek_v2_lite-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/deepseek_v2_lite-BF16-pretrain.yaml) | |
-| deepseek_v2      | [deepseek-ai/DeepSeek-V2](https://huggingface.co/deepseek-ai/DeepSeek-V2)           | [deepseek_v2-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/deepseek_v2-BF16-pretrain.yaml)           | |
-| deepseek_v3      | [deepseek-ai/DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3)           | [deepseek_v3-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/deepseek_v3-BF16-pretrain.yaml)           | |
-| Mixtral-8x7B-v0.1 | [mistralai/Mixtral-8x7B-v0.1 ](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)           | [mixtral_8x7B_v0.1-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/mixtral_8x7B_v0.1-BF16-pretrain.yaml)           | |
-| Mixtral-8x22B-v0.1 | [mistralai/Mixtral-8x22B-v0.1 ](https://huggingface.co/mistralai/Mixtral-8x22B-v0.1)           | [mixtral_8x22B_v0.1-BF16-pretrain.yaml](https://github.com/AMD-AIG-AIMA/Primus/blob/main/examples/megatron/configs/MI300X/mixtral_8x22B_v0.1-BF16-pretrain.yaml)           | |
+| llama2_7B        | [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf)         | [llama2_7B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml)               | |
+| llama2_70B       | [meta-llama/Llama-2-70b-hf](https://huggingface.co/meta-llama/Llama-2-70b-hf)       | [llama2_70B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/llama2_70B-BF16-pretrain.yaml)             | |
+| llama3_8B        | [meta-llama/Meta-Llama-3-8B](https://huggingface.co/meta-llama/Meta-Llama-3-8B)     | [llama3_8B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/llama3_8B-BF16-pretrain.yaml)               | |
+| llama3_70B       | [meta-llama/Meta-Llama-3-70B](https://huggingface.co/meta-llama/Meta-Llama-3-70B)   | [llama3_70B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/llama3_70B-BF16-pretrain.yaml)             | |
+| llama3.1_8B      | [meta-llama/Llama-3.1-8B](https://huggingface.co/meta-llama/Llama-3.1-8B)           | [llama3.1_8B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml)           | [llama3.1_8B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/torchtitan/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml)|
+| llama3.1_70B     | [meta-llama/Llama-3.1-70B](https://huggingface.co/meta-llama/Llama-3.1-70B)         | [llama3.1_70B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/llama3.1_70B-BF16-pretrain.yaml)         | [llama3.1_70B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/torchtitan/configs/MI300X/llama3.1_70B-BF16-pretrain.yaml)|
+| llama3.1_405B     | [meta-llama/Llama-3.1-405B](https://huggingface.co/meta-llama/Llama-3.1-405B)         | [llama3.1_405B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/llama3.1_405B-BF16-pretrain.yaml)         | [llama3.1_405B-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/torchtitan/configs/MI300X/llama3.1_405B-BF16-pretrain.yaml)|
+| deepseek_v2_lite | [deepseek-ai/DeepSeek-V2-Lite](https://huggingface.co/deepseek-ai/DeepSeek-V2-Lite) | [deepseek_v2_lite-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/deepseek_v2_lite-BF16-pretrain.yaml) | |
+| deepseek_v2      | [deepseek-ai/DeepSeek-V2](https://huggingface.co/deepseek-ai/DeepSeek-V2)           | [deepseek_v2-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/deepseek_v2-BF16-pretrain.yaml)           | |
+| deepseek_v3      | [deepseek-ai/DeepSeek-V3](https://huggingface.co/deepseek-ai/DeepSeek-V3)           | [deepseek_v3-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/deepseek_v3-BF16-pretrain.yaml)           | |
+| Mixtral-8x7B-v0.1 | [mistralai/Mixtral-8x7B-v0.1 ](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)           | [mixtral_8x7B_v0.1-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/mixtral_8x7B_v0.1-BF16-pretrain.yaml)           | |
+| Mixtral-8x22B-v0.1 | [mistralai/Mixtral-8x22B-v0.1 ](https://huggingface.co/mistralai/Mixtral-8x22B-v0.1)           | [mixtral_8x22B_v0.1-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/mixtral_8x22B_v0.1-BF16-pretrain.yaml)           | |
 
 ---
 

--- a/examples/megatron/prepare.py
+++ b/examples/megatron/prepare.py
@@ -33,7 +33,7 @@ def check_dir_nonempty(path: Path, name: str):
             f"{name} ({path}) does not exist or is empty.\n"
             "Please ensure Primus is properly initialized.\n"
             "If not yet cloned, run:\n"
-            "    git clone --recurse-submodules git@github.com:AMD-AIG-AIMA/Primus.git\n"
+            "    git clone --recurse-submodules git@github.com:AMD-AGI/Primus.git\n"
             "Or if already cloned, initialize submodules with:\n"
             "    git submodule update --init --recursive"
         )

--- a/runner/helpers/hooks/projection/performance/megatron/prepare.py
+++ b/runner/helpers/hooks/projection/performance/megatron/prepare.py
@@ -33,7 +33,7 @@ def check_dir_nonempty(path: Path, name: str):
             f"{name} ({path}) does not exist or is empty.\n"
             "Please ensure Primus is properly initialized.\n"
             "If not yet cloned, run:\n"
-            "    git clone --recurse-submodules git@github.com:AMD-AIG-AIMA/Primus.git\n"
+            "    git clone --recurse-submodules git@github.com:AMD-AGI/Primus.git\n"
             "Or if already cloned, initialize submodules with:\n"
             "    git submodule update --init --recursive"
         )

--- a/runner/helpers/hooks/train/pretrain/megatron/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/megatron/prepare.py
@@ -33,7 +33,7 @@ def check_dir_nonempty(path: Path, name: str):
             f"{name} ({path}) does not exist or is empty.\n"
             "Please ensure Primus is properly initialized.\n"
             "If not yet cloned, run:\n"
-            "    git clone --recurse-submodules git@github.com:AMD-AIG-AIMA/Primus.git\n"
+            "    git clone --recurse-submodules git@github.com:AMD-AGI/Primus.git\n"
             "Or if already cloned, initialize submodules with:\n"
             "    git submodule update --init --recursive"
         )

--- a/runner/helpers/hooks/train/pretrain/megatron_bridge/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/megatron_bridge/prepare.py
@@ -31,7 +31,7 @@ def check_dir_nonempty(path: Path, name: str):
             f"{name} ({path}) does not exist or is empty.\n"
             "Please ensure Primus is properly initialized.\n"
             "If not yet cloned, run:\n"
-            "    git clone --recurse-submodules git@github.com:AMD-AIG-AIMA/Primus.git\n"
+            "    git clone --recurse-submodules git@github.com:AMD-AGI/Primus.git\n"
             "Or if already cloned, initialize submodules with:\n"
             "    git submodule update --init --recursive"
         )

--- a/tools/daily/safe_wrapper.py
+++ b/tools/daily/safe_wrapper.py
@@ -55,7 +55,7 @@ class SafeWrapper:
             f"cd /tmp/Primus-Turbo &&  git checkout {self.PRIMUS_TURBO_COMMIT}",
             f"MAX_JOBS=128 pip install --cache-dir={self.PRIMUS_WORKDIR}/primus-cache --no-build-isolation --no-clean -r requirements.txt",
             f"pip3 install --no-build-isolation -e . -v",
-            f"cd && git clone --recurse-submodules https://github.com/AMD-AIG-AIMA/Primus.git && cd Primus && pip install -r requirements.txt",
+            f"cd && git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git && cd Primus && pip install -r requirements.txt",
         ]
         for config in args.config.split(","):
             path = Path(config)

--- a/tools/pip_index/build_pip_index.py
+++ b/tools/pip_index/build_pip_index.py
@@ -21,7 +21,7 @@ Layout produced under ``--output-dir`` (typically ``<site>/simple``)::
 Usage::
 
     python3 tools/pip_index/build_pip_index.py \
-        --repo AMD-AIG-AIMA/Primus \
+        --repo AMD-AGI/Primus \
         --package primus \
         --requires-python ">=3.10" \
         --output-dir /tmp/site/simple
@@ -138,7 +138,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Build a PEP 503 'simple' index for GitHub Release artifacts."
     )
-    parser.add_argument("--repo", required=True, help="owner/repo, e.g. AMD-AIG-AIMA/Primus")
+    parser.add_argument("--repo", required=True, help="owner/repo, e.g. AMD-AGI/Primus")
     parser.add_argument("--package", default="primus", help="Project name (default: primus)")
     parser.add_argument("--output-dir", required=True, help="Output dir for the simple/ index root")
     parser.add_argument(


### PR DESCRIPTION
The repository moved from the AMD-AIG-AIMA org to AMD-AGI. Align all remaining clone URLs, repo slugs and doc links for Primus/Primus-Turbo with the canonical AMD-AGI org across CI workflows, runner hooks, tools, examples and docs.