### PR TITLE
fix: fix padding bug and remove use_turbo_permute_padding flag

### DIFF
--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -1910,7 +1910,7 @@ class PrimusTurboDeepEPTokenDispatcher(MoETokenDispatcher):
                 permute_max_token_num = num_worst_tokens * config.moe_router_topk
 
         pad_multiple = 0
-        if args.use_turbo_permute_padding:
+        if args.moe_router_padding_for_quantization:
             if PrimusTurboLowPrecisionGlobalStateManager.is_turbo_fp8_enabled():
                 pad_multiple = (
                     32

--- a/primus/backends/megatron/core/transformer/experts.py
+++ b/primus/backends/megatron/core/transformer/experts.py
@@ -39,7 +39,7 @@ class PrimusGroupedMLP(TEGroupedMLP):
 
         # NOTE: use_turbo_fused_act_with_probs is prioritized over use_te_activation_func and bias_activation_fusion
         self.use_turbo_fused_act_with_probs = args.use_turbo_fused_act_with_probs
-        self.use_turbo_permute_padding = args.use_turbo_permute_padding
+        self.moe_router_padding_for_quantization = args.moe_router_padding_for_quantization
 
     def bias_act_func_with_mask(
         self,
@@ -94,11 +94,11 @@ class PrimusGroupedMLP(TEGroupedMLP):
         Return:
             output (torch.Tensor): The output of the local experts.
         """
-        if not self.use_turbo_permute_padding and (self.config.fp8 or self.config.fp4):
-            # NOTE: When use_turbo_permute_padding is true the token is padded. So we can skip the padding here to reduce cpu sync.
+        if not self.moe_router_padding_for_quantization and (self.config.fp8 or self.config.fp4):
+            # NOTE: When moe_router_padding_for_quantization is true the token is padded. So we can skip the padding here to reduce cpu sync.
             tokens_per_expert_cpu: list[int] = tokens_per_expert.tolist()
             actual_tokens_per_expert_cpu: list[int] = tokens_per_expert_cpu
-            permuted_local_hidden_states, tokens_per_expert = self.quantization_padding(
+            permuted_local_hidden_states, tokens_per_expert_cpu = self.quantization_padding(
                 permuted_local_hidden_states, tokens_per_expert_cpu
             )
             permuted_probs, _ = self.quantization_padding(
@@ -155,7 +155,7 @@ class PrimusGroupedMLP(TEGroupedMLP):
         output = self._apply_bias(output, output_bias, tokens_per_expert.tolist(), permuted_probs)
 
         # upad and concat the output
-        if not self.use_turbo_permute_padding and (self.config.fp8 or self.config.fp4):
+        if not self.moe_router_padding_for_quantization and (self.config.fp8 or self.config.fp4):
             output = self.quantization_unpadding(output, actual_tokens_per_expert_cpu)
 
         output_bias = None

--- a/primus/configs/modules/megatron/primus_turbo.yaml
+++ b/primus/configs/modules/megatron/primus_turbo.yaml
@@ -22,9 +22,6 @@ enable_turbo_attention_float8: false
 # use turbo gemm
 use_turbo_gemm: false
 
-# ===== Permute =====
-use_turbo_permute_padding: false
-
 # ===== Grouped MLP =====
 # use turbo grouped gemm
 use_turbo_grouped_gemm: false

--- a/primus/modules/trainer/megatron/utils.py
+++ b/primus/modules/trainer/megatron/utils.py
@@ -455,7 +455,9 @@ def dump_pp_data(args, num_mbs, pp_data_dir):
             json.dump(config_dict, f, indent=2)
 
 
-def _get_sync_free_moe_options(stage: int) -> dict:
+def _get_sync_free_moe_options(args) -> dict:
+    stage = args.turbo_sync_free_moe_stage
+
     if stage > 3 or stage < 0:
         raise ValueError("turbo_sync_free_moe_stage only support [0-3]")
 
@@ -463,21 +465,21 @@ def _get_sync_free_moe_options(stage: int) -> dict:
         1: {
             "moe_use_fused_router_with_aux_score": True,
             "moe_permute_fusion": True,
-            "use_turbo_permute_padding": True,
+            "moe_router_padding_for_quantization": True if args.fp8 or args.fp4 else False,
         },
         2: {
             "moe_use_fused_router_with_aux_score": True,
             "use_turbo_deepep": True,
             "moe_permute_fusion": True,
             "use_turbo_grouped_gemm": True,
-            "use_turbo_permute_padding": True,
+            "moe_router_padding_for_quantization": True if args.fp8 or args.fp4 else False,
         },
         3: {
             "moe_use_fused_router_with_aux_score": True,
             "use_turbo_deepep": True,
             "moe_permute_fusion": True,
             "use_turbo_grouped_gemm": True,
-            "use_turbo_permute_padding": True,
+            "moe_router_padding_for_quantization": True if args.fp8 or args.fp4 else False,
             "use_turbo_fused_act_with_probs": True,
         },
     }
@@ -554,7 +556,7 @@ def validate_args_on_rocm(args):
             raise ValueError(
                 "Sync-Free MoE stage 2 or 3 require PrimusTurboGroupedLinear, please set `use_turbo_grouped_gemm=True`"
             )
-        options = _get_sync_free_moe_options(args.turbo_sync_free_moe_stage)
+        options = _get_sync_free_moe_options(args)
         print_rank_last(
             f"========== Enable Sync-Free MoE Stage {args.turbo_sync_free_moe_stage} (Auto-Enabled Options) =========="
         )


### PR DESCRIPTION
# Description

This PR fixes a quantization-padding bug in `PrimusGroupedMLP` under FP8/FP4 and removes the `use_turbo_permute_padding` flag, reusing the standard Megatron-LM `moe_router_padding_for_quantization` flag instead.

Previously, the padded token counts returned by `quantization_padding` were assigned to a variable that was immediately overwritten, so the grouped GEMM ran on the padded hidden states but with the original (unpadded) `tokens_per_expert`,producing incorrect results under FP8/FP4.

In addition, `use_turbo_permute_padding` only took effect on the Primus-Turbo DeepEP path, which made the padding behavior inconsistent across token dispatchers.
By switching to the native `moe_router_padding_for_quantization` flag, the padding semantics are decoupled from the Turbo DeepEP path and become consistent for both the DeepEP and the non-DeepEP MoE paths.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix the padding bug in `PrimusGroupedMLP.forward`: the padded `tokens_per_expert` returned by `quantization_padding` is now written back to `tokens_per_expert_cpu`, so the grouped GEMM uses the padded token counts that match the padded hidden states (and the original unpadded counts are preserved for unpadding).
- Remove the `use_turbo_permute_padding` flag and gate the quantization padding/unpadding on `moe_router_padding_for_quantization` instead, decoupling the padding behavior from the Turbo DeepEP path.
- Use `moe_router_padding_for_quantization` (instead of `use_turbo_permute_padding`) when computing `pad_multiple` in `PrimusTurboDeepEPTokenDispatcher`.
- Update the Sync-Free MoE auto-enabled options (stages 1/2/3) to set `moe_router_padding_for_quantization` only when FP8/FP4 is enabled, and pass `args` into `_get_sync_free_moe_options` so the recipe can be taken into account.
- Remove the `use_turbo_permute_padding` entry from `primus/configs/modules/megatron/primus_turbo.yaml`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
