### PR TITLE
feat(projection): add DeepSeek-V4 iteration-timeline view + fix fwd/bwd split

### DIFF
--- a/deepseek-v4/projection/README.md
+++ b/deepseek-v4/projection/README.md
@@ -28,11 +28,12 @@ run profiling script (per cr)  ->  chrome trace JSON (rank 0)
                                 breakdown JSON (site/data/<model>.json)
                                            |
                                            v
-                              static site (site/index.html)
+                                static site (site/index.html)
                                   - model config view
                                   - per-cr fwd/bwd breakdown tables
                                   - GPU + parallelism controls
                                   - step-by-step iter-time / TFLOPs / tok/s derivation
+                                  - iteration timeline (3 levels: layer / PP ranks / schedule)
                                   - MI355X page + MI455X scaled page
 ```
 
@@ -46,6 +47,7 @@ deepseek-v4/projection/
     02-assumptions.md
     03-json-schema.md
     04-projection-math.md
+    07-iteration-timeline.md       # 3-level iteration-time composition view
   script/                        # profiling launchers (one trace per cr)
     deepseek_v4_layer_trace-projection.sh
   tools/                         # trace -> breakdown JSON

--- a/deepseek-v4/projection/design/02-assumptions.md
+++ b/deepseek-v4/projection/design/02-assumptions.md
@@ -54,8 +54,16 @@ start here.
   removing residual jitter.
 - **A13.** Kernel -> nn.module attribution uses `with_stack=True`: GPU kernels are
   linked to their launching CPU op via trace flow events, and the module is read
-  from the CPU op's python call stack. fwd/bwd is determined by the stack
-  (backward frames) and/or `_fwd_`/`_bwd_` in kernel names.
+  from the CPU op's python call stack. **fwd/bwd phase** is determined by, in
+  priority order: (1) a `_fwd_`/`_bwd_` tag in the kernel name; (2) for linked
+  kernels, whether the launching CPU op's timestamp lies inside an
+  `autograd::engine::evaluate_function` interval (= backward); (3) for unlinked
+  kernels (no `External id`), whether the kernel's GPU timestamp lies in the
+  backward GPU-time window reconstructed from the linked backward kernels. The
+  old rule (default-to-forward when unlinked) leaked backward compute -- incl.
+  the MoE dgrad/wgrad grouped GEMMs -- into forward; see `design/06`. One-off
+  device stalls billed to a compute kernel (> `_MAX_PLAUSIBLE_LAUNCH_US`) are
+  dropped as artifacts and reported in `provenance.dropped_stall_us_per_mb`.
 - **A14.** Only `gemm`, `grouped_gemm`, `attn` kernels get a TFLOPs number; all
   other kernels are memory-bound (TFLOPs = null) and contribute time only.
 - **A15.** Embedding / output-logits / loss are taken **once** (from any single

--- a/deepseek-v4/projection/design/04-projection-math.md
+++ b/deepseek-v4/projection/design/04-projection-math.md
@@ -67,8 +67,10 @@ Rules baked into the implementation:
 - **Time only, FLOPs stay analytic.** Manual input overrides time but not FLOPs;
   `TFLOP/s/GPU` continues to use the V4 analytic model FLOPs (Step 5), so it
   stays meaningful.
-- **Scope.** Manual covers the three per-cr decoder layers only. Non-layer parts
-  (embedding / output / loss) and MTP keep using the trace breakdown.
+- **Scope.** Manual covers the three per-cr decoder layers **and** the non-layer
+  parts — embedding (PP stage 0), output / loss / MTP (last PP stage) — each as a
+  fwd/bwd pair. Any field left unset falls back to its trace-derived value, so you
+  can override just the parts you care about. FLOPs stay analytic regardless.
 
 ## Step 1 — recompute (A16)
 

--- a/deepseek-v4/projection/design/07-iteration-timeline.md
+++ b/deepseek-v4/projection/design/07-iteration-timeline.md
@@ -1,0 +1,165 @@
+# 07 — Iteration timeline (3-level composition view)
+
+A visual, drill-down view of **how one training iteration's time is composed**,
+layered from a single layer up to the whole pipeline schedule. It reuses the
+projection math in `04-projection-math.md` (same controls, same per-layer times)
+and adds only rendering + one pipeline-schedule simulator. Nothing here changes
+the headline `iteration time` / `tokens/s/GPU` numbers; it explains them.
+
+All times are microseconds (µs) unless noted, scaled to the active GPU tab by
+Step 6 (`rowScaledTime`) exactly like the rest of the site.
+
+## Why three levels
+
+The iteration time is built bottom-up:
+
+```
+module time  --(sum per phase)-->  layer fwd/bwd        (Level 1)
+layer times  --(map to PP/VPP)-->  per-device chunk cost (Level 2)
+device costs --(1F1B schedule)-->  iteration timeline    (Level 3)
+```
+
+Each level answers one question:
+
+- **Level 1 — where does a single layer's time go?** (attn / mlp / a2a)
+- **Level 2 — how is work distributed across pipeline ranks?** (layer granularity)
+- **Level 3 — how do the ranks overlap in time, and where is the bubble?**
+
+## Module → category mapping (Level 1 granularity)
+
+The default minimum granularity is three categories plus an explicit
+"unattributed" bucket, derived from the `module` field (`03-json-schema.md`):
+
+| category | modules | meaning |
+|----------|---------|---------|
+| `attn`   | `attn.norm`, `attn.proj`, `attn.core`, `attn.indexer`, `attn.misc` | attention (varies by `cr`) |
+| `mlp`    | `moe.grouped_gemm`, `moe.shared_expert`, `moe.router` | expert / shared-expert compute (cr-independent) |
+| `a2a`    | `moe.dispatch`, `moe.combine` | EP all-to-all (captured at EP=8) |
+| `misc`   | any `*.misc` / unattributed | casts, scalar, control-flow; kept visible |
+
+Rules:
+
+- `attn.misc` counts as `attn` (it is attention-local unattributed time), while a
+  standalone `misc` category is only used if a non-attn/non-moe module is
+  unmapped. In practice every row maps to `attn` or `mlp`/`a2a`; the `misc`
+  bucket surfaces `*.misc` share the same way `unattributedShare` does today.
+- Because MoE is identical across `cr` (A10), only three representative layers are
+  shown: `cr=0`, `cr=4`, `cr=128`. "Same params/category → show one" reduces to
+  "one per cr".
+- Optional drill-down expands `attn` into `core/indexer/proj/norm` and `mlp` into
+  `grouped_gemm/shared_expert/router`.
+
+## Level 2 — per-device chunk composition
+
+Granularity is **one physical decoder layer**. The projection already maps every
+layer to a `PP*VPP` chunk and a device (`04` Step 2). Level 2 exposes that map:
+
+- Each device (PP rank) is a row; within it, chunks (VPP virtual chunks) are laid
+  out in schedule order, each chunk a run of layers coloured by `cr`.
+- Recomputed layers (their backward replays one forward, `04` Step 1) are marked
+  (hatched / outlined) because they cost extra in `Db`.
+- Non-layer parts are drawn on their owning device: `embedding` on device 0,
+  `output`+`loss`+`MTP` on the last device.
+- **Dedup:** devices with an identical ordered signature
+  `(cr-list, recompute-flags, hasEmb, hasOut, hasMtp)` are drawn once, annotated
+  `×N ranks (d..d)`.
+- The **critical device** (`max Df` / `max Db`, the one that sets the pipeline
+  critical path) is highlighted; each row shows its `Df`/`Db` and share of the
+  critical stage, making load imbalance (the bubble's root cause) visible.
+
+## Level 3 — pipeline schedule (Megatron-2 Figure 4 style)
+
+A Gantt chart: y-axis = device, x-axis = time. Forward cells one colour, backward
+another; VPP virtual chunks distinguished by lightness; bubbles are gaps.
+
+Reference: Narayanan et al., "Efficient Large-Scale Language Model Training on
+GPU Clusters Using Megatron-LM", arXiv:2104.04473, Figure 4 (default 1F1B on top,
+interleaved below).
+
+### Colour scheme
+
+- forward = `--accent` (#4f8cff), backward = `--accent-2` (#36c08f).
+- VPP chunk index shifts lightness (chunk 0 lightest → deeper for higher chunks),
+  mirroring the paper's light/dark model-chunk shading.
+- bubble = empty (optionally a faint diagonal hatch) with the fraction labelled.
+
+### Schedule simulator
+
+The site's analytic pipe time is
+`pipe_compute = (GA + (PP-1)/VPP) * (Df_crit + Db_crit)` (`04` Step 3). To *draw*
+the schedule we simulate 1F1B (optionally interleaved) microbatch ordering and
+let bubbles emerge from the gaps.
+
+Inputs: `PP`, `VPP`, `GA`, and per-virtual-chunk forward/backward cost. Each
+virtual chunk `k` (device `k % PP`, vpp `⌊k/PP⌋`) uses the **exact** per-chunk
+sums from `schedule.chunks` (`f_chunk[k]`, `b_chunk[k]`), with the non-layer
+parts folded into the first (`embedding`) and last (`output`/`loss`/`MTP`) virtual
+chunk so the drawn per-device length stays consistent with `Df`/`Db`. The
+non-interleaved view collapses to one chunk per device with `f=Df[d]`, `b=Db[d]`.
+Large `GA` is capped to `TL_VIS_GA_CAP` (48) microbatches for display only.
+
+Algorithm (interleaved 1F1B, `VPP` model chunks per device, `k mod PP` device
+map):
+
+```
+num_chunks   = PP * VPP
+num_warmup   = min(GA, (PP - 1 - device) * ... )   # standard interleaved warmup
+events[device] = ordered list of {kind:'F'|'B', mb, chunk, start, dur}
+- time advances per device; a device starts an op when both its own timeline and
+  the producing/consuming neighbour dependency are satisfied (F flows forward
+  along devices, B flows backward), with p2p comm assumed zero (A4).
+```
+
+The simulator returns per-device event lists with `start`/`dur`; the drawn
+iteration length `max_device(last_end)` is compared against the analytic
+`pipe_compute` (pre-`calibFactor`). For a balanced schedule they agree; a
+mismatch beyond tolerance is surfaced as a warning rather than hidden. The
+analytic number remains the official iteration time; the Gantt chart is the
+visualization and is scaled so its total width equals the analytic pipe time.
+
+### Interleaving follows VPP
+
+There is no separate interleaved/non-interleaved toggle: the schedule is driven
+directly by the `VPP` control. `VPP=1` renders plain 1F1B (Figure 4 top);
+`VPP>1` renders interleaved 1F1B (Figure 4 bottom), which shrinks the bubble from
+`(PP-1)/GA` to `(PP-1)/(GA*VPP)` (A5). Change `VPP` in the projection controls to
+compare.
+
+## UI: layout + cross-level linkage
+
+- **Layout toggle.** *Tabbed* shows one level at a time (L1/L2/L3 buttons);
+  *Stacked (all + link)* renders all three top-to-bottom with section headings.
+- **Drill-down linkage** (works in both layouts, most visible when stacked):
+  - click a **cr** in Level 1 (or a layer cell in Level 2) → highlights that cr's
+    layers in Level 2 and dims the rest; Level 1 emphasises the matching row.
+  - click a **PP rank** in Level 2 (or a device row in Level 3) → highlights the
+    linked rank in Levels 2 and 3, and Level 1 highlights the cr types present on
+    that rank.
+  - a "Clear" bar removes the selection.
+- **Export.** Level 3's Gantt has *Export SVG* / *Export PNG* buttons; the
+  serializer resolves the theme CSS variables and paints a background so the file
+  is self-contained (good for slides / the paper-style figure).
+- **Fit + zoom.** Level 3 fits the whole schedule in the panel at 1× (no
+  scrollbar) for an at-a-glance overview. A zoom slider (1×–10×) widens the time
+  axis so the per-cell microbatch numbers become readable; above 1× the chart
+  scrolls horizontally. Zoom stretches only the time axis (font/row height fixed).
+- **Cell tooltip.** Hovering a Gantt cell shows `compute <dur> µs` (the op's
+  duration) and `starts @ <t> ms` (its start time measured from the iteration
+  start). The x-axis is that same wall-clock time; gaps between cells are bubble.
+
+## Consistency / self-checks
+
+- Level 1 category sums per cr == `layerTimes(cr).fwd/bwd` (no time lost in
+  categorization).
+- Level 2 per-device `Df/Db` == `project().Df/Db` (same mapping, just detailed).
+- Level 3 simulated iteration length ≈ analytic `pipe_compute` (balanced case);
+  otherwise warn.
+- All three levels react live to the shared projection controls (GPU tab, PP/VPP,
+  GA/GBS/MBS/DP, recompute, manual layer-timing mode).
+
+## Scope / caveats (inherit from 02-assumptions)
+
+- `a2a` is captured at EP=8 intra-node; other EP values are not re-modeled (A7-A9).
+- p2p PP comm is hidden; only the bubble is shown (A4).
+- seq is fixed at the capture value (4096).
+- MI455X tab rescales module times per Step 6 before all three levels are drawn.

--- a/deepseek-v4/projection/site/assets/app.js
+++ b/deepseek-v4/projection/site/assets/app.js
@@ -8,6 +8,17 @@ const STATE = {
   data: null,
   gpu: "MI355X",
   controls: null,
+  // iteration-timeline view (design/07): active level (1|2|3). Level 3
+  // interleaving follows the VPP control directly (no separate toggle).
+  tlLevel: 1,
+  // layout: "tabs" (one level via buttons) or "stacked" (all three + linkage).
+  tlView: "stacked",
+  // Level 3 Gantt horizontal zoom (1 = fit-to-view, no scrollbar; >1 widens the
+  // chart and reveals per-cell microbatch numbers, with horizontal scroll).
+  tlZoom: 1,
+  // cross-level selection for drill-down highlight. cr: focus a compression
+  // ratio; devices: focus one or more PP ranks. Mutually exclusive.
+  tlSel: { cr: null, devices: null },
 };
 
 const $ = (sel) => document.querySelector(sel);
@@ -75,10 +86,23 @@ function defaultControls(data) {
 // trace-derived value, so toggling into manual mode never changes the result
 // until the user actually edits a field.
 function emptyManual() {
-  return { f0: null, b0: null, f4: null, b4: null, f128: null, b128: null };
+  return {
+    f0: null, b0: null, f4: null, b4: null, f128: null, b128: null,
+    // non-layer + MTP overrides (per iteration, one device)
+    emb_f: null, emb_b: null, out_f: null, out_b: null, loss_f: null, loss_b: null, mtp_f: null, mtp_b: null,
+  };
 }
 
 const MANUAL_CR_KEYS = { "0": ["f0", "b0"], "4": ["f4", "b4"], "128": ["f128", "b128"] };
+// Manually-overridable non-layer parts: key prefix, label, and the JSON section
+// (mtp is synthesized, not a non_layer entry).
+const MANUAL_NONLAYER = [
+  { key: "emb", label: "embedding", which: "embedding" },
+  { key: "out", label: "output", which: "output" },
+  { key: "loss", label: "loss", which: "loss" },
+  { key: "mtp", label: "MTP", which: "mtp" },
+];
+const MANUAL_NONLAYER_KEYS = MANUAL_NONLAYER.flatMap((n) => [`${n.key}_f`, `${n.key}_b`]);
 
 const CONTROL_DEFS = [
   { key: "world", label: "World size (GPUs)", kind: "int" },
@@ -121,6 +145,7 @@ function parseControlValue(input, kind) {
 const isPositiveInt = (x) => Number.isInteger(x) && x > 0;
 const isNonNegativeInt = (x) => Number.isInteger(x) && x >= 0;
 const isPositiveNumber = (x) => Number.isFinite(x) && x > 0;
+const isNonNegativeNumber = (x) => Number.isFinite(x) && x >= 0;
 
 function renderControls() {
   const grid = $("#controls-grid");
@@ -164,11 +189,28 @@ function renderControls() {
 function prefillManual(gpu) {
   const c = STATE.controls;
   const m = c.man[gpu];
+  const lt = {};
   for (const cr of ["0", "4", "128"]) {
     const [fk, bk] = MANUAL_CR_KEYS[cr];
     const t = layerTimes(STATE.data, cr, gpu, c);
+    lt[cr] = t;
     if (!isPositiveNumber(m[fk])) m[fk] = Math.round(t.fwd);
     if (!isPositiveNumber(m[bk])) m[bk] = Math.round(t.bwd);
+  }
+  // non-layer parts (embedding / output / loss). Skip seeding fields whose trace
+  // value is 0 (e.g. output/loss backward) — leaving them unset shows the "0"
+  // placeholder and falls back to trace, instead of pinning an explicit 0.
+  const seed = (key, val) => { if (!isPositiveNumber(m[key]) && Math.round(val) > 0) m[key] = Math.round(val); };
+  for (const which of ["embedding", "output", "loss"]) {
+    const key = NONLAYER_KEY[which];
+    seed(`${key}_f`, nonLayer(STATE.data, which, "forward", gpu, c));
+    seed(`${key}_b`, nonLayer(STATE.data, which, "backward", gpu, c));
+  }
+  // MTP (only when the model uses it)
+  if ((STATE.data.model_config.mtp_num_layers || 0) > 0) {
+    const base = mtpTimes(STATE.data, gpu, c, lt);
+    seed("mtp_f", base.fwd);
+    seed("mtp_b", base.bwd);
   }
 }
 
@@ -186,21 +228,29 @@ function renderManualGrid() {
   if (host.hidden) return;
   const c = STATE.controls, gpu = STATE.gpu;
   const counts = STATE.data.model_config.cr_layer_counts || {};
-  host.append(el("p", { class: "muted manual-grid__hint" },
-    `Per-layer fwd/bwd (µs) for ${gpu}. Set values override the trace; placeholders show the current trace baseline. Non-layer parts (embedding / output / loss) and MTP still come from the trace breakdown.`));
-  const rows = el("div", { class: "manual-rows" });
-  for (const cr of ["0", "4", "128"]) {
-    const [fk, bk] = MANUAL_CR_KEYS[cr];
-    const m = c.man[gpu];
-    const t = layerTimes(STATE.data, cr, gpu, c);
+  const m = c.man[gpu];
+  const header = el("div", { class: "manual-grid__header" });
+  header.append(el("p", { class: "muted manual-grid__hint" },
+    `Per-layer and non-layer fwd/bwd (µs) for ${gpu}. Set values override the trace; placeholders show the current trace baseline. Embedding is on PP stage 0; output / loss / MTP are on the last PP stage.`));
+  const resetBtn = el("button", { class: "manual-reset" }, "Restore defaults");
+  resetBtn.addEventListener("click", () => {
+    c.man[gpu] = emptyManual();
+    prefillManual(gpu);
+    renderAll();
+  });
+  header.append(resetBtn);
+  host.append(header);
+
+  // one fwd/bwd input row
+  const makeRow = (labelNode, fk, bk, traceF, traceB) => {
     const row = el("div", { class: "manual-row" });
-    row.append(el("span", { class: `manual-row__lab cr-tag cr-${cr}` }, `cr=${cr} ×${counts[cr] || 0}`));
-    for (const [label, key, traceVal] of [["fwd", fk, t.fwd], ["bwd", bk, t.bwd]]) {
+    row.append(labelNode);
+    for (const [label, key, traceVal] of [["fwd", fk, traceF], ["bwd", bk, traceB]]) {
       const field = el("div", { class: "field" });
       field.append(el("span", {}, `${label} µs`));
       const input = el("input", {
         id: `man-${gpu}-${key}`, type: "number", step: "1", min: "0",
-        placeholder: String(Math.round(traceVal)),
+        placeholder: String(Math.round(traceVal || 0)),
       });
       if (isPositiveNumber(m[key])) input.value = m[key];
       input.addEventListener("change", () => {
@@ -211,9 +261,38 @@ function renderManualGrid() {
       field.append(input);
       row.append(field);
     }
-    rows.append(row);
+    return row;
+  };
+
+  const rows = el("div", { class: "manual-rows" });
+  for (const cr of ["0", "4", "128"]) {
+    if (!(counts[cr] > 0)) continue;
+    const [fk, bk] = MANUAL_CR_KEYS[cr];
+    const t = layerTimes(STATE.data, cr, gpu, c);
+    const lab = el("span", { class: `manual-row__lab cr-tag cr-${cr}` }, `cr=${cr} ×${counts[cr] || 0}`);
+    rows.append(makeRow(lab, fk, bk, t.fwd, t.bwd));
   }
   host.append(rows);
+
+  // non-layer + MTP rows
+  host.append(el("p", { class: "muted manual-grid__subhead" }, "Non-layer (once per iteration)"));
+  const nlRows = el("div", { class: "manual-rows" });
+  const lt = {};
+  for (const cr of ["0", "4", "128"]) lt[cr] = layerTimes(STATE.data, cr, gpu, c);
+  for (const nl of MANUAL_NONLAYER) {
+    if (nl.which === "mtp" && !((STATE.data.model_config.mtp_num_layers || 0) > 0)) continue;
+    let tF, tB;
+    if (nl.which === "mtp") {
+      const base = mtpTimes(STATE.data, gpu, c, lt);
+      tF = base.fwd; tB = base.bwd;
+    } else {
+      tF = nonLayer(STATE.data, nl.which, "forward", gpu, c);
+      tB = nonLayer(STATE.data, nl.which, "backward", gpu, c);
+    }
+    const lab = el("span", { class: "manual-row__lab manual-row__lab--nl" }, nl.label);
+    nlRows.append(makeRow(lab, `${nl.key}_f`, `${nl.key}_b`, tF, tB));
+  }
+  host.append(nlRows);
 }
 
 // ---------------------------------------------------------------------------
@@ -358,12 +437,18 @@ function validateControls(data, c, gpu = STATE.gpu) {
       if (!count) continue; // cr not used by this model; ignore its inputs
       for (const k of MANUAL_CR_KEYS[cr]) {
         const v = man[k];
-        if (v != null && v !== "" && !isPositiveNumber(Number(v))) {
-          errors.push(`manual ${k} (cr=${cr}) must be a positive number (µs).`);
+        if (v != null && v !== "" && !isNonNegativeNumber(Number(v))) {
+          errors.push(`manual ${k} (cr=${cr}) must be a non-negative number (µs).`);
         }
       }
     }
-    warnings.push(`Manual mode for ${gpu}: per-cr fwd/bwd you set override the trace; unset fields fall back to trace. Non-layer (embedding/output/loss) and MTP still use the trace breakdown.`);
+    for (const k of MANUAL_NONLAYER_KEYS) {
+      const v = man[k];
+      if (v != null && v !== "" && !isNonNegativeNumber(Number(v))) {
+        errors.push(`manual ${k} must be a non-negative number (µs).`);
+      }
+    }
+    warnings.push(`Manual mode for ${gpu}: per-cr layer, non-layer (embedding/output/loss) and MTP fwd/bwd you set override the trace; unset fields fall back to trace.`);
   }
 
   const captureEp = data.capture?.ep;
@@ -384,6 +469,17 @@ function validateControls(data, c, gpu = STATE.gpu) {
 function nonLayer(data, which, phase, gpu, c) {
   const bd = data.non_layer[which];
   return bd ? sumTime(bd[phase], gpu, c) : 0;
+}
+
+// Non-layer time with manual override (embedding / output / loss). Falls back to
+// the trace time when the field is unset or not in manual mode.
+const NONLAYER_KEY = { embedding: "emb", output: "out", loss: "loss" };
+function effectiveNonLayer(data, which, phase, gpu, c) {
+  const trace = nonLayer(data, which, phase, gpu, c);
+  if (c.modelMode !== "manual") return trace;
+  const m = (c.man && c.man[gpu]) || {};
+  const v = m[`${NONLAYER_KEY[which]}_${phase === "forward" ? "f" : "b"}`];
+  return isPositiveNumber(v) ? v : trace;
 }
 function nonLayerFlops(data, which, phase) {
   const bd = data.non_layer[which];
@@ -413,6 +509,18 @@ function mtpTimes(data, gpu, c, lt) {
     fwd: depth * (inner.fwd + outF) + ehUs / 3,
     bwd: depth * (innerBwd + outB) + (2 * ehUs) / 3,
     ehUs,
+  };
+}
+
+// MTP time with manual override. Falls back to the analytic estimate.
+function effectiveMtp(data, gpu, c, lt) {
+  const base = mtpTimes(data, gpu, c, lt);
+  if (c.modelMode !== "manual" || !((data.model_config.mtp_num_layers || 0) > 0)) return base;
+  const m = (c.man && c.man[gpu]) || {};
+  return {
+    fwd: isPositiveNumber(m.mtp_f) ? m.mtp_f : base.fwd,
+    bwd: isPositiveNumber(m.mtp_b) ? m.mtp_b : base.bwd,
+    ehUs: base.ehUs,
   };
 }
 
@@ -466,37 +574,65 @@ function project(data, gpu, c, validation = validateControls(data, c, gpu)) {
   const layoutInfo = validation.layout;
   const layoutStages = layoutInfo.ok ? layoutInfo.stages : null;
   const stageOrdinals = new Array(c.pp).fill(0);
+  // Per virtual-chunk detail (k = 0..C-1): device = k % PP, vpp index = floor(k/PP).
+  // Kept for the iteration-timeline view (design/07); does not affect Df/Db math.
+  const chunks = [];
+  for (let k = 0; k < C; k++) {
+    chunks.push({ chunk: k, device: k % c.pp, vpp: Math.floor(k / c.pp), layers: [], fwd: 0, bwd: 0 });
+  }
+  const addLayer = (chunkIdx, i) => {
+    const dev = chunkIdx % c.pp;
+    const t = lt[String(crs[i])] || { fwd: 0, bwd: 0 };
+    const recompute = recomputeLayer(c, stageOrdinals[dev]++);
+    const effBwd = t.bwd + (recompute ? t.fwd : 0);
+    Df[dev] += t.fwd;
+    Db[dev] += effBwd;
+    const ch = chunks[chunkIdx];
+    ch.layers.push({ globalIdx: i, cr: crs[i], recompute, fwd: t.fwd, bwd: effBwd });
+    ch.fwd += t.fwd;
+    ch.bwd += effBwd;
+  };
   if (layoutStages) {
     layoutStages.forEach((layers, chunk) => {
-      const dev = chunk % c.pp;
-      for (const i of layers) {
-        const t = lt[String(crs[i])] || { fwd: 0, bwd: 0 };
-        const recompute = recomputeLayer(c, stageOrdinals[dev]++);
-        Df[dev] += t.fwd;
-        Db[dev] += t.bwd + (recompute ? t.fwd : 0);
-      }
+      for (const i of layers) addLayer(chunk, i);
     });
   } else {
-    for (let i = 0; i < L; i++) {
-      const chunk = Math.floor(i / perChunk);
-      const dev = chunk % c.pp;
-      const t = lt[String(crs[i])] || { fwd: 0, bwd: 0 };
-      const recompute = recomputeLayer(c, stageOrdinals[dev]++);
-      Df[dev] += t.fwd;
-      Db[dev] += t.bwd + (recompute ? t.fwd : 0);
-    }
+    for (let i = 0; i < L; i++) addLayer(Math.floor(i / perChunk), i);
   }
-  // non-layer parts on first / last device
-  Df[0] += nonLayer(data, "embedding", "forward", gpu, c);
-  Db[0] += nonLayer(data, "embedding", "backward", gpu, c);
+  // non-layer parts on first / last device (manual-overridable)
+  const embFwd = effectiveNonLayer(data, "embedding", "forward", gpu, c);
+  const embBwd = effectiveNonLayer(data, "embedding", "backward", gpu, c);
+  Df[0] += embFwd;
+  Db[0] += embBwd;
   const last = c.pp - 1;
-  Df[last] += nonLayer(data, "output", "forward", gpu, c) + nonLayer(data, "loss", "forward", gpu, c);
-  Db[last] += nonLayer(data, "output", "backward", gpu, c) + nonLayer(data, "loss", "backward", gpu, c);
-  const mtp = mtpTimes(data, gpu, c, lt);
+  const outFwd = effectiveNonLayer(data, "output", "forward", gpu, c) + effectiveNonLayer(data, "loss", "forward", gpu, c);
+  const outBwd = effectiveNonLayer(data, "output", "backward", gpu, c) + effectiveNonLayer(data, "loss", "backward", gpu, c);
+  Df[last] += outFwd;
+  Db[last] += outBwd;
+  const mtp = effectiveMtp(data, gpu, c, lt);
   Df[last] += mtp.fwd;
   Db[last] += mtp.bwd;
 
   const critF = Math.max(...Df), critB = Math.max(...Db);
+
+  // Assemble per-device schedule detail (design/07). Non-layer parts are attached
+  // to their owning device so the timeline can render them; Df/Db already include
+  // them above.
+  const critFdev = Df.indexOf(critF), critBdev = Db.indexOf(critB);
+  const devices = [];
+  for (let d = 0; d < c.pp; d++) {
+    devices.push({
+      device: d,
+      chunks: chunks.filter((ch) => ch.device === d).sort((a, b) => a.vpp - b.vpp),
+      Df: Df[d], Db: Db[d],
+      hasEmb: d === 0, hasOut: d === last, hasMtp: d === last && mtp.fwd > 0,
+      embFwd: d === 0 ? embFwd : 0, embBwd: d === 0 ? embBwd : 0,
+      outFwd: d === last ? outFwd : 0, outBwd: d === last ? outBwd : 0,
+      mtpFwd: d === last ? mtp.fwd : 0, mtpBwd: d === last ? mtp.bwd : 0,
+      isCritF: d === critFdev, isCritB: d === critBdev,
+    });
+  }
+  const schedule = { chunks, devices, C, critFdev, critBdev };
 
   // Step 3: pipeline compute time (us) ; GA = gbs/(dp*mbs)
   // calibFactor corrects the single-layer-capture -> full-model bias (~0.93,
@@ -550,6 +686,7 @@ function project(data, gpu, c, validation = validateControls(data, c, gpu)) {
     layoutMessage: layoutInfo.message,
     localModelParams: optParams.localModelParams, perRankParams, measuredOptUs: optParams.measuredUs,
     mtp, optUs, iterUs, tokIter, tokS, tokSgpu, flopsIter, tflopsGpu, seq,
+    schedule,
   };
 }
 
@@ -700,8 +837,20 @@ function renderResults(validation) {
   const steps = $("#results-steps");
   steps.innerHTML = "";
   if (!p) {
-    head.append(el("div", { class: "metric metric--error" }, el("b", {}, "Projection blocked"), el("span", {}, "Invalid controls")));
-    steps.append(step("Fix validation errors", "", "Projection is not recomputed while errors are present."));
+    const errs = (validation && validation.errors) || [];
+    const summary = errs.length === 0 ? "Invalid controls" : `${errs.length} error${errs.length > 1 ? "s" : ""}`;
+    head.append(el("div", { class: "metric metric--error" }, el("b", {}, "Projection blocked"), el("span", {}, summary)));
+    if (errs.length) {
+      for (const msg of errs) {
+        const s = el("div", { class: "step step--error" });
+        s.append(el("b", {}, "⚠ Validation error"));
+        s.append(document.createElement("br"));
+        s.append(el("small", {}, msg));
+        steps.append(s);
+      }
+    } else {
+      steps.append(step("Fix validation errors", "", "Projection is not recomputed while errors are present."));
+    }
     return;
   }
   const mk = (label, val, primary) => {
@@ -747,6 +896,576 @@ function renderResults(validation) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Iteration timeline (design/07): 3-level composition view
+// ---------------------------------------------------------------------------
+const TL_CATS = ["attn", "mlp", "a2a", "misc"];
+const TL_CAT_LABEL = { attn: "attn", mlp: "mlp", a2a: "a2a (dispatch+combine)", misc: "misc/unattrib" };
+const CR_HEX = { "0": "#6b4a2d", "4": "#2d6b4a", "128": "#2d4a6b" };
+
+// Map a module name to one of the Level-1 categories (design/07).
+function moduleCategory(module) {
+  const m = String(module || "");
+  if (m.startsWith("attn.")) return "attn";
+  if (m === "moe.dispatch" || m === "moe.combine") return "a2a";
+  if (/(^|\.)misc$|unattrib/.test(m)) return "misc";
+  return "mlp"; // moe.grouped_gemm / shared_expert / router and any other moe.*
+}
+
+// Per-cr forward/backward time split into categories, scaled to the active GPU.
+// In manual mode the trace composition is rescaled so the bar total matches the
+// effective (manual-overridden) per-layer time used by the projection.
+function categoryBreakdown(data, cr, gpu, c) {
+  const out = { forward: { attn: 0, mlp: 0, a2a: 0, misc: 0 }, backward: { attn: 0, mlp: 0, a2a: 0, misc: 0 } };
+  const L = data.layers[cr];
+  if (!L) return out;
+  for (const bucket of [L.attention, L.moe]) {
+    for (const phase of ["forward", "backward"]) {
+      for (const r of bucket[phase]) out[phase][moduleCategory(r.module)] += rowScaledTime(r, gpu, c);
+    }
+  }
+  if (c.modelMode === "manual") {
+    const eff = effectiveLayerTimes(data, cr, gpu, c);
+    for (const phase of ["forward", "backward"]) {
+      const sum = TL_CATS.reduce((a, k) => a + out[phase][k], 0);
+      const target = phase === "forward" ? eff.fwd : eff.bwd;
+      if (sum > 0 && target > 0) for (const k of TL_CATS) out[phase][k] *= target / sum;
+    }
+  }
+  return out;
+}
+
+// True when, in manual mode, the user has actually changed this cr's fwd/bwd away
+// from the trace-derived baseline (comparison is rounded to µs so the prefilled
+// baseline itself does not count as an edit).
+function layerManualEdited(data, cr, gpu, c) {
+  if (c.modelMode !== "manual") return false;
+  const trace = layerTimes(data, cr, gpu, c);
+  const eff = effectiveLayerTimes(data, cr, gpu, c);
+  return Math.round(eff.fwd) !== Math.round(trace.fwd) || Math.round(eff.bwd) !== Math.round(trace.bwd);
+}
+
+// Small hex lighten/darken for VPP chunk shading (Level 3).
+function shadeHex(hex, amt) {
+  const n = parseInt(hex.slice(1), 16);
+  const clamp = (x) => Math.max(0, Math.min(255, Math.round(x)));
+  const r = clamp(((n >> 16) & 255) + amt), g = clamp(((n >> 8) & 255) + amt), b = clamp((n & 255) + amt);
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`;
+}
+
+// Group PP devices with an identical ordered layer/recompute/non-layer signature
+// so identical middle stages are drawn once (design/07 Level 2 dedup).
+function dedupDevices(devices) {
+  const groups = [];
+  const byKey = new Map();
+  for (const dev of devices) {
+    const sig = JSON.stringify({
+      layers: dev.chunks.map((ch) => ch.layers.map((l) => `${l.cr}${l.recompute ? "r" : ""}`)),
+      emb: dev.hasEmb, out: dev.hasOut, mtp: dev.hasMtp,
+    });
+    if (byKey.has(sig)) byKey.get(sig).members.push(dev.device);
+    else {
+      const g = { rep: dev, members: [dev.device] };
+      byKey.set(sig, g);
+      groups.push(g);
+    }
+  }
+  return groups;
+}
+
+// 1F1B (optionally interleaved) schedule simulator (design/07 Level 3). Returns
+// per-device event lists with start/dur (µs) plus the drawn iteration length.
+const TL_VIS_GA_CAP = 48;
+function simulateSchedule(p, c, { interleaved }) {
+  const PP = c.pp;
+  const VPP = interleaved ? Math.max(1, c.vpp) : 1;
+  const C = PP * VPP;
+  const gaFull = Math.round(p.ga);
+  const GA = Math.min(gaFull, TL_VIS_GA_CAP);
+  const capped = gaFull > GA;
+
+  // per-virtual-chunk fwd/bwd durations (k = 0..C-1, device = k % PP)
+  const fdur = new Array(C).fill(0), bdur = new Array(C).fill(0);
+  if (VPP === 1) {
+    for (let d = 0; d < PP; d++) { fdur[d] = p.Df[d]; bdur[d] = p.Db[d]; }
+  } else {
+    for (const ch of p.schedule.chunks) { fdur[ch.chunk] = ch.fwd; bdur[ch.chunk] = ch.bwd; }
+    // fold non-layer parts into first/last virtual chunk so the drawn length is
+    // consistent with the per-device Df/Db (which include them).
+    const dev0 = p.schedule.devices[0], devL = p.schedule.devices[PP - 1];
+    fdur[0] += dev0.embFwd; bdur[0] += dev0.embBwd;
+    fdur[C - 1] += devL.outFwd + devL.mtpFwd; bdur[C - 1] += devL.outBwd + devL.mtpBwd;
+  }
+
+  const total = GA * VPP;
+  const group = PP * VPP;
+  const fwdChunkMb = (i) => {
+    const inGroup = i % group;
+    const v = Math.floor(inGroup / PP);
+    const m = Math.floor(i / group) * PP + (inGroup % PP);
+    return { v, m };
+  };
+
+  const ops = []; // per device ordered op list
+  for (let d = 0; d < PP; d++) {
+    const warmup = Math.min(
+      VPP === 1 ? PP - 1 - d : (PP - d - 1) * 2 + (VPP - 1) * PP,
+      total,
+    );
+    const list = [];
+    for (let i = 0; i < warmup; i++) {
+      const { v, m } = fwdChunkMb(i);
+      list.push({ kind: "F", m, k: v * PP + d });
+    }
+    let fptr = warmup, bptr = 0;
+    const n1f1b = total - warmup;
+    for (let i = 0; i < n1f1b; i++) {
+      const f = fwdChunkMb(fptr++);
+      list.push({ kind: "F", m: f.m, k: f.v * PP + d });
+      const b = fwdChunkMb(bptr++);
+      list.push({ kind: "B", m: b.m, k: (VPP - 1 - b.v) * PP + d });
+    }
+    for (let i = 0; i < warmup; i++) {
+      const b = fwdChunkMb(bptr++);
+      list.push({ kind: "B", m: b.m, k: (VPP - 1 - b.v) * PP + d });
+    }
+    ops.push(list);
+  }
+
+  // ASAP scheduling: forward flows k-1 -> k, backward flows k+1 -> k (p2p hidden).
+  const endF = new Map(), endB = new Map();
+  const kf = (m, k) => `${m}:${k}`;
+  const ptr = new Array(PP).fill(0);
+  const free = new Array(PP).fill(0);
+  const events = Array.from({ length: PP }, () => []);
+  let remaining = ops.reduce((a, l) => a + l.length, 0);
+  let guard = remaining * 4 + 16;
+  while (remaining > 0 && guard-- > 0) {
+    let progressed = false;
+    for (let d = 0; d < PP; d++) {
+      if (ptr[d] >= ops[d].length) continue;
+      const op = ops[d][ptr[d]];
+      let dep = 0, ready = true;
+      if (op.kind === "F") {
+        if (op.k > 0) {
+          const e = endF.get(kf(op.m, op.k - 1));
+          if (e == null) ready = false; else dep = e;
+        }
+      } else {
+        if (op.k < C - 1) {
+          const e = endB.get(kf(op.m, op.k + 1));
+          if (e == null) ready = false; else dep = e;
+        } else {
+          const e = endF.get(kf(op.m, op.k));
+          if (e == null) ready = false; else dep = e;
+        }
+      }
+      if (!ready) continue;
+      const dur = op.kind === "F" ? fdur[op.k] : bdur[op.k];
+      const start = Math.max(free[d], dep);
+      const end = start + dur;
+      events[d].push({ kind: op.kind, m: op.m, k: op.k, vpp: Math.floor(op.k / PP), start, dur });
+      free[d] = end;
+      (op.kind === "F" ? endF : endB).set(kf(op.m, op.k), end);
+      ptr[d]++; remaining--; progressed = true;
+    }
+    if (!progressed) break; // dependency stall guard
+  }
+  const drawnUs = Math.max(0, ...free);
+  return { events, drawnUs, GA, capped, PP, VPP, C };
+}
+
+// --- cross-level selection (drill-down linkage) ---
+function tlSelActive() {
+  return STATE.tlSel.cr != null || (STATE.tlSel.devices && STATE.tlSel.devices.length);
+}
+function tlSelectCr(cr) {
+  STATE.tlSel = STATE.tlSel.cr === cr ? { cr: null, devices: null } : { cr, devices: null };
+  renderTimeline();
+}
+function tlSelectDevices(devices) {
+  const same = STATE.tlSel.devices && STATE.tlSel.devices.length === devices.length && STATE.tlSel.devices.every((d, i) => d === devices[i]);
+  STATE.tlSel = same ? { cr: null, devices: null } : { cr: null, devices };
+  renderTimeline();
+}
+function tlClearSel() {
+  STATE.tlSel = { cr: null, devices: null };
+  renderTimeline();
+}
+// Compression ratios "active" under the current selection (drives L1 highlight).
+function tlActiveCrSet(p) {
+  if (STATE.tlSel.cr != null) return new Set([String(STATE.tlSel.cr)]);
+  if (STATE.tlSel.devices && STATE.tlSel.devices.length) {
+    const s = new Set();
+    for (const d of STATE.tlSel.devices) {
+      for (const ch of p.schedule.devices[d].chunks) for (const l of ch.layers) s.add(String(l.cr));
+    }
+    return s;
+  }
+  return null;
+}
+const tlDevSet = () => (STATE.tlSel.devices && STATE.tlSel.devices.length ? new Set(STATE.tlSel.devices) : null);
+
+function renderTimeline() {
+  const host = $("#tl-body");
+  if (!host) return;
+  $("#timeline-gpu").textContent = `· ${STATE.gpu}`;
+  const stacked = STATE.tlView === "stacked";
+  document.querySelectorAll(".tl-view").forEach((t) => t.classList.toggle("is-active", (t.dataset.view === "stacked") === stacked));
+  document.querySelectorAll(".tl-tab").forEach((t) => t.classList.toggle("is-active", Number(t.dataset.level) === STATE.tlLevel));
+  const tabs = $("#tl-tabs");
+  if (tabs) tabs.style.display = stacked ? "none" : "";
+  host.innerHTML = "";
+  const validation = validateControls(STATE.data, STATE.controls, STATE.gpu);
+  const p = project(STATE.data, STATE.gpu, STATE.controls, validation);
+  if (!p) {
+    host.append(el("p", { class: "tl-warn" }, "Timeline unavailable: fix the validation errors above."));
+    return;
+  }
+
+  // selection / linkage indicator: a fixed-position floating card appended to
+  // <body> (NOT into #tl-body) so it is fully outside the timeline's flow and
+  // toggling a selection never shifts the page layout at all.
+  document.getElementById("tl-selbar-float")?.remove();
+  if (tlSelActive()) {
+    const bar = el("div", { id: "tl-selbar-float", class: "tl-selbar" });
+    const txt = el("div", { class: "tl-selbar__txt" });
+    const desc = STATE.tlSel.cr != null
+      ? `Focused on cr=${STATE.tlSel.cr}`
+      : `Focused on PP rank(s) ${STATE.tlSel.devices.join(", ")}`;
+    txt.append(el("b", {}, desc));
+    txt.append(el("span", { class: "muted" }, stacked ? " — highlighted across all levels" : " — highlighted; switch to Stacked to see all levels"));
+    bar.append(txt);
+    const btn = el("button", { class: "tl-clear" }, "Clear");
+    btn.addEventListener("click", tlClearSel);
+    bar.append(btn);
+    document.body.append(bar);
+  }
+
+  if (stacked) {
+    const section = (title, sub, fn) => {
+      const sec = el("div", { class: "tl-section" });
+      const h = el("h3", { class: "tl-section__title" }, title);
+      if (sub) h.append(el("span", { class: "tl-section__sub" }, sub));
+      sec.append(h);
+      const body = el("div", {});
+      fn(body);
+      sec.append(body);
+      host.append(sec);
+    };
+    section("Level 1 · single layer", "attn / mlp / a2a — click a cr to link", (b) => renderTimelineL1(b, p));
+    section("Level 2 · pipeline ranks", "layer granularity — click a rank or a layer to link", (b) => renderTimelineL2(b, p));
+    section("Level 3 · pipeline schedule", "1F1B / interleaved — click a device to link", (b) => renderTimelineL3(b, p));
+  } else if (STATE.tlLevel === 1) renderTimelineL1(host, p);
+  else if (STATE.tlLevel === 2) renderTimelineL2(host, p);
+  else renderTimelineL3(host, p);
+}
+
+// --- gantt export (SVG / PNG) ---
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = el("a", { href: url, download: filename });
+  document.body.append(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 2000);
+}
+function serializeGantt(svg) {
+  const clone = svg.cloneNode(true);
+  const cs = getComputedStyle(document.documentElement);
+  const bg = (cs.getPropertyValue("--bg").trim() || "#0f1218");
+  let markup = new XMLSerializer().serializeToString(clone);
+  for (const v of ["--panel-2", "--border", "--muted", "--text", "--bg"]) {
+    markup = markup.split(`var(${v})`).join(cs.getPropertyValue(v).trim() || "#888");
+  }
+  if (!markup.includes("xmlns=")) markup = markup.replace("<svg", '<svg xmlns="http://www.w3.org/2000/svg"');
+  const vb = svg.viewBox.baseVal;
+  markup = markup.replace(/(<svg[^>]*>)/, `$1<rect x="0" y="0" width="${vb.width}" height="${vb.height}" fill="${bg}"/>`);
+  return markup;
+}
+function exportGanttSvg(svg) {
+  downloadBlob(new Blob([serializeGantt(svg)], { type: "image/svg+xml" }), `dsv4-pp-schedule-${STATE.gpu}.svg`);
+}
+function exportGanttPng(svg) {
+  const markup = serializeGantt(svg);
+  const vb = svg.viewBox.baseVal, scale = 2;
+  const img = new Image();
+  img.onload = () => {
+    const canvas = el("canvas");
+    canvas.width = vb.width * scale;
+    canvas.height = vb.height * scale;
+    const ctx = canvas.getContext("2d");
+    ctx.scale(scale, scale);
+    ctx.drawImage(img, 0, 0);
+    canvas.toBlob((b) => downloadBlob(b, `dsv4-pp-schedule-${STATE.gpu}.png`));
+  };
+  img.src = "data:image/svg+xml;base64," + btoa(unescape(encodeURIComponent(markup)));
+}
+
+function catLegend() {
+  return el("div", { class: "tl-legend", html:
+    '<span><i class="tl-c-attn"></i>attn</span>' +
+    '<span><i class="tl-c-mlp"></i>mlp (experts)</span>' +
+    '<span><i class="tl-c-a2a"></i>a2a (dispatch+combine)</span>' +
+    '<span><i class="tl-c-misc"></i>misc/unattributed</span>' });
+}
+
+function stackedTrack(phaseObj, maxTotal) {
+  const track = el("div", { class: "tl-bar__track" });
+  const total = TL_CATS.reduce((a, k) => a + phaseObj[k], 0);
+  for (const cat of TL_CATS) {
+    const t = phaseObj[cat];
+    if (t <= 0) continue;
+    const w = maxTotal > 0 ? (t / maxTotal) * 100 : 0;
+    const seg = el("div", {
+      class: `tl-seg tl-c-${cat}`,
+      style: `width:${w}%`,
+      title: `${TL_CAT_LABEL[cat]}: ${fmt(t, 0)} µs (${fmt(total > 0 ? (t / total) * 100 : 0, 0)}%)`,
+    }, w > 6 ? cat : "");
+    track.append(seg);
+  }
+  return { track, total };
+}
+
+// Single-segment bar used when a cr's layer time is manually set: no module split
+// is possible, so show only the total fwd/bwd.
+function aggregateTrack(timeUs, maxTotal, label) {
+  const track = el("div", { class: "tl-bar__track" });
+  const w = maxTotal > 0 ? (timeUs / maxTotal) * 100 : 0;
+  track.append(el("div", {
+    class: "tl-seg tl-c-manual", style: `width:${w}%`,
+    title: `${label}: ${fmt(timeUs, 0)} µs (manual per-layer)`,
+  }, w > 6 ? "manual" : ""));
+  return { track, total: timeUs };
+}
+
+function renderTimelineL1(host, p) {
+  const d = STATE.data, gpu = STATE.gpu, c = STATE.controls;
+  host.append(el("p", { class: "tl-note" },
+    "One representative layer per compression ratio (MoE is cr-independent, so only attention differs). Forward and backward split into attn / mlp / a2a; bar length is comparable across cr."));
+  const crs = ["0", "4", "128"].filter((cr) => (d.model_config.cr_layer_counts?.[cr] || 0) > 0);
+  const crSet = tlActiveCrSet(p);
+  // Per-cr: whether the layer time is manually overridden (then no module split),
+  // the module breakdown, and the fwd/bwd totals used for the shared scale.
+  const info = {};
+  let maxTotal = 0;
+  let anyManual = false;
+  for (const cr of crs) {
+    const edited = layerManualEdited(d, cr, gpu, c);
+    const bd = edited ? null : categoryBreakdown(d, cr, gpu, c);
+    const eff = effectiveLayerTimes(d, cr, gpu, c);
+    const fT = edited ? eff.fwd : TL_CATS.reduce((a, k) => a + bd.forward[k], 0);
+    const bT = edited ? eff.bwd : TL_CATS.reduce((a, k) => a + bd.backward[k], 0);
+    info[cr] = { edited, bd, fT, bT };
+    anyManual = anyManual || edited;
+    maxTotal = Math.max(maxTotal, fT, bT);
+  }
+  for (const cr of crs) {
+    const { edited, bd, fT, bT } = info[cr];
+    const isSel = STATE.tlSel.cr === cr;
+    const dim = crSet && !crSet.has(cr);
+    const row = el("div", { class: "tl-l1-row tl-clickable" + (isSel ? " is-sel" : "") + (dim ? " tl-dim" : "") });
+    row.addEventListener("click", () => tlSelectCr(cr));
+    const lab = el("div", { class: "tl-l1-lab" });
+    lab.append(el("b", {}, `cr=${cr}`), el("small", {}, `×${d.model_config.cr_layer_counts[cr]} layers${edited ? " · manual" : ""}`));
+    row.append(lab);
+    const bars = el("div", { class: "tl-bars" });
+    for (const [tag, phase, tot] of [["fwd", "forward", fT], ["bwd", "backward", bT]]) {
+      const bar = el("div", { class: "tl-bar" });
+      bar.append(el("span", { class: "tl-bar__tag" }, tag));
+      const { track, total } = edited ? aggregateTrack(tot, maxTotal, `${tag} layer`) : stackedTrack(bd[phase], maxTotal);
+      bar.append(track);
+      bar.append(el("span", { class: "tl-bar__total" }, `${fmt(total, 0)} µs`));
+      bars.append(bar);
+    }
+    row.append(bars);
+    host.append(row);
+  }
+  if (anyManual) {
+    host.append(el("div", { class: "tl-legend", html:
+      '<span><i class="tl-c-manual"></i>manual per-layer total (no module split)</span>' }));
+    host.append(el("p", { class: "tl-note" },
+      "A cr marked “manual” uses a hand-entered whole-layer fwd/bwd time, so it cannot be split into attn / mlp / a2a — only the total is shown. Switch layer timing back to “Trace-derived”, or click “Restore defaults”, to see the per-module breakdown again."));
+  }
+  host.append(catLegend());
+}
+
+function renderTimelineL2(host, p) {
+  const c = STATE.controls;
+  host.append(el("p", { class: "tl-note" },
+    "Each pipeline rank's layers (coloured by cr; hatched = recomputed). Identical ranks are drawn once. The critical stage (max fwd/bwd, sets the pipeline critical path) is outlined."));
+  const groups = dedupDevices(p.schedule.devices);
+  const maxTotal = Math.max(1, ...p.schedule.devices.map((dv) => dv.Df + dv.Db));
+  const selDevices = tlDevSet();
+  const selCr = STATE.tlSel.cr != null ? String(STATE.tlSel.cr) : null;
+  for (const g of groups) {
+    const dev = g.rep;
+    const isCrit = dev.isCritF || dev.isCritB;
+    const isSelGroup = selDevices && g.members.some((m) => selDevices.has(m));
+    const dimRow = (selDevices && !isSelGroup) || (selCr && !g.members.some((m) => p.schedule.devices[m].chunks.some((ch) => ch.layers.some((l) => String(l.cr) === selCr))));
+    const row = el("div", { class: "tl-l2-row tl-clickable" + (isCrit ? " is-critical" : "") + (isSelGroup ? " is-sel" : "") + (dimRow ? " tl-dim" : "") });
+    row.addEventListener("click", () => tlSelectDevices(g.members));
+    const lab = el("div", { class: "tl-l2-lab" });
+    const members = g.members;
+    const rangeTxt = members.length > 1 ? `PP ranks ${members[0]}–${members[members.length - 1]} (×${members.length})` : `PP rank ${members[0]}`;
+    lab.append(el("b", {}, rangeTxt));
+    lab.append(el("small", {}, `${dev.chunks.reduce((a, ch) => a + ch.layers.length, 0)} layers · ${dev.chunks.length} vpp chunk(s)${isCrit ? " · critical" : ""}`));
+    row.append(lab);
+
+    const total = dev.Df + dev.Db;
+    const strip = el("div", { class: "tl-strip", style: `width:${(total / maxTotal) * 100}%` });
+    if (dev.hasEmb) {
+      const t = dev.embFwd + dev.embBwd;
+      strip.append(el("div", { class: "tl-cell tl-cell--emb", style: `width:${(t / total) * 100}%`, title: `embedding F ${fmt(dev.embFwd, 0)} / B ${fmt(dev.embBwd, 0)} µs` }));
+    }
+    dev.chunks.forEach((ch, ci) => {
+      if (ci > 0 || dev.hasEmb) strip.append(el("div", { class: "tl-chunk-gap" }));
+      for (const l of ch.layers) {
+        const t = l.fwd + l.bwd;
+        const cellSel = selCr && String(l.cr) === selCr;
+        const cellDim = selCr && String(l.cr) !== selCr;
+        const cell = el("div", {
+          class: "tl-cell tl-clickable" + (l.recompute ? " tl-cell--recompute" : "") + (cellSel ? " tl-cell--sel" : "") + (cellDim ? " tl-dim" : ""),
+          style: `width:${(t / total) * 100}%; background:${CR_HEX[String(l.cr)] || "#555"}`,
+          title: `layer #${l.globalIdx} cr=${l.cr}${l.recompute ? " (recompute)" : ""} · F ${fmt(l.fwd, 0)} / B ${fmt(l.bwd, 0)} µs`,
+        });
+        cell.addEventListener("click", (e) => { e.stopPropagation(); tlSelectCr(String(l.cr)); });
+        strip.append(cell);
+      }
+    });
+    if (dev.hasOut) {
+      const t = dev.outFwd + dev.outBwd + dev.mtpFwd + dev.mtpBwd;
+      strip.append(el("div", { class: "tl-chunk-gap" }));
+      strip.append(el("div", { class: "tl-cell tl-cell--out", style: `width:${(t / total) * 100}%`, title: `output/loss${dev.hasMtp ? "+MTP" : ""} F ${fmt(dev.outFwd + dev.mtpFwd, 0)} / B ${fmt(dev.outBwd + dev.mtpBwd, 0)} µs` }));
+    }
+    row.append(strip);
+    row.append(el("div", { class: "tl-l2-meta" }, `Df ${fmt(dev.Df / 1000, 2)} / Db ${fmt(dev.Db / 1000, 2)} ms`));
+    host.append(row);
+  }
+  host.append(el("div", { class: "cr-legend", html:
+    '<span><i class="cr-0"></i>cr=0</span><span><i class="cr-4"></i>cr=4</span><span><i class="cr-128"></i>cr=128</span>' +
+    '<span><i class="tl-c-emb"></i>embedding</span><span><i class="tl-c-out"></i>output/loss/MTP</span>' }));
+}
+
+function renderTimelineL3(host, p) {
+  const c = STATE.controls;
+  // Interleaving is driven directly by the VPP control (no separate toggle):
+  // VPP=1 is plain 1F1B, VPP>1 is interleaved 1F1B.
+  const interleaved = c.vpp > 1;
+
+  const controls = el("div", { class: "tl-controls" });
+  controls.append(el("span", { class: "mode-switch__label" }, `Schedule · 1F1B${interleaved ? ` (interleaved, VPP=${c.vpp})` : ""}`));
+
+  // Zoom slider: 1x fits the whole schedule in view (no scrollbar); zooming in
+  // widens the chart so the per-cell microbatch numbers become readable.
+  const zoomWrap = el("span", { class: "tl-zoom-wrap" });
+  zoomWrap.append(el("span", { class: "mode-switch__label" }, "Zoom"));
+  const zoom = el("input", { type: "range", min: "1", max: "10", step: "0.5", value: String(STATE.tlZoom), class: "tl-zoom" });
+  const zlab = el("span", { class: "tl-zoom-val" }, `${STATE.tlZoom}×`);
+  zoom.addEventListener("input", () => { zlab.textContent = `${zoom.value}×`; });
+  zoom.addEventListener("change", () => { STATE.tlZoom = Number(zoom.value); renderTimeline(); });
+  zoomWrap.append(zoom, zlab);
+  controls.append(zoomWrap);
+  host.append(controls);
+  if (!interleaved) {
+    host.append(el("p", { class: "tl-note" }, "VPP=1 → plain 1F1B. Set VPP>1 in the controls to interleave the schedule and shrink the pipeline bubble."));
+  }
+
+  const sim = simulateSchedule(p, c, { interleaved });
+  const PP = sim.PP;
+  const rowH = 30, gap = 6, padL = 54, padT = 8, padB = 26;
+  // Zoom widens the coordinate system itself (more px per µs; font size stays
+  // fixed so cells become readable) instead of CSS-scaling the SVG. At 1x the
+  // chart is sized to the actual right-content width so it fits with no
+  // scrollbar; >1x overflows and scrolls horizontally, undistorted.
+  const avail = Math.max(600, (($("#tl-body")?.clientWidth) || 1100) - 16);
+  const plotW = Math.round((avail - padL) * STATE.tlZoom);
+  const width = padL + plotW + 8;
+  const scale = sim.drawnUs > 0 ? plotW / sim.drawnUs : 0;
+  const height = padT + PP * (rowH + gap) + padB;
+
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("class", "tl-gantt");
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  svg.setAttribute("width", String(width));
+  svg.setAttribute("height", String(height));
+  const mkEl = (tag, attrs, text) => {
+    const n = document.createElementNS("http://www.w3.org/2000/svg", tag);
+    for (const [k, v] of Object.entries(attrs)) n.setAttribute(k, v);
+    if (text != null) n.textContent = text;
+    return n;
+  };
+
+  const selDevices = tlDevSet();
+  for (let d = 0; d < PP; d++) {
+    const y = padT + d * (rowH + gap);
+    const isSel = selDevices ? selDevices.has(d) : false;
+    const g = mkEl("g", { class: "tl-devrow" });
+    if (selDevices) g.setAttribute("opacity", isSel ? "1" : "0.3");
+    g.append(mkEl("text", { x: padL - 8, y: y + rowH / 2 + 4, "text-anchor": "end", fill: "#e6eaf2", "font-size": "11" }, `dev ${d}`));
+    const bgRect = mkEl("rect", {
+      x: padL, y, width: plotW, height: rowH, rx: "3",
+      fill: isSel ? "var(--panel)" : "var(--panel-2)",
+      stroke: isSel ? "#36c08f" : "var(--border)", "stroke-width": isSel ? "2" : "1",
+      style: "cursor:pointer",
+    });
+    bgRect.addEventListener("click", () => tlSelectDevices([d]));
+    g.append(bgRect);
+    for (const ev of sim.events[d]) {
+      const x = padL + ev.start * scale;
+      const w = Math.max(1, ev.dur * scale);
+      const base = ev.kind === "F" ? "#4f8cff" : "#36c08f";
+      const fill = shadeHex(base, ev.vpp * -26);
+      const rect = mkEl("rect", {
+        x, y: y + 2, width: w, height: rowH - 4, rx: "2",
+        fill, class: ev.kind === "F" ? "tl-fwd" : "tl-bwd",
+      });
+      rect.append(mkEl("title", {}, `${ev.kind === "F" ? "Forward" : "Backward"} · microbatch ${ev.m}${sim.VPP > 1 ? ` · vpp chunk ${ev.vpp}` : ""} · compute ${fmt(ev.dur, 0)} µs · starts @ ${fmt(ev.start / 1000, 2)} ms (from iter start)`));
+      g.append(rect);
+      if (w >= 8) g.append(mkEl("text", { x: x + w / 2, y: y + rowH / 2 + 3, "text-anchor": "middle", fill: "#000000", "font-size": "9" }, String(ev.m)));
+    }
+    svg.append(g);
+  }
+  // time axis ticks
+  const yb = padT + PP * (rowH + gap);
+  for (let i = 0; i <= 4; i++) {
+    const tx = padL + (plotW * i) / 4;
+    svg.append(mkEl("text", { x: tx, y: yb + 16, "text-anchor": "middle", fill: "#8d97a8", "font-size": "10" }, `${fmt((sim.drawnUs * i) / 4 / 1000, 1)} ms`));
+  }
+
+  const toolbar = el("div", { class: "tl-export" });
+  const svgBtn = el("button", { class: "mode-tab" }, "Export SVG");
+  const pngBtn = el("button", { class: "mode-tab" }, "Export PNG");
+  svgBtn.addEventListener("click", () => exportGanttSvg(svg));
+  pngBtn.addEventListener("click", () => exportGanttPng(svg));
+  toolbar.append(svgBtn, pngBtn);
+  host.append(toolbar);
+
+  const wrap = el("div", { class: "tl-gantt-wrap" });
+  wrap.append(svg);
+  host.append(wrap);
+
+  // legend + axis/tooltip explanation + self-check vs analytic pipe time
+  host.append(el("div", { class: "tl-legend", html:
+    '<span><i class="tl-c-attn"></i>forward</span><span><i class="tl-c-mlp"></i>backward</span>' +
+    (sim.VPP > 1 ? '<span>lighter→darker = VPP chunk 0→' + (sim.VPP - 1) + '</span>' : '') +
+    '<span>gaps = pipeline bubble (idle)</span>' }));
+  host.append(el("p", { class: "tl-note tl-axis-note" },
+    "X-axis = wall-clock time measured from the start of the pipeline (ms). Each cell is one microbatch's forward or backward on that device; the number inside is the microbatch index. Hover a cell to read its compute duration in µs (the “… µs” before @) and its start time in ms from the iteration start (the “… ms” after @)."));
+
+  const analyticPipeUs = (p.ga + (c.pp - 1) / sim.VPP) * (p.critF + p.critB); // pre-calibFactor, matches the drawn schedule's VPP
+  const diff = analyticPipeUs > 0 ? Math.abs(sim.drawnUs - analyticPipeUs) / analyticPipeUs : 0;
+  const summary = el("div", { class: "tl-summary" });
+  const gaTxt = sim.capped ? `${sim.GA} of ${Math.round(p.ga)} microbatches (capped for display)` : `${sim.GA} microbatches`;
+  summary.append(el("div", {}, `Drawn iteration (pipeline compute): ${fmt(sim.drawnUs / 1000, 2)} ms over ${gaTxt}; PP=${c.pp}, VPP=${interleaved ? c.vpp : 1}. Analytic bubble fraction ${fmt(p.bubbleFrac * 100, 1)}%.`));
+  if (!sim.capped) {
+    const cls = diff > 0.08 ? "tl-warn" : "";
+    summary.append(el("div", { class: cls },
+      `Self-check vs analytic (GA + (PP−1)/VPP)·(F+B)_crit = ${fmt(analyticPipeUs / 1000, 2)} ms → ${fmt(diff * 100, 1)}% ${diff > 0.08 ? "difference (imbalanced stages; analytic uses per-device max)" : "match"}. Official iteration time uses the analytic value × calibFactor.`));
+  }
+  host.append(summary);
+}
+
 function renderAll() {
   const validation = validateControls(STATE.data, STATE.controls, STATE.gpu);
   // keep the derived-DP readonly box in sync
@@ -759,6 +1478,7 @@ function renderAll() {
   renderConfig();
   renderBreakdown();
   renderResults(validation);
+  renderTimeline();
 }
 
 // ---------------------------------------------------------------------------
@@ -787,6 +1507,10 @@ globalThis.DSV4Projection = {
   validateControls,
   effectiveLayerTimes,
   project,
+  moduleCategory,
+  categoryBreakdown,
+  dedupDevices,
+  simulateSchedule,
 };
 
 if (typeof document !== "undefined") {
@@ -816,6 +1540,27 @@ if (typeof document !== "undefined") {
       if (mode === "manual") prefillManual(STATE.gpu);
       renderAll();
     });
+  });
+
+  document.querySelectorAll(".tl-tab").forEach((tab) => {
+    tab.addEventListener("click", () => {
+      STATE.tlLevel = Number(tab.dataset.level);
+      renderTimeline();
+    });
+  });
+
+  document.querySelectorAll(".tl-view").forEach((tab) => {
+    tab.addEventListener("click", () => {
+      STATE.tlView = tab.dataset.view;
+      renderTimeline();
+    });
+  });
+
+  // Re-fit the schedule Gantt to the content width when the window is resized.
+  let _tlResizeTimer;
+  window.addEventListener("resize", () => {
+    clearTimeout(_tlResizeTimer);
+    _tlResizeTimer = setTimeout(() => { if (STATE.data) renderTimeline(); }, 150);
   });
 
   init(modelFromQuery());

--- a/deepseek-v4/projection/site/assets/style.css
+++ b/deepseek-v4/projection/site/assets/style.css
@@ -27,7 +27,7 @@ body {
   border-bottom: 1px solid var(--border);
   padding: 28px 0;
 }
-.hero__inner, .layout { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
+.hero__inner, .layout { max-width: 1600px; margin: 0 auto; padding: 0 24px; }
 .eyebrow { color: var(--accent); font-weight: 600; letter-spacing: .08em; text-transform: uppercase; font-size: 12px; margin: 0 0 4px; }
 .hero h1 { margin: 0 0 8px; font-size: 28px; }
 .hero__summary { color: var(--muted); max-width: 760px; margin: 0 0 16px; }
@@ -51,7 +51,7 @@ body {
   border-bottom: 1px solid var(--border);
 }
 .switcher__inner {
-  max-width: 1200px;
+  max-width: 1600px;
   margin: 0 auto;
   padding: 10px 24px;
   display: flex;
@@ -63,6 +63,21 @@ body {
 .switcher .tab { border-radius: 8px; }
 
 .layout { padding-top: 22px; padding-bottom: 60px; display: flex; flex-direction: column; gap: 18px; }
+
+/* Split layout: sticky Projection-controls sidebar on the left (scrolls on its
+   own), everything else in a scrolling content column on the right. Lets you
+   tweak a control and watch the relevant panel on the right update in place. */
+.layout--split { flex-direction: row; align-items: flex-start; }
+.sidebar {
+  flex: 0 0 300px;
+  position: sticky;
+  top: 72px;
+  max-height: calc(100vh - 88px);
+  overflow-y: auto;
+  overscroll-behavior: contain; /* wheel inside the panel does not scroll the page */
+}
+.content { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 18px; }
+
 .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px; }
 .panel--accent { border-color: #2d4f7a; }
 .panel h2 { margin: 0 0 12px; font-size: 18px; }
@@ -115,8 +130,19 @@ table.bd td.rowlab, table.bd th.rowlab { text-align: left; color: var(--muted); 
 .mode-tab.is-active { background: var(--accent); border-color: var(--accent); color: #fff; font-weight: 600; }
 
 .manual-grid { margin-bottom: 14px; }
-.manual-grid__hint { margin: 0 0 10px; }
+.manual-grid__header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.manual-grid__hint { margin: 0 0 10px; flex: 1; }
+.manual-reset {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  padding: 5px 12px; border-radius: 7px; cursor: pointer; font-size: 12px; white-space: nowrap;
+}
+.manual-reset:hover { border-color: var(--accent); }
 .manual-rows { display: flex; flex-direction: column; gap: 8px; }
+.manual-grid__subhead { margin: 12px 0 6px; font-size: 11px; text-transform: uppercase; letter-spacing: .05em; }
+.manual-row__lab--nl {
+  display: inline-block; padding: 3px 7px; border-radius: 6px; align-self: center;
+  background: var(--panel-2); border: 1px solid var(--border); color: var(--text); font-size: 12px;
+}
 .manual-row {
   display: grid; grid-template-columns: 92px 1fr 1fr; gap: 10px; align-items: end;
 }
@@ -165,9 +191,134 @@ table.bd td.rowlab, table.bd th.rowlab { text-align: left; color: var(--muted); 
 .step b { color: var(--accent); }
 .step .num { float: right; font-variant-numeric: tabular-nums; color: var(--text); }
 .step small { color: var(--muted); }
+.step--error { background: #2a1616; border-color: #6b2d2d; }
+.step--error b { color: #ffb4b4; }
+.step--error small { color: #ffd0d0; }
 
 .state--error { background: #3a1c1c; border: 1px solid #6b2d2d; color: #ffb4b4; padding: 12px 16px; border-radius: 8px; }
-.site-footer { border-top: 1px solid var(--border); padding: 20px 24px; color: var(--muted); font-size: 13px; max-width: 1200px; margin: 0 auto; }
+.site-footer { border-top: 1px solid var(--border); padding: 20px 24px; color: var(--muted); font-size: 13px; max-width: 1600px; margin: 0 auto; }
 code { background: var(--panel-2); padding: 1px 5px; border-radius: 4px; }
 
-@media (max-width: 880px) { .two-col { grid-template-columns: 1fr; } }
+@media (max-width: 880px) {
+  .two-col { grid-template-columns: 1fr; }
+  .layout--split { flex-direction: column; }
+  .sidebar { position: static; max-height: none; flex-basis: auto; width: 100%; overflow: visible; }
+}
+
+/* ---------------------------------------------------------------------------
+   Iteration timeline (design/07): 3-level composition view
+   --------------------------------------------------------------------------- */
+.tl-tabs { display: flex; gap: 6px; margin-top: 10px; flex-wrap: wrap; }
+.tl-tab {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  padding: 6px 14px; border-radius: 7px; cursor: pointer; font-size: 13px;
+}
+.tl-tab.is-active { background: var(--accent); border-color: var(--accent); color: #fff; font-weight: 600; }
+
+.tl-note { color: var(--muted); font-size: 12px; margin: 0 0 12px; }
+.tl-controls { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; flex-wrap: wrap; }
+
+/* category colours (Level 1 / shared legend) */
+.tl-legend { display: flex; gap: 16px; flex-wrap: wrap; margin: 10px 0 0; font-size: 12px; color: var(--muted); }
+.tl-legend i { display: inline-block; width: 12px; height: 12px; border-radius: 3px; margin-right: 5px; vertical-align: -1px; }
+.tl-c-attn { background: #4f8cff; }
+.tl-c-mlp  { background: #36c08f; }
+.tl-c-a2a  { background: #e0a03a; }
+.tl-c-misc { background: #8d97a8; }
+.tl-c-emb  { background: #a06cd5; }
+.tl-c-out  { background: #d5675a; }
+.tl-c-manual { background: #9a6cff; }
+
+/* Level 1: per-cr bidirectional stacked bars */
+.tl-l1-row { display: grid; grid-template-columns: 120px 1fr; gap: 12px; align-items: center; margin-bottom: 14px; }
+.tl-l1-lab { font-size: 13px; }
+.tl-l1-lab small { display: block; color: var(--muted); font-size: 11px; }
+.tl-bars { display: flex; flex-direction: column; gap: 6px; }
+.tl-bar { display: flex; align-items: center; gap: 8px; }
+.tl-bar__tag { width: 34px; font-size: 11px; color: var(--muted); text-align: right; }
+.tl-bar__track { position: relative; flex: 1; height: 26px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 6px; overflow: hidden; display: flex; }
+.tl-seg { height: 100%; display: flex; align-items: center; justify-content: center; font-size: 10px; color: #08101c; overflow: hidden; white-space: nowrap; cursor: default; }
+.tl-seg.tl-c-misc, .tl-seg.tl-c-out, .tl-seg.tl-c-manual { color: #f5f7fb; }
+.tl-bar__total { width: 70px; font-size: 12px; font-variant-numeric: tabular-nums; color: var(--text); }
+
+/* Level 2: per-device layer strips */
+.tl-l2-row { display: grid; grid-template-columns: 150px 1fr 120px; gap: 12px; align-items: center; margin-bottom: 8px; }
+.tl-l2-lab { font-size: 12px; }
+.tl-l2-lab small { display: block; color: var(--muted); font-size: 11px; }
+.tl-strip { display: flex; height: 22px; border: 1px solid var(--border); border-radius: 5px; overflow: hidden; background: var(--panel-2); }
+.tl-cell { height: 100%; min-width: 2px; border-right: 1px solid rgba(0,0,0,.25); }
+.tl-cell:last-child { border-right: none; }
+.tl-cell--recompute { background-image: repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,.35) 3px, rgba(255,255,255,.35) 5px); }
+.tl-chunk-gap { width: 3px; background: var(--bg); }
+.tl-cell--emb { background: #a06cd5 !important; }
+.tl-cell--out { background: #d5675a !important; }
+.tl-l2-meta { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.tl-l2-row.is-critical .tl-strip { outline: 2px solid var(--accent-2); outline-offset: 1px; }
+.tl-l2-row.is-critical .tl-l2-lab { color: var(--accent-2); }
+
+/* Level 3: pipeline schedule Gantt */
+.tl-gantt-wrap { overflow-x: auto; }
+.tl-gantt { display: block; }
+/* text colours are set via inline `fill` attributes in app.js (a stylesheet
+   `fill` here would override those SVG presentation attributes, e.g. forcing the
+   in-cell microbatch numbers grey instead of black). */
+.tl-gantt rect.tl-fwd { stroke: rgba(0,0,0,.35); stroke-width: .5; }
+.tl-gantt rect.tl-bwd { stroke: rgba(0,0,0,.35); stroke-width: .5; }
+.tl-gantt rect.tl-bubble { fill: transparent; }
+.tl-summary { font-size: 12px; color: var(--muted); margin-top: 10px; font-variant-numeric: tabular-nums; }
+.tl-warn { color: var(--warn); }
+
+/* layout switch + level tabs on one row */
+.tl-head-row { display: flex; align-items: center; gap: 18px; flex-wrap: wrap; margin-top: 10px; }
+.tl-viewswitch { display: flex; align-items: center; gap: 8px; }
+.tl-view {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  padding: 6px 12px; border-radius: 7px; cursor: pointer; font-size: 13px;
+}
+.tl-view.is-active { background: var(--accent-2); border-color: var(--accent-2); color: #06231a; font-weight: 600; }
+
+/* stacked sections */
+.tl-section { border-top: 1px solid var(--border); padding-top: 14px; margin-top: 14px; }
+.tl-section:first-of-type { border-top: none; padding-top: 0; margin-top: 4px; }
+.tl-section__title { font-size: 14px; margin: 0 0 10px; }
+.tl-section__sub { font-size: 12px; color: var(--muted); font-weight: 400; margin-left: 8px; }
+
+/* linkage selection indicator — floating card, does not affect page layout */
+.tl-selbar {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 60;
+  display: flex; align-items: center; gap: 14px;
+  background: rgba(23, 28, 38, .97);
+  border: 1px solid var(--accent-2);
+  box-shadow: 0 8px 26px rgba(0, 0, 0, .5);
+  border-radius: 10px;
+  padding: 10px 14px; font-size: 12px; color: var(--text);
+  max-width: 360px;
+  backdrop-filter: blur(6px);
+}
+.tl-selbar__txt { line-height: 1.35; }
+.tl-clear {
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+  padding: 5px 14px; border-radius: 7px; cursor: pointer; font-size: 12px; white-space: nowrap;
+}
+.tl-clear:hover { border-color: var(--accent-2); }
+@media (max-width: 640px) { .tl-selbar { left: 16px; right: 16px; bottom: 16px; max-width: none; } }
+
+/* linkage highlight states (shared) */
+.tl-clickable { cursor: pointer; }
+.tl-dim { opacity: .32; transition: opacity .12s; }
+.tl-l1-row.is-sel, .tl-l2-row.is-sel .tl-strip { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
+.tl-l1-row.is-sel { background: rgba(79,140,255,.08); border-radius: 8px; }
+.tl-cell--sel { outline: 2px solid #fff; outline-offset: -2px; }
+
+/* gantt export toolbar */
+.tl-export { display: flex; gap: 8px; margin-bottom: 8px; }
+.tl-export .mode-tab { background: var(--panel-2); }
+
+/* gantt zoom slider */
+.tl-zoom-wrap { display: inline-flex; align-items: center; gap: 8px; margin-left: 6px; }
+.tl-zoom { width: 160px; accent-color: var(--accent); }
+.tl-zoom-val { font-size: 12px; color: var(--muted); font-variant-numeric: tabular-nums; min-width: 30px; }
+.tl-axis-note { margin: 8px 0 0; }

--- a/deepseek-v4/projection/site/assets/style.css
+++ b/deepseek-v4/projection/site/assets/style.css
@@ -92,6 +92,15 @@ select, input {
   background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
   border-radius: 7px; padding: 7px 9px; font-size: 14px;
 }
+/* Drop the native number spinner buttons: in the narrow sidebar they eat ~17px
+   and clip long values (e.g. 15824 shown as "1582"). Values are typed, not
+   stepped, so the arrows add no value. */
+input[type="number"] { -moz-appearance: textfield; appearance: textfield; }
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+/* Slightly tighter type + padding for the sidebar grids so 5-6 digit numbers
+   fit their column without truncation. */
+.controls-grid input, .manual-row input { font-size: 13px; padding-left: 8px; padding-right: 8px; }
 .field { display: flex; flex-direction: column; gap: 4px; }
 .field--inline { flex-direction: row; align-items: center; gap: 8px; }
 .field > span { font-size: 12px; color: var(--muted); }

--- a/deepseek-v4/projection/site/data/flash.json
+++ b/deepseek-v4/projection/site/data/flash.json
@@ -19,7 +19,7 @@
     "seq": 4096,
     "note": "per-layer and MTP (B=1) Megatron-convention FLOPs at capture seq; site multiplies by GA x DP"
   },
-  "generated_at": "2026-06-25T12:18:45Z",
+  "generated_at": "2026-06-30T13:59:46Z",
   "provenance": {
     "traces": {
       "0": "/apps/tas/0_public/data/traces/dsv4_projection/projection_flash_cr0_seq4096_ep8/tensorboard/primus-megatron-exp[projection_flash_cr0_seq4096_ep8]-rank[0].1782149271209635673.pt.trace.json",
@@ -27,7 +27,12 @@
       "128": "/apps/tas/0_public/data/traces/dsv4_projection/projection_flash_cr128_seq4096_ep8/tensorboard/primus-megatron-exp[projection_flash_cr128_seq4096_ep8]-rank[0].1782149357925690324.pt.trace.json"
     },
     "graphed_crs_estimated_from_cr4": [],
-    "note": "cr in graphed_crs_estimated_from_cr4 were CUDA-graph/stream-captured (compute not visible in trace); their breakdown is copied from cr=4 as an estimate. Re-run those cr with graph capture disabled for exact numbers."
+    "dropped_stall_us_per_mb": {
+      "0": 0.0,
+      "4": 19280.7,
+      "128": 0.0
+    },
+    "note": "cr in graphed_crs_estimated_from_cr4 were CUDA-graph/stream-captured (compute not visible in trace); their breakdown is copied from cr=4 as an estimate. Re-run those cr with graph capture disabled for exact numbers. dropped_stall_us_per_mb: per-mb layer-compute kernel time dropped as implausible one-off device stalls (> _MAX_PLAUSIBLE_LAUNCH_US)."
   },
   "capture": {
     "gpu": "MI355X",
@@ -39,7 +44,15 @@
     "optimizer": "adam",
     "distributed_optimizer": false,
     "recompute": "off",
-    "measured_iter_time_ms": null
+    "measured_iter_time_ms": 4076.0,
+    "measured_anchor": {
+      "config": "PP8/VPP1/EP8/TP1, world 64, MBS1/GBS128, seq4096, full recompute, layout Et*4|t*5|(t*6|)*5,t*4mL (8-node MI355X)",
+      "iter_ms": 4076.0,
+      "tflops_gpu": 722,
+      "tok_s_gpu": 2010,
+      "calib_factor": 0.87,
+      "tolerance": "<0.1%"
+    }
   },
   "model_config": {
     "num_layers": 43,
@@ -125,83 +138,95 @@
         "forward": [
           {
             "module": "attn.misc",
-            "time_us": 6977.726,
+            "time_us": 2768.835,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 1255.515
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 600.524
               },
               {
-                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
-                "time_us": 897.244
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
+                "time_us": 488.376
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
+                "time_us": 252.844
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 881.515
+                "time_us": 190.953
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 881.067
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 151.259
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
-                "time_us": 746.936
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
-                "time_us": 341.962
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 136.028
               }
             ]
           },
           {
             "module": "attn.proj",
-            "time_us": 2797.584,
+            "time_us": 732.222,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 3149821640704.0,
-            "tflops": 1125.9,
+            "flops": 449360953344.0,
+            "tflops": 613.7,
             "kernels": [
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 1783.792
-              },
-              {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 306.172
-              },
-              {
-                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
-                "time_us": 145.373
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 260.835
               },
               {
                 "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 122.031
+                "time_us": 226.171
               },
               {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 106.597
+                "name": "Custom_Cijk_Alik_Bljk_BBS_BH_MT256x256x64_MI16x16x1_UserArgs_shortname1_gfx950",
+                "time_us": 96.207
               },
               {
-                "name": "Cijk_Ailk_Bjlk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 106.263
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 56.9
+              },
+              {
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 36.157
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 29.943
               }
             ]
           },
           {
             "module": "attn.norm",
-            "time_us": 237.042,
+            "time_us": 496.029,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 93.8
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 92.809
+              },
+              {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
                 "time_us": 83.298
+              },
+              {
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
+                "time_us": 63.337
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
@@ -210,18 +235,6 @@
               {
                 "name": "_apply_rope_fwd_kernel",
                 "time_us": 52.313
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 24.16
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 7.516
-              },
-              {
-                "name": "void transformer_engine::normalization::rmsnorm_fwd_tuned_kernel<transformer_eng",
-                "time_us": 6.959
               }
             ]
           },
@@ -246,70 +259,70 @@
         ],
         "backward": [
           {
-            "module": "attn.proj",
-            "time_us": 3227.069,
-            "class": "compute_bound",
-            "flop_class": "gemm",
-            "flops": 174483046400.0,
-            "tflops": 54.1,
-            "kernels": [
-              {
-                "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
-                "time_us": 2713.086
-              },
-              {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 260.835
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 104.141
-              },
-              {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 56.9
-              },
-              {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 36.157
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 29.943
-              }
-            ]
-          },
-          {
             "module": "attn.misc",
-            "time_us": 2057.571,
+            "time_us": 6266.462,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
-                "time_us": 488.376
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 1253.002
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 151.499
+                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
+                "time_us": 897.244
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 147.21
+                "time_us": 837.772
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 133.515
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
+                "time_us": 746.936
               },
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 112.703
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
+                "time_us": 341.962
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<2, at::native::AUnaryFunctor<floa",
-                "time_us": 107.214
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 280.544
+              }
+            ]
+          },
+          {
+            "module": "attn.proj",
+            "time_us": 5292.432,
+            "class": "compute_bound",
+            "flop_class": "gemm",
+            "flops": 2874943733760.0,
+            "tflops": 543.2,
+            "kernels": [
+              {
+                "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
+                "time_us": 2713.086
+              },
+              {
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 1783.792
+              },
+              {
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 306.172
+              },
+              {
+                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
+                "time_us": 145.373
+              },
+              {
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 106.597
+              },
+              {
+                "name": "Cijk_Ailk_Bjlk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 106.263
               }
             ]
           },
@@ -341,35 +354,15 @@
           },
           {
             "module": "attn.norm",
-            "time_us": 311.117,
+            "time_us": 52.13,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 93.8
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 85.294
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 63.337
-              },
-              {
                 "name": "_apply_rope_bwd_kernel",
                 "time_us": 52.13
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
-                "time_us": 4.162
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::sin_kernel_cuda(at",
-                "time_us": 4.139
               }
             ]
           }
@@ -379,7 +372,7 @@
         "forward": [
           {
             "module": "moe.grouped_gemm",
-            "time_us": 2876.507,
+            "time_us": 1470.924,
             "class": "compute_bound",
             "flop_class": "grouped_gemm",
             "flops": null,
@@ -387,117 +380,11 @@
             "kernels": [
               {
                 "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
-                "time_us": 2415.625
+                "time_us": 950.222
               },
               {
                 "name": "_stack_grouped_weight_fwd_kernel",
                 "time_us": 308.935
-              },
-              {
-                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
-                "time_us": 115.553
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 24.733
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
-                "time_us": 7.818
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
-                "time_us": 3.842
-              }
-            ]
-          },
-          {
-            "module": "moe.router",
-            "time_us": 47.987,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_sinkhorn_fwd_kernel",
-                "time_us": 24.829
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 10.252
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
-                "time_us": 8.02
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 3.543
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 1.343
-              }
-            ]
-          }
-        ],
-        "backward": [
-          {
-            "module": "moe.combine",
-            "time_us": 620.377,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
-                "time_us": 470.08
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
-                "time_us": 150.297
-              }
-            ]
-          },
-          {
-            "module": "moe.dispatch",
-            "time_us": 606.25,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
-                "time_us": 455.047
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
-                "time_us": 111.084
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
-                "time_us": 20.566
-              },
-              {
-                "name": "void primus_turbo::deep_ep::layout::get_dispatch_layout<256, 4, 8>(long const*, ",
-                "time_us": 19.553
-              }
-            ]
-          },
-          {
-            "module": "moe.grouped_gemm",
-            "time_us": 511.084,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_stack_grouped_weight_bwd_kernel",
-                "time_us": 327.882
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
@@ -508,16 +395,52 @@
                 "time_us": 29.89
               },
               {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 24.733
+              },
+              {
                 "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
                 "time_us": 22.62
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 363.919,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
+                "time_us": 233.282
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::BinaryFunctor<c10:",
-                "time_us": 21.476
+                "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
+                "time_us": 111.084
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::CUDAFunctorOnSelf_",
-                "time_us": 15.72
+                "name": "void primus_turbo::deep_ep::layout::get_dispatch_layout<256, 4, 8>(long const*, ",
+                "time_us": 19.553
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 321.999,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
+                "time_us": 231.632
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 90.367
               }
             ]
           },
@@ -553,7 +476,109 @@
           },
           {
             "module": "moe.router",
-            "time_us": 71.248,
+            "time_us": 74.758,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "_sinkhorn_fwd_kernel",
+                "time_us": 24.829
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 10.252
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
+                "time_us": 8.02
+              },
+              {
+                "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
+                "time_us": 6.869
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 5.616
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 4.652
+              }
+            ]
+          }
+        ],
+        "backward": [
+          {
+            "module": "moe.grouped_gemm",
+            "time_us": 1916.666,
+            "class": "compute_bound",
+            "flop_class": "grouped_gemm",
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
+                "time_us": 1465.403
+              },
+              {
+                "name": "_stack_grouped_weight_bwd_kernel",
+                "time_us": 327.882
+              },
+              {
+                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
+                "time_us": 115.553
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
+                "time_us": 3.986
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
+                "time_us": 3.842
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 298.379,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
+                "time_us": 238.449
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 59.93
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 242.331,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
+                "time_us": 221.765
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
+                "time_us": 20.566
+              }
+            ]
+          },
+          {
+            "module": "moe.router",
+            "time_us": 44.476,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -562,26 +587,6 @@
               {
                 "name": "_sinkhorn_bwd_kernel",
                 "time_us": 44.476
-              },
-              {
-                "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
-                "time_us": 6.869
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 4.652
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<long, at::native::fu",
-                "time_us": 4.603
-              },
-              {
-                "name": "void at::native::index_elementwise_kernel<128, 4, at::native::gpu_index_kernel<a",
-                "time_us": 3.05
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::f",
-                "time_us": 2.376
               }
             ]
           }
@@ -593,69 +598,103 @@
         "forward": [
           {
             "module": "attn.misc",
-            "time_us": 26890.347,
+            "time_us": 2773.299,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymo",
-                "time_us": 19292.33
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 1295.177
-              },
-              {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 1102.882
+                "time_us": 603.359
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
+                "time_us": 493.853
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
+                "time_us": 247.801
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 906.352
+                "time_us": 192.373
               },
               {
-                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
-                "time_us": 894.834
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 150.529
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
-                "time_us": 754.642
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 136.255
+              }
+            ]
+          },
+          {
+            "module": "attn.indexer",
+            "time_us": 797.919,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 152.083
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
+                "time_us": 98.513
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 86.043
+              },
+              {
+                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
+                "time_us": 68.023
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 61.763
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 45.115
               }
             ]
           },
           {
             "module": "attn.proj",
-            "time_us": 2882.571,
+            "time_us": 736.399,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 3218541117440.0,
-            "tflops": 1116.6,
+            "flops": 449360953344.0,
+            "tflops": 610.2,
             "kernels": [
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 1819.353
-              },
-              {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 305.419
-              },
-              {
-                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
-                "time_us": 144.986
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 266.672
               },
               {
                 "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 122.254
+                "time_us": 223.295
               },
               {
-                "name": "Cijk_Ailk_Bjlk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 106.44
+                "name": "Custom_Cijk_Alik_Bljk_BBS_BH_MT256x256x64_MI16x16x1_UserArgs_shortname1_gfx950",
+                "time_us": 95.721
               },
               {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 106.05
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 57.19
+              },
+              {
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 36.907
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 30.46
               }
             ]
           },
@@ -683,15 +722,27 @@
           },
           {
             "module": "attn.norm",
-            "time_us": 259.005,
+            "time_us": 576.738,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 119.475
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 92.917
+              },
+              {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
                 "time_us": 92.574
+              },
+              {
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
+                "time_us": 64.33
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
@@ -700,57 +751,45 @@
               {
                 "name": "_apply_rope_fwd_kernel",
                 "time_us": 55.569
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 24.28
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 11.242
-              },
-              {
-                "name": "void transformer_engine::normalization::rmsnorm_fwd_tuned_kernel<transformer_eng",
-                "time_us": 7.196
               }
             ]
-          },
+          }
+        ],
+        "backward": [
           {
-            "module": "attn.indexer",
-            "time_us": 178.229,
+            "module": "attn.misc",
+            "time_us": 6906.916,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
-                "time_us": 84.07
-              },
-              {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 36.993
+                "time_us": 1292.801
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::AbsFunctor<c10::BF",
-                "time_us": 17.858
+                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
+                "time_us": 894.834
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::float8_copy_kernel",
-                "time_us": 10.686
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 862.656
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
+                "time_us": 754.642
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 9.508
+                "time_us": 499.523
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 7.031
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
+                "time_us": 469.792
               }
             ]
-          }
-        ],
-        "backward": [
+          },
           {
             "module": "attn.core",
             "time_us": 6885.908,
@@ -783,137 +822,49 @@
           },
           {
             "module": "attn.proj",
-            "time_us": 3210.421,
+            "time_us": 5356.593,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 174483046400.0,
-            "tflops": 54.3,
+            "flops": 2943663210496.0,
+            "tflops": 549.5,
             "kernels": [
               {
                 "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
                 "time_us": 2691.996
               },
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 266.672
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 1819.353
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 101.041
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 305.419
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 57.19
+                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
+                "time_us": 144.986
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 36.907
+                "name": "Cijk_Ailk_Bjlk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 106.44
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 30.46
-              }
-            ]
-          },
-          {
-            "module": "attn.misc",
-            "time_us": 2070.519,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
-                "time_us": 493.853
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 150.829
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 148.676
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 133.879
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 114.076
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<2, at::native::AUnaryFunctor<floa",
-                "time_us": 106.767
-              }
-            ]
-          },
-          {
-            "module": "attn.indexer",
-            "time_us": 619.69,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 152.083
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 86.043
-              },
-              {
-                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
-                "time_us": 68.023
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 61.763
-              },
-              {
-                "name": "void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymo",
-                "time_us": 39.573
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT128x64x128_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 31.899
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 106.05
               }
             ]
           },
           {
             "module": "attn.norm",
-            "time_us": 372.195,
+            "time_us": 54.462,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 108.233
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 92.917
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 64.33
-              },
-              {
                 "name": "_apply_rope_bwd_kernel",
                 "time_us": 54.462
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::compare_scalar_ker",
-                "time_us": 22.636
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
-                "time_us": 6.285
               }
             ]
           }
@@ -923,7 +874,7 @@
         "forward": [
           {
             "module": "moe.grouped_gemm",
-            "time_us": 2869.901,
+            "time_us": 1461.438,
             "class": "compute_bound",
             "flop_class": "grouped_gemm",
             "flops": null,
@@ -931,117 +882,11 @@
             "kernels": [
               {
                 "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
-                "time_us": 2410.635
+                "time_us": 945.722
               },
               {
                 "name": "_stack_grouped_weight_fwd_kernel",
                 "time_us": 305.939
-              },
-              {
-                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
-                "time_us": 114.644
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 26.583
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
-                "time_us": 8.025
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
-                "time_us": 4.076
-              }
-            ]
-          },
-          {
-            "module": "moe.router",
-            "time_us": 47.87,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_sinkhorn_fwd_kernel",
-                "time_us": 24.839
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 10.072
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
-                "time_us": 8.086
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 3.57
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 1.303
-              }
-            ]
-          }
-        ],
-        "backward": [
-          {
-            "module": "moe.combine",
-            "time_us": 688.315,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
-                "time_us": 467.771
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
-                "time_us": 220.545
-              }
-            ]
-          },
-          {
-            "module": "moe.dispatch",
-            "time_us": 679.335,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
-                "time_us": 453.817
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
-                "time_us": 178.088
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
-                "time_us": 27.653
-              },
-              {
-                "name": "void primus_turbo::deep_ep::layout::get_dispatch_layout<256, 4, 8>(long const*, ",
-                "time_us": 19.776
-              }
-            ]
-          },
-          {
-            "module": "moe.grouped_gemm",
-            "time_us": 487.9,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_stack_grouped_weight_bwd_kernel",
-                "time_us": 308.679
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
@@ -1052,16 +897,52 @@
                 "time_us": 28.903
               },
               {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 26.583
+              },
+              {
                 "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
                 "time_us": 21.893
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 330.683,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
+                "time_us": 230.235
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::BinaryFunctor<c10:",
-                "time_us": 21.493
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 100.447
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 279.761,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
+                "time_us": 232.332
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::CUDAFunctorOnSelf_",
-                "time_us": 15.78
+                "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
+                "time_us": 27.653
+              },
+              {
+                "name": "void primus_turbo::deep_ep::layout::get_dispatch_layout<256, 4, 8>(long const*, ",
+                "time_us": 19.776
               }
             ]
           },
@@ -1097,7 +978,109 @@
           },
           {
             "module": "moe.router",
-            "time_us": 71.044,
+            "time_us": 74.189,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "_sinkhorn_fwd_kernel",
+                "time_us": 24.839
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 10.072
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
+                "time_us": 8.086
+              },
+              {
+                "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
+                "time_us": 6.905
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 5.669
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 4.696
+              }
+            ]
+          }
+        ],
+        "backward": [
+          {
+            "module": "moe.grouped_gemm",
+            "time_us": 1896.364,
+            "class": "compute_bound",
+            "flop_class": "grouped_gemm",
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
+                "time_us": 1464.913
+              },
+              {
+                "name": "_stack_grouped_weight_bwd_kernel",
+                "time_us": 308.679
+              },
+              {
+                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
+                "time_us": 114.644
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
+                "time_us": 4.076
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
+                "time_us": 4.052
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 399.573,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
+                "time_us": 221.485
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
+                "time_us": 178.088
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 357.633,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
+                "time_us": 237.535
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 120.097
+              }
+            ]
+          },
+          {
+            "module": "moe.router",
+            "time_us": 44.726,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -1106,26 +1089,6 @@
               {
                 "name": "_sinkhorn_bwd_kernel",
                 "time_us": 44.726
-              },
-              {
-                "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
-                "time_us": 6.905
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 4.696
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<long, at::native::fu",
-                "time_us": 4.213
-              },
-              {
-                "name": "void at::native::index_elementwise_kernel<128, 4, at::native::gpu_index_kernel<a",
-                "time_us": 3.083
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::f",
-                "time_us": 2.38
               }
             ]
           }
@@ -1137,69 +1100,103 @@
         "forward": [
           {
             "module": "attn.misc",
-            "time_us": 7106.777,
+            "time_us": 2784.297,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 1279.006
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 605.113
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
+                "time_us": 493.93
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
+                "time_us": 248.877
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 905.048
+                "time_us": 191.946
               },
               {
-                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
-                "time_us": 900.44
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 151.909
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 136.028
+              }
+            ]
+          },
+          {
+            "module": "attn.norm",
+            "time_us": 851.58,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymo",
+                "time_us": 322.669
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 96.885
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 94.427
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 891.868
+                "time_us": 86.567
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
-                "time_us": 759.74
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 63.153
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
-                "time_us": 346.078
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
+                "time_us": 63.077
               }
             ]
           },
           {
             "module": "attn.proj",
-            "time_us": 2865.993,
+            "time_us": 741.746,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 3184181379072.0,
-            "tflops": 1111.0,
+            "flops": 449360953344.0,
+            "tflops": 605.8,
             "kernels": [
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 1790.855
-              },
-              {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 304.992
-              },
-              {
-                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
-                "time_us": 144.849
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 262.638
               },
               {
                 "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 122.418
+                "time_us": 231.228
               },
               {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 106.241
+                "name": "Custom_Cijk_Alik_Bljk_BBS_BH_MT256x256x64_MI16x16x1_UserArgs_shortname1_gfx950",
+                "time_us": 96.854
               },
               {
-                "name": "Cijk_Ailk_Bjlk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 106.113
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 56.606
+              },
+              {
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 36.38
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 31.55
               }
             ]
           },
@@ -1222,47 +1219,29 @@
             ]
           },
           {
-            "module": "attn.norm",
-            "time_us": 253.122,
+            "module": "attn.indexer",
+            "time_us": 116.287,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 86.567
+                "name": "void at::native::(anonymous namespace)::cunn_SpatialSoftMaxForward<float, float,",
+                "time_us": 43.017
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 63.153
-              },
-              {
-                "name": "_apply_rope_fwd_kernel",
-                "time_us": 57.872
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x64x64_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 40.393
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 23.98
+                "time_us": 5.909
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 9.715
+                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
+                "time_us": 5.543
               },
-              {
-                "name": "void transformer_engine::normalization::rmsnorm_fwd_tuned_kernel<transformer_eng",
-                "time_us": 7.256
-              }
-            ]
-          },
-          {
-            "module": "attn.indexer",
-            "time_us": 8.795,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
                 "time_us": 4.436
@@ -1276,70 +1255,70 @@
         ],
         "backward": [
           {
-            "module": "attn.proj",
-            "time_us": 3222.049,
-            "class": "compute_bound",
-            "flop_class": "gemm",
-            "flops": 174483046400.0,
-            "tflops": 54.2,
-            "kernels": [
-              {
-                "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
-                "time_us": 2699.575
-              },
-              {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 262.638
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 108.811
-              },
-              {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 56.606
-              },
-              {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 36.38
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 31.55
-              }
-            ]
-          },
-          {
             "module": "attn.misc",
-            "time_us": 2105.442,
+            "time_us": 6427.921,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
-                "time_us": 493.93
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 1276.619
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 152.206
+                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
+                "time_us": 900.44
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 147.81
+                "time_us": 860.911
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 133.642
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
+                "time_us": 759.74
               },
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 112.49
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
+                "time_us": 346.078
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<2, at::native::AUnaryFunctor<floa",
-                "time_us": 107.301
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 286.755
+              }
+            ]
+          },
+          {
+            "module": "attn.proj",
+            "time_us": 5346.296,
+            "class": "compute_bound",
+            "flop_class": "gemm",
+            "flops": 2909303472128.0,
+            "tflops": 544.2,
+            "kernels": [
+              {
+                "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
+                "time_us": 2699.575
+              },
+              {
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 1790.855
+              },
+              {
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 304.992
+              },
+              {
+                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
+                "time_us": 144.849
+              },
+              {
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 106.241
+              },
+              {
+                "name": "Cijk_Ailk_Bjlk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 106.113
               }
             ]
           },
@@ -1375,69 +1354,15 @@
           },
           {
             "module": "attn.norm",
-            "time_us": 657.103,
+            "time_us": 58.646,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
-              {
-                "name": "void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymo",
-                "time_us": 322.669
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 94.427
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 87.17
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 63.077
-              },
               {
                 "name": "_apply_rope_bwd_kernel",
                 "time_us": 58.646
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::cos_kernel_cuda(at",
-                "time_us": 6.019
-              }
-            ]
-          },
-          {
-            "module": "attn.indexer",
-            "time_us": 107.492,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void at::native::(anonymous namespace)::cunn_SpatialSoftMaxForward<float, float,",
-                "time_us": 43.017
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x64x64_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 40.393
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 5.909
-              },
-              {
-                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
-                "time_us": 5.543
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::BinaryFunctor<c10:",
-                "time_us": 2.443
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 2.353
               }
             ]
           }
@@ -1447,7 +1372,7 @@
         "forward": [
           {
             "module": "moe.grouped_gemm",
-            "time_us": 2872.623,
+            "time_us": 1476.627,
             "class": "compute_bound",
             "flop_class": "grouped_gemm",
             "flops": null,
@@ -1455,117 +1380,11 @@
             "kernels": [
               {
                 "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
-                "time_us": 2408.911
+                "time_us": 950.715
               },
               {
                 "name": "_stack_grouped_weight_fwd_kernel",
                 "time_us": 312.572
-              },
-              {
-                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
-                "time_us": 113.277
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 25.726
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
-                "time_us": 8.081
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
-                "time_us": 4.056
-              }
-            ]
-          },
-          {
-            "module": "moe.router",
-            "time_us": 55.984,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_sinkhorn_fwd_kernel",
-                "time_us": 25.606
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
-                "time_us": 14.203
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 10.482
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 4.093
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 1.599
-              }
-            ]
-          }
-        ],
-        "backward": [
-          {
-            "module": "moe.combine",
-            "time_us": 653.521,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
-                "time_us": 460.577
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
-                "time_us": 192.944
-              }
-            ]
-          },
-          {
-            "module": "moe.dispatch",
-            "time_us": 535.863,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
-                "time_us": 450.94
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
-                "time_us": 60.447
-              },
-              {
-                "name": "void primus_turbo::deep_ep::layout::get_dispatch_layout<256, 4, 8>(long const*, ",
-                "time_us": 20.186
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
-                "time_us": 4.29
-              }
-            ]
-          },
-          {
-            "module": "moe.grouped_gemm",
-            "time_us": 492.827,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_stack_grouped_weight_bwd_kernel",
-                "time_us": 309.245
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
@@ -1576,16 +1395,52 @@
                 "time_us": 30.373
               },
               {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 25.726
+              },
+              {
                 "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
                 "time_us": 22.426
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 310.355,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
+                "time_us": 229.722
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::BinaryFunctor<c10:",
-                "time_us": 21.713
+                "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
+                "time_us": 60.447
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::CUDAFunctorOnSelf_",
-                "time_us": 15.546
+                "name": "void primus_turbo::deep_ep::layout::get_dispatch_layout<256, 4, 8>(long const*, ",
+                "time_us": 20.186
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 309.929,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
+                "time_us": 227.382
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 82.547
               }
             ]
           },
@@ -1621,7 +1476,109 @@
           },
           {
             "module": "moe.router",
-            "time_us": 72.341,
+            "time_us": 83.718,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "_sinkhorn_fwd_kernel",
+                "time_us": 25.606
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
+                "time_us": 14.203
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 10.482
+              },
+              {
+                "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
+                "time_us": 7.482
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 6.356
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 4.886
+              }
+            ]
+          }
+        ],
+        "backward": [
+          {
+            "module": "moe.grouped_gemm",
+            "time_us": 1888.822,
+            "class": "compute_bound",
+            "flop_class": "grouped_gemm",
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
+                "time_us": 1458.196
+              },
+              {
+                "name": "_stack_grouped_weight_bwd_kernel",
+                "time_us": 309.245
+              },
+              {
+                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
+                "time_us": 113.277
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
+                "time_us": 4.056
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
+                "time_us": 4.049
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 343.592,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024>(hip_bfloat",
+                "time_us": 233.195
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 110.397
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 225.508,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024>(HIP_vector_type<int, 4u",
+                "time_us": 221.218
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
+                "time_us": 4.29
+              }
+            ]
+          },
+          {
+            "module": "moe.router",
+            "time_us": 44.606,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -1630,26 +1587,6 @@
               {
                 "name": "_sinkhorn_bwd_kernel",
                 "time_us": 44.606
-              },
-              {
-                "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
-                "time_us": 7.482
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 4.886
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<long, at::native::fu",
-                "time_us": 4.17
-              },
-              {
-                "name": "void at::native::index_elementwise_kernel<128, 4, at::native::gpu_index_kernel<a",
-                "time_us": 2.923
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::f",
-                "time_us": 2.573
               }
             ]
           }
@@ -1716,42 +1653,30 @@
       "forward": [
         {
           "module": "output",
-          "time_us": 1529.095,
+          "time_us": 1553.935,
           "class": "compute_bound",
           "flop_class": "gemm",
-          "flops": 2171105968128.0,
-          "tflops": 1419.9,
+          "flops": 2171374403584.0,
+          "tflops": 1397.3,
           "kernels": [
             {
               "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
               "time_us": 1529.095
-            }
-          ]
-        }
-      ],
-      "backward": [
-        {
-          "module": "output",
-          "time_us": 24.84,
-          "class": "compute_bound",
-          "flop_class": "gemm",
-          "flops": 268435456.0,
-          "tflops": 10.8,
-          "kernels": [
+            },
             {
               "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB1_AFC1_AF",
               "time_us": 24.84
             }
           ]
         }
-      ]
+      ],
+      "backward": []
     },
     "loss": {
-      "forward": [],
-      "backward": [
+      "forward": [
         {
           "module": "loss",
-          "time_us": 565.694,
+          "time_us": 368.303,
           "class": "memory_bound",
           "flop_class": null,
           "flops": null,
@@ -1762,12 +1687,24 @@
               "time_us": 235.982
             },
             {
-              "name": "element_mul_kernel",
-              "time_us": 197.392
-            },
-            {
               "name": "online_softmax_kernel",
               "time_us": 132.321
+            }
+          ]
+        }
+      ],
+      "backward": [
+        {
+          "module": "loss",
+          "time_us": 197.392,
+          "class": "memory_bound",
+          "flop_class": null,
+          "flops": null,
+          "tflops": null,
+          "kernels": [
+            {
+              "name": "element_mul_kernel",
+              "time_us": 197.392
             }
           ]
         }

--- a/deepseek-v4/projection/site/data/pro.json
+++ b/deepseek-v4/projection/site/data/pro.json
@@ -19,7 +19,7 @@
     "seq": 4096,
     "note": "per-layer and MTP (B=1) Megatron-convention FLOPs at capture seq; site multiplies by GA x DP"
   },
-  "generated_at": "2026-06-22T17:51:57Z",
+  "generated_at": "2026-06-30T13:59:43Z",
   "provenance": {
     "traces": {
       "0": "/apps/tas/wenx/workspace/Primus-deepseek-v4/output/amd/tas-mi355x-20260618/projection_pro_cr0_seq4096_ep8/tensorboard/primus-megatron-exp[projection_pro_cr0_seq4096_ep8]-rank[0].1781792532762897620.pt.trace.json",
@@ -27,7 +27,12 @@
       "128": "/apps/tas/wenx/workspace/Primus-deepseek-v4/output/amd/tas-mi355x-20260618/projection_pro_cr128_seq4096_ep8/tensorboard/primus-megatron-exp[projection_pro_cr128_seq4096_ep8]-rank[0].1781792680203624431.pt.trace.json"
     },
     "graphed_crs_estimated_from_cr4": [],
-    "note": "cr in graphed_crs_estimated_from_cr4 were CUDA-graph/stream-captured (compute not visible in trace); their breakdown is copied from cr=4 as an estimate. Re-run those cr with graph capture disabled for exact numbers."
+    "dropped_stall_us_per_mb": {
+      "0": 36705.7,
+      "4": 0.0,
+      "128": 0.0
+    },
+    "note": "cr in graphed_crs_estimated_from_cr4 were CUDA-graph/stream-captured (compute not visible in trace); their breakdown is copied from cr=4 as an estimate. Re-run those cr with graph capture disabled for exact numbers. dropped_stall_us_per_mb: per-mb layer-compute kernel time dropped as implausible one-off device stalls (> _MAX_PLAUSIBLE_LAUNCH_US)."
   },
   "capture": {
     "gpu": "MI355X",
@@ -39,7 +44,8 @@
     "optimizer": "adam",
     "distributed_optimizer": false,
     "recompute": "off",
-    "measured_iter_time_ms": null
+    "measured_iter_time_ms": null,
+    "measured_anchor": null
   },
   "model_config": {
     "num_layers": 61,
@@ -143,7 +149,75 @@
         "forward": [
           {
             "module": "attn.misc",
-            "time_us": 50996.046,
+            "time_us": 7402.198,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 1437.355
+              },
+              {
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::N",
+                "time_us": 1366.235
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
+                "time_us": 1344.257
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
+                "time_us": 709.616
+              },
+              {
+                "name": "void at::native::unrolled_elementwise_kernel<at::native::AUnaryFunctor<float, fl",
+                "time_us": 374.819
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 324.583
+              }
+            ]
+          },
+          {
+            "module": "attn.proj",
+            "time_us": 1623.031,
+            "class": "compute_bound",
+            "flop_class": "gemm",
+            "flops": 1191719206912.0,
+            "tflops": 734.3,
+            "kernels": [
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 905.959
+              },
+              {
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 476.296
+              },
+              {
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 117.74
+              },
+              {
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 93.017
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 21.693
+              },
+              {
+                "name": "Cijk_SS_BiasS_HAS_ScaleAlphaVec_PostGSU4_VW4",
+                "time_us": 4.239
+              }
+            ]
+          },
+          {
+            "module": "attn.norm",
+            "time_us": 929.729,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -151,61 +225,27 @@
             "kernels": [
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 38789.717
+                "time_us": 177.157
               },
               {
-                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
-                "time_us": 3024.544
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 176.451
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 1906.817
+                "time_us": 148.509
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 1630.312
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 127.904
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
-                "time_us": 1333.78
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
+                "time_us": 117.211
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 726.343
-              }
-            ]
-          },
-          {
-            "module": "attn.proj",
-            "time_us": 5781.21,
-            "class": "compute_bound",
-            "flop_class": "gemm",
-            "flops": 6172539092992.0,
-            "tflops": 1067.7,
-            "kernels": [
-              {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 3769.201
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 654.028
-              },
-              {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 489.093
-              },
-              {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 201.328
-              },
-              {
-                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
-                "time_us": 168.756
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB0_AFC1",
-                "time_us": 161.16
+                "name": "_apply_rope_fwd_kernel",
+                "time_us": 105.693
               }
             ]
           },
@@ -226,108 +266,74 @@
                 "time_us": 4.396
               }
             ]
-          },
-          {
-            "module": "attn.norm",
-            "time_us": 449.337,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 148.509
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 127.904
-              },
-              {
-                "name": "_apply_rope_fwd_kernel",
-                "time_us": 105.693
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 47.277
-              },
-              {
-                "name": "void transformer_engine::normalization::rmsnorm_fwd_general_kernel<transformer_e",
-                "time_us": 9.38
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 7.716
-              }
-            ]
           }
         ],
         "backward": [
           {
             "module": "attn.misc",
-            "time_us": 6366.322,
+            "time_us": 13148.636,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::N",
-                "time_us": 1366.235
+                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
+                "time_us": 3024.544
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
-                "time_us": 1341.008
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 2081.72
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 1555.489
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
+                "time_us": 1328.534
               },
               {
                 "name": "void transformer_engine::normalization::rmsnorm_bwd_general_kernel<transformer_e",
                 "time_us": 641.61
               },
               {
-                "name": "void at::native::unrolled_elementwise_kernel<at::native::AUnaryFunctor<float, fl",
-                "time_us": 374.819
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 249.76
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 245.856
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
+                "time_us": 616.003
               }
             ]
           },
           {
             "module": "attn.proj",
-            "time_us": 5907.367,
+            "time_us": 10065.546,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 298366009344.0,
-            "tflops": 50.5,
+            "flops": 5279185895424.0,
+            "tflops": 524.5,
             "kernels": [
               {
                 "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
                 "time_us": 4938.364
               },
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 476.296
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 3769.201
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 251.931
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 489.093
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 117.74
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 201.328
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 93.017
+                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
+                "time_us": 168.756
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 21.693
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB0_AFC1",
+                "time_us": 161.16
               }
             ]
           },
@@ -359,35 +365,15 @@
           },
           {
             "module": "attn.norm",
-            "time_us": 480.392,
+            "time_us": 105.86,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 176.451
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 169.441
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 117.211
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::cos_kernel_cuda(at",
-                "time_us": 4.402
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
-                "time_us": 4.272
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::sin_kernel_cuda(at",
-                "time_us": 4.269
+                "name": "_apply_rope_bwd_kernel",
+                "time_us": 105.86
               }
             ]
           }
@@ -397,7 +383,7 @@
         "forward": [
           {
             "module": "moe.grouped_gemm",
-            "time_us": 8820.034,
+            "time_us": 4225.655,
             "class": "compute_bound",
             "flop_class": "grouped_gemm",
             "flops": null,
@@ -405,77 +391,19 @@
             "kernels": [
               {
                 "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
-                "time_us": 7130.401
+                "time_us": 2683.892
               },
               {
                 "name": "_stack_grouped_weight_fwd_kernel",
                 "time_us": 1208.776
               },
               {
-                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
-                "time_us": 423.883
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 135.577
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
                 "time_us": 44.34
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
-                "time_us": 8.108
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
-                "time_us": 4.526
-              }
-            ]
-          },
-          {
-            "module": "moe.router",
-            "time_us": 61.337,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_sinkhorn_fwd_kernel",
-                "time_us": 25.516
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 16.113
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
-                "time_us": 14.06
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 3.576
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 2.073
-              }
-            ]
-          }
-        ],
-        "backward": [
-          {
-            "module": "moe.grouped_gemm",
-            "time_us": 1339.59,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_stack_grouped_weight_bwd_kernel",
-                "time_us": 1055.078
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 135.577
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
@@ -484,20 +412,12 @@
               {
                 "name": "void at::native::vectorized_elementwise_kernel<8, at::native::BinaryFunctor<c10:",
                 "time_us": 41.19
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
-                "time_us": 33.95
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::CUDAFunctorOnSelf_",
-                "time_us": 23.546
               }
             ]
           },
           {
             "module": "moe.combine",
-            "time_us": 1014.7,
+            "time_us": 427.833,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -505,17 +425,17 @@
             "kernels": [
               {
                 "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024, true>(hip_",
-                "time_us": 781.249
+                "time_us": 386.653
               },
               {
                 "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
-                "time_us": 233.451
+                "time_us": 41.18
               }
             ]
           },
           {
             "module": "moe.dispatch",
-            "time_us": 872.042,
+            "time_us": 422.925,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -523,11 +443,7 @@
             "kernels": [
               {
                 "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024, true>(HIP_vector_type<i",
-                "time_us": 758.275
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
-                "time_us": 73.65
+                "time_us": 382.809
               },
               {
                 "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
@@ -575,15 +491,23 @@
           },
           {
             "module": "moe.router",
-            "time_us": 74.504,
+            "time_us": 91.185,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "_sinkhorn_bwd_kernel",
-                "time_us": 44.656
+                "name": "_sinkhorn_fwd_kernel",
+                "time_us": 25.516
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 16.113
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
+                "time_us": 14.06
               },
               {
                 "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
@@ -594,16 +518,90 @@
                 "time_us": 6.666
               },
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<long, at::native::fu",
-                "time_us": 4.276
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 5.559
+              }
+            ]
+          }
+        ],
+        "backward": [
+          {
+            "module": "moe.grouped_gemm",
+            "time_us": 5933.968,
+            "class": "compute_bound",
+            "flop_class": "grouped_gemm",
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
+                "time_us": 4446.509
               },
               {
-                "name": "void at::native::index_elementwise_kernel<128, 4, at::native::gpu_index_kernel<a",
-                "time_us": 3.003
+                "name": "_stack_grouped_weight_bwd_kernel",
+                "time_us": 1055.078
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::sqrt_kernel_cuda(a",
-                "time_us": 2.383
+                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
+                "time_us": 423.883
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
+                "time_us": 4.526
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
+                "time_us": 3.972
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 586.867,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024, true>(hip_",
+                "time_us": 394.596
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 192.271
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 449.116,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024, true>(HIP_vector_type<i",
+                "time_us": 375.466
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
+                "time_us": 73.65
+              }
+            ]
+          },
+          {
+            "module": "moe.router",
+            "time_us": 44.656,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "_sinkhorn_bwd_kernel",
+                "time_us": 44.656
               }
             ]
           }
@@ -615,69 +613,35 @@
         "forward": [
           {
             "module": "attn.misc",
-            "time_us": 15510.655,
+            "time_us": 7425.221,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
-                "time_us": 3023.79
-              },
-              {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 2337.985
+                "time_us": 1447.247
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 2222.28
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::N",
+                "time_us": 1378.227
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 1645.297
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
-                "time_us": 1337.91
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
+                "time_us": 1342.16
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 993.69
-              }
-            ]
-          },
-          {
-            "module": "attn.proj",
-            "time_us": 5935.704,
-            "class": "compute_bound",
-            "flop_class": "gemm",
-            "flops": 6292798177280.0,
-            "tflops": 1060.2,
-            "kernels": [
-              {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 3854.896
+                "time_us": 709.102
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 656.014
+                "name": "void at::native::unrolled_elementwise_kernel<at::native::AUnaryFunctor<float, fl",
+                "time_us": 378.692
               },
               {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 487.807
-              },
-              {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 200.238
-              },
-              {
-                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
-                "time_us": 168.36
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB0_AFC1",
-                "time_us": 159.567
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 323.907
               }
             ]
           },
@@ -704,13 +668,55 @@
             ]
           },
           {
+            "module": "attn.proj",
+            "time_us": 1622.73,
+            "class": "compute_bound",
+            "flop_class": "gemm",
+            "flops": 1191719206912.0,
+            "tflops": 734.4,
+            "kernels": [
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 914.619
+              },
+              {
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 468.363
+              },
+              {
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 117.723
+              },
+              {
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 92.227
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 21.286
+              },
+              {
+                "name": "Cijk_SS_BiasS_HAS_ScaleAlphaVec_PostGSU4_VW4",
+                "time_us": 4.346
+              }
+            ]
+          },
+          {
             "module": "attn.norm",
-            "time_us": 470.82,
+            "time_us": 1021.024,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 206.375
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 177.044
+              },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
                 "time_us": 160.454
@@ -720,54 +726,46 @@
                 "time_us": 127.904
               },
               {
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
+                "time_us": 123.664
+              },
+              {
                 "name": "_apply_rope_fwd_kernel",
                 "time_us": 107.629
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 44.506
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 11.722
-              },
-              {
-                "name": "void transformer_engine::normalization::rmsnorm_fwd_general_kernel<transformer_e",
-                "time_us": 9.399
               }
             ]
           },
           {
             "module": "attn.indexer",
-            "time_us": 188.612,
+            "time_us": 874.391,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 152.603
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 96.286
+              },
+              {
                 "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
-                "time_us": 80.63
+                "time_us": 96.272
+              },
+              {
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 84.363
+              },
+              {
+                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
+                "time_us": 66.402
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 39.999
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::AbsFunctor<c10::BF",
-                "time_us": 18.041
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 11.941
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::float8_copy_kernel",
-                "time_us": 11.579
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 9.551
+                "time_us": 48.821
               }
             ]
           }
@@ -805,137 +803,83 @@
           },
           {
             "module": "attn.misc",
-            "time_us": 6382.919,
+            "time_us": 14359.617,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::N",
-                "time_us": 1378.227
+                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
+                "time_us": 3023.79
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
-                "time_us": 1339.041
-              },
-              {
-                "name": "void transformer_engine::normalization::rmsnorm_bwd_general_kernel<transformer_e",
-                "time_us": 641.36
-              },
-              {
-                "name": "void at::native::unrolled_elementwise_kernel<at::native::AUnaryFunctor<float, fl",
-                "time_us": 378.692
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 2219.844
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 249.123
+                "time_us": 1570.513
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 244.986
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
+                "time_us": 1332.678
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
+                "time_us": 898.568
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 890.739
               }
             ]
           },
           {
             "module": "attn.proj",
-            "time_us": 5958.409,
+            "time_us": 10271.383,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 298366009344.0,
-            "tflops": 50.1,
+            "flops": 5399444979712.0,
+            "tflops": 525.7,
             "kernels": [
               {
                 "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
                 "time_us": 4991.694
               },
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 468.363
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 3854.896
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 258.605
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 487.807
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 117.723
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 200.238
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 92.227
+                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
+                "time_us": 168.36
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 21.286
-              }
-            ]
-          },
-          {
-            "module": "attn.indexer",
-            "time_us": 685.779,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 152.603
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 96.286
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 84.363
-              },
-              {
-                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
-                "time_us": 66.402
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT128x64x128_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 45.229
-              },
-              {
-                "name": "void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymo",
-                "time_us": 41.74
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB0_AFC1",
+                "time_us": 159.567
               }
             ]
           },
           {
             "module": "attn.norm",
-            "time_us": 550.204,
+            "time_us": 108.736,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 194.654
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 177.044
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 123.664
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::compare_scalar_ker",
-                "time_us": 22.782
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
-                "time_us": 6.495
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::cos_kernel_cuda(at",
-                "time_us": 6.475
+                "name": "_apply_rope_bwd_kernel",
+                "time_us": 108.736
               }
             ]
           }
@@ -945,7 +889,7 @@
         "forward": [
           {
             "module": "moe.grouped_gemm",
-            "time_us": 8765.885,
+            "time_us": 4214.341,
             "class": "compute_bound",
             "flop_class": "grouped_gemm",
             "flops": null,
@@ -953,77 +897,19 @@
             "kernels": [
               {
                 "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
-                "time_us": 7077.849
+                "time_us": 2677.845
               },
               {
                 "name": "_stack_grouped_weight_fwd_kernel",
                 "time_us": 1206.016
               },
               {
-                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
-                "time_us": 425.279
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 135.8
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
                 "time_us": 43.96
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
-                "time_us": 8.145
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
-                "time_us": 4.636
-              }
-            ]
-          },
-          {
-            "module": "moe.router",
-            "time_us": 60.97,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_sinkhorn_fwd_kernel",
-                "time_us": 25.176
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 16.116
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
-                "time_us": 13.973
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 3.589
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 2.116
-              }
-            ]
-          }
-        ],
-        "backward": [
-          {
-            "module": "moe.grouped_gemm",
-            "time_us": 1356.649,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_stack_grouped_weight_bwd_kernel",
-                "time_us": 1074.128
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 135.8
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
@@ -1032,20 +918,12 @@
               {
                 "name": "void at::native::vectorized_elementwise_kernel<8, at::native::BinaryFunctor<c10:",
                 "time_us": 40.16
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
-                "time_us": 33.813
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::CUDAFunctorOnSelf_",
-                "time_us": 23.283
               }
             ]
           },
           {
             "module": "moe.dispatch",
-            "time_us": 1066.796,
+            "time_us": 486.166,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -1053,11 +931,7 @@
             "kernels": [
               {
                 "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024, true>(HIP_vector_type<i",
-                "time_us": 760.542
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
-                "time_us": 204.325
+                "time_us": 384.236
               },
               {
                 "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
@@ -1071,7 +945,7 @@
           },
           {
             "module": "moe.combine",
-            "time_us": 973.473,
+            "time_us": 470.04,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -1079,11 +953,11 @@
             "kernels": [
               {
                 "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024, true>(hip_",
-                "time_us": 779.425
+                "time_us": 385.316
               },
               {
                 "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
-                "time_us": 194.047
+                "time_us": 84.724
               }
             ]
           },
@@ -1123,15 +997,23 @@
           },
           {
             "module": "moe.router",
-            "time_us": 75.574,
+            "time_us": 91.678,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "_sinkhorn_bwd_kernel",
-                "time_us": 44.866
+                "name": "_sinkhorn_fwd_kernel",
+                "time_us": 25.176
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 16.116
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
+                "time_us": 13.973
               },
               {
                 "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
@@ -1142,16 +1024,90 @@
                 "time_us": 6.562
               },
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<long, at::native::fu",
-                "time_us": 4.486
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 5.852
+              }
+            ]
+          }
+        ],
+        "backward": [
+          {
+            "module": "moe.grouped_gemm",
+            "time_us": 5908.193,
+            "class": "compute_bound",
+            "flop_class": "grouped_gemm",
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
+                "time_us": 4400.005
               },
               {
-                "name": "void at::native::index_elementwise_kernel<128, 4, at::native::gpu_index_kernel<a",
-                "time_us": 3.033
+                "name": "_stack_grouped_weight_bwd_kernel",
+                "time_us": 1074.128
               },
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::f",
-                "time_us": 2.446
+                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
+                "time_us": 425.279
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
+                "time_us": 4.636
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
+                "time_us": 4.146
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 580.63,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024, true>(HIP_vector_type<i",
+                "time_us": 376.306
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
+                "time_us": 204.325
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 503.433,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024, true>(hip_",
+                "time_us": 394.109
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 109.324
+              }
+            ]
+          },
+          {
+            "module": "moe.router",
+            "time_us": 44.866,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "_sinkhorn_bwd_kernel",
+                "time_us": 44.866
               }
             ]
           }
@@ -1163,69 +1119,103 @@
         "forward": [
           {
             "module": "attn.misc",
-            "time_us": 14536.037,
+            "time_us": 7410.422,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
-                "time_us": 3030.941
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 2201.218
-              },
-              {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 1924.649
+                "time_us": 1443.783
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 1658.726
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::N",
+                "time_us": 1371.851
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
-                "time_us": 1335.873
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
+                "time_us": 1343.05
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 730.665
+                "time_us": 708.356
+              },
+              {
+                "name": "void at::native::unrolled_elementwise_kernel<at::native::AUnaryFunctor<float, fl",
+                "time_us": 377.102
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 327.05
               }
             ]
           },
           {
             "module": "attn.proj",
-            "time_us": 5909.199,
+            "time_us": 1639.461,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 6232668635136.0,
-            "tflops": 1054.7,
+            "flops": 1191719206912.0,
+            "tflops": 726.9,
             "kernels": [
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 3794.003
-              },
-              {
                 "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 658.211
+                "time_us": 919.326
               },
               {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 487.776
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 478.756
               },
               {
-                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 201.361
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 117.167
               },
               {
-                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
-                "time_us": 169.553
+                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
+                "time_us": 94.187
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB0_AFC1",
-                "time_us": 160.704
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 21.563
+              },
+              {
+                "name": "Cijk_SS_BiasS_HAS_ScaleAlphaVec_PostGSU4_VW4",
+                "time_us": 4.369
+              }
+            ]
+          },
+          {
+            "module": "attn.norm",
+            "time_us": 1623.015,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymo",
+                "time_us": 653.885
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 181.199
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
+                "time_us": 177.308
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
+                "time_us": 156.111
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 127.617
+              },
+              {
+                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
+                "time_us": 119.317
               }
             ]
           },
@@ -1248,54 +1238,36 @@
             ]
           },
           {
-            "module": "attn.norm",
-            "time_us": 465.633,
+            "module": "attn.indexer",
+            "time_us": 127.799,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 156.111
+                "name": "void at::native::(anonymous namespace)::cunn_SpatialSoftMaxForward<float, float,",
+                "time_us": 45.123
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 127.617
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
+                "time_us": 40.536
               },
               {
-                "name": "_apply_rope_fwd_kernel",
-                "time_us": 108.926
+                "name": "Cijk_SB_BiasS_HAS_ScaleAlphaVec_PostGSU4_VW4",
+                "time_us": 8.172
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 45.056
+                "time_us": 5.979
               },
               {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 10.019
+                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
+                "time_us": 5.803
               },
-              {
-                "name": "void transformer_engine::normalization::rmsnorm_fwd_general_kernel<transformer_e",
-                "time_us": 9.47
-              }
-            ]
-          },
-          {
-            "module": "attn.indexer",
-            "time_us": 9.071,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
                 "time_us": 4.566
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
-                "time_us": 4.506
               }
             ]
           }
@@ -1303,69 +1275,69 @@
         "backward": [
           {
             "module": "attn.misc",
-            "time_us": 6422.7,
+            "time_us": 13440.13,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::N",
-                "time_us": 1371.851
+                "name": "void at::native::vectorized_templated_elementwise_kernel<4, at::native::CUDAFunc",
+                "time_us": 3030.941
               },
               {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::AUnaryFunctor<floa",
-                "time_us": 1340.061
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 2198.898
+              },
+              {
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 1584.346
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::BinaryFunctor<floa",
+                "time_us": 1330.558
               },
               {
                 "name": "void transformer_engine::normalization::rmsnorm_bwd_general_kernel<transformer_e",
                 "time_us": 641.923
               },
               {
-                "name": "void at::native::unrolled_elementwise_kernel<at::native::AUnaryFunctor<float, fl",
-                "time_us": 377.102
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 252.67
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 245.85
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::CUDAFunctor_add<fl",
+                "time_us": 621.813
               }
             ]
           },
           {
             "module": "attn.proj",
-            "time_us": 5933.939,
+            "time_us": 10203.677,
             "class": "compute_bound",
             "flop_class": "gemm",
-            "flops": 298366009344.0,
-            "tflops": 50.3,
+            "flops": 5339315437568.0,
+            "tflops": 523.3,
             "kernels": [
               {
                 "name": "Cijk_Ailk_Bjlk_BSS_BH_Bias_S_HA_S_SAV_UserArgs_MT256x256x32_MI16x16x1_SN_LDSB0_A",
                 "time_us": 4952.69
               },
               {
-                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
-                "time_us": 478.756
+                "name": "Cijk_Ailk_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 3794.003
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
-                "time_us": 261.115
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x16x32_MI16x16x1_SN_LDSB1_AFC1",
+                "time_us": 487.776
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT32x64x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 117.167
+                "name": "Cijk_Ailk_Bjlk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
+                "time_us": 201.361
               },
               {
-                "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT64x32x128_MI16x16x1_SN_LDSB1_AFC1_AF",
-                "time_us": 94.187
+                "name": "Cijk_Ailk_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT256x256x16_MI16x16x1_SN_LDSB0_AFC1_A",
+                "time_us": 169.553
               },
               {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 21.563
+                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB0_AFC1",
+                "time_us": 160.704
               }
             ]
           },
@@ -1401,69 +1373,15 @@
           },
           {
             "module": "attn.norm",
-            "time_us": 1157.382,
+            "time_us": 108.186,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "void at::native::(anonymous namespace)::CatArrayBatchedCopy<at::native::(anonymo",
-                "time_us": 653.885
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::(anonymous namespa",
-                "time_us": 177.308
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 171.18
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 119.317
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
-                "time_us": 6.499
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::sin_kernel_cuda(at",
-                "time_us": 6.232
-              }
-            ]
-          },
-          {
-            "module": "attn.indexer",
-            "time_us": 118.727,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "void at::native::(anonymous namespace)::cunn_SpatialSoftMaxForward<float, float,",
-                "time_us": 45.123
-              },
-              {
-                "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x128x64_MI16x16x1_SN_LDSB1_AFC",
-                "time_us": 40.536
-              },
-              {
-                "name": "Cijk_SB_BiasS_HAS_ScaleAlphaVec_PostGSU4_VW4",
-                "time_us": 8.172
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 5.979
-              },
-              {
-                "name": "void at::native::reduce_kernel<128, 4, at::native::ReduceOp<c10::BFloat16, at::n",
-                "time_us": 5.803
-              },
-              {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::M",
-                "time_us": 2.596
+                "name": "_apply_rope_bwd_kernel",
+                "time_us": 108.186
               }
             ]
           }
@@ -1473,7 +1391,7 @@
         "forward": [
           {
             "module": "moe.grouped_gemm",
-            "time_us": 8717.575,
+            "time_us": 4170.341,
             "class": "compute_bound",
             "flop_class": "grouped_gemm",
             "flops": null,
@@ -1481,77 +1399,19 @@
             "kernels": [
               {
                 "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
-                "time_us": 7085.123
+                "time_us": 2687.575
               },
               {
                 "name": "_stack_grouped_weight_fwd_kernel",
                 "time_us": 1151.912
               },
               {
-                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
-                "time_us": 423.59
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
+                "time_us": 135.587
               },
               {
                 "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16_copy_kern",
                 "time_us": 44.276
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
-                "time_us": 8.158
-              },
-              {
-                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
-                "time_us": 4.516
-              }
-            ]
-          },
-          {
-            "module": "moe.router",
-            "time_us": 61.157,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_sinkhorn_fwd_kernel",
-                "time_us": 25.629
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
-                "time_us": 16.009
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
-                "time_us": 13.92
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
-                "time_us": 3.529
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::FillFunctor<float>",
-                "time_us": 2.07
-              }
-            ]
-          }
-        ],
-        "backward": [
-          {
-            "module": "moe.grouped_gemm",
-            "time_us": 1359.113,
-            "class": "memory_bound",
-            "flop_class": null,
-            "flops": null,
-            "tflops": null,
-            "kernels": [
-              {
-                "name": "_stack_grouped_weight_bwd_kernel",
-                "time_us": 1076.558
-              },
-              {
-                "name": "void at::native::elementwise_kernel_manual_unroll<128, 8, at::native::gpu_kernel",
-                "time_us": 135.587
               },
               {
                 "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::(anonymous",
@@ -1560,20 +1420,12 @@
               {
                 "name": "void at::native::vectorized_elementwise_kernel<8, at::native::BinaryFunctor<c10:",
                 "time_us": 40.733
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::(anonymous namespa",
-                "time_us": 33.963
-              },
-              {
-                "name": "void at::native::vectorized_elementwise_kernel<8, at::native::CUDAFunctorOnSelf_",
-                "time_us": 23.29
               }
             ]
           },
           {
             "module": "moe.combine",
-            "time_us": 993.553,
+            "time_us": 514.457,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -1581,17 +1433,17 @@
             "kernels": [
               {
                 "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024, true>(hip_",
-                "time_us": 781.462
+                "time_us": 387.153
               },
               {
                 "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
-                "time_us": 212.091
+                "time_us": 127.304
               }
             ]
           },
           {
             "module": "moe.dispatch",
-            "time_us": 857.885,
+            "time_us": 448.916,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
@@ -1599,15 +1451,11 @@
             "kernels": [
               {
                 "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024, true>(HIP_vector_type<i",
-                "time_us": 759.865
+                "time_us": 384.249
               },
               {
                 "name": "void primus_turbo::deep_ep::intranode::notify_dispatch<8>(int const*, int*, int ",
                 "time_us": 45.283
-              },
-              {
-                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
-                "time_us": 33.353
               },
               {
                 "name": "void primus_turbo::deep_ep::layout::get_dispatch_layout<256, 4, 8>(long const*, ",
@@ -1651,15 +1499,23 @@
           },
           {
             "module": "moe.router",
-            "time_us": 75.321,
+            "time_us": 90.989,
             "class": "memory_bound",
             "flop_class": null,
             "flops": null,
             "tflops": null,
             "kernels": [
               {
-                "name": "_sinkhorn_bwd_kernel",
-                "time_us": 45.489
+                "name": "_sinkhorn_fwd_kernel",
+                "time_us": 25.629
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<4, at::native::bfloat16tofloat32_",
+                "time_us": 16.009
+              },
+              {
+                "name": "void at::native::vectorized_elementwise_kernel<16, at::native::FillFunctor<bool>",
+                "time_us": 13.92
               },
               {
                 "name": "void at::native::_scatter_gather_elementwise_kernel<256, 4, at::native::_cuda_sc",
@@ -1670,16 +1526,90 @@
                 "time_us": 6.402
               },
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<long, at::native::fu",
-                "time_us": 4.403
+                "name": "void at::native::elementwise_kernel_manual_unroll<128, 4, at::native::gpu_kernel",
+                "time_us": 5.779
+              }
+            ]
+          }
+        ],
+        "backward": [
+          {
+            "module": "moe.grouped_gemm",
+            "time_us": 5906.347,
+            "class": "compute_bound",
+            "flop_class": "grouped_gemm",
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void ck_tile::kentry<1, ck_tile::GroupedGemmKernel<ck_tile::GemmSpatiallyLocalTi",
+                "time_us": 4397.548
               },
               {
-                "name": "void at::native::index_elementwise_kernel<128, 4, at::native::gpu_index_kernel<a",
-                "time_us": 3.03
+                "name": "_stack_grouped_weight_bwd_kernel",
+                "time_us": 1076.558
               },
               {
-                "name": "void at::native::reduce_kernel<512, 1, at::native::ReduceOp<float, at::native::f",
-                "time_us": 2.44
+                "name": "void primus_turbo::grouped_gemm_variable_k_postprocess<std::bfloat16_t>(std::bfl",
+                "time_us": 423.59
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_variable_k_args<std::bfloat16_t, std::bf",
+                "time_us": 4.516
+              },
+              {
+                "name": "void primus_turbo::compute_grouped_gemm_args<std::bfloat16_t, std::bfloat16_t, s",
+                "time_us": 4.136
+              }
+            ]
+          },
+          {
+            "module": "moe.combine",
+            "time_us": 479.096,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::combine<hip_bfloat16, 8, 1024, true>(hip_",
+                "time_us": 394.309
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_combine<8>(void**, int*, in",
+                "time_us": 84.787
+              }
+            ]
+          },
+          {
+            "module": "moe.dispatch",
+            "time_us": 408.969,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "void primus_turbo::deep_ep::intranode::dispatch<8, 1024, true>(HIP_vector_type<i",
+                "time_us": 375.616
+              },
+              {
+                "name": "void primus_turbo::deep_ep::intranode::cached_notify_dispatch<8>(int const*, int",
+                "time_us": 33.353
+              }
+            ]
+          },
+          {
+            "module": "moe.router",
+            "time_us": 45.489,
+            "class": "memory_bound",
+            "flop_class": null,
+            "flops": null,
+            "tflops": null,
+            "kernels": [
+              {
+                "name": "_sinkhorn_bwd_kernel",
+                "time_us": 45.489
               }
             ]
           }
@@ -1746,42 +1676,30 @@
       "forward": [
         {
           "module": "output",
-          "time_us": 2634.481,
+          "time_us": 2688.195,
           "class": "compute_bound",
           "flop_class": "gemm",
-          "flops": 3799435444224.0,
-          "tflops": 1442.2,
+          "flops": 3799905206272.0,
+          "tflops": 1413.6,
           "kernels": [
             {
               "name": "Cijk_Alik_Bljk_BBS_BH_Bias_HA_S_SAV_UserArgs_MT256x256x64_MI16x16x1_CMS_SN_LDSB0",
               "time_us": 2634.481
-            }
-          ]
-        }
-      ],
-      "backward": [
-        {
-          "module": "output",
-          "time_us": 53.713,
-          "class": "compute_bound",
-          "flop_class": "gemm",
-          "flops": 469762048.0,
-          "tflops": 8.7,
-          "kernels": [
+            },
             {
               "name": "Cijk_Alik_Bljk_S_B_Bias_HA_S_SAV_UserArgs_MT16x16x512_MI16x16x1_SN_LDSB1_AFC1_AF",
               "time_us": 53.713
             }
           ]
         }
-      ]
+      ],
+      "backward": []
     },
     "loss": {
-      "forward": [],
-      "backward": [
+      "forward": [
         {
           "module": "loss",
-          "time_us": 546.313,
+          "time_us": 350.465,
           "class": "memory_bound",
           "flop_class": null,
           "flops": null,
@@ -1792,12 +1710,24 @@
               "time_us": 222.888
             },
             {
-              "name": "element_mul_kernel",
-              "time_us": 195.848
-            },
-            {
               "name": "online_softmax_kernel",
               "time_us": 127.577
+            }
+          ]
+        }
+      ],
+      "backward": [
+        {
+          "module": "loss",
+          "time_us": 195.848,
+          "class": "memory_bound",
+          "flop_class": null,
+          "flops": null,
+          "tflops": null,
+          "kernels": [
+            {
+              "name": "element_mul_kernel",
+              "time_us": 195.848
             }
           ]
         }

--- a/deepseek-v4/projection/site/index.html
+++ b/deepseek-v4/projection/site/index.html
@@ -36,7 +36,30 @@
       </div>
     </div>
 
-    <main class="layout">
+    <main class="layout layout--split">
+      <aside class="sidebar">
+        <section class="panel" id="controls-panel">
+          <h2>Projection controls</h2>
+          <div class="mode-switch" id="mode-switch">
+            <span class="mode-switch__label">Layer timing</span>
+            <div class="mode-switch__tabs" role="tablist">
+              <button class="mode-tab is-active" data-mode="trace" role="tab">Trace-derived</button>
+              <button class="mode-tab" data-mode="manual" role="tab">Manual per-layer</button>
+            </div>
+          </div>
+          <div id="manual-grid" class="manual-grid" hidden></div>
+          <div id="controls-grid" class="controls-grid"></div>
+          <div id="validation-panel" hidden></div>
+          <p class="muted">
+            DP is derived from World size / (PP·TP·CP); EP is a sub-group of DP.
+            Note: the captured MoE dispatch/combine is intra-node EP=8 and is not
+            re-modeled for other EP values; sequence length is fixed at the
+            capture value (4096).
+          </p>
+        </section>
+      </aside>
+
+      <div class="content">
       <div id="error-state" class="state state--error" hidden></div>
 
       <section class="panel" id="config-panel">
@@ -63,32 +86,38 @@
         <div id="breakdown-blocks"></div>
       </section>
 
-      <div class="two-col">
-        <section class="panel" id="controls-panel">
-          <h2>Projection controls</h2>
-          <div class="mode-switch" id="mode-switch">
-            <span class="mode-switch__label">Layer timing</span>
-            <div class="mode-switch__tabs" role="tablist">
-              <button class="mode-tab is-active" data-mode="trace" role="tab">Trace-derived</button>
-              <button class="mode-tab" data-mode="manual" role="tab">Manual per-layer</button>
+      <section class="panel panel--accent" id="results-panel">
+        <h2>Projected throughput <span id="results-gpu" class="muted"></span></h2>
+        <div id="results-headline" class="headline"></div>
+        <div id="results-steps" class="steps"></div>
+      </section>
+
+      <section class="panel" id="timeline-panel">
+        <div class="panel__head">
+          <h2>Iteration timeline <span id="timeline-gpu" class="muted"></span></h2>
+          <p class="muted">
+            How one iteration's time is composed, bottom-up: a single layer
+            (attn / mlp / a2a) → each pipeline rank's chunks (layer granularity) →
+            the whole 1F1B pipeline schedule. Reacts live to the controls on the left.
+            See <code>design/07-iteration-timeline.md</code>.
+          </p>
+          <div class="tl-head-row">
+            <div class="tl-viewswitch" id="tl-viewswitch">
+              <span class="mode-switch__label">Layout</span>
+              <div class="mode-switch__tabs" role="tablist">
+                <button class="tl-view" data-view="tabs" role="tab">Tabbed</button>
+                <button class="tl-view is-active" data-view="stacked" role="tab">Stacked (all + link)</button>
+              </div>
+            </div>
+            <div class="tl-tabs" id="tl-tabs" role="tablist">
+              <button class="tl-tab is-active" data-level="1" role="tab">L1 · Layer</button>
+              <button class="tl-tab" data-level="2" role="tab">L2 · PP ranks</button>
+              <button class="tl-tab" data-level="3" role="tab">L3 · Schedule</button>
             </div>
           </div>
-          <div id="manual-grid" class="manual-grid" hidden></div>
-          <div id="controls-grid" class="controls-grid"></div>
-          <div id="validation-panel" hidden></div>
-          <p class="muted">
-            DP is derived from World size / (PP·TP·CP); EP is a sub-group of DP.
-            Note: the captured MoE dispatch/combine is intra-node EP=8 and is not
-            re-modeled for other EP values; sequence length is fixed at the
-            capture value (4096).
-          </p>
-        </section>
-
-        <section class="panel panel--accent" id="results-panel">
-          <h2>Projected throughput <span id="results-gpu" class="muted"></span></h2>
-          <div id="results-headline" class="headline"></div>
-          <div id="results-steps" class="steps"></div>
-        </section>
+        </div>
+        <div id="tl-body"></div>
+      </section>
       </div>
     </main>
 

--- a/deepseek-v4/projection/tools/parse_trace.py
+++ b/deepseek-v4/projection/tools/parse_trace.py
@@ -24,11 +24,26 @@ Attribution (validated against the real ROCm/Kineto trace):
 from __future__ import annotations
 
 import argparse
+import bisect
 import json
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+# Merge gap (us) used when reconstructing the backward GPU-time window from the
+# linked backward kernels, so an unlinked kernel sitting in a small stall
+# between two backward kernels is still counted as backward.
+_BWD_WINDOW_GAP_US = 150.0
+
+# A single layer-compute GPU kernel launch at seq=4096/B=1 realistically tops
+# out around ~10 ms (e.g. the V4 attention bwd or a grouped GEMM). Some captures
+# bill a one-off device-side stall / busy-wait to an ordinary elementwise kernel
+# (observed: 3 launches of ~145 ms attributed to aten::mul/add_/div in the cr=0
+# pro trace, 17x the cr=4/128 value). Those are capture artifacts, not per-layer
+# cost, so layer-compute launches above this cap are dropped (and reported in
+# provenance). Optimizer/comm kernels are routed out before this cap applies.
+_MAX_PLAUSIBLE_LAUNCH_US = 50_000.0
 
 from kernel_module_map import flop_class_from_kernel, module_from_kernel
 from v4_flops import FB_FMA, layer_fmac, model_total_params, mtp_flops, nonlayer_fmac
@@ -79,6 +94,26 @@ DEFAULT_HARDWARE = {
     "MI455X": {"peak_tflops_bf16": 10000.0, "hbm_bandwidth_gbps": 19600.0},
 }
 
+# Measured multi-node anchors used to set/validate the site's calibFactor. The
+# projection, configured to the anchor's parallel layout, must reproduce these
+# (see design/06-calibration.md). flash: real 8-node MI355X run (image pr-768,
+# commit 2c9b). pro: production multi-node anchor still TODO (needs >=8 idle
+# nodes); until then pro reuses flash's cross-model calibFactor.
+MODEL_ANCHORS: dict[str, dict[str, Any]] = {
+    "flash": {
+        "measured_iter_time_ms": 4076.0,
+        "measured_anchor": {
+            "config": "PP8/VPP1/EP8/TP1, world 64, MBS1/GBS128, seq4096, full recompute, "
+                      "layout Et*4|t*5|(t*6|)*5,t*4mL (8-node MI355X)",
+            "iter_ms": 4076.0,
+            "tflops_gpu": 722,
+            "tok_s_gpu": 2010,
+            "calib_factor": 0.87,
+            "tolerance": "<0.1%",
+        },
+    },
+}
+
 ALL_MODULES = (
     "attn.proj",
     "attn.core",
@@ -111,6 +146,35 @@ def _dims_key(dims: Any) -> str:
         return json.dumps(dims, separators=(",", ":"))
     except TypeError:
         return str(dims)
+
+
+def _merge_intervals(intervals: list[tuple[float, float]], gap: float = 0.0) -> list[tuple[float, float]]:
+    """Merge [start, end] intervals; bridge neighbours separated by <= gap."""
+    out: list[tuple[float, float]] = []
+    for s, e in sorted(intervals):
+        if out and s <= out[-1][1] + gap:
+            out[-1] = (out[-1][0], max(out[-1][1], e))
+        else:
+            out.append((s, e))
+    return out
+
+
+def _make_membership(merged: list[tuple[float, float]]):
+    """Return a fn(ts)->bool: is ts inside one of the merged intervals."""
+    starts = [s for s, _ in merged]
+
+    def _in(ts: float | None) -> bool:
+        if ts is None or not merged:
+            return False
+        i = bisect.bisect_right(starts, ts) - 1
+        return i >= 0 and merged[i][0] <= ts <= merged[i][1]
+
+    return _in
+
+
+def _is_opt_or_comm_kernel(name: str) -> bool:
+    low = name.lower()
+    return "multi_tensor_apply" in name or "fusedadam" in low or "adamw" in low or "nccl" in low
 
 
 def _gemm_flops(dims_key: str) -> float | None:
@@ -228,6 +292,9 @@ def parse_trace(path: Path, ga: int = 2):
     cpu_by_extid: dict[Any, dict] = {}
     # interesting python_function intervals per tid: (ts, end, name)
     pf_by_tid: dict[Any, list[tuple[float, float, str]]] = defaultdict(list)
+    # `autograd::engine::evaluate_function` CPU intervals precisely bracket the
+    # backward pass; a kernel whose launching CPU op falls inside one is bwd.
+    eval_intervals: list[tuple[float, float]] = []
     kernels: list[dict] = []
     num_steps = 0  # real captured training steps (ProfilerStep events, dur>10ms)
 
@@ -240,6 +307,10 @@ def parse_trace(path: Path, ga: int = 2):
             ext = _arg(ev, "External id")
             if ext is not None and ext not in cpu_by_extid:
                 cpu_by_extid[ext] = ev
+            if ev.get("name", "").startswith("autograd::engine::evaluate_function"):
+                ets = ev.get("ts")
+                if ets is not None:
+                    eval_intervals.append((ets, ets + (ev.get("dur") or 0)))
         elif cat == "python_function" and ph == "X":
             name = ev.get("name", "")
             if name.startswith("nn.Module:") or "ackward" in name or "autograd" in name:
@@ -282,12 +353,54 @@ def parse_trace(path: Path, ga: int = 2):
     # and (b) sum dim-derived GEMM FLOPs correctly.
     num_mb = max(1, num_steps * ga)
 
+    # ---- phase classification (forward vs backward) ----------------------
+    # The backward pass is identified by the autograd engine: a kernel is
+    # backward iff its launching CPU op was issued inside an
+    # `autograd::engine::evaluate_function` interval (these precisely bracket
+    # the backward). A `_fwd_`/`_bwd_` tag in the kernel name (V4 Triton kernels
+    # encode it) wins. Unlinked kernels (no External id -> no CPU op; common for
+    # fused/elementwise launches Kineto fails to flow-link) are assigned by
+    # whether their GPU timestamp lands inside the backward GPU-time window
+    # rebuilt from the linked backward kernels. This replaces the old "default
+    # to forward" rule, which systematically leaked backward compute -- incl.
+    # the MoE dgrad/wgrad grouped GEMMs -- into the forward breakdown.
+    bwd_eval = _merge_intervals(eval_intervals)
+    in_bwd_eval = _make_membership(bwd_eval)
+
+    phase_by_idx: list[str | None] = [None] * len(kernels)
+    _bwd_windows: list[tuple[float, float]] = []
+    for i, ev in enumerate(kernels):
+        name = ev.get("name", "")
+        ln = name.lower()
+        if "_fwd" in ln and "_bwd" not in ln:
+            phase_by_idx[i] = "forward"
+            continue
+        if "_bwd" in ln:
+            phase_by_idx[i] = "backward"
+            if not _is_opt_or_comm_kernel(name) and ev["dur"] <= _MAX_PLAUSIBLE_LAUNCH_US:
+                _bwd_windows.append((ev["ts"], ev["ts"] + ev["dur"]))
+            continue
+        ext = _arg(ev, "External id")
+        cpu = cpu_by_extid.get(ext) if ext is not None else None
+        if cpu is not None:
+            ph = "backward" if in_bwd_eval(cpu.get("ts")) else "forward"
+            phase_by_idx[i] = ph
+            if ph == "backward" and not _is_opt_or_comm_kernel(name) and ev["dur"] <= _MAX_PLAUSIBLE_LAUNCH_US:
+                _bwd_windows.append((ev["ts"], ev["ts"] + ev["dur"]))
+        # else: unlinked -> decided below from the GPU-side backward window
+
+    in_bwd_gpu = _make_membership(_merge_intervals(_bwd_windows, _BWD_WINDOW_GAP_US))
+    for i, ev in enumerate(kernels):
+        if phase_by_idx[i] is None:
+            phase_by_idx[i] = "backward" if in_bwd_gpu(ev.get("ts")) else "forward"
+
     # (phase, module) -> { (kernel_name, dims_key): {"durs": [...], "flop_class", "flop_per_launch"} }
     groups: dict[tuple[str, str], dict] = defaultdict(dict)
     optimizer_us = 0.0
     dpcomm_us = 0.0
+    dropped_stall_us = 0.0
 
-    for ev in kernels:
+    for i, ev in enumerate(kernels):
         name = ev.get("name", "")
         dur = float(ev["dur"])
         ext = _arg(ev, "External id")
@@ -302,16 +415,12 @@ def parse_trace(path: Path, ga: int = 2):
         if module == "__dpcomm__":
             dpcomm_us += dur
             continue
-        # Phase: a kernel-name _fwd_/_bwd_ tag is authoritative (V4 triton
-        # kernels encode it). Otherwise use the backward-only "Fwd thread id".
-        ln = name.lower()
-        if "_fwd" in ln and "_bwd" not in ln:
-            phase = "forward"
-        elif "_bwd" in ln:
-            phase = "backward"
-        else:
-            fwd_tid = _arg(cpu, "Fwd thread id") if cpu else None
-            phase = "backward" if (fwd_tid is not None or "ackward" in cpu_name) else "forward"
+        # Drop one-off device-side stalls billed to a layer-compute kernel (see
+        # _MAX_PLAUSIBLE_LAUNCH_US); they are capture artifacts, not per-layer cost.
+        if dur > _MAX_PLAUSIBLE_LAUNCH_US:
+            dropped_stall_us += dur
+            continue
+        phase = phase_by_idx[i]
         dims_key = _dims_key(_arg(cpu, "Input Dims")) if cpu else ""
         flop_per_launch = _gemm_flops(dims_key) if (cpu and flop_class == "gemm") else None
         sub = groups[(phase, module)].setdefault(
@@ -322,6 +431,7 @@ def parse_trace(path: Path, ga: int = 2):
 
     optimizer_us /= max(1, num_steps)  # optimizer runs once per training iteration
     dpcomm_us /= num_mb
+    dropped_stall_us /= num_mb  # report per-microbatch, like the breakdown rows
 
     out = {b: {"forward": {}, "backward": {}} for b in ("attention", "moe", "embedding", "output", "loss")}
     for (phase, module), subs in groups.items():
@@ -374,7 +484,7 @@ def parse_trace(path: Path, ga: int = 2):
         else:
             bucket = "moe"
         out[bucket][phase][module] = entry
-    return out, optimizer_us, dpcomm_us
+    return out, optimizer_us, dpcomm_us, dropped_stall_us
 
 
 def _lists(bd: dict) -> dict:
@@ -397,10 +507,12 @@ def _fwd_total(buckets: dict) -> float:
 def build(model: str, traces: dict[str, Path], ga: int = 2) -> dict[str, Any]:
     cfg = MODEL_CONFIGS[model]
     per_cr, opt_us = {}, []
+    dropped_stall = {}
     for cr, path in traces.items():
-        buckets, o, _dp = parse_trace(path, ga)
+        buckets, o, _dp, stall = parse_trace(path, ga)
         per_cr[cr] = buckets
         opt_us.append(o)
+        dropped_stall[cr] = round(stall, 1)
 
     # Some cr layers (pure dense cr=0 / HCA cr=128) get CUDA-graph / stream-
     # captured, so their compute kernels are not individually visible in the
@@ -453,10 +565,13 @@ def build(model: str, traces: dict[str, Path], ga: int = 2) -> dict[str, Any]:
         "provenance": {
             "traces": {cr: str(p) for cr, p in traces.items()},
             "graphed_crs_estimated_from_cr4": graphed,
+            "dropped_stall_us_per_mb": dropped_stall,
             "note": (
                 "cr in graphed_crs_estimated_from_cr4 were CUDA-graph/stream-captured "
                 "(compute not visible in trace); their breakdown is copied from cr=4 as an "
-                "estimate. Re-run those cr with graph capture disabled for exact numbers."
+                "estimate. Re-run those cr with graph capture disabled for exact numbers. "
+                "dropped_stall_us_per_mb: per-mb layer-compute kernel time dropped as "
+                "implausible one-off device stalls (> _MAX_PLAUSIBLE_LAUNCH_US)."
             ),
         },
         "capture": {
@@ -469,7 +584,8 @@ def build(model: str, traces: dict[str, Path], ga: int = 2) -> dict[str, Any]:
             "optimizer": "adam",
             "distributed_optimizer": False,
             "recompute": "off",
-            "measured_iter_time_ms": None,
+            "measured_iter_time_ms": MODEL_ANCHORS.get(model, {}).get("measured_iter_time_ms"),
+            "measured_anchor": MODEL_ANCHORS.get(model, {}).get("measured_anchor"),
         },
         "model_config": {
             **cfg,


### PR DESCRIPTION
## Summary

Two commits on the DeepSeek-V4 performance-projection tool
(`deepseek-v4/projection`):

1. **feat: iteration-timeline view** (`3502b68b`) — a new 3-level view that
   visually decomposes one training iteration's time, bottom-up:
   - **Level 1 · layer** — one representative layer per compression ratio
     (`cr=0/4/128`), forward and backward split into `attn / mlp / a2a`.
   - **Level 2 · pipeline ranks** — each PP rank's chunks at layer granularity
     (coloured by `cr`, recomputed layers hatched); identical ranks are deduped
     and the critical stage (max fwd/bwd) is highlighted.
   - **Level 3 · schedule** — a 1F1B pipeline-schedule Gantt (interleaved when
     `VPP>1`), styled after the Megatron-2 paper (Fig. 4), with a zoom slider
     and SVG/PNG export.
   - Tabbed / stacked layouts with cross-level drill-down linkage, a sticky
     Projection-controls sidebar, and manual per-layer overrides extended to
     `embedding / output / loss / MTP`. Methodology in
     `design/07-iteration-timeline.md`.

2. **fix: correct fwd/bwd split in the trace parser** (`1a07b807`) — the
   kernel→phase attribution defaulted unlinked kernels to *forward*, leaking
   backward compute (incl. the MoE dgrad/wgrad grouped GEMMs) into the forward
   total and skewing the per-module fwd/bwd ratio. The phase is now determined
   in priority order: (1) `_fwd_`/`_bwd_` tag in the kernel name; (2) for linked
   kernels, whether the launching CPU op falls inside an autograd
   `evaluate_function` interval; (3) for unlinked kernels, whether the GPU
   timestamp lies in the reconstructed backward GPU-time window. Implausible
   one-off device stalls billed to compute kernels are dropped. The flash/pro
   breakdown JSON is regenerated with the fixed parser. (A13; see `design/02`.)

## Changes

- `site/` — `index.html`, `assets/app.js`, `assets/style.css`: timeline view,
  layouts, linkage, sidebar, manual non-layer overrides.
- `site/data/flash.json`, `site/data/pro.json`: regenerated breakdowns with the
  corrected fwd/bwd split.
- `tools/parse_trace.py`: fixed-phase kernel→module attribution.
- `design/02-assumptions.md` (A13), `design/04-projection-math.md`,
  `design/07-iteration-timeline.md`: docs.

## Test plan

- [ ] `python3 -m http.server -d deepseek-v4/projection/site 8000`; open
      `?model=pro` and `?model=flash`.
- [ ] Level 1 shows sane `attn/mlp/a2a` fwd/bwd bars; ratios look correct after
      the parser fix.
- [ ] Level 2 dedups identical PP ranks and highlights the critical stage.
- [ ] Level 3: default fits with no scrollbar; zoom reveals microbatch numbers;
      set `VPP>1` to see interleaving; Export SVG/PNG works.
- [ ] Tabbed↔Stacked, cross-level linkage, and manual per-layer/non-layer
      overrides behave as expected.
- [ ] `parse_trace.py` re-run reproduces the committed JSON.