### PR TITLE
perf(v4-attn): optimize `triton_v2` sparse-MLA forward + backward

### DIFF
--- a/deepseek-v4/benchmark/bench_v4_attention_results.md
+++ b/deepseek-v4/benchmark/bench_v4_attention_results.md
@@ -1,0 +1,74 @@
+# DeepSeek-V4 Attention — Backend Performance
+
+Full forward + backward benchmark of every V4 attention backend, produced by
+[`bench_v4_attention.py`](./bench_v4_attention.py).
+
+## Setup
+
+- **GPU**: AMD Instinct MI355X (gfx950), single GPU
+- **Config**: `seq_len=4096`, `mbs=1`, bf16, sink **on**, `swa_window=128`
+- **Models**: V4-Flash (`H=64`, index_topk=512), V4-Pro (`H=128`, index_topk=1024)
+- **Layer kinds**: `cr=0` dense/SWA, `cr=4` CSA (local SWA + sparse top-k pool),
+  `cr=128` HCA (local SWA + full compressed pool)
+- **Timing**: `--warmup 5 --iters 20`, median latency
+- **Cell format**: `latency ms | TFLOP/s`. TFLOP/s is over the *useful* work
+  (`2·T·H·TOPK·(D_V+D_V)`, head_dim=512; bwd = 2.5× fwd) with the **same formula
+  for every backend**, so rows are directly comparable (the fused backends'
+  zero-rope-pad overhead shows up in `ms`, not in counted FLOPs).
+
+## Backends
+
+| Backend | Description |
+|---------|-------------|
+| `triton` | Production separate-K/V Triton (dense/SWA/HCA launchers; cr=4 uses the split CSA pool fwd + segreduce bwd) |
+| `flydsl` | Legacy FlyDSL gathered CSA (**cr=4 only**, scalarized GEMV, no MFMA) — historical reference |
+| `gluon` | Fused single-latent (K==V) sparse-MLA, hand-tuned gfx950 gluon (async double-buffered pipeline) |
+| `triton_v2` | Fused single-latent sparse-MLA in plain Triton (`tl.dot` / MFMA) — **optimized in this PR** |
+| `flydsl_v1` | Fused single-latent sparse-MLA in native FlyDSL MFMA (**forward kernel WIP → FAIL**) |
+
+> FlyDSL requires the FlyDSL source at `/workspace/FlyDSL-amd` (clone
+> `https://github.com/ROCm/FlyDSL` tag `v0.2.2`) and the `flydsl` pip package.
+
+## Forward (`latency ms | TFLOP/s`)
+
+| variant | cr (layer) | triton | flydsl | gluon | triton_v2 | flydsl_v1 |
+|---------|-----------|--------|--------|-------|-----------|-----------|
+| flash | 0 (SWA)   | 0.47 \| 147.6 | — | 0.35 \| 197.4 | **0.31 \| 221.0** | FAIL |
+| flash | 4 (CSA)   | 1.40 \| 244.9 | 15.51 \| 22.2 | 1.01 \| 341.8 | **0.93 \| 369.4** | FAIL |
+| flash | 128 (HCA) | 0.68 \| 126.4 | — | 0.42 \| 205.9 | **0.39 \| 219.8** | FAIL |
+| pro | 0 (SWA)     | 0.84 \| 163.0 | — | 0.63 \| 219.5 | **0.58 \| 237.6** | FAIL |
+| pro | 4 (CSA)     | 4.01 \| 308.2 | 54.20 \| 22.8 | 3.05 \| 405.1 | **2.98 \| 414.5** | FAIL |
+| pro | 128 (HCA)   | 1.28 \| 133.8 | — | 0.77 \| 221.8 | **0.73 \| 236.8** | FAIL |
+
+## Backward (`latency ms | TFLOP/s`)
+
+| variant | cr (layer) | triton | flydsl | gluon | triton_v2 | flydsl_v1 |
+|---------|-----------|--------|--------|-------|-----------|-----------|
+| flash | 0 (SWA)   | 2.04 \| 84.4 | — | 1.21 \| 142.1 | **1.16 \| 148.6** | FAIL |
+| flash | 4 (CSA)   | 5.18 \| 165.8 | 2909.43 \| 0.3 | 5.28 \| 162.7 | **5.13 \| 167.6** | FAIL |
+| flash | 128 (HCA) | 3.04 \| 70.6 | — | 1.78 \| 120.9 | **1.72 \| 124.9** | FAIL |
+| pro | 0 (SWA)     | 3.94 \| 87.3 | — | 1.89 \| 182.1 | **1.79 \| 192.4** | FAIL |
+| pro | 4 (CSA)     | 15.02 \| 205.8 | 9413.50 \| 0.3 | 14.55 \| 212.6 | **10.87 \| 284.5** | FAIL |
+| pro | 128 (HCA)   | 5.92 \| 72.5 | — | 2.71 \| 158.4 | **2.48 \| 173.4** | FAIL |
+
+## Summary
+
+- **`triton_v2` is the fastest backend on all 6 shapes for both forward and
+  backward.** vs the hand-tuned `gluon`:
+  - Forward: **~1.02–1.13×** (geomean ~1.08×)
+  - Backward: **~1.02–1.34×** (geomean ~1.10×); `pro cr=4` bwd 10.87 ms vs 14.55 ms.
+- The production separate-K/V `triton` backend is significantly slower than the
+  fused backends, especially on backward dense/HCA.
+- `flydsl` (legacy) is cr=4-only and orders of magnitude slower (scalarized,
+  no MFMA); kept only as a historical reference.
+- `flydsl_v1` forward is an upstream WIP (`NotImplementedError`); fwd+bwd FAIL.
+
+## Reproduce
+
+```bash
+# one-time: FlyDSL source for the legacy cr=4 backend
+git clone --depth 1 --branch v0.2.2 https://github.com/ROCm/FlyDSL /workspace/FlyDSL-amd
+
+PYTHONPATH=<repo> python deepseek-v4/benchmark/bench_v4_attention.py \
+    --variant both --cr all --warmup 5 --iters 20
+```

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton_v2/dsa_bwd_kernels.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton_v2/dsa_bwd_kernels.py
@@ -1,0 +1,337 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""Owned plain-Triton backward compute kernels for the "triton v2" sparse-MLA
+backend. Forked from the shared ``_gluon_dsa/_dsa_bwd_gather.py`` plain-Triton
+kernels so this backend can be tuned independently of the gluon path.
+
+Three kernels implement the non-atomic chunked-gather backward:
+  * ``_bwd_chunk_dq_store_ds`` — dQ accumulation for one rank chunk, ALSO stores
+    per-tile dS and P to [T, H, R_CHUNK] buffers for reuse by the dKV kernel.
+  * ``_bwd_compute_dkv_intermediate`` — dKV intermediate for one chunk, REUSES
+    the stored dS/P (no S/P/dS recompute). Consumes q/do transposed to [T, D, H].
+  * ``_bwd_dkv_gather_acc`` — CSR inverted-topk reduce of the intermediate into
+    the fp32 dKV accumulator.
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _bwd_chunk_dq_store_ds(
+    Q_ptr,  # [T, H, D] bf16
+    KV_ptr,  # [T, 1, D] bf16
+    dO_ptr,  # [T, H, D_V] bf16
+    TopK_ptr,  # [T, TOPK] int32
+    LSE_ptr,  # [T, H] fp32
+    Delta_ptr,  # [T, H] fp32 (computed here on the first chunk, read after)
+    O_ptr,  # [T, H, D_V] bf16 (fwd output, for Delta = rowsum(O*dO))
+    dQ_ptr,  # [T, H, D] bf16 — read-modify-write across chunks
+    dS_ptr,  # [T, H, R_CHUNK] bf16 — output chunk dS
+    P_ptr,  # [T, H, R_CHUNK] bf16 — output chunk P
+    stride_q_t: tl.int64,
+    stride_q_h: tl.int64,
+    stride_kv_t: tl.int64,
+    stride_do_t: tl.int64,
+    stride_do_h: tl.int64,
+    stride_o_t: tl.int64,
+    stride_o_h: tl.int64,
+    stride_dq_t: tl.int64,
+    stride_dq_h: tl.int64,
+    stride_topk_t: tl.int64,
+    stride_ds_t: tl.int64,
+    stride_ds_h: tl.int64,
+    scale: tl.float32,
+    num_heads: tl.int32,
+    R_START: tl.int32,
+    R_CHUNK: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    TILE_K: tl.constexpr,
+    D_V: tl.constexpr,
+    D_ROPE: tl.constexpr,
+    HAS_ROPE: tl.constexpr,
+    IS_FIRST_CHUNK: tl.constexpr,
+):
+    """dQ accumulation for rank chunk [R_START, R_START+R_CHUNK), plus stores
+    chunk dS and P to [T, H, R_CHUNK] buffers for _bwd_compute_dkv_intermediate.
+    Grid: (total_tokens, num_hg).
+
+    Delta = rowsum(O*dO) is fused here (computed + stored on the first chunk,
+    reloaded on later chunks) instead of a separate preprocess kernel — dO is
+    already resident, so this only adds the O load and drops a whole kernel + a
+    duplicate dO read.
+
+    HAS_ROPE=False (V4 zero-pad): skips all rope MMAs/loads and writes the dQ rope
+    columns as zero (they are discarded downstream but kept well-defined)."""
+    token_idx = tl.program_id(0)
+    hg_idx = tl.program_id(1)
+    offs_h = hg_idx * BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = offs_h < num_heads
+    offs_v = tl.arange(0, D_V)
+    offs_r = tl.arange(0, D_ROPE)
+
+    q_base = token_idx * stride_q_t
+    Q_lora = tl.load(
+        Q_ptr + q_base + offs_h[:, None] * stride_q_h + offs_v[None, :], mask=mask_h[:, None], other=0.0
+    )
+    if HAS_ROPE:
+        Q_rope = tl.load(
+            Q_ptr + q_base + offs_h[:, None] * stride_q_h + (D_V + offs_r[None, :]),
+            mask=mask_h[:, None],
+            other=0.0,
+        )
+    do_base = token_idx * stride_do_t
+    dO_val = tl.load(
+        dO_ptr + do_base + offs_h[:, None] * stride_do_h + offs_v[None, :], mask=mask_h[:, None], other=0.0
+    )
+    lse = tl.load(LSE_ptr + token_idx * num_heads + offs_h, mask=mask_h, other=0.0)
+    if IS_FIRST_CHUNK:
+        # Delta = rowsum(O * dO): fold the preprocess in (dO already loaded).
+        O_val = tl.load(
+            O_ptr + token_idx * stride_o_t + offs_h[:, None] * stride_o_h + offs_v[None, :],
+            mask=mask_h[:, None],
+            other=0.0,
+        )
+        delta = tl.sum(O_val.to(tl.float32) * dO_val.to(tl.float32), axis=1)
+        tl.store(Delta_ptr + token_idx * num_heads + offs_h, delta, mask=mask_h)
+    else:
+        delta = tl.load(Delta_ptr + token_idx * num_heads + offs_h, mask=mask_h, other=0.0)
+
+    dq_base = token_idx * stride_dq_t
+    if IS_FIRST_CHUNK:
+        dQ_lora = tl.zeros([BLOCK_H, D_V], dtype=tl.float32)
+    else:
+        dQ_lora = tl.load(
+            dQ_ptr + dq_base + offs_h[:, None] * stride_dq_h + offs_v[None, :],
+            mask=mask_h[:, None],
+            other=0.0,
+        ).to(tl.float32)
+    if HAS_ROPE:
+        if IS_FIRST_CHUNK:
+            dQ_rope = tl.zeros([BLOCK_H, D_ROPE], dtype=tl.float32)
+        else:
+            dQ_rope = tl.load(
+                dQ_ptr + dq_base + offs_h[:, None] * stride_dq_h + (D_V + offs_r[None, :]),
+                mask=mask_h[:, None],
+                other=0.0,
+            ).to(tl.float32)
+
+    NUM_TILES: tl.constexpr = (R_CHUNK + TILE_K - 1) // TILE_K
+    topk_base = token_idx * stride_topk_t + R_START
+    offs_tile = tl.arange(0, TILE_K)
+    ds_base = token_idx * stride_ds_t + hg_idx * BLOCK_H * stride_ds_h
+
+    for t in range(NUM_TILES):
+        tile_start = t * TILE_K
+        tile_offs = tile_start + offs_tile
+        valid = tile_offs < R_CHUNK
+        topk_pos = tl.load(TopK_ptr + topk_base + tile_offs, mask=valid, other=-1)
+        valid = valid & (topk_pos != -1)
+        safe_pos = tl.where(valid, topk_pos, 0)
+
+        K_lora_T = tl.load(
+            KV_ptr + safe_pos[None, :] * stride_kv_t + offs_v[:, None], mask=valid[None, :], other=0.0
+        )
+
+        S = tl.dot(Q_lora, K_lora_T)
+        if HAS_ROPE:
+            K_rope_T = tl.load(
+                KV_ptr + safe_pos[None, :] * stride_kv_t + (D_V + offs_r[:, None]),
+                mask=valid[None, :],
+                other=0.0,
+            )
+            S += tl.dot(Q_rope, K_rope_T)
+        S = tl.where(valid[None, :] & mask_h[:, None], S * scale, float("-inf"))
+        P = tl.exp(S - lse[:, None])
+        P = tl.where(valid[None, :] & mask_h[:, None], P, 0.0)
+        dP = tl.dot(dO_val, K_lora_T)
+        dS = P * (dP - delta[:, None]) * scale
+        dS = tl.where(valid[None, :] & mask_h[:, None], dS, 0.0)
+
+        dS_bf = dS.to(tl.bfloat16)
+        dQ_lora += tl.dot(dS_bf, tl.trans(K_lora_T)).to(tl.float32)
+        if HAS_ROPE:
+            dQ_rope += tl.dot(dS_bf, tl.trans(K_rope_T)).to(tl.float32)
+
+        local_h = tl.arange(0, BLOCK_H)
+        tl.store(
+            dS_ptr + ds_base + local_h[:, None] * stride_ds_h + tile_offs[None, :],
+            dS_bf,
+            mask=mask_h[:, None] & valid[None, :],
+        )
+        tl.store(
+            P_ptr + ds_base + local_h[:, None] * stride_ds_h + tile_offs[None, :],
+            P.to(tl.bfloat16),
+            mask=mask_h[:, None] & valid[None, :],
+        )
+
+    tl.store(
+        dQ_ptr + dq_base + offs_h[:, None] * stride_dq_h + offs_v[None, :],
+        dQ_lora.to(Q_lora.dtype),
+        mask=mask_h[:, None],
+    )
+    if HAS_ROPE:
+        tl.store(
+            dQ_ptr + dq_base + offs_h[:, None] * stride_dq_h + (D_V + offs_r[None, :]),
+            dQ_rope.to(Q_lora.dtype),
+            mask=mask_h[:, None],
+        )
+    else:
+        tl.store(
+            dQ_ptr + dq_base + offs_h[:, None] * stride_dq_h + (D_V + offs_r[None, :]),
+            tl.zeros([BLOCK_H, D_ROPE], dtype=Q_lora.dtype),
+            mask=mask_h[:, None],
+        )
+
+
+@triton.jit
+def _bwd_compute_dkv_intermediate(
+    Q_ptr,  # [T, H, D_QK] bf16  (UNtransposed; loaded transposed via strided index)
+    dO_ptr,  # [T, H, D_V]  bf16 (UNtransposed)
+    dS_ptr,  # [T, H, R_CHUNK] bf16
+    P_ptr,  # [T, H, R_CHUNK] bf16
+    Interm_ptr,  # [T, R_CHUNK, D_QK] bf16 — output, one writer per (q, rank)
+    stride_q_t: tl.int64,
+    stride_q_h: tl.int64,
+    stride_do_t: tl.int64,
+    stride_do_h: tl.int64,
+    stride_ds_t: tl.int64,
+    stride_ds_h: tl.int64,
+    stride_interm_t: tl.int64,  # R_CHUNK * D_QK
+    stride_interm_k: tl.int64,  # D_QK
+    num_heads: tl.int32,
+    R_CHUNK: tl.constexpr,
+    TILE_K: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    NUM_HG: tl.constexpr,
+    D_V: tl.constexpr,
+    D_ROPE: tl.constexpr,
+    HAS_ROPE: tl.constexpr,
+):
+    """dKV intermediate for one chunk, REUSING stored dS/P (no recompute).
+    Loads Q/dO UNtransposed with a [D, BLOCK_H] strided index pattern (contiguous
+    along D per head), removing the external q.transpose(1,2).contiguous() /
+    do.transpose(...).contiguous() copies. Grid: (total_tokens,).
+
+    HAS_ROPE=False (V4 zero-pad): skips Q_rope load, the dKV_rope MMA and the
+    interm rope store (interm rope columns are never read by the gather)."""
+    token_idx = tl.program_id(0)
+
+    NUM_TILES: tl.constexpr = (R_CHUNK + TILE_K - 1) // TILE_K
+    offs_tile = tl.arange(0, TILE_K)
+    offs_v = tl.arange(0, D_V)
+    offs_r = tl.arange(0, D_ROPE)
+
+    interm_base_t = token_idx * stride_interm_t
+    q_base = token_idx * stride_q_t
+    do_base = token_idx * stride_do_t
+    ds_base = token_idx * stride_ds_t
+
+    for t in range(NUM_TILES):
+        tile_start = t * TILE_K
+        tile_offs = tile_start + offs_tile
+        valid = tile_offs < R_CHUNK
+
+        dKV_lora = tl.zeros([D_V, TILE_K], dtype=tl.float32)
+        if HAS_ROPE:
+            dKV_rope = tl.zeros([D_ROPE, TILE_K], dtype=tl.float32)
+
+        for hg in range(NUM_HG):
+            offs_h = hg * BLOCK_H + tl.arange(0, BLOCK_H)
+            mask_h = offs_h < num_heads
+
+            # [D_V, BLOCK_H] loaded transposed: rows=offs_v (stride 1, contiguous),
+            # cols=offs_h (stride stride_q_h). No HBM transpose copy needed.
+            Q_lora_T = tl.load(
+                Q_ptr + q_base + offs_h[None, :] * stride_q_h + offs_v[:, None],
+                mask=mask_h[None, :],
+                other=0.0,
+            )
+            dO_T = tl.load(
+                dO_ptr + do_base + offs_h[None, :] * stride_do_h + offs_v[:, None],
+                mask=mask_h[None, :],
+                other=0.0,
+            )
+
+            dS_val = tl.load(
+                dS_ptr + ds_base + offs_h[:, None] * stride_ds_h + tile_offs[None, :],
+                mask=mask_h[:, None] & valid[None, :],
+                other=0.0,
+            )
+            P_val = tl.load(
+                P_ptr + ds_base + offs_h[:, None] * stride_ds_h + tile_offs[None, :],
+                mask=mask_h[:, None] & valid[None, :],
+                other=0.0,
+            )
+
+            dKV_lora += tl.dot(Q_lora_T, dS_val.to(Q_lora_T.dtype)).to(tl.float32)
+            dKV_lora += tl.dot(dO_T, P_val.to(dO_T.dtype)).to(tl.float32)
+            if HAS_ROPE:
+                Q_rope_T = tl.load(
+                    Q_ptr + q_base + offs_h[None, :] * stride_q_h + (D_V + offs_r[:, None]),
+                    mask=mask_h[None, :],
+                    other=0.0,
+                )
+                dKV_rope += tl.dot(Q_rope_T, dS_val.to(Q_rope_T.dtype)).to(tl.float32)
+
+        interm_lora_ptrs = Interm_ptr + interm_base_t + tile_offs[None, :] * stride_interm_k + offs_v[:, None]
+        tl.store(interm_lora_ptrs, dKV_lora.to(tl.bfloat16), mask=valid[None, :])
+
+        if HAS_ROPE:
+            interm_rope_ptrs = (
+                Interm_ptr + interm_base_t + tile_offs[None, :] * stride_interm_k + D_V + offs_r[:, None]
+            )
+            tl.store(interm_rope_ptrs, dKV_rope.to(tl.bfloat16), mask=valid[None, :])
+
+
+@triton.jit
+def _bwd_dkv_gather_acc(
+    Interm_ptr,  # [T, R_CHUNK, D] bf16 — chunk intermediate
+    InvPtr_ptr,  # [T+1] int32 — CSR row pointers
+    InvData_ptr,  # [T*R_CHUNK] int32 — encoded as q*R_CHUNK + local_r
+    dKV_acc_ptr,  # [T, D] fp32 — accumulator (read-modify-write across chunks)
+    stride_interm_r: tl.int64,  # D
+    stride_acc_t: tl.int64,  # D
+    D_V: tl.constexpr,
+    D_ROPE: tl.constexpr,
+    HAS_ROPE: tl.constexpr,
+    BLOCK_K: tl.constexpr = 64,
+):
+    """Gather one chunk's bf16 intermediate into the fp32 dKV accumulator.
+    Grid: (num_kv,) — one CTA per KV token, no atomics. Tiled BLOCK_K rows/iter.
+
+    HAS_ROPE=False (V4 zero-pad): interm rope columns are never written, so skip
+    reading/accumulating them; dKV_acc rope stays at its zero-init value."""
+    k = tl.program_id(0)
+    offs_v = tl.arange(0, D_V)
+    offs_r = tl.arange(0, D_ROPE)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    start = tl.load(InvPtr_ptr + k)
+    end = tl.load(InvPtr_ptr + k + 1)
+
+    acc_base = k.to(tl.int64) * stride_acc_t
+    dkv_acc_lora = tl.load(dKV_acc_ptr + acc_base + offs_v).to(tl.float32)
+    if HAS_ROPE:
+        dkv_acc_rope = tl.load(dKV_acc_ptr + acc_base + D_V + offs_r).to(tl.float32)
+
+    n_entries = end - start
+    for ti in range(0, tl.cdiv(n_entries, BLOCK_K)):
+        e_local = ti * BLOCK_K + offs_k
+        valid = e_local < n_entries
+        entry = tl.load(InvData_ptr + start + e_local, mask=valid, other=0).to(tl.int64)
+        rp = entry[:, None] * stride_interm_r
+        rows_v = tl.load(Interm_ptr + rp + offs_v[None, :], mask=valid[:, None], other=0.0).to(tl.float32)
+        dkv_acc_lora += tl.sum(rows_v, axis=0)
+        if HAS_ROPE:
+            rows_r = tl.load(Interm_ptr + rp + D_V + offs_r[None, :], mask=valid[:, None], other=0.0).to(
+                tl.float32
+            )
+            dkv_acc_rope += tl.sum(rows_r, axis=0)
+
+    tl.store(dKV_acc_ptr + acc_base + offs_v, dkv_acc_lora)
+    if HAS_ROPE:
+        tl.store(dKV_acc_ptr + acc_base + D_V + offs_r, dkv_acc_rope)

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton_v2/dsa_bwd_v4_triton.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton_v2/dsa_bwd_v4_triton.py
@@ -21,15 +21,15 @@ reduction ``-sum_t exp(sink - lse) * delta``.
 import torch
 import triton
 
-# These bwd-gather kernels are plain @triton.jit (not gluon) and backend-neutral;
-# reuse them rather than duplicate ~600 lines.
-from .._gluon_dsa._dsa_bwd_gather import (
-    _build_inverted_topk_slice,
-    _bwd_chunk_dkv_interm,
-    _bwd_chunk_dq,
+# CSR-inverted-topk builder + Delta preprocess are backend-neutral torch/host
+# helpers; reuse them. The compute kernels are owned locally (dsa_bwd_kernels)
+# so this backend can be tuned independently of the gluon path.
+from .._gluon_dsa._dsa_bwd_gather import _build_inverted_topk_slice
+from .dsa_bwd_kernels import (
+    _bwd_chunk_dq_store_ds,
+    _bwd_compute_dkv_intermediate,
     _bwd_dkv_gather_acc,
 )
-from .._gluon_dsa._dsa_bwd_preprocess import _sparse_mla_bwd_preprocess
 
 
 def sparse_mla_bwd_v4_triton(q, kv, o, do, topk_indices, lse, attn_sink=None, kv_lora_rank=512, scale=None):
@@ -54,34 +54,46 @@ def sparse_mla_bwd_v4_triton(q, kv, o, do, topk_indices, lse, attn_sink=None, kv
     if has_sink:
         assert attn_sink.dtype == torch.float32 and attn_sink.shape == (num_heads,)
 
-    # ---- preprocess: Delta = rowsum(O*dO) ----
+    # Delta = rowsum(O*dO) is fused into the first dQ chunk (no preprocess kernel).
     delta = torch.empty(total_tokens, num_heads, dtype=torch.float32, device=q.device)
-    BLOCK_H_PRE = triton.next_power_of_2(min(64, num_heads))
-    _sparse_mla_bwd_preprocess[(total_tokens, triton.cdiv(num_heads, BLOCK_H_PRE))](
-        O_ptr=o,
-        dO_ptr=do,
-        Delta_ptr=delta,
-        stride_o_t=o.stride(0),
-        stride_o_h=o.stride(1),
-        num_heads=num_heads,
-        D_V=kv_lora_rank,
-        BLOCK_H=BLOCK_H_PRE,
-    )
 
     # ---- config (mirror the gluon bwd chunking) ----
-    R_CHUNK = min(256, topk)
+    # R_CHUNK (rank-chunk width): dQ is read-modify-written across chunks, so more
+    # chunks = more redundant dq reload passes + repeated launches/CSR builds. For
+    # high head counts (H>=128) the dq RMW volume is large, so a single chunk over
+    # the whole topk (bounded for memory) is a big win (-22% on pro cr4). For low
+    # head counts (H<=64) the smaller dq RMW is outweighed by the larger per-chunk
+    # buffers/occupancy, and 256 stays best — so keep the cap there.
+    if num_heads >= 128:
+        R_CHUNK = min(topk, 1536)
+    else:
+        R_CHUNK = min(256, topk)
     BH_DQ, TK_DQ = 64, 16
-    BH_DKV, TK_DKV = 32, 64
+    # dKV tiling: the default (BH_DKV=32, TK_DKV=64) is best for high head counts
+    # (H>=128) and for chunk widths that are not 128-aligned. For low head counts
+    # (H<=64) with a 128-aligned chunk, a wider TILE_K=128 over a single head-group
+    # (BH_DKV=64, NUM_HG=1) reduces redundant Q/dO re-loads and issues fuller MMAs,
+    # which is faster there; it regresses for H>=128 (register pressure) and for
+    # non-128-aligned chunks (partial tiles), so it is guarded on both.
+    if num_heads <= 64 and R_CHUNK % 128 == 0:
+        BH_DKV, TK_DKV = 64, 128
+    else:
+        BH_DKV, TK_DKV = 32, 64
     num_hg_dq = triton.cdiv(num_heads, BH_DQ)
     num_hg_dkv = triton.cdiv(num_heads, BH_DKV)
 
+    # In the V4 single-latent form the D_ROPE block of q/kv is a zero pad (RoPE is
+    # baked in-place over the 512 latent) and its gradient is discarded by the
+    # adapter (dq[..., :D_V], dkv[..., :D_V]). So all rope MMAs / K_rope loads /
+    # interm-rope traffic compute a provably-zero result that is thrown away.
+    # Skip them: bit-identical non-rope outputs, zero rope outputs (== gluon).
+    HAS_ROPE = False
+
     dq = torch.empty_like(q)
+    chunk_dS = torch.empty(total_tokens, num_heads, R_CHUNK, dtype=torch.bfloat16, device=q.device)
+    chunk_P = torch.empty(total_tokens, num_heads, R_CHUNK, dtype=torch.bfloat16, device=q.device)
     dkv_acc = torch.zeros(num_kv, d_qk, dtype=torch.float32, device=q.device)
     interm = torch.empty(total_tokens, R_CHUNK, d_qk, dtype=torch.bfloat16, device=q.device)
-
-    # dKV-interm consumes q/do transposed to [T, D, H].
-    q_t = q.transpose(1, 2).contiguous()
-    do_t = do[..., :kv_lora_rank].transpose(1, 2).contiguous()
 
     # pad topk to an R_CHUNK multiple (-1 = invalid).
     topk_padded_len = ((topk + R_CHUNK - 1) // R_CHUNK) * R_CHUNK
@@ -99,22 +111,29 @@ def sparse_mla_bwd_v4_triton(q, kv, o, do, topk_indices, lse, attn_sink=None, kv
     for chunk_idx, r_start in enumerate(range(0, topk, R_CHUNK)):
         is_first = r_start == 0
 
-        _bwd_chunk_dq[(total_tokens, num_hg_dq)](
+        _bwd_chunk_dq_store_ds[(total_tokens, num_hg_dq)](
             q,
             kv,
             do,
             topk_padded,
             lse,
             delta,
+            o,
             dq,
+            chunk_dS,
+            chunk_P,
             q.stride(0),
             q.stride(1),
             kv.stride(0),
             do.stride(0),
             do.stride(1),
+            o.stride(0),
+            o.stride(1),
             dq.stride(0),
             dq.stride(1),
             topk_padded.stride(0),
+            chunk_dS.stride(0),
+            chunk_dS.stride(1),
             scale,
             num_heads,
             r_start,
@@ -123,34 +142,34 @@ def sparse_mla_bwd_v4_triton(q, kv, o, do, topk_indices, lse, attn_sink=None, kv
             TILE_K=TK_DQ,
             D_V=kv_lora_rank,
             D_ROPE=rope_rank,
+            HAS_ROPE=HAS_ROPE,
             IS_FIRST_CHUNK=is_first,
             num_warps=4,
             waves_per_eu=1,
         )
 
-        _bwd_chunk_dkv_interm[(total_tokens,)](
-            q_t,
-            do_t,
-            topk_padded,
-            lse,
-            delta,
-            kv,
+        _bwd_compute_dkv_intermediate[(total_tokens,)](
+            q,
+            do,
+            chunk_dS,
+            chunk_P,
             interm,
-            q_t.stride(0),
-            do_t.stride(0),
-            topk_padded.stride(0),
-            kv.stride(0),
+            q.stride(0),
+            q.stride(1),
+            do.stride(0),
+            do.stride(1),
+            chunk_dS.stride(0),
+            chunk_dS.stride(1),
             interm.stride(0),
             interm.stride(1),
-            scale,
             num_heads,
-            r_start,
             R_CHUNK=R_CHUNK,
             TILE_K=TK_DKV,
             BLOCK_H=BH_DKV,
             NUM_HG=num_hg_dkv,
             D_V=kv_lora_rank,
             D_ROPE=rope_rank,
+            HAS_ROPE=HAS_ROPE,
             num_warps=4,
         )
 
@@ -164,6 +183,7 @@ def sparse_mla_bwd_v4_triton(q, kv, o, do, topk_indices, lse, attn_sink=None, kv
             dkv_acc.stride(0),
             D_V=kv_lora_rank,
             D_ROPE=rope_rank,
+            HAS_ROPE=HAS_ROPE,
             num_warps=4,
         )
 

--- a/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton_v2/dsa_fwd_v4_triton.py
+++ b/primus/backends/megatron/core/transformer/v4_attention_kernels/_triton_v2/dsa_fwd_v4_triton.py
@@ -25,15 +25,19 @@ import triton.language as tl
 
 
 def _get_fwd_configs():
+    # Focused around the autotune winners from the wide sweep (TILE_K=16,
+    # num_stages=3 dominated -> latency-bound; deep pipelining is the lever), plus
+    # num_stages=4 to probe deeper pipelining. Keeps first-call autotune cheap.
     return [
-        triton.Config({"BLOCK_H": bh, "TILE_K": tk}, num_warps=4, num_stages=ns)
-        for bh in (16, 32, 64)
-        for tk in (32, 64)
-        for ns in (1, 2)
+        triton.Config({"BLOCK_H": bh, "TILE_K": tk, "waves_per_eu": wpe}, num_warps=4, num_stages=ns)
+        for bh in (32, 64)
+        for tk in (16, 32)
+        for ns in (2, 3, 4)
+        for wpe in (0, 1)
     ]
 
 
-@triton.autotune(configs=_get_fwd_configs(), key=["num_heads", "TOPK", "D_V", "D_ROPE"])
+@triton.autotune(configs=_get_fwd_configs(), key=["num_heads", "TOPK", "D_V", "D_ROPE", "HAS_ROPE"])
 @triton.jit
 def _sparse_mla_fwd_tr_kernel(
     Q_ptr,  # [total_tokens, num_heads, D_QK] bf16
@@ -55,6 +59,7 @@ def _sparse_mla_fwd_tr_kernel(
     TILE_K: tl.constexpr,
     D_V: tl.constexpr,
     D_ROPE: tl.constexpr,
+    HAS_ROPE: tl.constexpr,
     HAS_SINK: tl.constexpr,
 ):
     tok = tl.program_id(0)
@@ -67,7 +72,8 @@ def _sparse_mla_fwd_tr_kernel(
 
     q_base = tok.to(tl.int64) * stride_q_t + offs_h.to(tl.int64)[:, None] * stride_q_h
     q_lora = tl.load(Q_ptr + q_base + offs_v[None, :], mask=mask_h[:, None], other=0.0)
-    q_rope = tl.load(Q_ptr + q_base + (D_V + offs_r)[None, :], mask=mask_h[:, None], other=0.0)
+    if HAS_ROPE:
+        q_rope = tl.load(Q_ptr + q_base + (D_V + offs_r)[None, :], mask=mask_h[:, None], other=0.0)
 
     m_i = tl.full([BLOCK_H], float("-inf"), dtype=tl.float32)
     l_i = tl.zeros([BLOCK_H], dtype=tl.float32)
@@ -82,11 +88,12 @@ def _sparse_mla_fwd_tr_kernel(
 
         kv_base = safe[:, None] * stride_kv_t
         k_lora = tl.load(KV_ptr + kv_base + offs_v[None, :], mask=valid[:, None], other=0.0)
-        k_rope = tl.load(KV_ptr + kv_base + (D_V + offs_r)[None, :], mask=valid[:, None], other=0.0)
 
         # S = q @ k^T over [lora ++ rope]  -> [BLOCK_H, TILE_K]
         s = tl.dot(q_lora, tl.trans(k_lora))
-        s += tl.dot(q_rope, tl.trans(k_rope))
+        if HAS_ROPE:
+            k_rope = tl.load(KV_ptr + kv_base + (D_V + offs_r)[None, :], mask=valid[:, None], other=0.0)
+            s += tl.dot(q_rope, tl.trans(k_rope))
         s = s * scale
         s = tl.where(valid[None, :] & mask_h[:, None], s, float("-inf"))
 
@@ -153,6 +160,10 @@ def sparse_mla_fwd_v4_triton(q, kv, topk_indices, attn_sink=None, kv_lora_rank=5
     o = torch.empty(total_tokens, num_heads, kv_lora_rank, dtype=q.dtype, device=q.device)
     lse = torch.empty(total_tokens, num_heads, dtype=torch.float32, device=q.device)
 
+    # V4 single-latent form: the D_ROPE block of q/kv is a zero pad (RoPE baked
+    # in-place over the 512 latent), so the rope QK term is provably zero — skip it.
+    has_rope = False
+
     grid = lambda META: (total_tokens, triton.cdiv(num_heads, META["BLOCK_H"]))
     _sparse_mla_fwd_tr_kernel[grid](
         Q_ptr=q,
@@ -172,6 +183,7 @@ def sparse_mla_fwd_v4_triton(q, kv, topk_indices, attn_sink=None, kv_lora_rank=5
         TOPK=topk,
         D_V=kv_lora_rank,
         D_ROPE=rope_rank,
+        HAS_ROPE=has_rope,
         HAS_SINK=has_sink,
     )
     return o, lse


### PR DESCRIPTION
# perf(v4-attn): optimize `triton_v2` sparse-MLA forward + backward

Optimizes the plain-Triton fused single-latent sparse-MLA backend (`triton_v2`)
so it beats the hand-tuned `gluon` backend on **every** V4 attention shape, for
both forward and backward, while matching eager accuracy. No changes to any other
backend (`gluon` / `triton` / `flydsl` untouched).

Target GPU: **MI355X (gfx950)**. Shapes: `cr={0,4,128}` × `{flash H=64, pro H=128}`,
`S=4096`, `mbs=1`, bf16, sink on, `swa=128`.

## What changed

`primus/backends/megatron/core/transformer/v4_attention_kernels/_triton_v2/`
- `dsa_bwd_v4_triton.py`, new `dsa_bwd_kernels.py` (owned bwd compute kernels)
- `dsa_fwd_v4_triton.py`

**Backward**
- Reuse `dS`/`P` from the dQ kernel instead of recomputing `S/P/dS` in the dKV kernel.
- Load `q`/`do` untransposed via a strided `[D, BLOCK_H]` index → drop the
  `.transpose(1,2).contiguous()` HBM copies.
- Skip the provably-zero rope compute (V4 bakes RoPE in-place; the 64-dim rope pad
  is zero and its grad is discarded by the adapter).
- Adaptive dKV tiling for `H<=64`; single-chunk `R_CHUNK` for `H>=128`.
- Fuse `Delta = rowsum(O*dO)` into the dQ kernel (drop the separate preprocess kernel).

**Forward**
- Skip the provably-zero rope QK term.
- Widen then focus the autotune space (`TILE_K=16` + `num_stages=3` win → latency-bound).

## Backward performance trend (geomean bwd TFLOPS / speedup vs gluon)

Reference gluon bwd geomean: **160.7 TFLOPS**.

| Round | Status | Change | Bwd geomean TFLOPS | vs gluon | Shapes won |
|------:|--------|--------|-------------------:|---------:|:----------:|
| 1 | BASELINE | recompute-dKV + external transpose copies | 52.1 | 0.324 | 0/6 |
| 2 | ACCEPTED | store dS/P in dQ, reuse in dKV (no recompute) | 105.5 | 0.658 | 0/6 |
| 3 | ACCEPTED | drop q/do transpose copies (load untransposed) | 154.1 | 0.967 | 1/6 |
| 4 | ROLLBACK | config sweep (BLOCK_H/TILE_K/warps/wpe/stages) | 154.1 | 0.967 | 1/6 |
| 5 | ACCEPTED | skip provably-zero rope compute (V4 zero-pad) | 160.9 | 1.016 | 4/6 |
| 6 | ROLLBACK | num_stages=2 pipelining | 160.9 | 1.016 | 4/6 |
| 7 | ACCEPTED | adaptive dKV tiling (H<=64 & R_CHUNK%128==0) | 168.2 | 1.033 | 6/6 |
| 8 | ROLLBACK | atomic dKV (drop interm+gather+CSR) | 55.6 | 0.345 | 0/6 |
| 9 | ACCEPTED | adaptive R_CHUNK: single-chunk for H>=128 | 172.1 | 1.075 | 6/6 |
| 10 | ACCEPTED | fuse Delta=rowsum(O*dO) into dQ (drop preprocess) | **175.6** | **1.099** | **6/6** |

Net: **0.32× → 1.10× gluon** (≈3.4× vs the original triton_v2 bwd); `pro cr4` bwd
reaches 284 TFLOPS (1.34×).

## Forward performance trend (geomean fwd TFLOPS / speedup vs gluon)

Reference gluon fwd geomean: **257 TFLOPS**. (Goal was 1.2×; not reached — see note.)

| Round | Status | Change | Fwd geomean TFLOPS | vs gluon | Shapes ≥1.2× |
|------:|--------|--------|-------------------:|---------:|:------------:|
| 1 | BASELINE | plain flash kernel, narrow autotune, computes zero rope | 230 | 0.896 | 0/6 |
| 2 | ACCEPTED | skip zero-rope QK term (V4 zero-pad) | 243 | 0.945 | 0/6 |
| 3 | ACCEPTED | expand autotune {BH:16/32/64, TK:16/32/64/128, ns:1/2/3, wpe:0/1/2} | 277 | 1.088 | 0/6 |
| 4 | ACCEPTED | focus autotune {BH:32/64, TK:16/32, ns:2/3/4, wpe:0/1} (24 cfg, 5× faster tune) | ~276 | ~1.085 | 0/6 |
| 5 | ROLLBACK | add num_warps=8 | ~273 | ~1.074 | 0/6 |

Net: **0.90× → ~1.08× gluon** (triton_v2 fwd went from slower-than-gluon to beating
gluon on all 6 shapes). The 1.2× target is not achievable in plain Triton: profiling
shows the fwd is occupancy/register-bound (~13.6% occupancy, `MemUnitStalled≈0`,
`MfmaUtil≈20%`, `VALUBusy≈33%`) — the `acc[BLOCK_H,512]` fp32 accumulator caps
occupancy. This is the same wall gluon hits, which gluon overcomes only via its
hand-scheduled async double-buffered LDS pipeline (not expressible in plain Triton).

## Final benchmark — all backends

MI355X (gfx950), `S=4096`, `mbs=1`, bf16, sink on, `swa=128`, `--warmup 5 --iters 20`.
Cell = `latency ms | TFLOP/s` (useful-work FLOPs, same formula for every backend).

**Forward**

| variant | cr (layer) | triton | flydsl | gluon | triton_v2 | flydsl_v1 |
|---------|-----------|--------|--------|-------|-----------|-----------|
| flash | 0 (SWA)   | 0.47 \| 147.6 | — | 0.35 \| 197.4 | **0.31 \| 221.0** | FAIL |
| flash | 4 (CSA)   | 1.40 \| 244.9 | 15.51 \| 22.2 | 1.01 \| 341.8 | **0.93 \| 369.4** | FAIL |
| flash | 128 (HCA) | 0.68 \| 126.4 | — | 0.42 \| 205.9 | **0.39 \| 219.8** | FAIL |
| pro | 0 (SWA)     | 0.84 \| 163.0 | — | 0.63 \| 219.5 | **0.58 \| 237.6** | FAIL |
| pro | 4 (CSA)     | 4.01 \| 308.2 | 54.20 \| 22.8 | 3.05 \| 405.1 | **2.98 \| 414.5** | FAIL |
| pro | 128 (HCA)   | 1.28 \| 133.8 | — | 0.77 \| 221.8 | **0.73 \| 236.8** | FAIL |

**Backward**

| variant | cr (layer) | triton | flydsl | gluon | triton_v2 | flydsl_v1 |
|---------|-----------|--------|--------|-------|-----------|-----------|
| flash | 0 (SWA)   | 2.04 \| 84.4 | — | 1.21 \| 142.1 | **1.16 \| 148.6** | FAIL |
| flash | 4 (CSA)   | 5.18 \| 165.8 | 2909.43 \| 0.3 | 5.28 \| 162.7 | **5.13 \| 167.6** | FAIL |
| flash | 128 (HCA) | 3.04 \| 70.6 | — | 1.78 \| 120.9 | **1.72 \| 124.9** | FAIL |
| pro | 0 (SWA)     | 3.94 \| 87.3 | — | 1.89 \| 182.1 | **1.79 \| 192.4** | FAIL |
| pro | 4 (CSA)     | 15.02 \| 205.8 | 9413.50 \| 0.3 | 14.55 \| 212.6 | **10.87 \| 284.5** | FAIL |
| pro | 128 (HCA)   | 5.92 \| 72.5 | — | 2.71 \| 158.4 | **2.48 \| 173.4** | FAIL |

`triton_v2` is fastest on all 6 shapes for both fwd and bwd. `flydsl` (legacy) is
cr=4-only and orders of magnitude slower. `flydsl_v1` forward is an upstream WIP
(`NotImplementedError`).

## Correctness

`test_v4_gluon_dsa_attention.py -k triton_v2` → **9/9 passed** (cr=0/4/128,
dense/HCA/CSA, fwd+bwd vs fp32 eager). All optimizations are kernel-internal (no
`id(...)`-keyed caches, no data-distribution assumptions) and transfer 1:1 to real
training. The rope-skip relies on the V4 invariant that the rope pad is structurally
zero (adapter discards its gradient).

## Notes
- FlyDSL benchmarking needs the source at `/workspace/FlyDSL-amd`
  (`git clone --depth 1 --branch v0.2.2 https://github.com/ROCm/FlyDSL`) + `pip install flydsl`.
- Full backend table also added at `deepseek-v4/benchmark/bench_v4_attention_results.md`.