### PR TITLE
improve the logging format for the megatron backend

### DIFF
--- a/primus/backends/megatron/patches/training_log/print_rank_last_patches.py
+++ b/primus/backends/megatron/patches/training_log/print_rank_last_patches.py
@@ -425,7 +425,7 @@ class ThroughputAverageExtension:
                     idx = parsed.throughput_index
                     if idx is not None and 0 <= idx < len(parsed.segments):
                         parsed.segments[idx] = (
-                            f"throughput per GPU (TFLOP/s/GPU): " f"{tflops_value:.1f}/{avg_tflops:.1f}"
+                            f"compute per GPU (TFLOP/s/GPU): {tflops_value:.1f} (avg {avg_tflops:.1f})"
                         )
 
             # ---------------- Tokens/s ----------------
@@ -466,7 +466,16 @@ class ThroughputAverageExtension:
                 warning_rank_0(f"[Patch:megatron.training_log] No token throughput")
                 return log_string
 
-            avg_tokens = sum(self._recent_token_throughputs) / len(self._recent_token_throughputs)
+            # Use the harmonic mean for the token throughput average. The harmonic
+            # mean is the correct way to average rates (tokens/s) over iterations of
+            # equal token count, since it weights slow iterations more heavily.
+            positive_token_throughputs = [t for t in self._recent_token_throughputs if t > 0]
+            if positive_token_throughputs:
+                avg_tokens = len(positive_token_throughputs) / sum(
+                    1.0 / t for t in positive_token_throughputs
+                )
+            else:
+                avg_tokens = 0.0
 
             # Append token throughput directly after the TFLOP throughput within
             # the same segment. We do not create a new segment to keep the log
@@ -475,7 +484,7 @@ class ThroughputAverageExtension:
             if idx is not None and 0 <= idx < len(parsed.segments):
                 parsed.segments[idx] = (
                     f"{parsed.segments[idx]} "
-                    f" | tokens per GPU (tokens/s/GPU): {token_value:.1f}/{avg_tokens:.1f}"
+                    f" | tokens/s/GPU inst/harmonic mean: {token_value:.1f}/{avg_tokens:.1f}"
                 )
 
             # String result is ignored by the main patch when parsed is provided.


### PR DESCRIPTION
## made some minor changes to the logging format of Megatron backend for training steps

1. Currently, we label TFLOP/s/GPU as throughput. Per customer's feedback, throughput is ambiguous and not the best to describe TFLOP/s/GPU. Change it to `Compute per GPU`.

2. For the tokens/s/GPU, we report two numbers in the format of `###/###`. It's not clear what they are. The number before `/` is perf of the step, the number after `/` is arithmetic mean of many steps. Since we measure tokens/s/GPU, which is a rate, it's better to use harmonic mean. So, change this to harmonic mean.

**Before change**
<img width="1449" height="221" alt="image" src="https://github.com/user-attachments/assets/3e4331d9-6fa6-4477-bd68-ce2eec726227" />

**After change**
<img width="1452" height="220" alt="image" src="https://github.com/user-attachments/assets/6d6d6a97-429b-44c8-b3db-f673f3586187" />
