### PR TITLE
feat(megatron): migrate MLPerf GPT-OSS-20B pretrain trainer & patches into Primus

### DIFF
--- a/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-mlperf-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-mlperf-pretrain.yaml
@@ -52,13 +52,13 @@ modules:
       profile_step_end: ${PRIMUS_PROFILE_STEP_END:32}
       profile_step_start: ${PRIMUS_PROFILE_STEP_START:16}
       profile_ranks: [0,1,2,3,4,5,6,7]
-      
+
       # enable fp8 training
       fp8: e4m3
       fp8_recipe: tensorwise
       clip_grad: 1.0  # Gradient clipping (already default, but explicit)
       check_for_nan_in_loss_and_grad: false
-      
+
       # hyper parameters
       train_iters: ${PRIMUS_TRAIN_ITERS:1200000}
       micro_batch_size: ${PRIMUS_MICRO_BATCH_SIZE:2}
@@ -73,7 +73,7 @@ modules:
       lr_decay_style: cosine
       weight_decay: 0.1
       optimizer: adam
-      use_distributed_optimizer: true # use distributed optimizer 
+      use_distributed_optimizer: true # use distributed optimizer
       adam_beta1: 0.9
       adam_beta2: 0.95
       adam_eps: 1.0e-5

--- a/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-mlperf-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-mlperf-pretrain.yaml
@@ -1,0 +1,222 @@
+work_group: ${TEAM:amd}
+user_name: ${USER:root}
+exp_name: ${EXP_NAME:gpt_oss_20b}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:gpt_oss_20B}.yaml
+    overrides:
+
+      # Activate the migrated MLPerf pretrain trainer (mllog + MLPerf hooks).
+      stage: mlperf_pretrain
+
+      # tokenizer
+      tokenizer_type: Llama3Tokenizer
+      tokenizer_model: ${MODEL:meta-llama/Llama-3.1-8B}
+
+      # model
+      num_layers: 24
+      hidden_size: 2880
+      ffn_hidden_size: 2880
+      num_attention_heads: 64
+      num_query_groups: 8  # Group Query Attention (GQA) - matches HF num_key_value_heads
+      num_experts: 32
+      activation_func: swiglu  # SiLU activation (matches HF hidden_act: "silu")
+
+      # rotary
+      position_embedding_type: rope
+      rotary_base: 150000
+
+      # mixed-precision
+      attention_softmax_in_fp32: false
+      grad_reduce_in_bf16: ${PRIMUS_GRAD_REDUCE_IN_BF16:true}
+
+      # log
+      wandb_project: "Primus_GPT_OSS_20B"
+      stderr_sink_level: DEBUG
+      log_interval: ${LOG_INTERVAL:10}
+
+      # debug
+      # moe_router_force_load_balancing: true
+      # log_avg_skip_iterations: 2
+      # log_avg_reset_interval: 50
+
+      # profile
+      profile: ${PRIMUS_PROFILE:false}
+      use_pytorch_profiler: ${PRIMUS_PROFILE:false}
+      profile_step_end: ${PRIMUS_PROFILE_STEP_END:32}
+      profile_step_start: ${PRIMUS_PROFILE_STEP_START:16}
+      profile_ranks: [0,1,2,3,4,5,6,7]
+      
+      # enable fp8 training
+      fp8: e4m3
+      fp8_recipe: tensorwise
+      clip_grad: 1.0  # Gradient clipping (already default, but explicit)
+      check_for_nan_in_loss_and_grad: false
+      
+      # hyper parameters
+      train_iters: ${PRIMUS_TRAIN_ITERS:1200000}
+      micro_batch_size: ${PRIMUS_MICRO_BATCH_SIZE:2}
+      global_batch_size: ${PRIMUS_GLOBAL_BATCH_SIZE:16}
+      seq_length: ${PRIMUS_SEQ_LENGTH:8192}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
+      seed: ${SEED:1234}  # Random seed for reproducibility
+      lr: ${PRIMUS_LR:8.0e-4}  # Reduced from 8e-4 for FP8 stability
+      min_lr: ${PRIMUS_MIN_LR:8.0e-5}  # Set to 10% of max LR
+      lr_warmup_iters: ${PRIMUS_LR_WARMUP_ITERS:128}
+      lr_decay_iters: ${PRIMUS_LR_DECAY_ITERS:1199872}
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      optimizer: adam
+      use_distributed_optimizer: true # use distributed optimizer 
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      adam_eps: 1.0e-5
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+      layernorm_epsilon: 1.0e-05  # RMSNorm epsilon (matches HF rms_norm_eps)
+
+      # Dropout (disabled for training)
+      hidden_dropout: 0.0
+      attention_dropout: 0.0
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+      ddp_num_buckets: 8
+      ddp_average_in_collective: true
+
+      # data
+      mock_data: false
+      num_workers: ${PRIMUS_NUM_WORKERS:0}
+      train_data_path: "10 /data/c4-train.en_6_text_document"
+      valid_data_path: "/data/c4-validation-91205-samples.en_text_document"
+      test_data_path: "/data/c4-validation-91205-samples.en_text_document"
+      # Avoid copying a dense (B, 1, S, S) CPU attention mask every step.
+      # TE receives causal/sliding-window metadata from attn_mask_type + window_size.
+      # Use numeric 0/1 because Primus env expansion only type-casts numbers.
+      create_attention_mask_in_dataloader: ${PRIMUS_CREATE_ATTENTION_MASK_IN_DATALOADER:0}
+
+      # fusion
+      moe_permute_fusion: true
+      gradient_accumulation_fusion: true
+      moe_use_legacy_grouped_gemm: false # Sync-Free MoE stage 2 or 3 require PrimusTurboGroupedMLP, please set `moe_use_legacy_grouped_gemm=True
+      moe_use_fused_router_with_aux_score: true
+      multi_latent_attention: false # Flag config.ENABLE_EXPERIMENTAL not enabled
+      apply_rope_fusion: true
+
+
+      # sliding window attention (GPT-OSS-20B model definition; matches HF sliding_window: 128)
+      # use_turbo_attention is false so non-turbo attention (which supports sliding window) is used.
+      # Pattern: alternating sliding_attention (1) and full_attention (0) for 24 layers
+      # window_size must be a tuple (left_window, right_window) for Transformer Engine
+      # For causal attention: left = past tokens, right = 0 (no future tokens)
+      # HF sliding_window: 128 means 128 past tokens, so use (128, 0)
+      window_size: [128, 0]  # Left window: 128 past tokens, Right: 0 (causal)
+      window_attn_skip_freq: [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+
+      # MoE settings
+      moe_apply_probs_on_input: false
+      moe_aux_loss_coeff: 0.0 #0.9
+      moe_deepep_num_sms: 20
+      moe_enable_deepep: false
+      moe_expert_capacity_factor: null
+      moe_extended_tp: false
+      moe_ffn_hidden_size: 2880
+      moe_flex_dispatcher_backend: deepep
+      moe_grouped_gemm: true
+      moe_hybridep_num_sms: 16
+      moe_input_jitter_eps: null
+      moe_latent_size: null
+      moe_layer_freq: 1
+      moe_layer_recompute: false
+      moe_pad_expert_input_to_capacity: false
+      moe_per_layer_logging: false
+      moe_router_bias_update_rate: 0.001
+      moe_router_dtype: fp32 # DeepEP only supports float32 probs
+      moe_router_enable_expert_bias: false
+      moe_router_force_load_balancing: false
+      moe_router_fusion: true
+      moe_router_group_topk: null
+      moe_router_load_balancing_type: none
+      moe_router_num_groups: null
+      moe_router_padding_for_fp8: false
+      moe_router_padding_for_quantization: false
+      moe_router_pre_softmax: false
+      moe_router_score_function: softmax
+      moe_router_topk: 4
+      moe_router_topk_limited_devices: null
+      moe_router_topk_scaling_factor: null
+      moe_shared_expert_gate: false
+      moe_shared_expert_intermediate_size: null
+      moe_shared_expert_overlap: false
+      moe_token_dispatcher_type: alltoall
+      moe_token_drop_policy: probs
+      moe_token_dropping: false
+      moe_z_loss_coeff: null
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 100000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      exit_on_missing_checkpoint: false
+      ckpt_format: torch
+      eval_iters: ${EVAL_ITERS:64}  # eval_samples = eval_iters * GBS = 1024; set EVAL_ITERS in config shell (1024/GBS).
+      eval_interval: ${PRIMUS_EVAL_INTERVAL:768}
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_gemm: true
+      use_turbo_rms_norm: ${USE_TURBO_RMS_NORM:true}
+      use_turbo_fused_act_with_probs : true
+      # Pad tokens-per-expert so the fp8 grouped GEMM path skips the buggy
+      # quantization_padding branch in PrimusGroupedMLP.forward (experts.py:97-109),
+      # which yields NaN with recompute. Not auto-enabled here because
+      # turbo_sync_free_moe_stage=0 (it is only auto-set for sync-free stages 1-3).
+      use_turbo_permute_padding: true
+
+      # deepep
+      use_turbo_deepep: false
+
+      # 64 or 80 for ep8, 32 for ep16-64 is best practice
+      turbo_deepep_num_cu: 64
+      turbo_deepep_use_comm_stream: false
+
+      # sync-free moe support stage 0-3, 0 means not use sync-free moe
+      # stage 3 is completely no gpu-cpu sync in MoE, but cost more memory
+      # stage 2 is recommended for better performance
+      turbo_sync_free_moe_stage: 0
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # tensorboard logging, set 'disable_tensorboard: false' to enable tensorboard logging
+      disable_tensorboard: true
+      tensorboard_dir: /workspace/code/tensorboard
+      tensorboard_log_interval: 1
+      tensorboard_queue_size: 1000
+      log_timers_to_tensorboard: true
+      log_batch_size_to_tensorboard: true
+      log_learning_rate_to_tensorboard: true
+      log_validation_ppl_to_tensorboard: true
+      log_memory_to_tensorboard: true
+      log_world_size_to_tensorboard: true
+      log_loss_scale_to_tensorboard: true

--- a/primus/backends/megatron/__init__.py
+++ b/primus/backends/megatron/__init__.py
@@ -7,8 +7,10 @@
 from primus.backends.megatron.megatron_adapter import MegatronAdapter
 from primus.backends.megatron.megatron_pretrain_trainer import MegatronPretrainTrainer
 from primus.backends.megatron.megatron_sft_trainer import MegatronSFTTrainer
+from primus.backends.megatron.mlperf import MLPerfMegatronPretrainTrainer
 from primus.core.backend.backend_registry import BackendRegistry
 
 BackendRegistry.register_adapter("megatron", MegatronAdapter)
 BackendRegistry.register_trainer_class(MegatronPretrainTrainer, "megatron")
 BackendRegistry.register_trainer_class(MegatronSFTTrainer, "megatron", "sft")
+BackendRegistry.register_trainer_class(MLPerfMegatronPretrainTrainer, "megatron", "mlperf_pretrain")

--- a/primus/backends/megatron/core/distributed/sdma_param_gather.py
+++ b/primus/backends/megatron/core/distributed/sdma_param_gather.py
@@ -1,0 +1,256 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""SDMA (copy-engine) param all-gather helpers for the distributed optimizer.
+
+Migrated from the source patch ``megatron_sdma_allgather.patch`` (mpo branch).
+
+These helpers implement a ``torch.distributed.all_gather_into_tensor``-compatible
+all-gather that routes the gather through Primus-Turbo symmetric memory + HIP
+copy-engine (SDMA) memcpys instead of RCCL kernels. The intent is to free up
+CU/compute resources by performing the param all-gather purely on the copy
+engine, overlapping it with forward compute.
+
+The implementation is consumed by
+:mod:`primus.backends.megatron.patches.parallelism.sdma_param_all_gather_patches`,
+which swaps Megatron's ``_ParamAndGradBucketGroup.start_param_sync`` distributed
+optimizer path to dispatch per-bucket all-gathers through
+:func:`all_gather_into_tensor_sdma`.
+
+Activation:
+    ``ENABLE_SDMA_ALLGATHER=1`` (gated by the patch). When the required
+    Primus-Turbo / ``hip`` primitives are unavailable, every call falls back to
+    ``torch.distributed.all_gather_into_tensor`` so behaviour is preserved.
+"""
+
+import importlib
+import os
+import warnings
+from typing import Callable, Dict, Optional, Tuple
+
+import torch
+
+# Minimum symmetric-memory workspace size (bytes) requested per group. The
+# workspace is reused across calls, so it is sized for the largest expected
+# bucket. Overridable via env for A/B sizing.
+_SDMA_SYMM_MEM_MIN_BYTES = int(os.getenv("MEGATRON_SDMA_SYMM_MEM_MIN_BYTES", str(749887296)))
+
+
+class _WaitableHandle:
+    """Lightweight waitable handle that mimics ``torch.distributed.Work``."""
+
+    def __init__(self, wait_fn: Optional[Callable[[], None]] = None, work=None):
+        self._wait_fn = wait_fn
+        self._work = work
+        self._done = False
+
+    def wait(self):
+        if self._done:
+            return True
+        if self._work is not None:
+            self._work.wait()
+        if self._wait_fn is not None:
+            self._wait_fn()
+        self._done = True
+        return True
+
+
+def _all_gather_into_tensor_waitable_fallback(
+    output_tensor: torch.Tensor,
+    input_tensor: torch.Tensor,
+    group: Optional[torch.distributed.ProcessGroup] = None,
+    async_op: bool = False,
+):
+    """Fallback to ``torch.distributed.all_gather_into_tensor`` with a waitable handle."""
+    work = torch.distributed.all_gather_into_tensor(
+        output_tensor, input_tensor, group=group, async_op=async_op
+    )
+    if async_op and work is not None:
+        return _WaitableHandle(work=work)
+    return _WaitableHandle()
+
+
+def _get_sdma_peer_copy_stream_count(world_size: int) -> int:
+    """Resolve the number of peer-copy streams for SDMA param all-gather."""
+    max_streams = max(world_size - 1, 1)
+    default_streams = min(max_streams, 8)
+    env_value = os.getenv("MEGATRON_SDMA_PEER_COPY_STREAMS")
+    if env_value is None:
+        return default_streams
+
+    try:
+        configured_streams = int(env_value)
+    except ValueError:
+        warnings.warn(
+            f"Invalid MEGATRON_SDMA_PEER_COPY_STREAMS={env_value!r}; using default "
+            f"{default_streams}."
+        )
+        return default_streams
+
+    if configured_streams < 1:
+        warnings.warn(
+            f"MEGATRON_SDMA_PEER_COPY_STREAMS must be >= 1, got {configured_streams}; "
+            f"using default {default_streams}."
+        )
+        return default_streams
+
+    return min(configured_streams, max_streams)
+
+
+class _SDMAGroupRuntime:
+    """Shared SDMA runtime for a process group (comm + peer-copy streams)."""
+
+    def __init__(self, world_size: int):
+        # Barrier/publish/local-copy run on one shared communication stream.
+        self.comm_stream = torch.cuda.Stream()
+        # Limit peer-copy fan-out by default to reduce SDMA/memory-system
+        # pressure and improve overlap with forward compute.
+        peer_copy_stream_count = _get_sdma_peer_copy_stream_count(world_size)
+        self.peer_copy_streams = [torch.cuda.Stream() for _ in range(peer_copy_stream_count)]
+
+
+_sdma_group_runtime_cache: Dict[Tuple[str, int], _SDMAGroupRuntime] = {}
+
+
+def _get_sdma_group_runtime(group_name: str, world_size: int) -> _SDMAGroupRuntime:
+    cache_key = (group_name, world_size)
+    runtime = _sdma_group_runtime_cache.get(cache_key)
+    if runtime is None:
+        runtime = _SDMAGroupRuntime(world_size=world_size)
+        _sdma_group_runtime_cache[cache_key] = runtime
+    return runtime
+
+
+def all_gather_into_tensor_sdma(
+    output_tensor: torch.Tensor,
+    input_tensor: torch.Tensor,
+    group: Optional[torch.distributed.ProcessGroup] = None,
+    async_op: bool = False,
+):
+    """SDMA all-gather with ``all_gather_into_tensor``-compatible signature.
+
+    Follows the Primus-Turbo async-tp style (symmetric memory + DMA copies) and
+    always returns a ``.wait()``-able handle. Falls back to
+    ``torch.distributed.all_gather_into_tensor`` when SDMA primitives are
+    unavailable.
+    """
+    if not torch.distributed.is_initialized():
+        raise RuntimeError("torch.distributed must be initialized before all_gather_into_tensor_sdma")
+
+    if group is None:
+        group = torch.distributed.distributed_c10d._get_default_group()
+
+    world_size = torch.distributed.get_world_size(group=group)
+    rank = torch.distributed.get_rank(group=group)
+
+    if output_tensor.numel() != input_tensor.numel() * world_size:
+        raise ValueError(
+            "output_tensor.numel() must equal input_tensor.numel() * world_size "
+            "for all_gather_into_tensor"
+        )
+    if output_tensor.dtype != input_tensor.dtype:
+        raise ValueError(
+            "output_tensor.dtype must match input_tensor.dtype for SDMA all_gather_into_tensor"
+        )
+
+    # SDMA path is CUDA-only and expects a contiguous flattened layout.
+    if (
+        not output_tensor.is_cuda
+        or not input_tensor.is_cuda
+        or output_tensor.device != input_tensor.device
+        or output_tensor.device.index != torch.cuda.current_device()
+        or not output_tensor.is_contiguous()
+    ):
+        return _all_gather_into_tensor_waitable_fallback(
+            output_tensor, input_tensor, group=group, async_op=async_op
+        )
+    assert input_tensor.is_contiguous(), "SDMA all_gather_into_tensor requires contiguous input_tensor"
+
+    try:
+        hip = importlib.import_module("hip").hip
+        get_amd_symm_mem_workspace = importlib.import_module(
+            "primus_turbo.pytorch.kernels.async_tp.amd_symmetric_memory"
+        ).get_amd_symm_mem_workspace
+        hip_check = importlib.import_module(
+            "primus_turbo.pytorch.kernels.async_tp.common_ops"
+        ).hip_check
+    except Exception:
+        return _all_gather_into_tensor_waitable_fallback(
+            output_tensor, input_tensor, group=group, async_op=async_op
+        )
+
+    group_name = getattr(group, "group_name", None)
+    if group_name is None:
+        return _all_gather_into_tensor_waitable_fallback(
+            output_tensor, input_tensor, group=group, async_op=async_op
+        )
+
+    input_nbytes = input_tensor.nbytes
+    output_flat = output_tensor.view(-1)
+
+    memcpy_comm_kind = getattr(
+        hip.hipMemcpyKind, "hipMemcpyDeviceToDeviceNoCU", hip.hipMemcpyKind.hipMemcpyDeviceToDevice
+    )
+
+    # Allocate/reuse symmetric workspace and expose each rank's local shard buffer.
+    symm_mem = get_amd_symm_mem_workspace(
+        group_name, min_size=max(input_nbytes, _SDMA_SYMM_MEM_MIN_BYTES)
+    )
+    gather_buffers = [
+        symm_mem.get_buffer(r, input_tensor.shape, input_tensor.dtype) for r in range(world_size)
+    ]
+    runtime = _get_sdma_group_runtime(group_name=group_name, world_size=world_size)
+
+    current_stream = torch.cuda.current_stream()
+    # Per-call barrier event so each handle tracks its own all-gather point.
+    barrier_event = torch.cuda.Event()
+
+    # Ensure input is ready on the communication stream.
+    runtime.comm_stream.wait_stream(current_stream)
+
+    with torch.cuda.stream(runtime.comm_stream):
+        # Barrier (workspace safety), publish local shard, post-publish barrier.
+        symm_mem.barrier()
+        gather_buffers[rank].copy_(input_tensor, True)
+        symm_mem.barrier()
+        # Peer copies may start after the publish barrier completes.
+        barrier_event.record(runtime.comm_stream)
+        # Copy local shard into its slot in the output.
+        hip_check(
+            hip.hipMemcpyAsync(
+                output_flat.data_ptr() + rank * input_nbytes,
+                input_tensor.data_ptr(),
+                input_nbytes,
+                memcpy_comm_kind,
+                runtime.comm_stream.cuda_stream,
+            )
+        )
+
+    for peer_idx, src_rank in enumerate(r for r in range(world_size) if r != rank):
+        src_buf = gather_buffers[src_rank]
+        copy_stream = runtime.peer_copy_streams[peer_idx % len(runtime.peer_copy_streams)]
+        with torch.cuda.stream(copy_stream):
+            copy_stream.wait_event(barrier_event)
+            hip_check(
+                hip.hipMemcpyAsync(
+                    output_flat.data_ptr() + src_rank * input_nbytes,
+                    src_buf.data_ptr(),
+                    input_nbytes,
+                    memcpy_comm_kind,
+                    copy_stream.cuda_stream,
+                )
+            )
+
+    def _wait_impl():
+        wait_stream = torch.cuda.current_stream()
+        wait_stream.wait_stream(runtime.comm_stream)
+        for copy_stream in runtime.peer_copy_streams:
+            wait_stream.wait_stream(copy_stream)
+
+    handle = _WaitableHandle(wait_fn=_wait_impl)
+    if not async_op:
+        handle.wait()
+    return handle

--- a/primus/backends/megatron/core/distributed/sdma_param_gather.py
+++ b/primus/backends/megatron/core/distributed/sdma_param_gather.py
@@ -85,8 +85,7 @@ def _get_sdma_peer_copy_stream_count(world_size: int) -> int:
         configured_streams = int(env_value)
     except ValueError:
         warnings.warn(
-            f"Invalid MEGATRON_SDMA_PEER_COPY_STREAMS={env_value!r}; using default "
-            f"{default_streams}."
+            f"Invalid MEGATRON_SDMA_PEER_COPY_STREAMS={env_value!r}; using default " f"{default_streams}."
         )
         return default_streams
 
@@ -148,13 +147,10 @@ def all_gather_into_tensor_sdma(
 
     if output_tensor.numel() != input_tensor.numel() * world_size:
         raise ValueError(
-            "output_tensor.numel() must equal input_tensor.numel() * world_size "
-            "for all_gather_into_tensor"
+            "output_tensor.numel() must equal input_tensor.numel() * world_size " "for all_gather_into_tensor"
         )
     if output_tensor.dtype != input_tensor.dtype:
-        raise ValueError(
-            "output_tensor.dtype must match input_tensor.dtype for SDMA all_gather_into_tensor"
-        )
+        raise ValueError("output_tensor.dtype must match input_tensor.dtype for SDMA all_gather_into_tensor")
 
     # SDMA path is CUDA-only and expects a contiguous flattened layout.
     if (
@@ -174,9 +170,7 @@ def all_gather_into_tensor_sdma(
         get_amd_symm_mem_workspace = importlib.import_module(
             "primus_turbo.pytorch.kernels.async_tp.amd_symmetric_memory"
         ).get_amd_symm_mem_workspace
-        hip_check = importlib.import_module(
-            "primus_turbo.pytorch.kernels.async_tp.common_ops"
-        ).hip_check
+        hip_check = importlib.import_module("primus_turbo.pytorch.kernels.async_tp.common_ops").hip_check
     except Exception:
         return _all_gather_into_tensor_waitable_fallback(
             output_tensor, input_tensor, group=group, async_op=async_op
@@ -196,9 +190,7 @@ def all_gather_into_tensor_sdma(
     )
 
     # Allocate/reuse symmetric workspace and expose each rank's local shard buffer.
-    symm_mem = get_amd_symm_mem_workspace(
-        group_name, min_size=max(input_nbytes, _SDMA_SYMM_MEM_MIN_BYTES)
-    )
+    symm_mem = get_amd_symm_mem_workspace(group_name, min_size=max(input_nbytes, _SDMA_SYMM_MEM_MIN_BYTES))
     gather_buffers = [
         symm_mem.get_buffer(r, input_tensor.shape, input_tensor.dtype) for r in range(world_size)
     ]

--- a/primus/backends/megatron/core/extensions/fused_residual_rmsnorm.py
+++ b/primus/backends/megatron/core/extensions/fused_residual_rmsnorm.py
@@ -1,0 +1,460 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Runtime monkeypatch — fuse residual+add into RMSNorm at two sites.
+
+This is the runtime install hook (callable from a trainer entry point such
+as ``small_llm_moe_pretraining/primus/src/train.py``). The Triton RMSNorm
+kernels live in Primus-Turbo (``primus_turbo.pytorch.ops.normalization``,
+which exposes ``rmsnorm`` and the fused ``rmsnorm_residual`` variant).
+
+V1 — IN-LAYER fuse  (``PRIMUS_FUSED_RESIDUAL_NORM=1``)
+    self_attn_bda(residual + attn_out) → pre_mlp_layernorm
+    Kills 1 of 2 ``vectorized_elementwise_kernel<CUDAFunctor_add<bf16>>``
+    launches per layer (the in-layer ADD#1).
+
+V2 — CROSS-LAYER fuse  (``PRIMUS_FUSED_RESIDUAL_NORM_V2=1``, implies V1)
+    layer N: skip mlp_bda(mlp_out + residual_post_attn), instead stash
+             ``(mlp_out, residual_post_attn)`` as a "carry" on layer N+1
+    layer N+1: input_layernorm(carry) does the fused add+norm
+    last layer: carry goes to final_layernorm via ``_v2_pending_carry``.
+    Kills the remaining ADD#2 in the bf16 add tax (24 → 1 launches per step;
+    the last layer keeps its add when final_layernorm isn't a
+    ``PrimusTurboRMSNorm``, otherwise that one is fused too).
+
+Activation
+----------
+* V1: ``PRIMUS_FUSED_RESIDUAL_NORM=1`` (default 0).
+* V2: ``PRIMUS_FUSED_RESIDUAL_NORM_V2=1`` (default 0). Implies V1.
+* Requires ``use_turbo_rms_norm=true`` so the norms are ``PrimusTurboRMSNorm``
+  instances we can extend with a ``residual=`` arg.
+
+Falls back silently to the original ``TransformerLayer.forward`` whenever
+any precondition fails (recompute paths, fp32 residual, inference fused TP,
+non-zero hidden_dropout, cross-attention layers, non-PrimusTurboRMSNorm
+pre-norm).
+
+Safety
+------
+* Both gates default off; A/B is always reproducible.
+* On any exception in the fused path the patch reverts permanently and the
+  rest of the run uses the original Megatron forward.
+* V2 keeps the original mlp_bda when the next consumer cannot fuse (e.g.
+  final_layernorm is not a PrimusTurboRMSNorm, or the next layer doesn't
+  pass ``_can_fuse``), so partial coverage degrades gracefully.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+
+def _enabled() -> bool:
+    """V1 gate (or implied by V2)."""
+    if _v2_enabled():
+        return True
+    v = os.environ.get("PRIMUS_FUSED_RESIDUAL_NORM", "0").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
+def _v2_enabled() -> bool:
+    v = os.environ.get("PRIMUS_FUSED_RESIDUAL_NORM_V2", "0").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
+def _log(msg: str) -> None:
+    rank = os.environ.get("RANK", "0")
+    if rank == "0":
+        print(f"[fused_residual_rmsnorm] {msg}", file=sys.stderr, flush=True)
+
+
+_INSTALLED = False
+
+
+def install() -> bool:
+    """Install the monkeypatch. Returns True on success."""
+    global _INSTALLED
+    if _INSTALLED:
+        return True
+    if not _enabled():
+        _log("disabled (set PRIMUS_FUSED_RESIDUAL_NORM=1 or "
+             "PRIMUS_FUSED_RESIDUAL_NORM_V2=1 to enable)")
+        return False
+
+    try:
+        from primus_turbo.pytorch.ops.normalization import (
+            rmsnorm_residual as triton_rmsnorm_residual,
+        )
+    except ImportError as exc:
+        _log(f"could not import primus_turbo rmsnorm_residual: {exc}; abort install")
+        return False
+
+    try:
+        from primus.backends.megatron.core.extensions.primus_turbo import (
+            PrimusTurboRMSNorm,
+        )
+    except ImportError as exc:
+        _log(f"PrimusTurboRMSNorm not importable: {exc}; abort install")
+        return False
+
+    try:
+        from megatron.core.transformer.transformer_block import TransformerBlock
+        from megatron.core.transformer.transformer_layer import TransformerLayer
+    except ImportError as exc:
+        _log(f"Megatron transformer modules not importable: {exc}; abort install")
+        return False
+
+    # ----- 1. Extend PrimusTurboRMSNorm to accept residual ------------------
+    if not getattr(PrimusTurboRMSNorm, "_fused_residual_patched", False):
+        _orig_norm_forward = PrimusTurboRMSNorm.forward
+
+        def _new_norm_forward(self, x, residual=None):
+            # V2 path: an upstream layer stashed a carry for *this* norm to
+            # consume on its next forward call. The carry takes priority
+            # over an explicit ``residual=`` arg (which is V1-style and is
+            # only used when the layer's own _do_fused_forward already
+            # picked the right pair).
+            pending = getattr(self, "_v2_pending_carry", None)
+            if pending is not None:
+                self._v2_pending_carry = None
+                x_pending, r_pending = pending
+                gamma = self.weight
+                if getattr(self, "zero_centered_gamma", False):
+                    gamma = gamma + 1
+                norm_out, _xpr = triton_rmsnorm_residual(
+                    x_pending, r_pending, gamma, self.eps
+                )
+                return norm_out
+            if residual is None:
+                return _orig_norm_forward(self, x)
+            gamma = self.weight
+            if getattr(self, "zero_centered_gamma", False):
+                gamma = gamma + 1
+            return triton_rmsnorm_residual(x, residual, gamma, self.eps)
+
+        PrimusTurboRMSNorm.forward = _new_norm_forward
+        PrimusTurboRMSNorm._fused_residual_patched = True
+        _log("patched PrimusTurboRMSNorm.forward (residual= arg + V2 _pending_carry)")
+
+    # ----- 2. Patch TransformerBlock.__init__ to wire V2 layer links --------
+    if _v2_enabled() and not getattr(
+        TransformerBlock, "_fused_residual_v2_init_patched", False
+    ):
+        _orig_block_init = TransformerBlock.__init__
+
+        def _v2_init(self, *args, **kwargs):
+            _orig_block_init(self, *args, **kwargs)
+            try:
+                _wire_v2_layer_links(self)
+            except Exception as exc:
+                _log(f"V2 layer-link wiring raised {type(exc).__name__}: {exc}; "
+                     "block will run V1-only")
+
+        TransformerBlock.__init__ = _v2_init
+        TransformerBlock._fused_residual_v2_init_patched = True
+        _log("patched TransformerBlock.__init__ (V2 layer-link wiring active)")
+
+    # ----- 3. Replace TransformerLayer.forward with fused variant -----------
+    if not getattr(TransformerLayer, "_fused_residual_patched", False):
+        _orig_layer_forward = TransformerLayer.forward
+
+        def _fused_layer_forward(self, *args, **kwargs):
+            if not _can_fuse(self):
+                # Per-layer fallback. If a carry was queued for *this* layer
+                # but the layer itself can't fuse, drop it back to a real
+                # add so the layer sees a correct hidden_states.
+                _drain_carry_into_hidden_states(self, args, kwargs)
+                return _orig_layer_forward(self, *args, **kwargs)
+            try:
+                return _do_fused_forward(self, *args, **kwargs)
+            except Exception as exc:
+                _log(f"fused forward raised {type(exc).__name__}: {exc}; "
+                     f"falling back to original forward for all layers")
+                TransformerLayer.forward = _orig_layer_forward
+                return _orig_layer_forward(self, *args, **kwargs)
+
+        TransformerLayer.forward = _fused_layer_forward
+        TransformerLayer._fused_residual_patched = True
+        if _v2_enabled():
+            _log("patched TransformerLayer.forward (V1 ADD#1 + V2 cross-layer ADD#2 fusion active)")
+        else:
+            _log("patched TransformerLayer.forward (V1 in-layer ADD#1+norm fusion active)")
+
+    _INSTALLED = True
+    return True
+
+
+# ---------------------------------------------------------------------------
+# V2 layer-link wiring
+# ---------------------------------------------------------------------------
+def _wire_v2_layer_links(block: Any) -> None:
+    """Annotate each layer in ``block`` with V2 navigation pointers.
+
+    Sets per-layer attributes:
+      * ``_v2_block``           -> back-reference to the owning block
+      * ``_v2_next_layer``      -> the next TransformerLayer or None
+      * ``_v2_is_last_layer``   -> True for the final layer in the block
+      * ``_v2_final_layernorm`` -> reference to block.final_layernorm if any
+                                   (only set on the last layer)
+    """
+    layers = getattr(block, "layers", None)
+    if layers is None:
+        return
+    n = len(layers)
+    if n == 0:
+        return
+    final_ln = getattr(block, "final_layernorm", None)
+    # CRITICAL: nn.Module.__setattr__ auto-registers any nn.Module-valued
+    # attribute as a child module. Setting layer._v2_next_layer = next_layer
+    # would create cycles (each layer becomes a child of the previous one)
+    # and blow up tree-walking ops like .cuda() / .children() with
+    # RecursionError. Bypass with object.__setattr__ so these are plain
+    # Python attributes invisible to nn.Module bookkeeping.
+    for i, layer in enumerate(layers):
+        nxt = layers[i + 1] if (i + 1) < n else None
+        is_last = (i + 1) == n
+        object.__setattr__(layer, "_v2_block", block)
+        object.__setattr__(layer, "_v2_next_layer", nxt)
+        object.__setattr__(layer, "_v2_is_last_layer", is_last)
+        object.__setattr__(
+            layer, "_v2_final_layernorm", final_ln if is_last else None
+        )
+        object.__setattr__(layer, "_v2_carry", None)
+
+
+def _drain_carry_into_hidden_states(layer: Any, args: tuple, kwargs: dict) -> None:
+    """If a V2 carry was left for ``layer`` but we are about to take the
+    *original* (unpatched) forward, materialise the carry as a regular add
+    into ``hidden_states`` so the original forward still gets the right
+    activations.
+    """
+    carry = getattr(layer, "_v2_carry", None)
+    if carry is None:
+        return
+    layer._v2_carry = None
+    mlp_out, residual = carry
+    new_hs = mlp_out + residual
+    if args:
+        # python tuples are immutable; the caller (TransformerBlock loop)
+        # passes hidden_states via kwargs. We can't mutate the caller's
+        # args tuple from here, so route via kwargs (the kwargs path is
+        # always taken for hidden_states in current Megatron).
+        kwargs["hidden_states"] = new_hs
+        return
+    kwargs["hidden_states"] = new_hs
+
+
+# ---------------------------------------------------------------------------
+# Per-layer "can we fuse?" guard
+# ---------------------------------------------------------------------------
+def _can_fuse(layer: Any) -> bool:
+    """Return True when ``layer`` matches the assumptions of the fused path."""
+    cfg = getattr(layer, "config", None)
+    if cfg is None:
+        return False
+    if getattr(cfg, "fp32_residual_connection", False):
+        return False
+    if getattr(cfg, "inference_fuse_tp_communication", False):
+        return False
+    if getattr(layer, "recompute_input_layernorm", False):
+        return False
+    if getattr(layer, "recompute_pre_mlp_layernorm", False):
+        return False
+    if getattr(layer, "hidden_dropout", 0.0) != 0.0:
+        return False
+    if getattr(layer, "offload_attn_norm", False):
+        return False
+    if getattr(layer, "offload_mlp_norm", False):
+        return False
+
+    pre_mlp = getattr(layer, "pre_mlp_layernorm", None)
+    if pre_mlp is None:
+        return False
+    try:
+        from primus.backends.megatron.core.extensions.primus_turbo import (
+            PrimusTurboRMSNorm,
+        )
+    except ImportError:
+        return False
+    if not isinstance(pre_mlp, PrimusTurboRMSNorm):
+        return False
+
+    from megatron.core.transformer.identity_op import IdentityOp
+    cross_attn = getattr(layer, "cross_attention", None)
+    if cross_attn is not None and not isinstance(cross_attn, IdentityOp):
+        return False
+
+    return True
+
+
+def _v2_next_can_consume_carry(layer: Any) -> bool:
+    """Return True when layer N can stash an unfused carry instead of
+    running mlp_bda. Requires that the next consumer (next layer's
+    input_layernorm OR this block's final_layernorm) is a
+    ``PrimusTurboRMSNorm`` so it can absorb the residual at no extra cost.
+    """
+    if not _v2_enabled():
+        return False
+
+    try:
+        from primus.backends.megatron.core.extensions.primus_turbo import (
+            PrimusTurboRMSNorm,
+        )
+    except ImportError:
+        return False
+
+    is_last = getattr(layer, "_v2_is_last_layer", False)
+    if not is_last:
+        nxt = getattr(layer, "_v2_next_layer", None)
+        if nxt is None:
+            return False
+        nxt_in_ln = getattr(nxt, "input_layernorm", None)
+        if not isinstance(nxt_in_ln, PrimusTurboRMSNorm):
+            return False
+        # If the next layer can't fuse for its own reasons, we shouldn't
+        # leave a carry it has to drain — drain it ourselves via the
+        # _drain_carry_into_hidden_states fallback in the wrapper.
+        return _can_fuse(nxt)
+    # Last layer: route through final_layernorm if it's a PrimusTurboRMSNorm.
+    final_ln = getattr(layer, "_v2_final_layernorm", None)
+    if final_ln is None:
+        return False
+    return isinstance(final_ln, PrimusTurboRMSNorm)
+
+
+# ---------------------------------------------------------------------------
+# The fused forward
+# ---------------------------------------------------------------------------
+def _do_fused_forward(layer: Any, hidden_states=None, *args, **kwargs):
+    """Mirror of ``TransformerLayer.forward`` with V1 + V2 fusion paths.
+
+    V1: pre_mlp_layernorm receives ``(attn_out, residual)`` and emits both
+        the normed activation AND ``x_plus_r`` for the next bda.
+    V2: input_layernorm consumes a ``_v2_carry`` left by the previous
+        layer, and at exit either stashes a new carry (next layer / final
+        layernorm) or falls back to the explicit mlp_bda add.
+    """
+    from megatron.core.utils import (
+        deprecate_inference_params,
+        make_viewless_tensor,
+        nvtx_range_pop,
+        nvtx_range_push,
+    )
+    if hidden_states is None:
+        hidden_states = kwargs.pop("hidden_states")
+    else:
+        kwargs.pop("hidden_states", None)
+
+    inference_context = deprecate_inference_params(
+        kwargs.get("inference_context"), kwargs.get("inference_params")
+    )
+
+    v2_active = _v2_enabled()
+
+    # ---- input_layernorm (with optional V2 carry consume) ----------------
+    nvtx_range_push(suffix="input_layernorm")
+    carry = getattr(layer, "_v2_carry", None) if v2_active else None
+    if carry is not None:
+        # Fused path: input_layernorm absorbs the previous layer's deferred
+        # mlp_bda add. The returned x_plus_r becomes our residual base.
+        layer._v2_carry = None
+        prev_mlp_out, prev_residual = carry
+        # We bypass PrimusTurboRMSNorm.forward to access x_plus_r directly,
+        # which is needed as the residual for ADD#1.
+        from primus_turbo.pytorch.ops.normalization import (
+            rmsnorm_residual as triton_rmsnorm_residual,
+        )
+        in_ln = layer.input_layernorm
+        gamma = in_ln.weight
+        if getattr(in_ln, "zero_centered_gamma", False):
+            gamma = gamma + 1
+        input_layernorm_output, hidden_states = triton_rmsnorm_residual(
+            prev_mlp_out, prev_residual, gamma, in_ln.eps
+        )
+    else:
+        input_layernorm_output = layer.input_layernorm(hidden_states)
+    nvtx_range_pop(suffix="input_layernorm")
+
+    residual = hidden_states  # base for ADD#1 (post input_layernorm)
+
+    # ---- self attention --------------------------------------------------
+    nvtx_range_push(suffix="self_attention")
+    attention_output_with_bias = layer.self_attention(
+        input_layernorm_output,
+        attention_mask=kwargs.get("attention_mask"),
+        inference_context=inference_context,
+        rotary_pos_emb=kwargs.get("rotary_pos_emb"),
+        rotary_pos_cos=kwargs.get("rotary_pos_cos"),
+        rotary_pos_sin=kwargs.get("rotary_pos_sin"),
+        rotary_pos_cos_sin=kwargs.get("rotary_pos_cos_sin"),
+        attention_bias=kwargs.get("attention_bias"),
+        packed_seq_params=kwargs.get("packed_seq_params"),
+        sequence_len_offset=kwargs.get("sequence_len_offset"),
+    )
+    nvtx_range_pop(suffix="self_attention")
+
+    attn_out, attn_bias = attention_output_with_bias
+    if attn_bias is not None:
+        attn_out = attn_out + attn_bias.to(attn_out.dtype)
+
+    # ---- V1 fuse: bda(attn_out, residual) + pre_mlp_layernorm ------------
+    nvtx_range_push(suffix="fused_residual_pre_mlp_layernorm")
+    pre_mlp_layernorm_output, hidden_states = layer.pre_mlp_layernorm(
+        attn_out, residual=residual
+    )
+    nvtx_range_pop(suffix="fused_residual_pre_mlp_layernorm")
+    # hidden_states now == attn_out + residual (= residual_post_attn).
+
+    # ---- mlp -------------------------------------------------------------
+    padding_mask = kwargs.get("padding_mask", None)
+    try:
+        mlp_output_with_bias = layer.mlp(
+            pre_mlp_layernorm_output, padding_mask=padding_mask
+        )
+    except TypeError:
+        mlp_output_with_bias = layer.mlp(pre_mlp_layernorm_output)
+
+    # ---- mlp_bda OR V2 carry stash ---------------------------------------
+    if v2_active and _v2_next_can_consume_carry(layer):
+        # Skip mlp_bda. Stash carry on the next consumer, return
+        # residual_post_attn as the layer's "output" tensor (used only by
+        # TransformerBlock for offload commit / make_viewless plumbing;
+        # the next layer / final_layernorm reads the carry instead).
+        mlp_out, mlp_bias = mlp_output_with_bias
+        if mlp_bias is not None:
+            mlp_out = mlp_out + mlp_bias.to(mlp_out.dtype)
+
+        is_last = getattr(layer, "_v2_is_last_layer", False)
+        if is_last:
+            final_ln = layer._v2_final_layernorm
+            final_ln._v2_pending_carry = (mlp_out, hidden_states)
+        else:
+            layer._v2_next_layer._v2_carry = (mlp_out, hidden_states)
+
+        nvtx_range_push(suffix="v2_skip_mlp_bda")
+        output = make_viewless_tensor(
+            inp=hidden_states,
+            requires_grad=hidden_states.requires_grad,
+            keep_graph=True,
+        )
+        nvtx_range_pop(suffix="v2_skip_mlp_bda")
+        return output, None
+
+    # V1-only path (or V2 last-layer-without-norm-final): explicit mlp_bda.
+    nvtx_range_push(suffix="mlp_bda")
+    with layer.bias_dropout_add_exec_handler():
+        hidden_states = layer.mlp_bda(layer.training, layer.config.bias_dropout_fusion)(
+            mlp_output_with_bias, hidden_states, layer.hidden_dropout
+        )
+    nvtx_range_pop(suffix="mlp_bda")
+
+    output = make_viewless_tensor(
+        inp=hidden_states,
+        requires_grad=hidden_states.requires_grad,
+        keep_graph=True,
+    )
+    return output, None

--- a/primus/backends/megatron/core/extensions/fused_residual_rmsnorm.py
+++ b/primus/backends/megatron/core/extensions/fused_residual_rmsnorm.py
@@ -81,8 +81,7 @@ def install() -> bool:
     if _INSTALLED:
         return True
     if not _enabled():
-        _log("disabled (set PRIMUS_FUSED_RESIDUAL_NORM=1 or "
-             "PRIMUS_FUSED_RESIDUAL_NORM_V2=1 to enable)")
+        _log("disabled (set PRIMUS_FUSED_RESIDUAL_NORM=1 or " "PRIMUS_FUSED_RESIDUAL_NORM_V2=1 to enable)")
         return False
 
     try:
@@ -125,9 +124,7 @@ def install() -> bool:
                 gamma = self.weight
                 if getattr(self, "zero_centered_gamma", False):
                     gamma = gamma + 1
-                norm_out, _xpr = triton_rmsnorm_residual(
-                    x_pending, r_pending, gamma, self.eps
-                )
+                norm_out, _xpr = triton_rmsnorm_residual(x_pending, r_pending, gamma, self.eps)
                 return norm_out
             if residual is None:
                 return _orig_norm_forward(self, x)
@@ -141,9 +138,7 @@ def install() -> bool:
         _log("patched PrimusTurboRMSNorm.forward (residual= arg + V2 _pending_carry)")
 
     # ----- 2. Patch TransformerBlock.__init__ to wire V2 layer links --------
-    if _v2_enabled() and not getattr(
-        TransformerBlock, "_fused_residual_v2_init_patched", False
-    ):
+    if _v2_enabled() and not getattr(TransformerBlock, "_fused_residual_v2_init_patched", False):
         _orig_block_init = TransformerBlock.__init__
 
         def _v2_init(self, *args, **kwargs):
@@ -151,8 +146,7 @@ def install() -> bool:
             try:
                 _wire_v2_layer_links(self)
             except Exception as exc:
-                _log(f"V2 layer-link wiring raised {type(exc).__name__}: {exc}; "
-                     "block will run V1-only")
+                _log(f"V2 layer-link wiring raised {type(exc).__name__}: {exc}; " "block will run V1-only")
 
         TransformerBlock.__init__ = _v2_init
         TransformerBlock._fused_residual_v2_init_patched = True
@@ -172,8 +166,10 @@ def install() -> bool:
             try:
                 return _do_fused_forward(self, *args, **kwargs)
             except Exception as exc:
-                _log(f"fused forward raised {type(exc).__name__}: {exc}; "
-                     f"falling back to original forward for all layers")
+                _log(
+                    f"fused forward raised {type(exc).__name__}: {exc}; "
+                    f"falling back to original forward for all layers"
+                )
                 TransformerLayer.forward = _orig_layer_forward
                 return _orig_layer_forward(self, *args, **kwargs)
 
@@ -220,9 +216,7 @@ def _wire_v2_layer_links(block: Any) -> None:
         object.__setattr__(layer, "_v2_block", block)
         object.__setattr__(layer, "_v2_next_layer", nxt)
         object.__setattr__(layer, "_v2_is_last_layer", is_last)
-        object.__setattr__(
-            layer, "_v2_final_layernorm", final_ln if is_last else None
-        )
+        object.__setattr__(layer, "_v2_final_layernorm", final_ln if is_last else None)
         object.__setattr__(layer, "_v2_carry", None)
 
 
@@ -284,6 +278,7 @@ def _can_fuse(layer: Any) -> bool:
         return False
 
     from megatron.core.transformer.identity_op import IdentityOp
+
     cross_attn = getattr(layer, "cross_attention", None)
     if cross_attn is not None and not isinstance(cross_attn, IdentityOp):
         return False
@@ -344,6 +339,7 @@ def _do_fused_forward(layer: Any, hidden_states=None, *args, **kwargs):
         nvtx_range_pop,
         nvtx_range_push,
     )
+
     if hidden_states is None:
         hidden_states = kwargs.pop("hidden_states")
     else:
@@ -368,6 +364,7 @@ def _do_fused_forward(layer: Any, hidden_states=None, *args, **kwargs):
         from primus_turbo.pytorch.ops.normalization import (
             rmsnorm_residual as triton_rmsnorm_residual,
         )
+
         in_ln = layer.input_layernorm
         gamma = in_ln.weight
         if getattr(in_ln, "zero_centered_gamma", False):
@@ -403,18 +400,14 @@ def _do_fused_forward(layer: Any, hidden_states=None, *args, **kwargs):
 
     # ---- V1 fuse: bda(attn_out, residual) + pre_mlp_layernorm ------------
     nvtx_range_push(suffix="fused_residual_pre_mlp_layernorm")
-    pre_mlp_layernorm_output, hidden_states = layer.pre_mlp_layernorm(
-        attn_out, residual=residual
-    )
+    pre_mlp_layernorm_output, hidden_states = layer.pre_mlp_layernorm(attn_out, residual=residual)
     nvtx_range_pop(suffix="fused_residual_pre_mlp_layernorm")
     # hidden_states now == attn_out + residual (= residual_post_attn).
 
     # ---- mlp -------------------------------------------------------------
     padding_mask = kwargs.get("padding_mask", None)
     try:
-        mlp_output_with_bias = layer.mlp(
-            pre_mlp_layernorm_output, padding_mask=padding_mask
-        )
+        mlp_output_with_bias = layer.mlp(pre_mlp_layernorm_output, padding_mask=padding_mask)
     except TypeError:
         mlp_output_with_bias = layer.mlp(pre_mlp_layernorm_output)
 

--- a/primus/backends/megatron/mlperf/__init__.py
+++ b/primus/backends/megatron/mlperf/__init__.py
@@ -1,0 +1,26 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Primus MLPerf logging integration for the Megatron pretrain backend.
+
+This package integrates the (formerly external) ``primus_mllog`` thin wrapper
+directly into Primus, mapping it onto the new ``BaseTrainer`` lifecycle.
+
+``mlperf_logging`` and other MLPerf-only dependencies are imported lazily
+inside methods so that importing this package (which happens whenever the
+Megatron backend is loaded) never breaks non-MLPerf runs.
+"""
+
+from primus.backends.megatron.mlperf.mlperf_logger import MLPerfLogger, ThroughputTimer
+from primus.backends.megatron.mlperf.mlperf_pretrain_trainer import (
+    MLPerfMegatronPretrainTrainer,
+)
+
+__all__ = [
+    "MLPerfLogger",
+    "ThroughputTimer",
+    "MLPerfMegatronPretrainTrainer",
+]

--- a/primus/backends/megatron/mlperf/mlperf_logger.py
+++ b/primus/backends/megatron/mlperf/mlperf_logger.py
@@ -1,0 +1,159 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""MLPERF Logging support for Primus Megatron backend."""
+
+import os
+import time
+from typing import Any, Dict, Optional
+
+
+class MLPerfLogger:
+    """Wrapper around mllog library with rank-aware logging."""
+
+    def __init__(self):
+        from mlperf_logging import mllog
+
+        self.mllogger = mllog.get_mllogger()
+        self._configured = False
+        self._rank = None
+        self._save_to_file = os.getenv("MLLOG_SAVE_TO_FILE", "1").lower() not in ("0", "false", "no")
+
+    def configure(self, filepath: str, args) -> Dict[str, Any]:
+        from mlperf_logging import mllog
+
+        if self._save_to_file:
+            mllog.config(filename=filepath, default_stack_offset=3)
+        else:
+            mllog.config(default_stack_offset=3)
+        self._configured = True
+        self._rank = self._get_rank()
+        return self.extract_mlperf_configs(args)
+
+    def _get_rank(self) -> int:
+        import torch
+
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            return torch.distributed.get_rank()
+        return int(os.environ.get("RANK", 0))
+
+    def log_event_all_ranks(self, key: str, value: Any, metadata: Optional[Dict] = None):
+        self.mllogger.event(key=key, value=value, metadata=metadata or {})
+
+    def log_event(self, key: str, value: Any, metadata: Optional[Dict] = None, stack_offset: int = 2):
+        if self._rank == 0:
+            self.mllogger.event(key=key, value=value, metadata=metadata or {}, stack_offset=stack_offset)
+
+    def log_start(self, key: str, metadata: Optional[Dict] = None, stack_offset: int = 2):
+        if self._rank == 0:
+            self.mllogger.start(key=key, metadata=metadata or {}, stack_offset=stack_offset)
+
+    def log_end(self, key: str, metadata: Optional[Dict] = None, stack_offset: int = 2):
+        if self._rank == 0:
+            self.mllogger.end(key=key, metadata=metadata or {}, stack_offset=stack_offset)
+
+    def extract_mlperf_configs(self, args) -> Dict[str, Any]:
+        """Extract MLPERF config parameters from Megatron args."""
+        from mlperf_logging.mllog import constants
+
+        data_parallel_size = getattr(args, "data_parallel_size", 1)
+        if data_parallel_size == 0:
+            data_parallel_size = 1
+        micro_batches = args.global_batch_size // (args.micro_batch_size * data_parallel_size)
+
+        eval_samples = args.eval_iters * args.global_batch_size if args.eval_iters > 0 else 1024
+
+        train_samples = getattr(args, "train_samples", None)
+        if not train_samples:
+            train_samples = args.train_iters * args.global_batch_size
+
+        optimizer_name = getattr(args, "optimizer", "adam")
+        if optimizer_name.lower() == "adam":
+            optimizer_name = "adamw"
+        else:
+            optimizer_name = optimizer_name.lower()
+
+        configs = {
+            constants.GLOBAL_BATCH_SIZE: args.global_batch_size,
+            constants.GRADIENT_ACCUMULATION_STEPS: micro_batches,
+            "max_sequence_length": args.seq_length,
+            constants.TRAIN_SAMPLES: train_samples,
+            constants.EVAL_SAMPLES: eval_samples,
+            constants.SEED: args.seed,
+            "init_checkpoint_step": args.iteration,
+            constants.OPT_NAME: optimizer_name,
+            constants.OPT_BASE_LR: args.lr,
+            constants.OPT_ADAMW_BETA_1: getattr(args, "adam_beta1", 0.9),
+            constants.OPT_ADAMW_BETA_2: getattr(args, "adam_beta2", 0.999),
+            constants.OPT_ADAMW_EPSILON: getattr(args, "adam_eps", 1e-8),
+            constants.OPT_ADAMW_WEIGHT_DECAY: args.weight_decay,
+            "opt_gradient_clip_norm": getattr(args, "clip_grad", 1.0),
+            "opt_end_learning_rate": args.min_lr,
+            "opt_learning_rate_warmup_steps": getattr(args, "lr_warmup_iters", 0),
+            "opt_learning_rate_decay_steps": args.lr_decay_iters if args.lr_decay_iters else args.train_iters,
+            "opt_learning_rate_decay_schedule": self._get_lr_schedule_name(args.lr_decay_style),
+            "max_steps": args.train_iters,
+            constants.SUBMISSION_BENCHMARK: os.getenv("MLLOG_SUBMISSION_BENCHMARK", ""),
+            constants.SUBMISSION_DIVISION: os.getenv("MLLOG_SUBMISSION_DIVISION", ""),
+            constants.SUBMISSION_STATUS: os.getenv("MLLOG_SUBMISSION_STATUS", ""),
+            constants.SUBMISSION_ORG: os.getenv("MLLOG_SUBMISSION_ORG", ""),
+            constants.SUBMISSION_PLATFORM: os.getenv("MLLOG_SUBMISSION_PLATFORM", ""),
+            constants.TENSOR_PARALLELISM: int(os.getenv("MLLOG_TENSOR_PARALLELISM", 1)),
+            constants.PIPELINE_PARALLELISM: int(os.getenv("MLLOG_PIPELINE_PARALLELISM", 1)),
+            constants.CONTEXT_PARALLELISM: int(os.getenv("MLLOG_CONTEXT_PARALLELISM", 1)),
+            constants.EXPERT_PARALLELISM: int(os.getenv("MLLOG_EXPERT_PARALLELISM", 1)),
+            constants.MICRO_BATCH_SIZE: int(os.getenv("MLLOG_MICRO_BATCH_SIZE", 1)),
+            constants.CONFIG_FILENAME: os.getenv("MLLOG_CONFIG_FILENAME", ""),
+            "lowest_numerical_precision_linear": os.getenv("MLLOG_LOWEST_NUMERICAL_PRECISION_LINEAR", ""),
+        }
+        return configs
+
+    def _get_lr_schedule_name(self, style: str) -> str:
+        mapping = {
+            "cosine": "cosine with linear warmup",
+            "linear": "linear",
+            "constant": "constant",
+        }
+        return mapping.get(style, style)
+
+
+class ThroughputTimer:
+    """Per-step accumulation timer for training throughput (samples/sec).
+
+    Measures only the time inside each training step, excluding eval time
+    and inter-step overhead (dataloader, callbacks, Python gaps).  This
+    matches the approach used by nemo's Timer class.
+    """
+
+    def __init__(self, global_batch_size: int):
+        self.gbs = global_batch_size
+        self._step_start_time = None
+        self._accumulated_time = 0.0
+        self._accumulated_samples = 0
+
+    def step_start(self):
+        """Mark the beginning of a training step."""
+        self._step_start_time = time.time()
+
+    def step_stop(self):
+        """Mark the end of a training step and accumulate elapsed time."""
+        if self._step_start_time is not None:
+            self._accumulated_time += time.time() - self._step_start_time
+            self._accumulated_samples += self.gbs
+            self._step_start_time = None
+
+    def get_throughput(self) -> Optional[float]:
+        """Return throughput for the accumulated steps and reset counters.
+
+        Returns:
+            Samples per second, or None if no steps were accumulated.
+        """
+        if self._accumulated_time <= 0:
+            return None
+        throughput = self._accumulated_samples / self._accumulated_time
+        self._accumulated_time = 0.0
+        self._accumulated_samples = 0
+        return throughput

--- a/primus/backends/megatron/mlperf/mlperf_pretrain_trainer.py
+++ b/primus/backends/megatron/mlperf/mlperf_pretrain_trainer.py
@@ -264,7 +264,11 @@ class MLPerfMegatronPretrainTrainer(MegatronPretrainTrainer):
 
             if not skipped_iter and loss_dict and not self._warmup_active:
                 optimizer = _get_arg(args, kwargs, 3, "optimizer")
-                self._on_train_step_end(loss_dict, optimizer)
+                # Upstream passes the real loop iteration as the 8th positional
+                # (index 7) / ``iteration`` kwarg of train_step. ``args.iteration``
+                # is NOT updated until after train_step returns, so use this.
+                iteration = _get_arg(args, kwargs, 7, "iteration")
+                self._on_train_step_end(loss_dict, optimizer, iteration)
 
             if self.rpd and self.mllogger._get_rank() == 0 and self.profile_segment == "train_step":
                 self.rpd.stop()
@@ -361,12 +365,16 @@ class MLPerfMegatronPretrainTrainer(MegatronPretrainTrainer):
     # Helpers
     # ------------------------------------------------------------------
 
-    def _on_train_step_end(self, loss_dict, optimizer):
+    def _on_train_step_end(self, loss_dict, optimizer, iteration=None):
         from megatron.training import get_args
         from mlperf_logging.mllog import constants
 
         args = get_args()
-        iteration = args.iteration
+        # Prefer the iteration passed into train_step (real loop counter); fall
+        # back to args.iteration only if it was not provided. args.iteration is
+        # stale during train_step, which made ``% freq`` true every step.
+        if iteration is None:
+            iteration = args.iteration
         consumed_samples = args.consumed_train_samples
 
         if self.train_loss_log_freq <= 0 or iteration % self.train_loss_log_freq != 0:

--- a/primus/backends/megatron/mlperf/mlperf_pretrain_trainer.py
+++ b/primus/backends/megatron/mlperf/mlperf_pretrain_trainer.py
@@ -1,0 +1,409 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""MLPerf-enabled Megatron pretrain trainer for the Primus new architecture.
+
+Unlike the legacy ``primus_mllog.MLPerfMegatronPretrainTrainer`` (which
+subclassed the *old* Primus trainer and overrode Primus-owned ``init`` /
+``run`` / ``train`` / ``train_step`` methods), the new architecture delegates
+the entire training loop to upstream ``megatron.training.pretrain()`` inside
+:meth:`MegatronPretrainTrainer.train`.  There are therefore no Primus-owned
+loop methods to override.
+
+This trainer maps the MLPerf logging onto the new ``BaseTrainer`` lifecycle
+(``setup -> init -> train -> cleanup``) by **monkey-patching the upstream
+Megatron functions** that the loop calls:
+
+    * ``megatron.training.training.train``                 (loop entry/exit)
+    * ``megatron.training.training.train_step``            (per-step hooks)
+    * ``megatron.training.training.evaluate``              (capture val loss)
+    * ``megatron.training.training.evaluate_and_print_results`` (eval markers)
+
+All ``mlperf_logging`` imports are lazy so importing this module never breaks
+non-MLPerf runs.
+"""
+
+import os
+import time
+
+from primus.backends.megatron.megatron_pretrain_trainer import MegatronPretrainTrainer
+from primus.backends.megatron.mlperf.mlperf_logger import MLPerfLogger, ThroughputTimer
+
+try:
+    from rpdTracerControl import rpdTracerControl
+except ImportError:
+    rpdTracerControl = None
+
+
+def _get_arg(args, kwargs, index, name):
+    """Fetch a positional-or-keyword argument from a wrapped call.
+
+    Upstream Megatron calls ``train`` / ``train_step`` positionally, but we
+    accept either form so the patch is robust across signature tweaks.
+    """
+    if name in kwargs:
+        return kwargs[name]
+    if index < len(args):
+        return args[index]
+    return None
+
+
+class MLPerfMegatronPretrainTrainer(MegatronPretrainTrainer):
+    """MegatronPretrainTrainer with MLPerf (mllog) logging."""
+
+    def __init__(self, backend_args):
+        super().__init__(backend_args)
+
+        self.mllogger = MLPerfLogger()
+        self.throughput_timer = None
+        self.train_start_time = None
+        self.train_stop_time = None
+        self.last_validation_loss = None
+        self.train_loss_log_freq = int(os.getenv("MLLOG_TRAIN_LOSS_LOG_FREQ", "1"))
+        self.block_tput_log = os.getenv("MLLOG_BLOCK_TPUT_LOG", "0") == "1"
+        self.target_eval_loss = float(os.getenv("MLLOG_TARGET_EVAL_LOSS", "0.0"))
+        self.is_target_reached = False
+        self._warmup_active = False
+
+        # RPD profiler (optional). Mirrors the legacy wrapper.
+        profiler = os.getenv("PROFILER", "")
+        self.profile_segment = os.getenv("PROFILE_SEGMENT", "train")
+        self.rpd = None
+        if profiler == "rpd" and rpdTracerControl is not None:
+            rpdTracerControl.setFilename(name="trace.rpd", append=True)
+            self.rpd = rpdTracerControl()
+            enable_python_trace = os.getenv("ENABLE_PYTHON_TRACE", "false").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+            self.rpd.setPythonTrace(doTrace=enable_python_trace)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def setup(self):
+        """Megatron setup + MLPerf CACHE_CLEAR / INIT_START.
+
+        ``setup()`` runs before ``init()`` and before ``train()`` (which
+        calls upstream ``pretrain()`` that performs the heavy init), so this
+        is the correct place to bracket the start of initialisation.
+        """
+        super().setup()
+
+        # Primus reconfigures stdlib ``logging`` via loguru during setup,
+        # which resets the per-logger levels installed by the log-suppression
+        # module at import time. Re-apply the quiet levels (no-op unless
+        # PRIMUS_LOG_SUPPRESSION=1 and not verbose).
+        try:
+            from primus.mlperf_log_suppression import reapply_quiet_logger_levels
+
+            reapply_quiet_logger_levels()
+        except Exception:
+            pass
+
+        from mlperf_logging.mllog import constants
+
+        self.mllogger.log_event_all_ranks(key=constants.CACHE_CLEAR, value=True)
+        self.mllogger.log_event_all_ranks(key=constants.INIT_START, value=None)
+
+    def train(self):
+        """Install MLPerf hooks on upstream Megatron, then run pretrain()."""
+        import megatron.training.training as mt
+
+        orig_train = mt.train
+        orig_train_step = mt.train_step
+        orig_evaluate = mt.evaluate
+        orig_eval_and_print = mt.evaluate_and_print_results
+
+        wrapped_train = self._make_wrapped_train(mt, orig_train)
+        wrapped_train_step = self._make_wrapped_train_step(orig_train_step)
+        wrapped_evaluate = self._make_wrapped_evaluate(orig_evaluate)
+        wrapped_eval_and_print = self._make_wrapped_eval_and_print(orig_eval_and_print)
+
+        mt.train = wrapped_train
+        mt.train_step = wrapped_train_step
+        mt.evaluate = wrapped_evaluate
+        mt.evaluate_and_print_results = wrapped_eval_and_print
+
+        try:
+            return super().train()
+        finally:
+            mt.train = orig_train
+            mt.train_step = orig_train_step
+            mt.evaluate = orig_evaluate
+            mt.evaluate_and_print_results = orig_eval_and_print
+
+    # ------------------------------------------------------------------
+    # Patch builders
+    # ------------------------------------------------------------------
+
+    def _make_wrapped_train(self, mt, orig_train):
+        def wrapped_train(*args, **kwargs):
+            from megatron.training import get_args
+            from mlperf_logging.mllog import constants
+
+            from primus.backends.megatron.mlperf.warmup import run_synthetic_warmup
+
+            megatron_args = get_args()
+
+            # Configure mllog + log hyper-parameters + INIT_STOP. ``get_args``
+            # is valid here because upstream pretrain() has finished init by
+            # the time it calls train().
+            output_file = os.getenv("MLLOG_OUTPUT_FILE", "/results/mlperf_output.log")
+            configs = self.mllogger.configure(output_file, megatron_args)
+            for key, value in configs.items():
+                self.mllogger.log_event(key=key, value=value)
+            self.mllogger.log_end(key=constants.INIT_STOP)
+
+            self.throughput_timer = ThroughputTimer(megatron_args.global_batch_size)
+
+            forward_step_func = _get_arg(args, kwargs, 0, "forward_step_func")
+            model = _get_arg(args, kwargs, 1, "model")
+            optimizer = _get_arg(args, kwargs, 2, "optimizer")
+            opt_param_scheduler = _get_arg(args, kwargs, 3, "opt_param_scheduler")
+            config = _get_arg(args, kwargs, 7, "config")
+
+            # Synthetic warmup runs BEFORE RUN_START so its time is excluded
+            # from the timed run. It calls the (patched) module-level
+            # train_step; _warmup_active suppresses per-step loss logging.
+            self._warmup_active = True
+            try:
+                run_synthetic_warmup(
+                    mt.train_step,
+                    forward_step_func,
+                    model,
+                    optimizer,
+                    opt_param_scheduler,
+                    config,
+                    megatron_args,
+                )
+            finally:
+                self._warmup_active = False
+            # Discard warmup step timings.
+            self.throughput_timer.get_throughput()
+
+            self.mllogger.log_start(key=constants.RUN_START)
+            self.train_start_time = time.time()
+            self.mllogger.log_start(key=constants.EPOCH_START, metadata={constants.SAMPLES_COUNT: 0})
+            self.mllogger.log_start(key=constants.BLOCK_START, metadata={constants.SAMPLES_COUNT: 0})
+
+            if self.rpd and self.profile_segment == "train":
+                self.rpd.start()
+
+            result = orig_train(*args, **kwargs)
+
+            if self.rpd and self.profile_segment == "train":
+                self.rpd.stop()
+                self.rpd = None
+
+            final_args = get_args()
+            consumed_samples = final_args.consumed_train_samples
+            self.mllogger.log_end(
+                key=constants.EPOCH_STOP, metadata={constants.SAMPLES_COUNT: consumed_samples}
+            )
+
+            if self.is_target_reached:
+                self.mllogger.log_end(
+                    key=constants.RUN_STOP,
+                    metadata={
+                        constants.SAMPLES_COUNT: consumed_samples,
+                        constants.STATUS: constants.SUCCESS,
+                    },
+                )
+            else:
+                self.train_stop_time = time.time()
+                self.mllogger.log_end(
+                    key=constants.RUN_STOP,
+                    metadata={
+                        constants.SAMPLES_COUNT: consumed_samples,
+                        constants.STATUS: constants.ABORTED,
+                    },
+                )
+
+            # Overall run summary (rank-0 only; informational keys).
+            duration = (self.train_stop_time or time.time()) - (self.train_start_time or time.time())
+            duration_minutes = duration / 60.0
+            overall_throughput = consumed_samples / duration if duration > 0 else 0.0
+            self.mllogger.log_event(
+                key="run_duration",
+                value=f"{round(duration, 2)}s -> {round(duration_minutes, 2)} minutes",
+                metadata={"samples": consumed_samples},
+            )
+            self.mllogger.log_event(
+                key="overall_throughput",
+                value=round(overall_throughput, 2),
+                metadata={"samples": consumed_samples},
+            )
+
+            return result
+
+        return wrapped_train
+
+    def _make_wrapped_train_step(self, orig_train_step):
+        def wrapped_train_step(*args, **kwargs):
+            if self.rpd and self.mllogger._get_rank() == 0 and self.profile_segment == "train_step":
+                self.rpd.start()
+
+            if self.throughput_timer is not None:
+                self.throughput_timer.step_start()
+            result = orig_train_step(*args, **kwargs)
+            if self.throughput_timer is not None:
+                self.throughput_timer.step_stop()
+
+            # Upstream train_step returns an 8-tuple:
+            # (loss_dict, skipped_iter, should_checkpoint, should_exit,
+            #  exit_code, grad_norm, num_zeros_in_grad, log_max_attention_logit)
+            loss_dict = result[0]
+            skipped_iter = result[1]
+
+            if not skipped_iter and loss_dict and not self._warmup_active:
+                optimizer = _get_arg(args, kwargs, 3, "optimizer")
+                self._on_train_step_end(loss_dict, optimizer)
+
+            if self.rpd and self.mllogger._get_rank() == 0 and self.profile_segment == "train_step":
+                self.rpd.stop()
+                self.rpd = None
+
+            return result
+
+        return wrapped_train_step
+
+    def _make_wrapped_evaluate(self, orig_evaluate):
+        def wrapped_evaluate(*args, **kwargs):
+            if self.rpd and self.mllogger._get_rank() == 0 and self.profile_segment == "eval":
+                self.rpd.start()
+
+            result = orig_evaluate(*args, **kwargs)
+
+            if self.rpd and self.mllogger._get_rank() == 0 and self.profile_segment == "eval":
+                self.rpd.stop()
+                self.rpd = None
+
+            total_loss_dict = result[0]
+            if total_loss_dict and "lm loss" in total_loss_dict:
+                val_loss = total_loss_dict["lm loss"]
+                if hasattr(val_loss, "item"):
+                    self.last_validation_loss = val_loss.item()
+                else:
+                    self.last_validation_loss = float(val_loss)
+
+            return result
+
+        return wrapped_evaluate
+
+    def _make_wrapped_eval_and_print(self, orig_eval_and_print):
+        def wrapped_eval_and_print(*args, **kwargs):
+            from megatron.training import get_args
+            from mlperf_logging.mllog import constants
+
+            eval_args = get_args()
+            consumed_samples = eval_args.consumed_train_samples
+
+            self._log_tracked_stats(eval_args.iteration, consumed_samples)
+
+            self.mllogger.log_end(
+                key=constants.BLOCK_STOP, metadata={constants.SAMPLES_COUNT: consumed_samples}
+            )
+            self.mllogger.log_start(
+                key=constants.EVAL_START, metadata={constants.SAMPLES_COUNT: consumed_samples}
+            )
+
+            if self.rpd and self.mllogger._get_rank() == 0 and self.profile_segment == "eval":
+                self.rpd.start()
+
+            result = orig_eval_and_print(*args, **kwargs)
+
+            if self.rpd and self.mllogger._get_rank() == 0 and self.profile_segment == "eval":
+                self.rpd.stop()
+                self.rpd = None
+
+            validation_loss = self._get_validation_loss()
+            if validation_loss is not None:
+                self.mllogger.log_event(
+                    key=constants.EVAL_ACCURACY,
+                    value=validation_loss,
+                    metadata={constants.SAMPLES_COUNT: consumed_samples},
+                )
+
+                if self.target_eval_loss > 0.0 and validation_loss <= self.target_eval_loss:
+                    if not self.is_target_reached:
+                        self.is_target_reached = True
+                        self.train_stop_time = time.time()
+                        if self.mllogger._get_rank() == 0:
+                            print(
+                                f"[MLPERF] Target eval loss {self.target_eval_loss} reached "
+                                f"with validation loss {validation_loss}"
+                            )
+                        eval_args.train_iters = eval_args.iteration
+                        eval_args.do_valid = False
+                        eval_args.do_test = False
+
+            self.mllogger.log_end(
+                key=constants.EVAL_STOP, metadata={constants.SAMPLES_COUNT: consumed_samples}
+            )
+
+            if not self.is_target_reached:
+                self.mllogger.log_start(
+                    key=constants.BLOCK_START, metadata={constants.SAMPLES_COUNT: consumed_samples}
+                )
+
+            return result
+
+        return wrapped_eval_and_print
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _on_train_step_end(self, loss_dict, optimizer):
+        from megatron.training import get_args
+        from mlperf_logging.mllog import constants
+
+        args = get_args()
+        iteration = args.iteration
+        consumed_samples = args.consumed_train_samples
+
+        if self.train_loss_log_freq <= 0 or iteration % self.train_loss_log_freq != 0:
+            return
+
+        loss_value = loss_dict.get("lm loss")
+        if loss_value is None:
+            return
+
+        if isinstance(loss_value, (tuple, list)):
+            loss_value = loss_value[0]
+        if hasattr(loss_value, "item"):
+            loss_value = loss_value.item()
+
+        learning_rate = None
+        if optimizer is not None:
+            for param_group in optimizer.param_groups:
+                if not param_group.get("is_decoupled_lr", False):
+                    learning_rate = param_group["lr"]
+                    break
+
+        self.mllogger.log_event(
+            key="train_loss",
+            value=loss_value,
+            metadata={constants.SAMPLES_COUNT: consumed_samples, "lr": learning_rate},
+        )
+
+    def _log_tracked_stats(self, iteration, consumed_samples):
+        if self.throughput_timer is None:
+            return
+        throughput = self.throughput_timer.get_throughput()
+        if throughput is not None and self.block_tput_log:
+            self.mllogger.log_event(
+                key="tracked_stats",
+                value={"throughput": throughput},
+                metadata={"step": consumed_samples},
+            )
+
+    def _get_validation_loss(self):
+        return getattr(self, "last_validation_loss", None)

--- a/primus/backends/megatron/mlperf/warmup.py
+++ b/primus/backends/megatron/mlperf/warmup.py
@@ -1,0 +1,776 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Synthetic-data warmup for Primus / Megatron training.
+
+Adds optional FP4 (MXFP4 / NVFP4) warmup support on top of the original FP8
+warmup helpers.  The original FP8 / BF16 path is preserved exactly:
+
+  * No autocast wrapping by default — ``train_step`` runs at the model's
+    native precision, identical to the committed pre-FP4 behaviour.
+  * After warmup, ``reset_fp8_state`` + ``seed_fp8_amax(1.0)`` always runs
+    (no-op for BF16 / non-FP8 modules).
+  * ``ChainedOptimizer`` support (EP < num_gpus) is preserved.
+
+FP4 mode is **opt-in** via ``WARMUP_RECIPE=fp4_mxfp4`` / ``fp4_nvfp4``.  When
+set, the warmup loop is wrapped in ``te.fp8_autocast(fp8_recipe=...)`` and
+an additional ``reset_fp4_state()`` pass runs after warmup.
+
+Runs N forward+backward passes with random token sequences before the real
+training loop starts.  This pre-compiles Triton / CK / hipBLASLt kernels and
+amortizes:
+
+  * distributed-optimizer FP32 main-param allocation
+  * DDP gradient-bucket allocation
+  * NCCL communicator init + collective autotune
+  * hipBLASLt heuristic / Triton / CK JIT caches (recipe-dependent)
+  * PyTorch HIP allocator block layout
+
+After warmup:
+  * Model parameters are restored from a pre-warmup snapshot.
+  * Optimizer state is restored (neutered during warmup so weights never move).
+  * Adam buffers (exp_avg / exp_avg_sq) are zeroed and grads cleared.
+  * LR scheduler state is rolled back and re-synced (param_groups['lr']).
+  * FP8 scaling state (amax_history, scale, scale_inv, fp8_initialized) is
+    fully reset and seeded with safe defaults.
+  * If WARMUP_RECIPE selected an FP4 recipe, FP4 state is also reset.
+
+Controlled by:
+
+  SYNTH_WARMUP_STEPS         default 3,  0 disables.
+  WARMUP_RECIPE              default "" (no autocast, original behaviour),
+                             one of:
+                               "" | "bf16"
+                               | "fp8_hybrid" | "fp8_e4m3"
+                               | "fp4_mxfp4"  | "fp4_nvfp4"
+                             Legacy alias WARMUP_FP8_RECIPE=hybrid|e4m3 also
+                             accepted (maps to fp8_hybrid / fp8_e4m3).
+                             FP8/BF16 models do NOT need to set this; it
+                             only affects which autocast (if any) wraps the
+                             warmup train_step.
+  WARMUP_FP8_HISTORY_LEN     default 4, only used for fp8_* recipes.
+  SYNTH_WARMUP_EMPTY_CACHE   default 1, call torch.cuda.empty_cache() per step.
+"""
+
+import os
+import time
+from contextlib import nullcontext
+
+import torch
+import torch.distributed
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+def _log(msg):
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    if rank == 0:
+        print(f"[SYNTH_WARMUP] {msg}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data
+# ---------------------------------------------------------------------------
+
+
+class SyntheticGPTDataIterator:
+    """Infinite iterator yielding random token batches for Primus/Megatron GPT.
+
+    Primus's ``get_batch_on_this_tp_rank`` expects the iterator to yield a dict
+    with ``tokens``, ``labels``, ``loss_mask``, and ``position_ids`` tensors,
+    each of shape ``[mbs, seq_length]``.
+    """
+
+    def __init__(self, seq_length, micro_batch_size, vocab_size=32000):
+        self.seq_length = seq_length
+        self.micro_batch_size = micro_batch_size
+        self.vocab_size = vocab_size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        mbs = self.micro_batch_size
+        sl = self.seq_length
+        tokens = torch.randint(0, self.vocab_size, (mbs, sl), dtype=torch.int64)
+        labels = torch.randint(0, self.vocab_size, (mbs, sl), dtype=torch.int64)
+        loss_mask = torch.ones(mbs, sl, dtype=torch.float32)
+        position_ids = torch.arange(sl, dtype=torch.int64).unsqueeze(0).expand(mbs, -1)
+        return {
+            "tokens": tokens,
+            "labels": labels,
+            "loss_mask": loss_mask,
+            "position_ids": position_ids,
+        }
+
+
+# ---------------------------------------------------------------------------
+# FP8 state management  --  ORIGINAL from committed warmup.py.
+#
+# The only change vs. the committed version is one defensive line at the top
+# of ``_is_delayed_scaling_recipe`` that returns False for FP4-flagged
+# modules so the FP8 reset path skips them (handled by reset_fp4_state()
+# instead).  No behavioural change for FP8 / BF16 / current-scaling models.
+# ---------------------------------------------------------------------------
+
+
+def _is_delayed_scaling_recipe(module):
+    """Return True if the module uses delayed scaling (which has scale/amax_history).
+
+    Current scaling (tensorwise) is stateless — no scale or amax_history to
+    manage — so reset / seed operations must be skipped for it.
+    FP4 (MXFP4 / NVFP4) modules also have no scale/amax_history; they are
+    skipped here and handled by reset_fp4_state() if WARMUP_RECIPE is fp4_*.
+    Returns True when recipe type cannot be determined (safe default).
+    """
+    # Defensive: FP4 modules use a different recipe state class with no
+    # scale/amax_history. Calling FP8 helpers on them is at best a no-op
+    # and at worst raises AttributeError.
+    if bool(getattr(module, "fp4", False)) or hasattr(module, "fp4_initialized"):
+        return False
+
+    from transformer_engine.common.recipe import DelayedScaling
+
+    fp8_meta = getattr(module, "fp8_meta", None)
+    if fp8_meta is None:
+        return True
+    fwd_state = fp8_meta.get("scaling_fwd", None)
+    if fwd_state is None:
+        return True
+    return isinstance(getattr(fwd_state, "recipe", None), DelayedScaling)
+
+
+def _manual_reset_fp8_meta(module):
+    """Reset FP8 amax / scale tensors when reset_fp8_meta_tensors() is absent."""
+    if not hasattr(module, "fp8_meta"):
+        return False
+    if not _is_delayed_scaling_recipe(module):
+        return False
+    meta = module.fp8_meta
+    reset_count = 0
+    for key in ("scaling_fwd", "scaling_bwd"):
+        if key not in meta:
+            continue
+        tensor_meta = meta[key]
+        if hasattr(tensor_meta, "amax_history"):
+            tensor_meta.amax_history.fill_(0.0)
+            reset_count += 1
+        if hasattr(tensor_meta, "scale"):
+            tensor_meta.scale.fill_(1.0)
+            reset_count += 1
+        if hasattr(tensor_meta, "scale_inv"):
+            tensor_meta.scale_inv.fill_(1.0)
+            reset_count += 1
+    return reset_count > 0
+
+
+def reset_fp8_state(model, reset_meta_tensors=True):
+    """Clear ``fp8_initialized`` on every TE layer, forcing re-init.
+
+    When *reset_meta_tensors* is True, also zeros out amax_history and
+    resets scale / scale_inv to 1.0.
+
+    Skips FP4 modules (handled by reset_fp4_state() when WARMUP_RECIPE=fp4_*).
+    """
+    count = 0
+    method_count = 0
+    manual_count = 0
+
+    def _reset(m):
+        nonlocal count, method_count, manual_count
+        if hasattr(m, "fp8_initialized"):
+            m.fp8_initialized = False
+            count += 1
+            if reset_meta_tensors:
+                if hasattr(m, "reset_fp8_meta_tensors"):
+                    if _is_delayed_scaling_recipe(m):
+                        m.reset_fp8_meta_tensors()
+                        method_count += 1
+                elif _manual_reset_fp8_meta(m):
+                    manual_count += 1
+
+    models = model if isinstance(model, (list, tuple)) else [model]
+    for m in models:
+        m.apply(_reset)
+    _log(f"reset_fp8_state: {count} modules, " f"{method_count} via method, {manual_count} via manual reset")
+    return count
+
+
+def seed_fp8_amax(model, seed_value=1.0):
+    """Fill amax_history with *seed_value* to prevent scale=inf after reset.
+
+    Delayed scaling computes ``scale = fp8_max / max(amax_history)``.
+    If amax_history is all-zero after reset, scale becomes inf -> NaN.
+    Seeding with 1.0 gives scale = fp8_max / 1.0 ~ 448 (E4M3), which is safe.
+    """
+    count = 0
+
+    def _seed(m):
+        nonlocal count
+        if not hasattr(m, "fp8_meta"):
+            return
+        if not _is_delayed_scaling_recipe(m):
+            return
+        meta = m.fp8_meta
+        for key in ("scaling_fwd", "scaling_bwd"):
+            if key not in meta:
+                continue
+            tensor_meta = meta[key]
+            if hasattr(tensor_meta, "amax_history"):
+                tensor_meta.amax_history.fill_(seed_value)
+                count += 1
+
+    models = model if isinstance(model, (list, tuple)) else [model]
+    for m in models:
+        m.apply(_seed)
+    _log(f"seed_fp8_amax: seeded {count} amax_history tensors with {seed_value}")
+    return count
+
+
+# ===========================================================================
+# FP4 state management  --  NEW, only invoked when WARMUP_RECIPE=fp4_*
+# ===========================================================================
+#
+# Notes on FP4 vs FP8 in TE:
+#   * MXFP4BlockScaling and NVFP4BlockScaling derive scales **per tile** from
+#     the current activation/weight on every forward — there is no
+#     amax_history and no global scale-inv to bias.  So no seeding step.
+#   * Some TE versions store FP4 quantizer caches under fp8_meta as well
+#     (under attrs like ``block_scales``, ``mxfp4_quantizer``, etc.).  We
+#     try to clear those defensively; they're allowed to be missing.
+#   * Different TE versions may track init via ``fp4_initialized``,
+#     ``fp8_initialized`` (shared with FP8), or both.  We touch whichever
+#     attribute exists.
+
+# Per-tensor-meta attribute names that may hold FP4-specific cached state.
+# Cleared opportunistically if present; missing attrs are silently skipped.
+_FP4_META_ATTRS = (
+    "block_scales",
+    "block_scales_inv",
+    "mxfp4_block_scale",
+    "fp4_quantizer_state",
+    "fp4_amax",
+)
+
+
+def _is_fp4_module(m):
+    """True if a TE module is configured for FP4 (MXFP4 / NVFP4).
+
+    FP4 modules in TE share ``fp8_initialized`` and ``fp8_meta`` with FP8 but
+    populate them with an FP4 recipe state (``MXFP4BlockScalingRecipeState``,
+    ``NVFP4BlockScalingRecipeState``) that has no ``scale``/``amax_history``.
+    """
+    if bool(getattr(m, "fp4", False)):
+        return True
+    if hasattr(m, "fp4_initialized"):
+        return True
+    meta = getattr(m, "fp8_meta", None)
+    if isinstance(meta, dict):
+        for key in ("scaling_fwd", "scaling_bwd"):
+            tm = meta.get(key)
+            if tm is None:
+                continue
+            cls = type(tm).__name__
+            if "FP4" in cls or "Fp4" in cls:
+                return True
+    return False
+
+
+def _manual_reset_fp4_meta(module):
+    """Reset FP4 per-tile block-scale buffers when reset_fp4_meta_tensors() is absent."""
+    if not hasattr(module, "fp8_meta"):
+        return False
+    meta = module.fp8_meta
+    reset_count = 0
+    for key in ("scaling_fwd", "scaling_bwd"):
+        if key not in meta:
+            continue
+        tensor_meta = meta[key]
+        for attr in _FP4_META_ATTRS:
+            if not hasattr(tensor_meta, attr):
+                continue
+            t = getattr(tensor_meta, attr)
+            if hasattr(t, "zero_"):
+                try:
+                    t.zero_()
+                    reset_count += 1
+                except Exception:
+                    pass
+    return reset_count > 0
+
+
+def reset_fp4_state(model, reset_meta_tensors=True):
+    """Clear ``fp4_initialized`` (or shared ``fp8_initialized``) on FP4 layers.
+
+    Parallel to :func:`reset_fp8_state` but for FP4 modules.  Unlike FP8 this
+    does NOT seed any history — block-scaling recipes have no amax_history,
+    so TE will recompute per-tile scales from real data on the next forward.
+
+    Returns the number of modules touched.
+    """
+    count = 0
+    method_count = 0
+    manual_count = 0
+
+    def _reset(m):
+        nonlocal count, method_count, manual_count
+        if not _is_fp4_module(m):
+            return
+
+        touched = False
+        if hasattr(m, "fp4_initialized"):
+            m.fp4_initialized = False
+            touched = True
+        if hasattr(m, "fp8_initialized"):
+            m.fp8_initialized = False
+            touched = True
+        if touched:
+            count += 1
+
+        if reset_meta_tensors:
+            if hasattr(m, "reset_fp4_meta_tensors"):
+                try:
+                    m.reset_fp4_meta_tensors()
+                    method_count += 1
+                except Exception:
+                    pass
+            elif hasattr(m, "reset_fp8_meta_tensors"):
+                # FP4 modules typically share the meta-reset method with FP8.
+                try:
+                    m.reset_fp8_meta_tensors()
+                    method_count += 1
+                except Exception:
+                    if _manual_reset_fp4_meta(m):
+                        manual_count += 1
+            elif _manual_reset_fp4_meta(m):
+                manual_count += 1
+
+    models = model if isinstance(model, (list, tuple)) else [model]
+    for m in models:
+        m.apply(_reset)
+    _log(f"reset_fp4_state: {count} modules, " f"{method_count} via method, {manual_count} via manual reset")
+    return count
+
+
+# ===========================================================================
+# Warmup recipe selection  --  NEW, opt-in via WARMUP_RECIPE
+# ===========================================================================
+
+
+def _resolve_recipe_str():
+    """Return the warmup recipe string, honouring legacy WARMUP_FP8_RECIPE.
+
+    Default is "" (empty) → no autocast wrapping, identical to the original
+    pre-FP4 warmup.  FP8/BF16 users do not need to set anything.
+    """
+    val = os.getenv("WARMUP_RECIPE", "").strip().lower()
+    if val:
+        return val
+    legacy = os.getenv("WARMUP_FP8_RECIPE", "").strip().lower()
+    if legacy in ("hybrid", "e4m3"):
+        return f"fp8_{legacy}"
+    return ""
+
+
+def _build_warmup_recipe():
+    """Return a TE recipe object if WARMUP_RECIPE selects one, else None.
+
+    Supports FP8 (DelayedScaling) and FP4 (MXFP4BlockScaling, NVFP4BlockScaling).
+    Both kinds are consumed by ``te.fp8_autocast(fp8_recipe=...)``.
+
+    Returns
+    -------
+    (recipe, kind) where kind is one of ``"fp8"``, ``"fp4"`` or ``None``.
+    """
+    recipe_str = _resolve_recipe_str()
+    if not recipe_str or recipe_str == "bf16":
+        if recipe_str == "bf16":
+            _log("WARMUP_RECIPE=bf16: no autocast wrapping")
+        return None, None
+
+    # ---- FP8 family ------------------------------------------------------
+    if recipe_str.startswith("fp8_"):
+        try:
+            from transformer_engine.common.recipe import DelayedScaling, Format
+        except ImportError:
+            _log(f"WARMUP_RECIPE={recipe_str!r} but transformer_engine missing; no autocast")
+            return None, None
+        fmt = {"fp8_hybrid": Format.HYBRID, "fp8_e4m3": Format.E4M3}.get(recipe_str)
+        if fmt is None:
+            _log(f"Unknown FP8 WARMUP_RECIPE={recipe_str!r}; no autocast")
+            return None, None
+        history_len = int(os.getenv("WARMUP_FP8_HISTORY_LEN", "4"))
+        _log(
+            f"Warmup will wrap train_step in fp8_autocast"
+            f"(format={recipe_str[4:]}, amax_history_len={history_len}, algo=most_recent)"
+        )
+        return (
+            DelayedScaling(
+                margin=0,
+                fp8_format=fmt,
+                amax_history_len=history_len,
+                amax_compute_algo="most_recent",
+            ),
+            "fp8",
+        )
+
+    # ---- FP4 family ------------------------------------------------------
+    if recipe_str.startswith("fp4_"):
+        try:
+            import transformer_engine.common.recipe as te_recipe
+        except ImportError:
+            _log(f"WARMUP_RECIPE={recipe_str!r} but transformer_engine missing; no autocast")
+            return None, None
+
+        # Try to nudge Primus's MXFP4 recipe-state patch into place if the
+        # model was built without FP4 (so the patch never ran).  No-op otherwise.
+        try:
+            from primus.backends.megatron.core.fp4_utils import (
+                _ensure_mxfp4_recipe_support,
+            )
+
+            _ensure_mxfp4_recipe_support()
+        except Exception:
+            pass
+
+        cls_name = {
+            "fp4_mxfp4": "MXFP4BlockScaling",
+            "fp4_nvfp4": "NVFP4BlockScaling",
+        }.get(recipe_str)
+        if cls_name is None:
+            _log(f"Unknown FP4 WARMUP_RECIPE={recipe_str!r}; no autocast")
+            return None, None
+
+        recipe_cls = getattr(te_recipe, cls_name, None)
+        if recipe_cls is None:
+            _log(f"WARMUP_RECIPE={recipe_str!r} but {cls_name} not in this TE build; no autocast")
+            return None, None
+        try:
+            recipe = recipe_cls()
+        except Exception as e:
+            _log(f"Failed to construct {cls_name}() for warmup: {e}; no autocast")
+            return None, None
+        _log(f"Warmup will wrap train_step in fp8_autocast(fp8_recipe={cls_name}())")
+        return recipe, "fp4"
+
+    _log(f"Unknown WARMUP_RECIPE={recipe_str!r}; no autocast")
+    return None, None
+
+
+def _warmup_autocast(recipe):
+    """Return a context-manager factory for the warmup loop."""
+    if recipe is None:
+        return nullcontext
+    import transformer_engine.pytorch as te
+
+    def _ctx():
+        return te.fp8_autocast(enabled=True, fp8_recipe=recipe)
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# Optimizer save / restore  --  ORIGINAL from committed warmup.py
+# (preserves ChainedOptimizer support for EP < num_gpus configs)
+# ---------------------------------------------------------------------------
+
+
+def _get_inner_optimizers(optimizer):
+    """Return a list of leaf-level torch optimizers from any Megatron wrapper.
+
+    When expert_parallel < num_gpus, Megatron creates a ChainedOptimizer with
+    separate sub-optimizers for dense and expert parameters.  The previous code
+    used ``optimizer.optimizer`` which asserts ``len == 1`` on ChainedOptimizer.
+    This helper iterates over all chained sub-optimizers when present, and falls
+    back to the single-optimizer path otherwise.
+    """
+    if hasattr(optimizer, "chained_optimizers"):
+        inners = []
+        for sub_opt in optimizer.chained_optimizers:
+            inners.append(getattr(sub_opt, "optimizer", sub_opt))
+        return inners
+    return [getattr(optimizer, "optimizer", optimizer)]
+
+
+def _neuter_optimizer(optimizer):
+    """Set betas=[1,1], weight_decay=0, bias_correction=False.
+
+    With betas=[1,1] the Adam momentum/variance stays at its initial (zero)
+    value, so the effective weight update is zero.
+
+    Handles ChainedOptimizer by iterating over all sub-optimizers.
+    """
+    all_saved = []
+    for inner in _get_inner_optimizers(optimizer):
+        saved = []
+        for group in inner.param_groups:
+            state = {}
+            for key in ("betas", "weight_decay", "bias_correction", "pre_mult_wd"):
+                if key in group:
+                    state[key] = group[key]
+            saved.append(state)
+
+            if "betas" in group:
+                group["betas"] = [1.0, 1.0]
+            if "weight_decay" in group:
+                group["weight_decay"] = 0.0
+            if "bias_correction" in group:
+                group["bias_correction"] = False
+            if "pre_mult_wd" in group:
+                group["pre_mult_wd"] = 0.0
+        all_saved.append(saved)
+    return all_saved
+
+
+def _restore_optimizer(optimizer, all_saved):
+    """Restore optimizer state, handling ChainedOptimizer."""
+    for inner, saved in zip(_get_inner_optimizers(optimizer), all_saved):
+        for group, state in zip(inner.param_groups, saved):
+            for key, val in state.items():
+                group[key] = val
+            if "step" in group:
+                del group["step"]
+
+
+# ---------------------------------------------------------------------------
+# Model parameter snapshot  --  ORIGINAL from committed warmup.py, unchanged
+# ---------------------------------------------------------------------------
+
+
+def _save_model_params(models):
+    """Snapshot all model parameters to CPU to avoid doubling GPU memory."""
+    saved = {}
+    for m in models:
+        for name, p in m.named_parameters():
+            saved[(id(m), name)] = p.data.to("cpu", copy=True)
+    return saved
+
+
+def _restore_model_params(models, saved):
+    restored = 0
+    for m in models:
+        for name, p in m.named_parameters():
+            key = (id(m), name)
+            if key in saved:
+                p.data.copy_(saved[key].to(p.device))
+                restored += 1
+    return restored
+
+
+# ---------------------------------------------------------------------------
+# LR scheduler save / restore  --  ORIGINAL + step(0) re-sync after restore
+# ---------------------------------------------------------------------------
+
+_SCHEDULER_KEYS = (
+    "num_steps",
+    "num_floating_point_operations_so_far",
+)
+
+
+def _save_scheduler_state(scheduler):
+    if scheduler is None:
+        return None
+    return {k: getattr(scheduler, k) for k in _SCHEDULER_KEYS if hasattr(scheduler, k)}
+
+
+def _restore_scheduler_state(scheduler, state):
+    if scheduler is None or state is None:
+        return
+    for k, v in state.items():
+        setattr(scheduler, k, v)
+    # Re-sync param_groups['lr'] and ['weight_decay'] to match the restored
+    # num_steps. Without this, the optimizer still holds the LR from the last
+    # warmup step even though num_steps has been rewound to its pre-warmup value.
+    scheduler.step(0)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def run_synthetic_warmup(
+    train_step_func,
+    forward_step_func,
+    model,
+    optimizer,
+    opt_param_scheduler,
+    config,
+    megatron_args,
+):
+    """Run *warmup_steps* forward+backward passes with synthetic data.
+
+    Called from ``MLPerfMegatronPretrainTrainer``'s patched ``train()``
+    **before** ``RUN_START`` is logged, so warmup time is excluded from the
+    timed run.  All side-effects (model params, optimizer, LR scheduler,
+    FP8/FP4 state) are reverted after warmup.
+
+    Default behaviour (``WARMUP_RECIPE`` unset): no autocast wrapping,
+    identical to the pre-FP4 committed version.  Set
+    ``WARMUP_RECIPE=fp4_mxfp4`` or ``fp4_nvfp4`` to opt into FP4 warmup.
+
+    Args:
+        train_step_func: The (already MLPerf-patched) upstream
+            ``megatron.training.training.train_step`` function.  It is called
+            with the new-style signature
+            ``(forward_step_func, data_iterator, model, optimizer,
+            opt_param_scheduler, config, forward_backward_func, iteration=0)``.
+            ``forward_backward_func`` is resolved here via
+            ``get_forward_backward_func()`` (mirrors ``training.train()``).
+    """
+    warmup_steps = int(os.getenv("SYNTH_WARMUP_STEPS", "3"))
+    if warmup_steps <= 0:
+        _log(f"Skipped (SYNTH_WARMUP_STEPS={warmup_steps})")
+        return
+
+    empty_cache_each_step = os.getenv("SYNTH_WARMUP_EMPTY_CACHE", "1") not in ("0", "false", "False")
+
+    t0 = time.time()
+    _log(
+        f"Starting {warmup_steps}-step synthetic warmup "
+        f"(seq_len={megatron_args.seq_length}, "
+        f"mbs={megatron_args.micro_batch_size}, "
+        f"empty_cache_each_step={empty_cache_each_step})"
+    )
+
+    vocab_size = getattr(
+        megatron_args,
+        "padded_vocab_size",
+        getattr(megatron_args, "vocab_size", 32000),
+    )
+    synth_iter = SyntheticGPTDataIterator(
+        megatron_args.seq_length,
+        megatron_args.micro_batch_size,
+        vocab_size,
+    )
+
+    models = model if isinstance(model, (list, tuple)) else [model]
+
+    # Resolve the forward-backward func the same way upstream
+    # ``megatron.training.training.train()`` does (see training.py).  Newer
+    # Megatron ``train_step`` takes this as an explicit positional argument.
+    from megatron.core.pipeline_parallel import get_forward_backward_func
+
+    forward_backward_func = get_forward_backward_func()
+
+    # Temporarily set config fields needed by forward_backward_func.
+    # Megatron's train() normally sets these, but warmup runs before it.
+    from megatron.core.distributed import finalize_model_grads
+    from megatron.core.distributed.distributed_data_parallel import (
+        DistributedDataParallel as DDP,
+    )
+
+    saved_config = {}
+    for key in ("finalize_model_grads_func", "grad_scale_func", "no_sync_func"):
+        saved_config[key] = getattr(config, key, None)
+    if config.finalize_model_grads_func is None:
+        config.finalize_model_grads_func = finalize_model_grads
+    if config.grad_scale_func is None:
+        config.grad_scale_func = optimizer.scale_loss
+    if megatron_args.overlap_grad_reduce and config.no_sync_func is None:
+        if isinstance(models[0], DDP):
+            config.no_sync_func = models[0].no_sync if len(models) == 1 else [m.no_sync for m in models]
+
+    # ---- save state ------------------------------------------------------
+    _log(f"Saving {sum(p.numel() for m in models for p in m.parameters())} parameters")
+    saved_params = _save_model_params(models)
+    saved_opt = _neuter_optimizer(optimizer)
+    saved_sched = _save_scheduler_state(opt_param_scheduler)
+
+    # ---- decide warmup precision (default: no autocast = original path) -
+    recipe, recipe_kind = _build_warmup_recipe()
+    warmup_ctx_factory = _warmup_autocast(recipe)
+
+    # ---- warmup steps ----------------------------------------------------
+    for step in range(1, warmup_steps + 1):
+        step_t0 = time.time()
+        with warmup_ctx_factory():
+            train_step_func(
+                forward_step_func,
+                synth_iter,
+                model,
+                optimizer,
+                opt_param_scheduler,
+                config,
+                forward_backward_func,
+                iteration=0,
+            )
+        torch.cuda.synchronize()
+        if empty_cache_each_step:
+            torch.cuda.empty_cache()
+        _log(f"Step {step}/{warmup_steps} done in {time.time() - step_t0:.1f}s")
+
+    # ---- restore state ---------------------------------------------------
+    _log("Restoring optimizer")
+    _restore_optimizer(optimizer, saved_opt)
+
+    _log("Restoring LR scheduler")
+    _restore_scheduler_state(opt_param_scheduler, saved_sched)
+
+    _log("Restoring model parameters")
+    n_restored = _restore_model_params(models, saved_params)
+    del saved_params
+    _log(f"Restored {n_restored} parameter tensors")
+
+    if hasattr(optimizer, "reload_model_params"):
+        optimizer.reload_model_params()
+        _log("Called optimizer.reload_model_params()")
+
+    # ---- zero Adam state buffers (defensive) ----------------------------
+    # With betas=[1,1] during warmup, exp_avg / exp_avg_sq should already be
+    # zero, but zero them explicitly in case any param group lacked betas.
+    # Iterate over chained sub-optimizers for ChainedOptimizer support.
+    zeroed_state_tensors = 0
+    for inner_opt in _get_inner_optimizers(optimizer):
+        for param_states in inner_opt.state.values():
+            for k, v in param_states.items():
+                if isinstance(v, torch.Tensor) and v.is_floating_point():
+                    v.zero_()
+                    zeroed_state_tensors += 1
+    _log(f"Zeroed {zeroed_state_tensors} optimizer state tensors (exp_avg / exp_avg_sq)")
+
+    for m in models:
+        m.zero_grad(set_to_none=True)
+    _log("Zeroed all model gradients")
+
+    # ---- reset FP8 (always; no-op for BF16 / non-FP8 modules) -----------
+    _log("Resetting FP8 state")
+    total_reset = 0
+    for m in models:
+        total_reset += reset_fp8_state(m, reset_meta_tensors=True)
+    seed_fp8_amax(models, seed_value=1.0)
+
+    # ---- reset FP4 (only when warmup explicitly used an FP4 recipe) -----
+    total_fp4_reset = 0
+    if recipe_kind == "fp4":
+        _log("Resetting FP4 state (no seeding)")
+        for m in models:
+            total_fp4_reset += reset_fp4_state(m, reset_meta_tensors=True)
+
+    # ---- release cached allocator blocks --------------------------------
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    if torch.distributed.is_initialized():
+        torch.distributed.barrier()
+
+    # ---- restore Megatron config ----------------------------------------
+    for key, val in saved_config.items():
+        setattr(config, key, val)
+
+    nan_params = sum(
+        1
+        for m in models
+        for _, p in m.named_parameters()
+        if p.data.is_floating_point() and torch.isnan(p.data).any()
+    )
+    elapsed = time.time() - t0
+    _log(
+        f"Warmup complete in {elapsed:.1f}s "
+        f"(fp8_reset={total_reset}, fp4_reset={total_fp4_reset}, "
+        f"recipe={recipe_kind or 'native'}, nan_params={nan_params})"
+    )

--- a/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
+++ b/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
@@ -33,7 +33,7 @@ import weakref
 import torch
 
 from primus.core.patches import PatchContext, register_patch
-from primus.core.utils.module_utils import log_rank_0, warning_rank_0
+from primus.modules.module_utils import log_rank_0, warning_rank_0
 
 # Cache the identity decision keyed on the index tensor's ``id()``. The topology
 # index tensors persist for the dispatcher's lifetime, so caching by identity is

--- a/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
+++ b/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
@@ -33,7 +33,7 @@ import weakref
 import torch
 
 from primus.core.patches import PatchContext, register_patch
-from primus.modules.module_utils import log_rank_0, warning_rank_0
+from primus.core.utils.module_utils import log_rank_0, warning_rank_0
 
 # Cache the identity decision keyed on the index tensor's ``id()``. The topology
 # index tensors persist for the dispatcher's lifetime, so caching by identity is

--- a/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
+++ b/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
@@ -35,10 +35,15 @@ import torch
 from primus.core.patches import PatchContext, register_patch
 from primus.modules.module_utils import log_rank_0, warning_rank_0
 
-# Cache the identity decision keyed on the index tensor object. The topology
-# index tensors persist for the dispatcher's lifetime, so a WeakKeyDictionary
-# evicts entries automatically once a dispatcher is freed.
-_IDENTITY_CACHE: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
+# Cache the identity decision keyed on the index tensor's ``id()``. The topology
+# index tensors persist for the dispatcher's lifetime, so caching by identity is
+# stable across steps. A ``WeakKeyDictionary`` cannot be used here because weakref
+# equality falls back to ``tensor == tensor`` (which yields a tensor, not a bool)
+# and raises "Boolean value of Tensor ... is ambiguous". Instead we key on
+# ``id(idxs)`` and register a ``weakref.finalize`` callback so the entry is
+# evicted when the tensor is garbage-collected (preventing stale hits from
+# ``id()`` reuse).
+_IDENTITY_CACHE: dict = {}
 
 
 def _skip_enabled(_ctx: PatchContext) -> bool:
@@ -48,14 +53,18 @@ def _skip_enabled(_ctx: PatchContext) -> bool:
 def _is_identity(idxs) -> bool:
     if idxs is None or not torch.is_tensor(idxs) or idxs.dim() != 1 or idxs.numel() == 0:
         return False
-    cached = _IDENTITY_CACHE.get(idxs)
+    key = id(idxs)
+    cached = _IDENTITY_CACHE.get(key)
     if cached is not None:
         return cached
     result = bool(
         torch.equal(idxs, torch.arange(idxs.numel(), device=idxs.device, dtype=idxs.dtype))
     )
     try:
-        _IDENTITY_CACHE[idxs] = result
+        # Evict on GC so a future tensor reusing this ``id()`` cannot hit a stale
+        # decision.
+        weakref.finalize(idxs, _IDENTITY_CACHE.pop, key, None)
+        _IDENTITY_CACHE[key] = result
     except TypeError:
         # Some tensors are not weak-referenceable; fall back to no caching.
         pass

--- a/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
+++ b/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
@@ -1,0 +1,115 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MoE identity-sort short-circuit patch.
+
+Migrated from the source patch ``megatron_moe_skip_identity_sort.patch``
+(mpo branch).
+
+In the all-to-all MoE token dispatcher, ``sort_chunks_by_idxs`` is called with
+``sort_input_by_local_experts`` (dispatch) and ``restore_output_by_local_experts``
+(combine). When the EP/TP topology yields an *identity* permutation
+(``[0, 1, ..., N-1]``) -- the common ``EP=1`` / ``TP=1`` case -- the call
+degrades into a full-tensor ``split`` + ``cat`` round-trip that produces an
+output identical to its input. This patch short-circuits those calls.
+
+Rather than editing ``third_party/Megatron-LM`` in place, we wrap the
+``sort_chunks_by_idxs`` symbol bound inside the ``token_dispatcher`` module.
+The identity decision is cached per index tensor (the topology indices are
+created once per dispatcher and reused every step), so the ``torch.equal``
+probe -- and the device sync it implies -- happens at most once per tensor.
+
+Gate:
+    ``MOE_SKIP_IDENTITY_SORT`` (default ``1`` / enabled; set ``0`` to disable).
+"""
+
+import os
+import weakref
+
+import torch
+
+from primus.core.patches import PatchContext, register_patch
+from primus.modules.module_utils import log_rank_0, warning_rank_0
+
+# Cache the identity decision keyed on the index tensor object. The topology
+# index tensors persist for the dispatcher's lifetime, so a WeakKeyDictionary
+# evicts entries automatically once a dispatcher is freed.
+_IDENTITY_CACHE: "weakref.WeakKeyDictionary" = weakref.WeakKeyDictionary()
+
+
+def _skip_enabled(_ctx: PatchContext) -> bool:
+    return os.environ.get("MOE_SKIP_IDENTITY_SORT", "1") != "0"
+
+
+def _is_identity(idxs) -> bool:
+    if idxs is None or not torch.is_tensor(idxs) or idxs.dim() != 1 or idxs.numel() == 0:
+        return False
+    cached = _IDENTITY_CACHE.get(idxs)
+    if cached is not None:
+        return cached
+    result = bool(
+        torch.equal(idxs, torch.arange(idxs.numel(), device=idxs.device, dtype=idxs.dtype))
+    )
+    try:
+        _IDENTITY_CACHE[idxs] = result
+    except TypeError:
+        # Some tensors are not weak-referenceable; fall back to no caching.
+        pass
+    return result
+
+
+def _make_wrapped_sort(orig_sort):
+    def sort_chunks_by_idxs(input, split_sizes, sorted_idxs, probs=None, fused=False):
+        # Identity permutation -> output == input, permuted_probs == probs.
+        if _is_identity(sorted_idxs):
+            return input, probs
+        return orig_sort(input, split_sizes, sorted_idxs, probs=probs, fused=fused)
+
+    return sort_chunks_by_idxs
+
+
+@register_patch(
+    "megatron.moe.skip_identity_sort",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Short-circuit sort_chunks_by_idxs in the MoE token dispatcher when the "
+        "local-expert permutation is identity (e.g. EP=1/TP=1); gated by "
+        "MOE_SKIP_IDENTITY_SORT (default on)."
+    ),
+    condition=_skip_enabled,
+)
+def patch_moe_skip_identity_sort(ctx: PatchContext):
+    del ctx
+
+    try:
+        from megatron.core.transformer.moe import token_dispatcher as td_mod
+    except ImportError as exc:
+        warning_rank_0(
+            f"[Patch:megatron.moe.skip_identity_sort] token_dispatcher not "
+            f"importable; skipping: {exc}"
+        )
+        return
+
+    orig_sort = getattr(td_mod, "sort_chunks_by_idxs", None)
+    if orig_sort is None:
+        warning_rank_0(
+            "[Patch:megatron.moe.skip_identity_sort] sort_chunks_by_idxs not bound "
+            "in token_dispatcher; skipping."
+        )
+        return
+
+    if getattr(orig_sort, "_primus_skip_identity_sort", False):
+        return
+
+    wrapped = _make_wrapped_sort(orig_sort)
+    wrapped._primus_skip_identity_sort = True
+    td_mod.sort_chunks_by_idxs = wrapped
+    log_rank_0(
+        "[Patch:megatron.moe.skip_identity_sort] Patched "
+        "token_dispatcher.sort_chunks_by_idxs to skip identity permutations."
+    )

--- a/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
+++ b/primus/backends/megatron/patches/moe_patches/skip_identity_sort_patches.py
@@ -57,9 +57,7 @@ def _is_identity(idxs) -> bool:
     cached = _IDENTITY_CACHE.get(key)
     if cached is not None:
         return cached
-    result = bool(
-        torch.equal(idxs, torch.arange(idxs.numel(), device=idxs.device, dtype=idxs.dtype))
-    )
+    result = bool(torch.equal(idxs, torch.arange(idxs.numel(), device=idxs.device, dtype=idxs.dtype)))
     try:
         # Evict on GC so a future tensor reusing this ``id()`` cannot hit a stale
         # decision.
@@ -99,8 +97,7 @@ def patch_moe_skip_identity_sort(ctx: PatchContext):
         from megatron.core.transformer.moe import token_dispatcher as td_mod
     except ImportError as exc:
         warning_rank_0(
-            f"[Patch:megatron.moe.skip_identity_sort] token_dispatcher not "
-            f"importable; skipping: {exc}"
+            f"[Patch:megatron.moe.skip_identity_sort] token_dispatcher not " f"importable; skipping: {exc}"
         )
         return
 

--- a/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
+++ b/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
@@ -37,7 +37,7 @@ import os
 import torch
 
 from primus.core.patches import PatchContext, register_patch
-from primus.modules.module_utils import log_rank_0, warning_rank_0
+from primus.core.utils.module_utils import log_rank_0, warning_rank_0
 
 
 def _sdma_allgather_enabled(_ctx: PatchContext) -> bool:

--- a/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
+++ b/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
@@ -1,0 +1,204 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+SDMA (copy-engine) distributed-optimizer param all-gather patch.
+
+Migrated from the source patch ``megatron_sdma_allgather.patch`` (mpo branch).
+
+This replaces the in-place edits the source patch made to
+``third_party/Megatron-LM`` with three runtime monkey-patches, all gated by
+``ENABLE_SDMA_ALLGATHER=1``:
+
+  1. ``_ParamAndGradBucketGroup.start_param_sync`` -- the distributed-optimizer
+     path is re-implemented to dispatch one all-gather per bucket through
+     :func:`all_gather_into_tensor_sdma` (copy-engine) instead of the RCCL
+     ``_coalescing_manager`` group. The first two bucket groups (by gather
+     order) stay on the regular RCCL fallback. The layer-wise optimizer path is
+     delegated unchanged to the original method.
+  2. ``DistributedDataParallel.__init__`` -- after construction, each bucket
+     group is annotated with ``param_gather_order`` (reverse dispatch order,
+     mirroring the source patch).
+  3. MoE experts ``forward`` -- ``tokens_per_expert`` is moved onto the
+     dispatched-input device before the experts run (the source patch's
+     ``moe_layer.py`` one-liner).
+
+When the SDMA primitives (Primus-Turbo symmetric memory + ``hip``) are
+unavailable, :func:`all_gather_into_tensor_sdma` falls back to
+``torch.distributed.all_gather_into_tensor``, so enabling the flag is safe even
+on images without the kernels.
+"""
+
+import os
+
+import torch
+
+from primus.core.patches import PatchContext, register_patch
+from primus.modules.module_utils import log_rank_0, warning_rank_0
+
+
+def _sdma_allgather_enabled(_ctx: PatchContext) -> bool:
+    return os.environ.get("ENABLE_SDMA_ALLGATHER", "0") == "1"
+
+
+def _make_start_param_sync(orig_start_param_sync):
+    """Build a replacement ``start_param_sync`` for ``_ParamAndGradBucketGroup``."""
+    from megatron.core.distributed.param_and_grad_buffer import shard_buffer
+
+    from primus.backends.megatron.core.distributed.sdma_param_gather import (
+        _all_gather_into_tensor_waitable_fallback,
+        _WaitableHandle,
+        all_gather_into_tensor_sdma,
+    )
+
+    def start_param_sync(self, force_sync: bool = False):
+        # Layer-wise optimizer path is unchanged; only the distributed-optimizer
+        # path routes through SDMA.
+        if not self.ddp_config.use_distributed_optimizer:
+            return orig_start_param_sync(self, force_sync=force_sync)
+
+        if force_sync:
+            if self.param_gather_handle is not None:
+                self.param_gather_handle.wait()
+                self.param_gather_handle = None
+                return
+        else:
+            assert self.param_gather_handle is None
+
+        async_op = self.ddp_config.overlap_param_gather and not force_sync
+
+        # Keep the first two bucket groups (by gather order) on the regular
+        # RCCL all-gather; route the rest through SDMA. param_gather_order is
+        # assigned in the DDP __init__ wrapper below.
+        param_gather_order = getattr(self, "param_gather_order", None)
+        enable_sdma = os.getenv("ENABLE_SDMA_ALLGATHER") == "1"
+        all_gather_func = (
+            _all_gather_into_tensor_waitable_fallback
+            if (param_gather_order is not None and param_gather_order < 2) or not enable_sdma
+            else all_gather_into_tensor_sdma
+        )
+
+        param_gather_handles = []
+        for idx, bucket in enumerate(self.buckets):
+            if self.cached_param_buffer_shard_list[idx] is None:
+                self.cached_param_buffer_shard_list[idx] = shard_buffer(
+                    bucket.param_data, self.intra_distributed_optimizer_instance_size
+                )
+            local_data_view = self.cached_param_buffer_shard_list[idx][
+                self.intra_distributed_optimizer_instance_rank
+            ]
+            handle = all_gather_func(
+                bucket.param_data,
+                local_data_view,
+                group=self.intra_distributed_optimizer_instance_group,
+                async_op=async_op,
+            )
+            if async_op:
+                param_gather_handles.append(handle)
+
+        if async_op:
+
+            def _wait_all_param_gathers():
+                for handle in param_gather_handles:
+                    handle.wait()
+
+            self.param_gather_handle = _WaitableHandle(wait_fn=_wait_all_param_gathers)
+        else:
+            self.param_gather_handle = None
+        self.param_gather_dispatched = True
+
+    return start_param_sync
+
+
+def _make_wrapped_ddp_init(orig_init):
+    def __init__(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        # Mirror the source patch: number bucket groups in reverse dispatch
+        # order so start_param_sync can keep the first two on RCCL.
+        for groups_attr in ("bucket_groups", "expert_parallel_bucket_groups"):
+            groups = getattr(self, groups_attr, None) or []
+            for order, bucket_group in enumerate(reversed(groups)):
+                bucket_group.param_gather_order = order
+
+    return __init__
+
+
+def _make_wrapped_experts_forward(orig_forward):
+    def forward(self, permuted_local_hidden_states, tokens_per_expert, *args, **kwargs):
+        # Source patch moved tokens_per_expert onto the dispatched-input device
+        # before the experts run.
+        if torch.is_tensor(tokens_per_expert):
+            tokens_per_expert = tokens_per_expert.to(permuted_local_hidden_states.device)
+        return orig_forward(self, permuted_local_hidden_states, tokens_per_expert, *args, **kwargs)
+
+    return forward
+
+
+@register_patch(
+    "megatron.distributed.sdma_param_all_gather",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Route the distributed-optimizer param all-gather through Primus-Turbo "
+        "SDMA (copy-engine) memcpys; gated by ENABLE_SDMA_ALLGATHER=1."
+    ),
+    condition=_sdma_allgather_enabled,
+)
+def patch_sdma_param_all_gather(ctx: PatchContext):
+    del ctx
+
+    try:
+        import megatron.core.distributed.param_and_grad_buffer as pgb
+        from megatron.core.distributed.distributed_data_parallel import (
+            DistributedDataParallel,
+        )
+    except ImportError as exc:
+        warning_rank_0(
+            f"[Patch:megatron.distributed.sdma_param_all_gather] Megatron distributed "
+            f"modules not importable; skipping: {exc}"
+        )
+        return
+
+    bucket_group_cls = getattr(pgb, "_ParamAndGradBucketGroup", None)
+    if bucket_group_cls is None:
+        warning_rank_0(
+            "[Patch:megatron.distributed.sdma_param_all_gather] "
+            "_ParamAndGradBucketGroup not found; skipping."
+        )
+        return
+
+    if not getattr(bucket_group_cls, "_primus_sdma_param_gather_patched", False):
+        bucket_group_cls.start_param_sync = _make_start_param_sync(
+            bucket_group_cls.start_param_sync
+        )
+        bucket_group_cls._primus_sdma_param_gather_patched = True
+
+    if not getattr(DistributedDataParallel, "_primus_sdma_param_gather_patched", False):
+        DistributedDataParallel.__init__ = _make_wrapped_ddp_init(
+            DistributedDataParallel.__init__
+        )
+        DistributedDataParallel._primus_sdma_param_gather_patched = True
+
+    # MoE experts: move tokens_per_expert onto the dispatched-input device.
+    try:
+        from megatron.core.transformer.moe import experts as experts_mod
+
+        for cls_name in ("GroupedMLP", "TEGroupedMLP", "SequentialMLP"):
+            cls = getattr(experts_mod, cls_name, None)
+            if cls is None or getattr(cls, "_primus_sdma_tokens_to_device", False):
+                continue
+            cls.forward = _make_wrapped_experts_forward(cls.forward)
+            cls._primus_sdma_tokens_to_device = True
+    except ImportError as exc:
+        warning_rank_0(
+            f"[Patch:megatron.distributed.sdma_param_all_gather] MoE experts module "
+            f"not importable; skipping tokens_per_expert device fixup: {exc}"
+        )
+
+    log_rank_0(
+        "[Patch:megatron.distributed.sdma_param_all_gather] Installed SDMA param "
+        "all-gather (start_param_sync + param_gather_order + experts tokens_per_expert)."
+    )

--- a/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
+++ b/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
@@ -171,15 +171,11 @@ def patch_sdma_param_all_gather(ctx: PatchContext):
         return
 
     if not getattr(bucket_group_cls, "_primus_sdma_param_gather_patched", False):
-        bucket_group_cls.start_param_sync = _make_start_param_sync(
-            bucket_group_cls.start_param_sync
-        )
+        bucket_group_cls.start_param_sync = _make_start_param_sync(bucket_group_cls.start_param_sync)
         bucket_group_cls._primus_sdma_param_gather_patched = True
 
     if not getattr(DistributedDataParallel, "_primus_sdma_param_gather_patched", False):
-        DistributedDataParallel.__init__ = _make_wrapped_ddp_init(
-            DistributedDataParallel.__init__
-        )
+        DistributedDataParallel.__init__ = _make_wrapped_ddp_init(DistributedDataParallel.__init__)
         DistributedDataParallel._primus_sdma_param_gather_patched = True
 
     # MoE experts: move tokens_per_expert onto the dispatched-input device.

--- a/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
+++ b/primus/backends/megatron/patches/parallelism/sdma_param_all_gather_patches.py
@@ -37,7 +37,7 @@ import os
 import torch
 
 from primus.core.patches import PatchContext, register_patch
-from primus.core.utils.module_utils import log_rank_0, warning_rank_0
+from primus.modules.module_utils import log_rank_0, warning_rank_0
 
 
 def _sdma_allgather_enabled(_ctx: PatchContext) -> bool:

--- a/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
+++ b/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
@@ -30,7 +30,7 @@ import functools
 import os
 
 from primus.core.patches import PatchContext, register_patch
-from primus.modules.module_utils import log_rank_0, warning_rank_0
+from primus.core.utils.module_utils import log_rank_0, warning_rank_0
 
 
 def _bshd_enabled(_ctx: PatchContext) -> bool:

--- a/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
+++ b/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
@@ -1,0 +1,147 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Transformer Engine attention BSHD-layout patch.
+
+Migrated from the source patch ``megatron_te_bshd_layout.patch`` (mpo branch).
+
+Some TE FMHA kernels are faster with a ``bshd`` memory layout than with the
+default ``sbhd`` layout Megatron feeds them. When ``NVTE_FMHA_USE_BSHD=1`` is
+set, this patch transposes the ``sbhd`` ``query``/``key``/``value`` tensors to
+``bshd`` before the TE ``DotProductAttention`` call and transposes the result
+back to ``sbhd`` afterwards, so the change is transparent to the rest of
+Megatron.
+
+Instead of editing ``third_party/Megatron-LM`` in place, we wrap
+``TEDotProductAttention.forward`` and temporarily flip the effective
+``qkv_format`` for the duration of the wrapped call so TE interprets the
+already-transposed tensors correctly.
+
+Gate:
+    ``NVTE_FMHA_USE_BSHD=1`` (off by default; the patch is not installed at
+    all when unset, so there is zero overhead).
+"""
+
+import functools
+import os
+
+from primus.core.patches import PatchContext, register_patch
+from primus.modules.module_utils import log_rank_0, warning_rank_0
+
+
+def _bshd_enabled(_ctx: PatchContext) -> bool:
+    return os.environ.get("NVTE_FMHA_USE_BSHD", "0") == "1"
+
+
+def _effective_qkv_format(self, packed_seq_params):
+    """Mirror TEDotProductAttention.forward's qkv_format resolution."""
+    if packed_seq_params is not None:
+        fmt = getattr(packed_seq_params, "qkv_format", None)
+        if fmt is not None:
+            return fmt
+    return self.qkv_format
+
+
+def _make_wrapped_forward(orig_forward):
+    @functools.wraps(orig_forward)
+    def forward(
+        self,
+        query,
+        key,
+        value,
+        attention_mask,
+        attn_mask_type,
+        attention_bias=None,
+        packed_seq_params=None,
+        **kwargs,
+    ):
+        # Only convert when the effective layout is sbhd; otherwise behave
+        # exactly like the original.
+        if _effective_qkv_format(self, packed_seq_params) != "sbhd":
+            return orig_forward(
+                self,
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+                **kwargs,
+            )
+
+        query = query.transpose(0, 1).contiguous()
+        key = key.transpose(0, 1).contiguous()
+        value = value.transpose(0, 1).contiguous()
+
+        # Temporarily flip the qkv_format TE will read so the transposed
+        # tensors are interpreted as bshd. Restore it afterwards even on error.
+        if packed_seq_params is not None and hasattr(packed_seq_params, "qkv_format"):
+            restore_target, restore_value = packed_seq_params, packed_seq_params.qkv_format
+            packed_seq_params.qkv_format = "bshd"
+        else:
+            restore_target, restore_value = self, self.qkv_format
+            self.qkv_format = "bshd"
+
+        try:
+            core_attn_out = orig_forward(
+                self,
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+                **kwargs,
+            )
+        finally:
+            restore_target.qkv_format = restore_value
+
+        return core_attn_out.transpose(0, 1).contiguous()
+
+    return forward
+
+
+@register_patch(
+    "megatron.te.fmha_bshd_layout",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Run TE DotProductAttention in bshd layout (transpose sbhd<->bshd "
+        "around the kernel) when NVTE_FMHA_USE_BSHD=1."
+    ),
+    condition=_bshd_enabled,
+)
+def patch_te_fmha_bshd_layout(ctx: PatchContext):
+    del ctx
+
+    try:
+        from megatron.core.extensions import transformer_engine as te_ext
+    except ImportError as exc:
+        warning_rank_0(
+            f"[Patch:megatron.te.fmha_bshd_layout] transformer_engine extension "
+            f"not importable; skipping: {exc}"
+        )
+        return
+
+    cls = getattr(te_ext, "TEDotProductAttention", None)
+    if cls is None:
+        warning_rank_0(
+            "[Patch:megatron.te.fmha_bshd_layout] TEDotProductAttention not found; skipping."
+        )
+        return
+
+    if getattr(cls, "_primus_bshd_patched", False):
+        return
+
+    cls.forward = _make_wrapped_forward(cls.forward)
+    cls._primus_bshd_patched = True
+    log_rank_0(
+        "[Patch:megatron.te.fmha_bshd_layout] Patched TEDotProductAttention.forward "
+        "to use bshd layout (NVTE_FMHA_USE_BSHD=1)."
+    )

--- a/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
+++ b/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
@@ -131,9 +131,7 @@ def patch_te_fmha_bshd_layout(ctx: PatchContext):
 
     cls = getattr(te_ext, "TEDotProductAttention", None)
     if cls is None:
-        warning_rank_0(
-            "[Patch:megatron.te.fmha_bshd_layout] TEDotProductAttention not found; skipping."
-        )
+        warning_rank_0("[Patch:megatron.te.fmha_bshd_layout] TEDotProductAttention not found; skipping.")
         return
 
     if getattr(cls, "_primus_bshd_patched", False):

--- a/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
+++ b/primus/backends/megatron/patches/te_patches/bshd_layout_patches.py
@@ -30,7 +30,7 @@ import functools
 import os
 
 from primus.core.patches import PatchContext, register_patch
-from primus.core.utils.module_utils import log_rank_0, warning_rank_0
+from primus.modules.module_utils import log_rank_0, warning_rank_0
 
 
 def _bshd_enabled(_ctx: PatchContext) -> bool:

--- a/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
+++ b/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
@@ -26,7 +26,7 @@ gracefully otherwise, so it's safe to register unconditionally.
 import os
 
 from primus.core.patches import PatchContext, register_patch
-from primus.modules.module_utils import log_rank_0
+from primus.core.utils.module_utils import log_rank_0
 
 
 def _env_truthy(name: str) -> bool:

--- a/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
+++ b/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
@@ -26,7 +26,7 @@ gracefully otherwise, so it's safe to register unconditionally.
 import os
 
 from primus.core.patches import PatchContext, register_patch
-from primus.core.utils.module_utils import log_rank_0
+from primus.modules.module_utils import log_rank_0
 
 
 def _env_truthy(name: str) -> bool:

--- a/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
+++ b/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
@@ -35,9 +35,7 @@ def _env_truthy(name: str) -> bool:
 
 
 def _is_fused_residual_norm_enabled(ctx: PatchContext) -> bool:
-    return _env_truthy("PRIMUS_FUSED_RESIDUAL_NORM") or _env_truthy(
-        "PRIMUS_FUSED_RESIDUAL_NORM_V2"
-    )
+    return _env_truthy("PRIMUS_FUSED_RESIDUAL_NORM") or _env_truthy("PRIMUS_FUSED_RESIDUAL_NORM_V2")
 
 
 @register_patch(
@@ -66,9 +64,7 @@ def patch_fused_residual_norm(ctx: PatchContext):
     )
     ok = fused_residual_rmsnorm.install()
     if ok:
-        log_rank_0(
-            "[Patch:megatron.turbo.fused_residual_norm]   install() returned True"
-        )
+        log_rank_0("[Patch:megatron.turbo.fused_residual_norm]   install() returned True")
     else:
         log_rank_0(
             "[Patch:megatron.turbo.fused_residual_norm]   install() returned False "

--- a/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
+++ b/primus/backends/megatron/patches/turbo/fused_residual_norm_patches.py
@@ -1,0 +1,76 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Tier 1A — fused (residual + RMSNorm) patches.
+
+Wraps the runtime install hook
+:mod:`primus.backends.megatron.core.extensions.fused_residual_rmsnorm` in a
+``@register_patch`` so it runs at the standard ``before_train`` phase via
+``run_patches(...)`` instead of being explicitly installed from the trainer
+entry point.
+
+Two gates (mirroring the install hook):
+  * ``PRIMUS_FUSED_RESIDUAL_NORM=1``    — V1, in-layer ADD#1+norm fusion.
+  * ``PRIMUS_FUSED_RESIDUAL_NORM_V2=1`` — V2, cross-layer ADD#2 carry
+    (implies V1).
+
+Either env var enables the patch. The install hook itself further requires
+``PrimusTurboRMSNorm`` (i.e. ``use_turbo_rms_norm=true``) and bails
+gracefully otherwise, so it's safe to register unconditionally.
+"""
+
+import os
+
+from primus.core.patches import PatchContext, register_patch
+from primus.modules.module_utils import log_rank_0
+
+
+def _env_truthy(name: str) -> bool:
+    v = os.environ.get(name, "0").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
+def _is_fused_residual_norm_enabled(ctx: PatchContext) -> bool:
+    return _env_truthy("PRIMUS_FUSED_RESIDUAL_NORM") or _env_truthy(
+        "PRIMUS_FUSED_RESIDUAL_NORM_V2"
+    )
+
+
+@register_patch(
+    "megatron.turbo.fused_residual_norm",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Fuse residual+add into PrimusTurboRMSNorm via Primus-Turbo "
+        "rmsnorm_residual; gated by PRIMUS_FUSED_RESIDUAL_NORM(_V2)."
+    ),
+    condition=_is_fused_residual_norm_enabled,
+    # Run after megatron.turbo.rms_norm so PrimusTurboRMSNorm is in place
+    # before we extend its forward signature.
+    priority=60,
+)
+def patch_fused_residual_norm(ctx: PatchContext):
+    """Install the fused residual+RMSNorm runtime monkeypatch."""
+    from primus.backends.megatron.core.extensions import fused_residual_rmsnorm
+
+    log_rank_0(
+        "[Patch:megatron.turbo.fused_residual_norm] Installing fused "
+        "residual+RMSNorm (V2={v2}, V1={v1})".format(
+            v1=_env_truthy("PRIMUS_FUSED_RESIDUAL_NORM"),
+            v2=_env_truthy("PRIMUS_FUSED_RESIDUAL_NORM_V2"),
+        )
+    )
+    ok = fused_residual_rmsnorm.install()
+    if ok:
+        log_rank_0(
+            "[Patch:megatron.turbo.fused_residual_norm]   install() returned True"
+        )
+    else:
+        log_rank_0(
+            "[Patch:megatron.turbo.fused_residual_norm]   install() returned False "
+            "(precondition not met; e.g. use_turbo_rms_norm=false)"
+        )

--- a/primus/cli/main.py
+++ b/primus/cli/main.py
@@ -4,6 +4,12 @@
 # See LICENSE for license information.
 ###############################################################################
 
+# MLPerf log suppression must run before any heavy import (Megatron, TE,
+# aiter, ...) that may print/log at import time. Importing this module only
+# triggers the light ``primus/__init__.py`` and installs the FD-level filter
+# when ``PRIMUS_LOG_SUPPRESSION=1`` is set; it is a complete no-op otherwise.
+import primus.mlperf_log_suppression  # noqa: F401  # isort: skip
+
 import argparse
 import importlib
 import pkgutil

--- a/primus/mlperf_log_suppression.py
+++ b/primus/mlperf_log_suppression.py
@@ -1,0 +1,273 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+# ---------------------------------------------------------------------------
+# Non-MLLOG log suppression for MLPerf submission runs.
+#
+# The MLPerf reference/submission logs (":::MLLOG ...") plus the run banners
+# emitted by the launch script are the only required stdout lines for a
+# submission run. All other noisy framework output (Primus loguru banners,
+# Megatron deprecations, aiter JIT build chatter, TE-RoPE, hipify, torchrun
+# warnings, UserWarnings, ...) is suppressed when this module is enabled, to
+# keep the run logs clean.
+#
+# Activation is GATED so that importing this module is a complete no-op for
+# normal (non-MLPerf) Primus runs:
+#
+#   PRIMUS_LOG_SUPPRESSION=1  -> enable the suppression (MLPerf launch sets it)
+#   PRIMUS_LOG_SUPPRESSION=0  -> default: install() is a no-op
+#
+# When enabled, verbosity is further controlled by:
+#
+#   MLPERF_VERBOSE_LOGS=1  -> restore the full verbose output (old behaviour),
+#                            i.e. enabled-but-not-quiet.
+#   MLPERF_VERBOSE_LOGS=0  -> quiet mode (default when enabled): only MLLOG +
+#                            training timing/result lines are emitted.
+#
+# Strategy (strongly preferred over stdout scraping):
+#   1. Export env vars that the noisy libraries honour (AITER_LOG_LEVEL,
+#      PYTHONWARNINGS, TRANSFORMERS_VERBOSITY, HF_HUB_DISABLE_PROGRESS_BARS).
+#   2. Raise Python ``logging`` levels for the actual logger names emitting
+#      noise (``aiter``, ``megatron`` families, ``torch.distributed``, ...).
+#      Safe to call multiple times via ``reapply_quiet_logger_levels``.
+#   3. Silence ``warnings`` category to match ``PYTHONWARNINGS=ignore``.
+#
+# A handful of sources (unconditional C++ ``std::cout`` in aiter / hipify;
+# Primus ``loguru`` sinks that bypass ``logging``; raw ``print()`` in TE
+# ``rope.py``; ...) cannot be controlled via the above. For those a narrow
+# FD-level line filter is installed on stdout so even native writes get
+# matched. Stderr carries no useful signal in quiet mode so FD 2 is
+# redirected wholesale to ``/dev/null``. If you need stderr back (e.g. to
+# debug a crash) re-run with ``MLPERF_VERBOSE_LOGS=1``.
+#
+# IMPORTANT: This module must be imported BEFORE any other import that may
+# log/print at import time (Megatron, TE, aiter, ...). For the Primus CLI it
+# is imported at the very top of ``primus/cli/main.py``. Because it lives
+# directly under the ``primus`` package, importing it only triggers the light
+# ``primus/__init__.py`` (config/logging utilities) and pulls in none of the
+# heavy native libraries that emit the banners we want to hide.
+# ---------------------------------------------------------------------------
+import logging as _logging
+import os as _os
+
+ENABLED = _os.environ.get("PRIMUS_LOG_SUPPRESSION", "0") == "1"
+VERBOSE_LOGS = _os.environ.get("MLPERF_VERBOSE_LOGS", "0") == "1"
+
+# Logger names that emit the non-MLLOG noise we want to silence. Safe to
+# set even when a given logger is not present in the process.
+QUIET_LOGGER_NAMES = (
+    # aiter: Primus also raises this logger to ERROR inside the trainer,
+    # but we do it earlier (before the aiter JIT build banner fires).
+    "aiter",
+    # Megatron-LM deprecation + rerun-state-machine warnings and the
+    # "Setting RerunStateMachine mode" warning from rerun_state_machine.py.
+    "megatron",
+    "megatron.core",
+    "megatron.core.utils",
+    "megatron.core.rerun_state_machine",
+    "megatron.core.pipeline_parallel",
+    # Primus / Primus-Turbo stdlib loggers (Primus routes most output
+    # through loguru instead, which we drop at the FD level below).
+    "primus",
+    "primus_turbo",
+    "primus_mllog",
+    # TransformerEngine import / RoPE banners that use stdlib logging.
+    "transformer_engine",
+    # torch.distributed elastic / launcher chatter.
+    "torch.distributed",
+    "torch.distributed.run",
+    "torch.distributed.elastic",
+    "torch.distributed.elastic.multiprocessing",
+    "torch.distributed.launcher.api",
+    # HuggingFace Hub / transformers progress + warnings.
+    "transformers",
+    "huggingface_hub",
+    # General misc.
+    "filelock",
+    "urllib3",
+)
+
+
+def reapply_quiet_logger_levels() -> None:
+    """Raise levels on noisy Python loggers. Safe to call multiple times.
+
+    No-op unless suppression is enabled and quiet mode is active.
+    """
+    if not ENABLED or VERBOSE_LOGS:
+        return
+    for _logger_name in QUIET_LOGGER_NAMES:
+        _logging.getLogger(_logger_name).setLevel(_logging.ERROR)
+
+
+def _configure_non_mllog_logs_quiet() -> None:
+    """Silence every non-MLLOG log source we can control via env vars or
+    the standard ``logging`` / ``warnings`` modules. :::MLLOG output is
+    untouched because ``mlperf_logging`` has its own stdout handler.
+    """
+    _os.environ.setdefault("AITER_LOG_LEVEL", "ERROR")
+    _os.environ.setdefault("AITER_LOG_MORE", "0")
+    _os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+    _os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+    _os.environ.setdefault("PYTHONWARNINGS", "ignore")
+    # Tell Primus-Turbo / GPT-OSS helpers to keep JIT tuning traces off.
+    _os.environ.setdefault("AITER_LOG_TUNED_CONFIG", "0")
+
+    for _logger_name in QUIET_LOGGER_NAMES:
+        _logging.getLogger(_logger_name).setLevel(_logging.ERROR)
+
+    # ``warnings.filterwarnings("ignore")`` covers cases where
+    # ``PYTHONWARNINGS=ignore`` has no effect because Python was started
+    # before we ran (e.g. re-exec'd by a launcher).
+    try:
+        import warnings as _warnings
+
+        _warnings.filterwarnings("ignore")
+    except Exception:
+        pass
+
+
+def _install_fd_level_fallback_filter() -> None:
+    """Last-resort line filter for logs that bypass Python ``logging``
+    entirely: unconditional ``std::cout`` writes in aiter / hipify C++,
+    raw ``print()`` statements in TE / Megatron, and Primus loguru output
+    that landed on stdout.
+
+    Design:
+      * FD 2 (stderr) is redirected straight to ``/dev/null``. In quiet
+        mode the only stderr sources observed in practice are Primus's
+        ``loguru`` sink, ``warnings.warn`` output, the hipify
+        ``"Successfully preprocessed all matching files."`` banner, and
+        torchrun's elastic SIGTERM chatter -- none of which carry a
+        training or MLLOG signal.
+      * FD 1 (stdout) is routed through an ``os.pipe`` + reader thread.
+        The thread runs each line through the suppression regexes and
+        forwards surviving lines to the saved original stdout FD.
+      * ``:::MLLOG`` lines always pass through.
+    """
+    import re
+    import sys
+    import threading
+
+    ansi_re = re.compile(r"\x1b\[[0-9;]*[ -/]*[@-~]")
+
+    suppress_patterns = tuple(
+        re.compile(p)
+        for p in (
+            # aiter JIT module-load / build / baton-wait banners.
+            r"^\[aiter\] ",
+            # TE-RoPE banner from transformer_engine rope.py (raw print).
+            r"^\[TE-RoPE\] ",
+            # "[MLPerf Train] ..." status prints -- all informational, all
+            # emitted N times in distributed mode. Re-run verbose to see them.
+            r"^\[MLPerf Train\] ",
+            # Primus runtime/CLI/patch informational prints that bypass loguru
+            # (e.g. "[Primus:Runtime] ...", "[Primus:Env] ...", "[Primus] ...",
+            # "[Primus CLI] ...", "[PrimusPatch] ..."). Covers the new-arch
+            # runtime/launcher print() calls. Re-run verbose to see them.
+            r"^\[Primus",
+            # Gloo C++ peer-connect banner ("[Gloo] Rank N is connected
+            # to 7 peer ranks. Expected number of connected peer ranks
+            # is : 7") -- native std::cout from libgloo.
+            r"^\[Gloo\] Rank \d+ is connected to ",
+            r"^Expected number of connected peer ranks is\s*:",
+            # hipify preprocessing banner (mostly fires on stderr, listed
+            # here as a safety net for any leak to stdout).
+            r"^Successfully preprocessed all matching files\.",
+            # Primus loguru lines, in case they end up on stdout for any
+            # reason (e.g. ``colorize=False`` configurations). The Primus
+            # format always starts with ``[YYYYMMDD HH:MM:SS]``.
+            r"^\[\d{8} \d{2}:\d{2}:\d{2}\]\[(?:rank|node)-\d+/",
+            # "Setting RerunStateMachine mode RerunMode.DISABLED" fires
+            # from Megatron's rerun_state_machine.py as a root-logger
+            # warning (the default Python logging handler dumps the message
+            # unformatted to stderr, but belt-and-braces: cover stdout too).
+            r"^Setting RerunStateMachine mode ",
+        )
+    )
+
+    def _should_suppress(line: str) -> bool:
+        stripped = ansi_re.sub("", line)
+        if ":::MLLOG" in stripped:
+            return False
+        for pat in suppress_patterns:
+            if pat.search(stripped):
+                return True
+        return False
+
+    def _start_reader(read_fd: int, out_fd: int) -> None:
+        def _run() -> None:
+            buf = b""
+            try:
+                while True:
+                    chunk = _os.read(read_fd, 4096)
+                    if not chunk:
+                        break
+                    buf += chunk
+                    while b"\n" in buf:
+                        raw, buf = buf.split(b"\n", 1)
+                        line = raw.decode("utf-8", errors="replace")
+                        if not _should_suppress(line):
+                            _os.write(out_fd, raw + b"\n")
+            except Exception:
+                # Never let the filter thread bring down the training run.
+                pass
+            finally:
+                if buf:
+                    line = buf.decode("utf-8", errors="replace")
+                    if not _should_suppress(line):
+                        try:
+                            _os.write(out_fd, buf)
+                        except Exception:
+                            pass
+
+        threading.Thread(target=_run, daemon=True).start()
+
+    # Flush any buffered Python stdout/stderr output before we steal the FDs.
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    orig_stdout_fd = _os.dup(1)
+
+    # Drop stderr unconditionally: nothing useful lands on FD 2 in quiet
+    # mode (Primus loguru, warnings, hipify). Users who need stderr back
+    # (e.g. crash debug) can re-run with ``MLPERF_VERBOSE_LOGS=1``.
+    devnull_fd = _os.open(_os.devnull, _os.O_WRONLY)
+    _os.dup2(devnull_fd, 2)
+    _os.close(devnull_fd)
+
+    stdout_r, stdout_w = _os.pipe()
+    _os.dup2(stdout_w, 1)
+    _os.close(stdout_w)
+
+    _start_reader(stdout_r, orig_stdout_fd)
+
+    sys.stdout = _os.fdopen(1, "w", buffering=1, closefd=False)
+    sys.stderr = _os.fdopen(2, "w", buffering=1, closefd=False)
+
+
+_INSTALLED = False
+
+
+def install() -> None:
+    """Install the quiet-mode suppression exactly once per process.
+
+    No-op unless ``PRIMUS_LOG_SUPPRESSION=1``. Calling this a second time is
+    also a no-op.
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    _INSTALLED = True
+    if not ENABLED:
+        return
+    if VERBOSE_LOGS:
+        return
+    _configure_non_mllog_logs_quiet()
+    _install_fd_level_fallback_filter()
+
+
+# Auto-install on import (gated by PRIMUS_LOG_SUPPRESSION).
+install()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ mlflow==3.4.0
 pyrsmi
 plotext
 hip-python
+git+https://github.com/mlcommons/logging.git@6.0.0-rc5


### PR DESCRIPTION
## Summary
Migrate the MLPerf GPT-OSS-20B pretraining flow and its optimizations from the
standalone mlperf source tree into Primus, so it runs through the native
`primus-cli ... train pretrain` path (`stage: mlperf_pretrain`) instead of a
separate entrypoint/wheel.

- **MLPerf trainer & logging** integrated into the BaseTrainer architecture
  (`primus/backends/megatron/mlperf/`: `mlperf_pretrain_trainer.py`,
  `mlperf_logger.py`, `warmup.py`), registered as the `mlperf_pretrain` stage.
- **Source patches migrated to `register_patch`** (`primus/backends/megatron/patches/`):
  MoE skip-identity-sort, SDMA param all-gather, TE BSHD-layout, turbo
  fused-residual-norm.
- Honor `MLLOG_TRAIN_LOSS_LOG_FREQ`; add MLPerf log suppression
  (`mlperf_log_suppression.py`); fix a tensor-keyed `WeakKeyDictionary` in the
  MoE skip-identity-sort patch.

## Changes
- 13 files, +2926 (additive). New `primus/backends/megatron/mlperf/` and
  `primus/backends/megatron/patches/{moe,parallelism,te,turbo}_patches` modules;
  `sdma_param_gather.py`, `fused_residual_rmsnorm.py`; `cli/main.py` wiring.

## Test plan
- [x] End-to-end on MI355X (1 node × 8 GPUs), image `tasimage/primus:pr-830`,
      config `gpt_oss_20B-pretrain-fp8.yaml`, EP=1, fp8(e4m3, tensorwise),
      `use_turbo_grouped_gemm=false` (TE grouped GEMM).
- [x] Trains cleanly, ~580 TFLOP/s/GPU, no NaN; **train loss 11.85 → 3.34**,
      **eval loss 4.57 → 3.35** (approaching the MLPerf target 3.34); eval +
      `:::MLLOG` events emitted correctly.

## Notes / known limitation (not in this PR)
- With `use_turbo_grouped_gemm=true` on gfx950 (MI350/MI355), the Primus-Turbo
  fp8 tensorwise grouped-GEMM backward hits `K mismatch (5760 vs 2880)` on the
  non-square expert fc1, because the gfx950 NT-layout backward consumes the
  extension's pre-quantized `b_t` (col-wise, non-transposed) directly. The raw
  op is fine standalone; this is a framework/turbo interop issue tracked
  separately. TE grouped GEMM is the working fp8 path on MI355 for now.