### PR TITLE
feat: add AITER_LOG_LEVEL to suppress log

### DIFF
--- a/runner/helpers/hooks/03_enable_aiter.sh
+++ b/runner/helpers/hooks/03_enable_aiter.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+#
+# Global hook: enable AITER.
+#
+# Trigger:
+#   export AITER_LOG_LEVEL=ERROR
+#
+# This hook emits env.* lines which will be exported by execute_hooks.sh.
+#
+
+set -euo pipefail
+
+# Set AITER log level to ERROR to suppress the verbose logs.
+echo "env.AITER_LOG_LEVEL=ERROR"


### PR DESCRIPTION
# Description

This PR adds a new global runner hook that sets `AITER_LOG_LEVEL=ERROR` to suppress the verbose AITER logs during training runs.

AITER emits a large amount of log output by default, which clutters the run logs and makes it harder to spot the relevant training information. The new hook raises the AITER log level to `ERROR` so that only errors are surfaced.

The hook emits an `env.*` line that is exported by `execute_hooks.sh`, following the existing global-hook convention under `runner/helpers/hooks/`.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `runner/helpers/hooks/03_enable_aiter.sh`, a global hook that exports `AITER_LOG_LEVEL=ERROR` to suppress the verbose AITER logs.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
