### PR TITLE
[Megatron-LM] fix: duplicated memory footprint when enable turbo grouped gemm

### DIFF
--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -1625,9 +1625,7 @@ class PrimusTurboGroupedLinear(TEGroupedLinear):
                 weight = getattr(self, f"weight{i}")
                 buffer[i].copy_(weight)
 
-            weights = buffer.clone()
-
-        self.register_parameter("weights", torch.nn.Parameter(weights))
+        self.register_parameter("weights", torch.nn.Parameter(buffer))
 
         # Capture the per-expert weights' extra attributes BEFORE deleting them.
         saved_weight_attrs = [dict(getattr(self, f"weight{i}").__dict__) for i in range(self.num_gemms)]
@@ -1643,31 +1641,41 @@ class PrimusTurboGroupedLinear(TEGroupedLinear):
             name = f"weight{i}"
             if name in self._parameters:
                 del self._parameters[name]
-        del buffer
 
         gc.collect()
         torch.cuda.empty_cache()
 
-        # Re-expose each expert's slice as a zero-copy weight{i} Parameter view
-        # of self.weights, so existing code paths and checkpoints that look up
-        # weight{i} by name keep working without allocating a new buffer.
-        # ``requires_grad=False`` is required: self.weights is the canonical
-        # trainable Parameter and these views share its storage, so leaving
-        # them trainable would make the optimizer (and DDP) update / sync the
-        # same memory twice.  ``.detach()`` strips the view's autograd graph
-        # so each Parameter ends up as a leaf with ``_base is None`` (which is
-        # what Megatron's distributed-optimizer param-bucket re-mapping
-        # expects), while still aliasing the same underlying storage.
-        # We also restore each weight{i}'s saved extra attributes so checkpoint /
-        # state-dict code that inspects them keeps seeing the right markers.
-        for i in range(self.num_gemms):
-            weight_i = torch.nn.Parameter(self.weights[i].detach(), requires_grad=False)
-            for attr_name, attr_val in saved_weight_attrs[i].items():
-                setattr(weight_i, attr_name, attr_val)
-            self.register_parameter(f"weight{i}", weight_i)
+        # Defer weight{i} view registration until after DDP has remapped
+        # self.weights into the distributed-optimizer param buffer. Registering
+        # views here would pin the pre-remap storage and leave a duplicate copy
+        # of the consolidated weights resident on GPU.
+        self._saved_weight_attrs = saved_weight_attrs
+        self._weight_views_registered = False
+        self.register_forward_pre_hook(self._forward_pre_hook_ensure_weight_views)
 
         self.register_buffer("quantized_weight_buffer", None, persistent=False)
         self.register_buffer("quantized_weight_t_buffer", None, persistent=False)
+
+    def _ensure_weight_views(self) -> None:
+        """Register per-expert weight{i} views after DDP param-buffer remap."""
+        if self._weight_views_registered:
+            return
+
+        for i in range(self.num_gemms):
+            weight_i = torch.nn.Parameter(self.weights[i], requires_grad=False)
+            for attr_name, attr_val in self._saved_weight_attrs[i].items():
+                setattr(weight_i, attr_name, attr_val)
+            self.register_parameter(f"weight{i}", weight_i)
+
+        self._weight_views_registered = True
+
+    @staticmethod
+    def _forward_pre_hook_ensure_weight_views(module, _inputs):
+        module._ensure_weight_views()
+
+    def state_dict(self, *args, **kwargs):
+        self._ensure_weight_views()
+        return super().state_dict(*args, **kwargs)
 
     def forward(self, x: torch.Tensor, m_splits: torch.Tensor):
         _is_first_microbatch = self.is_first_microbatch

--- a/runner/helpers/hooks/03_enable_aiter.sh
+++ b/runner/helpers/hooks/03_enable_aiter.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+#
+# Global hook: enable AITER.
+#
+# Trigger:
+#   export AITER_LOG_LEVEL=ERROR
+#
+# This hook emits env.* lines which will be exported by execute_hooks.sh.
+#
+
+set -euo pipefail
+
+# Set AITER log level to ERROR to suppress the verbose logs.
+echo "env.AITER_LOG_LEVEL=ERROR"


### PR DESCRIPTION
# Description

This PR fixes duplicated GPU memory usage in `PrimusTurboGroupedLinear` when turbo grouped GEMM is enabled for MoE expert layers.

`PrimusTurboGroupedLinear` consolidates per-expert `weight{i}` parameters into a single `self.weights` tensor for grouped GEMM execution. The previous implementation had two issues that left an extra copy of the consolidated weights resident on GPU:

1. `buffer.clone()` was used when registering `self.weights`, allocating a redundant tensor.
2. Per-expert `weight{i}` views were registered immediately in `__init__`. Those views pinned the pre-DDP-remap storage. After the distributed optimizer remapped `self.weights` into the param buffer, both the old pinned storage and the remapped buffer remained on GPU.

This change registers `self.weights` directly from the consolidation buffer and defers `weight{i}` view creation until after DDP param-buffer remapping. Views are created lazily on the first forward pass (via a forward pre-hook) or when `state_dict()` is called, preserving checkpoint and legacy `weight{i}` lookup compatibility without retaining duplicate weight storage.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Remove the unnecessary `buffer.clone()` when registering the consolidated `self.weights` parameter in `PrimusTurboGroupedLinear.__init__`.
- Defer per-expert `weight{i}` view registration until after DDP distributed-optimizer param-buffer remapping, avoiding pinned pre-remap storage.
- Add `_ensure_weight_views()` with lazy registration triggered by a forward pre-hook and overridden `state_dict()`.
- Preserve per-expert weight metadata via `_saved_weight_attrs` so checkpoint and state-dict code paths continue to work.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
