### PR TITLE
merge to main of docs(flux): diffusion training documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@ In-depth technical documentation:
 - **[Backend Extension Guide](./backends/extending-backends.md)** - How to add a new backend using the current adapter/trainer architecture
  - **[Megatron Model Extension Guide](./backends/adding-megatron-models.md)** - How to add a new Megatron model config
  - **[TorchTitan Model Extension Guide](./backends/adding-torchtitan-models.md)** - How to add a new TorchTitan model config
+- **[Flux Diffusion Models](./backends/megatron/diffusion/README.md)** - Flux diffusion model architecture, training, and API reference
+- **[FP8 Training Guide](./backends/megatron/diffusion/fp8_training.md)** - FP8 precision training on AMD MI300X/MI355X: configuration, benchmarks, and tuning
 
 ### 💡 Help & Support
 

--- a/docs/backends/megatron/diffusion/README.md
+++ b/docs/backends/megatron/diffusion/README.md
@@ -1,0 +1,371 @@
+# Diffusion Models in Primus - Developer & Architecture Guide
+
+**Purpose:** Developer-focused documentation for understanding Primus diffusion architecture, design decisions, and implementation details.
+
+**For training/usage instructions, see:** [examples/megatron/diffusion/README.md](../../../../examples/megatron/diffusion/README.md)
+
+**For test documentation, see:** [tests/unit_tests/backends/megatron/diffusion/](../../../../tests/unit_tests/backends/megatron/diffusion/)
+
+---
+
+## Architecture Philosophy
+
+Primus diffusion models are built as **Megatron-Core native implementations**, designed for:
+- Production-scale distributed training
+- Seamless integration with Megatron parallelism strategies (TP, PP, DP, EP)
+- Advanced checkpoint management with heterogeneous layers
+- Clean separation of concerns (no framework dependencies like PyTorch Lightning)
+
+### Key Design Decisions
+
+**1. Megatron-Core Integration**
+- Models in `core/models/diffusion/` follow Megatron-Core patterns
+- Extends `TransformerConfig` for configurations (inherits all Megatron features)
+- Uses `TransformerBlock` with heterogeneous layer support
+- Compatible with Megatron's distributed checkpointing
+
+**2. Unified TransformerBlock Architecture**
+- Unlike HuggingFace's ModuleLists, uses Megatron's unified TransformerBlock
+- Simplifies checkpoint management
+- More efficient gradient synchronization
+- Note: pipeline parallelism is not supported for diffusion models (`pipeline_model_parallel_size` must be 1)
+
+**3. No Framework Dependencies**
+- Direct PyTorch implementation (no PyTorch Lightning)
+- Uses Megatron's distributed primitives directly
+- Simpler debugging and profiling
+- Better control over distributed training
+
+**4. Extensibility First**
+- Base classes designed for multiple diffusion models (Flux, DiT, MovieGen)
+- Clear shared vs model-specific separation
+- Hierarchical encoder registry for easy extension
+
+---
+
+## Supported Models
+
+### Flux ✅ Production Ready
+Flow-based diffusion model with MMDiT (Multimodal Diffusion Transformer) architecture.
+
+- **Architecture**: Dual-stream with joint and single transformer blocks
+- **Sizes**: 535M (testing) and 12B (production)
+- **Reference**: [Black Forest Labs FLUX.1](https://huggingface.co/black-forest-labs/FLUX.1-dev)
+- **Status**: Fully implemented and tested (390 tests)
+
+### Future Models ⏳ Planned
+- **DiT**: Diffusion Transformer for image generation
+- **MovieGen**: Video diffusion models
+- **Custom Models**: Extensible framework for new architectures
+
+---
+
+## Project Structure
+
+```
+primus/backends/megatron/
+├── core/models/
+│   ├── common/diffusion_module/    # DiffusionModule (base class with sharded state dict)
+│   │   └── diffusion_module.py
+│   └── diffusion/                  # Model implementations (Megatron-Core style)
+│       ├── common/                 # Shared components (MMDiT layers, attention)
+│       │   ├── config.py           # BaseDiffusionConfig (extends TransformerConfig)
+│       │   └── layers.py           # Shared layers (if any)
+│       └── flux/                   # Flux-specific code
+│           ├── config.py           # FluxConfig with factory methods (535M, 12B)
+│           ├── model.py            # Flux model (extends DiffusionModule)
+│           └── layer_spec.py       # Flux layer specifications
+│
+├── training/diffusion/             # Training utilities
+│   ├── noise_utils.py              # Noise application (flow matching, DDPM)
+│   ├── loss_computation.py         # Loss functions (flow matching, epsilon, v-prediction)
+│   ├── timestep_sampling.py        # Timestep sampling strategies
+│   └── schedulers/
+│       ├── base.py                 # BaseScheduler
+│       └── flow_matching.py        # FlowMatchEulerDiscreteScheduler
+│
+└── data/
+    ├── energon/                    # Shared Energon infrastructure
+    └── diffusion/                  # Diffusion-specific data
+        ├── encoders/               # Hierarchical encoder registry
+        │   ├── image/vae/          # VAE variants (SD VAE, custom VAEs)
+        │   ├── text/t5/            # T5 variants (XXL, etc.)
+        │   └── text/clip/          # CLIP variants (L, H, etc.)
+        ├── preprocessing/          # Data preprocessing utilities
+        │   ├── download.py         # Reusable download utils (retry, MD5, manifests)
+        │   ├── finalize.py         # Energon dataset finalization
+        │   ├── validate.py         # Dataset structure validation
+        │   └── pipelines/          # Dataset preparation pipelines
+        │       ├── base.py         # DatasetPipeline abstract base class
+        │       ├── raw.py          # Raw image pipeline
+        │       ├── encoded.py      # Pre-encoded pipeline
+        │       └── ingest.py       # StreamingIngestPipeline (MLPerf Arrow->WDS)
+        └── task_encoders/          # Energon TaskEncoders for diffusion
+
+primus/configs/models/megatron/diffusion/
+├── flux_535m.yaml                  # Flux 535M config
+├── flux_12b.yaml                   # Flux 12B config
+└── encoders.yaml                   # Encoder configuration
+
+tests/unit_tests/backends/megatron/diffusion/  # Comprehensive test suite (390 tests)
+├── models/                         # Model-level tests
+├── layers/                         # Layer-level tests
+├── unit/                          # Unit tests for utilities
+├── distributed/                    # Distributed training tests
+├── functional/                     # End-to-end functional tests
+└── checkpointing/                  # Checkpoint tests
+
+docs/backends/megatron/diffusion/   # This directory
+├── README.md                       # This file (developer guide)
+├── architecture_overview.md        # Detailed architecture
+├── data_preprocessing.md           # Data pipeline guide (includes Flux-specific section)
+├── energon_integration.md          # Energon patterns
+├── flux_architecture.md            # Flux deep dive
+├── fp8_training.md                 # FP8 training guide (benchmarks, tuning, troubleshooting)
+├── api_reference.md                # API documentation
+├── adding_new_models.md            # Extension guide
+└── STRUCTURE.md                    # Directory tree and organization
+```
+
+---
+
+## Key Technical Features
+
+### 1. DiffusionModule Base Class
+
+All diffusion models inherit from `DiffusionModule`, which provides:
+- Megatron-Core integration (process groups, parallelism)
+- Sharded state dict support for distributed checkpointing
+- Gradient checkpointing
+- Mixed precision support
+- Device placement utilities
+
+**Location:** `primus/backends/megatron/core/models/common/diffusion_module/diffusion_module.py`
+
+### 2. BaseDiffusionConfig
+
+Configuration class extending `TransformerConfig`:
+- Inherits all Megatron-Core configuration (TP, PP, sequence_parallel, etc.)
+- Adds diffusion-specific parameters (channels, patch_size, etc.)
+- Factory methods for common presets
+
+**Location:** `primus/backends/megatron/core/models/diffusion/common/config.py`
+
+### 3. Hierarchical Encoder Registry
+
+Organized by modality → type → variant:
+```
+encoders/
+├── image/vae/
+│   ├── sd_vae.py              # Standard SD VAE
+│   └── (future: custom VAEs)
+├── text/t5/
+│   ├── t5_xxl.py              # T5-XXL encoder
+│   └── (future: T5 variants)
+└── text/clip/
+    ├── clip_l.py              # CLIP-L encoder
+    └── (future: CLIP-H, etc.)
+```
+
+Benefits:
+- Easy to add new encoder variants (5+ planned per modality)
+- Config-driven selection via `encoders.yaml`
+- Lazy loading (encoders loaded only when needed)
+- Shared base classes for common functionality
+
+### 4. Training Utilities Structure
+
+**Noise Application** (`noise_utils.py`):
+- `apply_flow_matching_noise()`: For flow matching models (Flux)
+- `apply_ddpm_noise()`: For DDPM-based models
+- Support for different noise schedules
+
+**Loss Computation** (`loss_computation.py`):
+- `compute_flow_matching_loss()`: For flow matching
+- `compute_epsilon_loss()`: For epsilon prediction (DDPM)
+- `compute_v_prediction_loss()`: For v-prediction
+- Unified interface for different loss types
+
+**Timestep Sampling** (`timestep_sampling.py`):
+- `LogitNormalSampler`: Logit-normal distribution
+- `UniformSampler`: Uniform distribution
+- `ModeSampler`: Mode-focused sampling
+- Base class for custom samplers
+
+### 5. Shared Energon Infrastructure
+
+Located in `data/energon/` for reusability across models:
+- Shared data loading utilities
+- Common preprocessing functions
+- WebDataset integration
+- Model-specific TaskEncoders in `data/diffusion/task_encoders/`
+
+### 6. Precalculated Data Support
+
+**Performance**: 5-10x faster training than on-the-fly encoding
+
+**Supported encodings**:
+- `preencoded` -- Primus-encoded PyTorch `.pth` format (VAE latents + text embeddings)
+- `preencoded_numpy` -- MLPerf NumPy uint16 format (bfloat16 tensors as `.bytes` entries)
+
+**Workflow**:
+1. Precompute VAE latents and text embeddings offline
+2. Store in WebDataset/Energon format
+3. Load directly during training (no encoder overhead)
+
+**Benefits**:
+- Faster training iteration
+- Consistent encoder versions across runs
+- Lower GPU memory (no encoders loaded during training)
+- Better reproducibility
+
+### 7. MLPerf Streaming Ingest Pipeline
+
+**Location:** `data/diffusion/preprocessing/pipelines/ingest.py`
+
+The `StreamingIngestPipeline` downloads Apache Arrow IPC files from MLCommons R2 storage and converts them directly into Energon WebDataset tar shards in a single streaming pass. This avoids storing the full ~6 TB raw Arrow dataset on disk.
+
+**Architecture**: Producer-consumer with concurrent download and sequential conversion:
+- **Producer thread**: Acquires a semaphore permit, submits downloads to a `ThreadPoolExecutor`, passes completed futures to a drain thread
+- **Drain thread**: Processes futures in submission order and feeds the prefetch queue
+- **Consumer (main thread)**: Converts Arrow data to tar shards, deletes temporary files, releases semaphore permits
+
+**Key properties**:
+- Bounded disk usage: `threading.Semaphore(prefetch_depth)` limits Arrow files on disk
+- Deterministic shard ordering preserved via in-order future draining
+- Retry with exponential backoff for HTTP 429/503 and MD5 mismatches (`download.py`)
+- Skip-and-log: individual failures are recorded in `failed_files.json`
+- Resume: re-running skips shards that already exist on disk
+
+**Related modules**:
+- `download.py`: `download_with_backoff()`, `fetch_manifest()`, `parse_md5_manifest()`
+- `pipelines/base.py`: `DatasetPipeline` ABC (shared by `raw.py`, `encoded.py`, `ingest.py`)
+- `finalize.py`: Energon dataset finalization (`.nv-meta/dataset.yaml` + `energon prepare`)
+- `validate.py`: Post-finalization structural validation
+
+---
+
+## Implementation Status
+
+### Core Infrastructure ✅
+- ✅ Directory structure with 25+ directories
+- ✅ Base classes (DiffusionModule, BaseDiffusionConfig, BaseScheduler)
+- ✅ DiffusionModule with Megatron-Core integration
+- ✅ FluxConfig with factory methods (flux_535m, flux_12b)
+- ✅ FlowMatchEulerDiscreteScheduler
+- ✅ Configuration system (YAML files)
+- ✅ Testing framework (390 tests)
+- ✅ Comprehensive documentation
+
+### Flux Model Implementation ✅
+- ✅ Flux model architecture (dual-stream MMDiT)
+- ✅ MMDiT layers and attention (joint + single blocks)
+- ✅ Embeddings (3D RoPE, timestep, vector)
+- ✅ Hierarchical encoder registry
+- ✅ Data pipeline and TaskEncoders
+- ✅ Training utilities (noise, loss, sampling)
+- ✅ Checkpoint conversion (HF <-> Megatron)
+
+---
+
+## Documentation Map
+
+### Core Guides
+
+📖 **[Architecture Overview](architecture_overview.md)**
+High-level design, directory structure, and architectural decisions.
+
+📖 **[Directory Structure](STRUCTURE.md)**
+Complete directory tree and file organization.
+
+📖 **[Data Preprocessing Guide](data_preprocessing.md)**
+How to prepare datasets, precalculate latents, and use Energon.
+
+📖 **[Energon Integration](energon_integration.md)**
+Megatron-Energon patterns and TaskEncoder implementation.
+
+📖 **[Adding New Models](adding_new_models.md)**
+Step-by-step guide for implementing new diffusion models.
+
+### Advanced Documentation
+
+📖 **[Flux Architecture Deep Dive](flux_architecture.md)**
+Mathematical formulation, detailed component descriptions, and performance optimizations.
+
+📖 **[API Reference](api_reference.md)**
+Complete API documentation with function signatures and usage examples.
+
+📖 **[FP8 Training Guide](fp8_training.md)**
+FP8 precision training on AMD MI300X: configuration, benchmarks, tuning recipes, and troubleshooting.
+
+### Related Documentation
+
+📖 **[Training Guide](../../../../examples/megatron/diffusion/README.md)**
+User-facing guide for training Flux models (quick start, configurations, troubleshooting).
+
+📖 **[Test Directory](../../../../tests/unit_tests/backends/megatron/diffusion/)**
+Test suite for diffusion models.
+
+---
+
+## Testing Architecture
+
+**Test Organization** (following Megatron-LM patterns):
+- One comprehensive file per model (`test_flux_model.py`)
+- Unit tests for utilities (`unit/test_utils.py`, etc.)
+- Distributed tests in separate directory (`distributed/`)
+- Functional tests for workflows (`functional/`)
+
+**Test Status**: ✅ 390 tests passing
+
+See [tests/unit_tests/backends/megatron/diffusion/](../../../../tests/unit_tests/backends/megatron/diffusion/) for details.
+
+---
+
+## Hardware Requirements
+
+### Flux 535M (Testing)
+- **Training**: 1x MI300X 192GB (compatible with H100/A100)
+- **Inference**: 1x MI300X 192GB
+- **Batch Size**: 1-8 per GPU
+
+### Flux 12B (Production)
+- **Training**: 8x MI300X 192GB (recommended) or 4x MI300X 192GB with TP=2
+- **Inference**: 1x MI300X 192GB
+- **Batch Size**: 1-2 per GPU for training, 1-4 for inference
+
+---
+
+## Contributing
+
+See the main guide: [Adding New Models](adding_new_models.md)
+
+**To contribute:**
+1. Follow the established directory structure
+2. Extend base classes (DiffusionModule, BaseDiffusionConfig)
+3. Add comprehensive tests in `tests/unit_tests/backends/megatron/diffusion/`
+4. Update documentation (architecture guide + API reference)
+5. Submit PR with clear description
+
+---
+
+## License
+
+- **Primus Code**: AMD Copyright 2025, Apache License 2.0
+- **Flux Encoders**:
+  - FLUX.1 [dev]: Non-commercial license
+  - FLUX.1 [schnell]: Apache 2.0 (commercial use allowed)
+  - Individual components (T5, CLIP, VAE): Check respective licenses
+
+---
+
+## Resources
+
+- **Megatron-Core**: [nvidia/Megatron-LM](https://github.com/NVIDIA/Megatron-LM) - Core framework
+- **Flux Model**: [black-forest-labs/FLUX.1-dev](https://huggingface.co/black-forest-labs/FLUX.1-dev)
+- **Flow Matching**: Rectified flow and flow matching papers
+- **NeMo**: [nvidia/NeMo](https://github.com/NVIDIA/NeMo) - Alternative diffusion implementation
+
+---
+
+**Last Updated**: January 2026

--- a/docs/backends/megatron/diffusion/STRUCTURE.md
+++ b/docs/backends/megatron/diffusion/STRUCTURE.md
@@ -1,0 +1,254 @@
+# Flux Diffusion Infrastructure - Directory Structure
+
+**Created**: December 5, 2025
+**Status**: ✓ Implementation Complete
+
+## Overview
+
+This document describes the directory structure created for Flux diffusion model support in Primus, following Megatron-Core conventions with production-ready enhancements.
+
+---
+
+## Directory Tree
+
+```
+Primus/
+├── primus/backends/megatron/
+│   ├── core/models/
+│   │   ├── common/diffusion_module/         # DiffusionModule base class
+│   │   │   └── diffusion_module.py
+│   │   └── diffusion/                      # Diffusion models (Megatron-Core convention)
+│   │       ├── common/                     # Shared components (MMDiT layers, attention)
+│   │       │   ├── __init__.py
+│   │       │   ├── config.py               # ✓ BaseDiffusionConfig
+│   │       │   ├── embeddings.py           # ✓ TimeStepEmbedder, MLPEmbedder
+│   │       │   └── normalization.py        # ✓ AdaLN, AdaLNContinuous, RMSNorm
+│   │       ├── flux/                       # Flux-specific components
+│   │       │   ├── __init__.py
+│   │       │   ├── config.py               # ✓ FluxConfig (with factory methods)
+│   │       │   ├── model.py                # ✓ Flux model
+│   │       │   ├── layers.py               # ✓ EmbedND, embedders
+│   │       │   ├── layer_spec.py           # ✓ get_flux_layer_spec, get_flux_*_spec_for_backend, MMDiTLayer
+│   │       │   ├── attention.py            # ✓ JointSelfAttention, FluxSingleAttention
+│   │       │   ├── utils.py                # ✓ generate_image_position_ids
+│   │       │   ├── checkpoint_utils.py     # ✓ Checkpoint utilities
+│   │       │   └── checkpoint_converter.py # ✓ HF <-> Megatron conversion
+│   │       └── __init__.py
+│   │
+│   ├── training/diffusion/                 # Training utilities
+│   │   ├── schedulers/
+│   │   │   ├── __init__.py
+│   │   │   ├── base.py                     # ✓ BaseScheduler
+│   │   │   └── flow_matching.py            # ✓ FlowMatchEulerDiscreteScheduler
+│   │   ├── noise_utils.py                  # ✓ apply_flow_matching_noise, apply_ddpm_noise
+│   │   ├── loss_computation.py             # ✓ compute_flow_matching_loss, etc.
+│   │   ├── timestep_sampling.py             # ✓ LogitNormalSampler, UniformSampler
+│   │   └── __init__.py
+│   │
+│   └── data/
+│       ├── energon/                        # Shared Energon infrastructure
+│       │   └── __init__.py                 # ✓ Energon wrappers
+│       │
+│       └── diffusion/                      # Diffusion-specific data
+│           ├── encoders/                   # Hierarchical encoder registry
+│           │   ├── image/
+│           │   │   ├── vae/                # VAE variants
+│           │   │   │   └── __init__.py     # ✓ AutoencoderKL, VQVAE, etc.
+│           │   │   └── __init__.py
+│           │   ├── text/
+│           │   │   ├── t5/                 # T5 variants
+│           │   │   │   └── __init__.py     # ✓ T5-XXL, T5-Large, etc.
+│           │   │   ├── clip/               # CLIP variants
+│           │   │   │   └── __init__.py     # ✓ CLIP-L, CLIP-H, etc.
+│           │   │   └── __init__.py
+│           │   └── __init__.py             # ✓ EncoderRegistry
+│           │
+│           ├── preprocessing/
+│           │   ├── image/
+│           │   │   └── __init__.py         # ✓ Resizing, augmentation
+│           │   └── __init__.py
+│           │
+│           ├── task_encoders/              # Energon TaskEncoders
+│           │   ├── __init__.py
+│           │   └── image.py                # ✓ EncodedDiffusionTaskEncoder, RawDiffusionTaskEncoder
+│           │
+│           └── __init__.py
+│
+├── primus/modules/trainer/megatron/
+│   └── diffusion/                          # Diffusion trainer
+│       └── __init__.py                     # ✓ DiffusionTrainer
+│
+├── primus/configs/models/megatron/
+│   └── diffusion/                          # YAML configs
+│       ├── __init__.py
+│       ├── flux_535m.yaml                  # ✓ Flux 535M config
+│       ├── flux_12b.yaml                   # ✓ Flux 12B config
+│       └── encoders.yaml                   # ✓ Encoder configs
+│
+├── examples/megatron/
+│   ├── diffusion/
+│   │   └── README.md                       # ✓ Training guide (consolidated)
+│   ├── configs/MI300X/diffusion/           # MI300X training configs
+│   │   ├── flux_535m_pretrain.yaml
+│   │   ├── flux_12b_fsdp2_energon_schnell_resample_local_spec.yaml
+│   │   ├── flux_12b_ddp_energon_schnell_resample_te_spec_fp8.yaml
+│   │   └── ...
+│   ├── configs/MI355X/diffusion/           # MI355X training configs (mirrors MI300X + MXFP4/MLPerf)
+│   │   ├── flux_12b_ddp_energon_schnell_resample_*.yaml
+│   │   ├── flux_12b_fsdp2_energon_schnell_resample_*.yaml
+│   │   └── ...
+│   └── prepare.py
+│
+├── examples/run_pretrain.sh                # Main training script
+│
+├── tests/
+│   ├── unit_tests/backends/megatron/diffusion/   # Unit test suite
+│   │   ├── test_flux_model.py
+│   │   ├── test_flux_config.py
+│   │   ├── test_flux_layers.py
+│   │   ├── test_flux_embeddings.py
+│   │   ├── test_flux_normalization.py
+│   │   ├── test_flux_utils.py
+│   │   ├── test_flux_checkpoint_converter.py
+│   │   ├── test_flux_checkpoint_utils.py
+│   │   ├── test_flux_layer_spec_backend_selection.py
+│   │   ├── test_flux_compile_checkpoint_keys.py
+│   │   ├── training/
+│   │   ├── data/
+│   │   └── distributed/
+│   └── integration_tests/backends/megatron/diffusion/
+│       ├── data/
+│       └── distributed/
+│
+└── docs/backends/megatron/
+    └── diffusion/                          # Documentation
+        ├── README.md                       # ✓ Overview
+        ├── STRUCTURE.md                    # ✓ This file
+        ├── architecture_overview.md        # ✓ Design details
+        ├── data_preprocessing.md           # ✓ Data guide (includes Flux-specific section)
+        ├── energon_integration.md          # ✓ Energon patterns
+        ├── flux_architecture.md            # ✓ Flux deep dive
+        ├── fp8_training.md                 # ✓ FP8 training guide
+        ├── api_reference.md                # ✓ API documentation
+        └── adding_new_models.md            # ✓ Extension guide
+```
+
+---
+
+## Completed Components
+
+### ✓ Base Classes
+
+1. **DiffusionModule** (`core/models/common/diffusion_module/diffusion_module.py`)
+   - Base class for all diffusion models (extends MegatronModule)
+   - Provides Megatron-Core integration
+   - Required methods: `forward()`
+   - Loss computation: Use standalone functions from `loss_computation.py`
+   - Utility methods: `get_num_params()`, `set_requires_grad()`
+
+2. **BaseDiffusionConfig** (`common/config.py`)
+   - Extends `megatron.core.transformer.transformer_config.TransformerConfig`
+   - Common parameters: `in_channels`, `out_channels`, `patch_size`
+   - Validation method for configuration integrity
+
+3. **FluxConfig** (`flux/config.py`)
+   - Flux-specific configuration
+   - Parameters: `num_joint_layers`, `num_single_layers`, `context_dim`, `vec_in_dim`
+   - Factory methods: `flux_535m()`, `flux_12b()`
+   - 3D RoPE configuration: `axes_dim`, `theta`
+
+3. **BaseScheduler** (`schedulers/base.py`)
+   - Abstract base for diffusion schedulers
+   - Required: `add_noise()`, `get_velocity_target()`, `sample_timesteps()`
+   - Optional: `scale_model_input()`, `get_snr()`, `get_alpha()`, `get_sigma()`
+
+4. **FlowMatchEulerDiscreteScheduler** (`schedulers/flow_matching.py`)
+   - Concrete implementation for Flux
+   - Linear interpolation: `x_t = (1-t)*noise + t*data`
+   - Velocity target: `v = data - noise`
+
+### ✓ Directory Structure
+
+- **25 `__init__.py` files** with comprehensive docstrings
+- **Multiple implementation files** (models, configs, schedulers, data pipeline)
+- **Complete test suite** with fixtures and helpers
+
+---
+
+## Architectural Decisions
+
+### 1. Models under `core/models/`
+- Follows Megatron-Core convention (`megatron/core/models/gpt/`, etc.)
+- Easier upstream tracking when Megatron-Core adds diffusion support
+
+### 2. Shared Components in `common/`
+- Standard approach stores shared code in model-specific directories
+- Primus: `common/` for MMDiT layers, attention, shared utilities
+- Flux-specific: Only `EmbedND` and Flux model class
+
+### 3. Hierarchical Encoder Structure
+- `encoders/image/vae/`, `encoders/text/t5/`, `encoders/text/clip/`
+- Registry pattern for config-driven selection
+- Easy to add new encoder variants (5+ planned per modality)
+
+### 4. Shared Energon Infrastructure
+- `data/energon/` for cross-model utilities (VLM, diffusion, future)
+- `data/diffusion/task_encoders/` for diffusion-specific TaskEncoders
+- Traditional approach nests Energon under model-specific directories
+
+### 5. Mock Data in Tests
+- `tests/fixtures/diffusion/` (not production code)
+- Traditional approach mixes test utilities with production code
+- Follows pytest best practices
+
+### 6. No PyTorch Lightning
+- Pure Megatron patterns (no PTL DataModules)
+- Better integration with Megatron training loop
+
+---
+
+## Import Examples
+
+```python
+# Base classes
+from primus.backends.megatron.core.models.diffusion.common import (
+    BaseDiffusionConfig,
+)
+
+# Flux configuration
+from primus.backends.megatron.core.models.diffusion.flux import FluxConfig
+
+# Create configs
+config_535m = FluxConfig.flux_535m()
+config_12b = FluxConfig.flux_12b()
+
+# Schedulers
+from primus.backends.megatron.training.diffusion.schedulers import (
+    BaseScheduler,
+    FlowMatchEulerDiscreteScheduler,
+)
+
+# Create scheduler
+scheduler = FlowMatchEulerDiscreteScheduler()
+timesteps = scheduler.sample_timesteps(batch_size=8, device='cuda')
+```
+
+---
+
+## Validation Status
+
+✓ All Python files syntactically correct
+✓ No linter errors detected
+✓ All imports properly structured
+✓ Comprehensive docstrings
+✓ Copyright headers applied (AMD 2025, Apache 2.0)
+
+---
+
+## Files Summary
+
+All infrastructure files, model implementations, data pipeline components, tests, and documentation are complete and ready for production use.
+
+---
+
+**End of Structure Document**

--- a/docs/backends/megatron/diffusion/adding_new_models.md
+++ b/docs/backends/megatron/diffusion/adding_new_models.md
@@ -1,0 +1,711 @@
+# Adding New Diffusion Models
+
+This guide explains how to add new diffusion models to Primus, following the established patterns and architecture.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Prerequisites](#prerequisites)
+3. [Step-by-Step Guide](#step-by-step-guide)
+4. [Example: Adding DiT](#example-adding-dit)
+5. [Testing Your Model](#testing-your-model)
+6. [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+Adding a new diffusion model involves:
+1. Creating model configuration
+2. Implementing model class
+3. Adding necessary layers
+4. Creating data pipeline components
+5. Writing tests
+6. Updating documentation
+
+**Time Estimate**: 5-10 days depending on model complexity
+
+---
+
+## Prerequisites
+
+Before adding a new model, ensure you have:
+- ✅ Understanding of the model architecture (paper, reference implementation)
+- ✅ Access to pretrained weights (if applicable)
+- ✅ Sample dataset for testing
+- ✅ Familiarity with Primus diffusion architecture
+- ✅ Development environment setup
+
+**Required Reading**:
+- [Architecture Overview](architecture_overview.md)
+- [Data Preprocessing Guide](data_preprocessing.md)
+- [Energon Integration](energon_integration.md)
+
+---
+
+## Step-by-Step Guide
+
+### Step 1: Create Model Directory
+
+Create a directory for your model under `core/models/diffusion/`:
+
+```bash
+mkdir -p primus/backends/megatron/core/models/diffusion/dit
+cd primus/backends/megatron/core/models/diffusion/dit
+```
+
+Create files:
+```bash
+touch __init__.py
+touch config.py
+touch model.py
+touch layers.py  # If model-specific layers needed
+```
+
+### Step 2: Implement Configuration
+
+**File**: `config.py`
+
+```python
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Configuration for DiT (Diffusion Transformer) model."""
+
+from dataclasses import dataclass
+from typing import Optional
+from ..common.config import BaseDiffusionConfig
+
+
+@dataclass
+class DiTConfig(BaseDiffusionConfig):
+    """
+    DiT-specific configuration.
+
+    DiT uses a standard transformer architecture for diffusion.
+    """
+
+    # Model identification
+    model_type: str = "dit"
+
+    # Architecture: Number of layers
+    num_layers: int = 28  # DiT-XL/2 default
+
+    # Architecture: Dimensions
+    hidden_size: int = 1152
+    num_attention_heads: int = 16
+
+    # Input dimensions
+    in_channels: int = 4  # VAE latent channels (standard SD VAE)
+
+    # Context dimensions
+    context_dim: int = 768  # CLIP text embedding dimension
+
+    # Patchification
+    patch_size: int = 2  # DiT uses 2x2 patches
+
+    # Class conditioning (for conditional generation)
+    num_classes: int = 1000  # ImageNet classes
+    class_dropout_prob: float = 0.1
+
+    # Adaptive LayerNorm (DiT-specific)
+    use_adaptive_layernorm: bool = True
+
+    def validate(self):
+        """Validate DiT-specific configuration."""
+        # Call parent validation
+        super().validate()
+
+        # DiT-specific validations
+        if self.num_layers <= 0:
+            raise ValueError(f"num_layers must be positive, got {self.num_layers}")
+
+        if self.patch_size <= 0:
+            raise ValueError(f"patch_size must be positive, got {self.patch_size}")
+
+        if self.num_classes < 0:
+            raise ValueError(f"num_classes must be non-negative, got {self.num_classes}")
+
+    @classmethod
+    def dit_xl_2(cls, **kwargs):
+        """
+        Create configuration for DiT-XL/2.
+
+        Args:
+            **kwargs: Override default parameters
+
+        Returns:
+            DiTConfig instance
+        """
+        defaults = {
+            'num_layers': 28,
+            'hidden_size': 1152,
+            'num_attention_heads': 16,
+            'patch_size': 2,
+        }
+        defaults.update(kwargs)
+        return cls(**defaults)
+
+    @classmethod
+    def dit_l_2(cls, **kwargs):
+        """Create configuration for DiT-L/2."""
+        defaults = {
+            'num_layers': 24,
+            'hidden_size': 1024,
+            'num_attention_heads': 16,
+            'patch_size': 2,
+        }
+        defaults.update(kwargs)
+        return cls(**defaults)
+```
+
+### Step 3: Implement Model Class
+
+**File**: `model.py`
+
+```python
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""DiT model implementation."""
+
+import torch
+import torch.nn as nn
+from primus.backends.megatron.core.models.common.diffusion_module.diffusion_module import DiffusionModule
+from megatron.core.process_groups_config import ProcessGroupCollection
+from ..common.layers import MMDiTLayer  # Reuse shared components if applicable
+from .config import DiTConfig
+
+
+class DiT(DiffusionModule):
+    """
+    DiT (Diffusion Transformer) model.
+
+    Reference: "Scalable Diffusion Models with Transformers" (Peebles & Xie, 2023)
+
+    Note: Inherits from DiffusionModule for Megatron-Core integration
+    (process groups, distributed checkpointing, attention backend config)
+    """
+
+    def __init__(
+        self,
+        config: DiTConfig,
+        encoder_configs: Optional[Dict[str, Any]] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ):
+        """
+        Initialize DiT model.
+
+        Args:
+            config: DiT configuration
+            encoder_configs: Optional encoder configurations (VAE, T5, CLIP)
+            pg_collection: Process group collection for distributed training
+        """
+        super().__init__(config, pg_collection=pg_collection, encoder_configs=encoder_configs)
+
+        self.config = config
+
+        # Input projection (patchify)
+        self.input_proj = nn.Conv2d(
+            config.in_channels,
+            config.hidden_size,
+            kernel_size=config.patch_size,
+            stride=config.patch_size,
+        )
+
+        # Positional embedding
+        self.pos_embed = nn.Parameter(
+            torch.zeros(1, (config.seq_length // config.patch_size) ** 2, config.hidden_size)
+        )
+
+        # Timestep embedding
+        self.time_embed = nn.Sequential(
+            nn.Linear(config.hidden_size, config.hidden_size * 4),
+            nn.SiLU(),
+            nn.Linear(config.hidden_size * 4, config.hidden_size),
+        )
+
+        # Class embedding (for conditional generation)
+        if config.num_classes > 0:
+            self.class_embed = nn.Embedding(config.num_classes, config.hidden_size)
+
+        # Transformer blocks
+        self.blocks = nn.ModuleList([
+            DiTBlock(config) for _ in range(config.num_layers)
+        ])
+
+        # Output projection
+        self.output_proj = nn.Sequential(
+            nn.LayerNorm(config.hidden_size),
+            nn.Linear(config.hidden_size, config.patch_size ** 2 * config.out_channels),
+        )
+
+        # Initialize weights
+        self._init_weights()
+
+    def forward(self, x, timesteps, context=None, class_labels=None, **kwargs):
+        """
+        Forward pass through DiT.
+
+        Args:
+            x: Noisy latents [B, C, H, W]
+            timesteps: Diffusion timesteps [B]
+            context: Text conditioning [B, S, D] (optional)
+            class_labels: Class labels [B] (optional)
+
+        Returns:
+            Model prediction [B, C, H, W]
+        """
+        B, C, H, W = x.shape
+
+        # Patchify input
+        x = self.input_proj(x)  # [B, hidden_size, H/p, W/p]
+        x = x.flatten(2).transpose(1, 2)  # [B, N, hidden_size]
+
+        # Add positional embedding
+        x = x + self.pos_embed
+
+        # Embed timesteps
+        t_emb = self.time_embed(self._timestep_embedding(timesteps))  # [B, hidden_size]
+
+        # Embed class labels (if provided)
+        if class_labels is not None and self.config.num_classes > 0:
+            c_emb = self.class_embed(class_labels)  # [B, hidden_size]
+            # Combine with timestep embedding
+            cond = t_emb + c_emb
+        else:
+            cond = t_emb
+
+        # Transformer blocks
+        for block in self.blocks:
+            x = block(x, cond, context)
+
+        # Output projection
+        x = self.output_proj(x)  # [B, N, p^2 * C]
+
+        # Unpatchify
+        x = self._unpatchify(x, H, W)  # [B, C, H, W]
+
+        return x
+
+            target: Ground truth target [B, C, H, W]
+
+        Returns:
+            Loss scalar
+        """
+        # Simple MSE loss (can be extended)
+        loss = nn.functional.mse_loss(model_output, target)
+        return loss
+
+    def _timestep_embedding(self, timesteps):
+        """Create sinusoidal timestep embeddings."""
+        # Standard sinusoidal embedding
+        half_dim = self.config.hidden_size // 2
+        emb = torch.exp(
+            -torch.arange(half_dim, device=timesteps.device) *
+            (torch.log(torch.tensor(10000.0)) / (half_dim - 1))
+        )
+        emb = timesteps[:, None] * emb[None, :]
+        emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)
+        return emb
+
+    def _unpatchify(self, x, H, W):
+        """Convert patched tensor back to image."""
+        p = self.config.patch_size
+        h = H // p
+        w = W // p
+        x = x.reshape(x.shape[0], h, w, p, p, self.config.out_channels)
+        x = x.permute(0, 5, 1, 3, 2, 4).contiguous()
+        x = x.reshape(x.shape[0], self.config.out_channels, H, W)
+        return x
+
+    def _init_weights(self):
+        """Initialize model weights."""
+        # Standard initialization (customize as needed)
+        pass
+
+
+class DiTBlock(nn.Module):
+    """DiT transformer block with adaptive LayerNorm."""
+
+    def __init__(self, config):
+        super().__init__()
+        # Implementation details...
+        pass
+
+    def forward(self, x, cond, context=None):
+        # Block forward pass
+        pass
+```
+
+### Step 4: Add Model-Specific Layers (If Needed)
+
+If your model has unique layers not shared with other models, add them to `layers.py`.
+
+### Step 5: Export Model
+
+**File**: `__init__.py`
+
+```python
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""DiT model implementation."""
+
+from .config import DiTConfig
+from .model import DiT
+
+__all__ = [
+    'DiTConfig',
+    'DiT',
+]
+```
+
+### Step 6: Create Configuration Files
+
+**File**: `primus/configs/models/megatron/diffusion/dit_xl_2.yaml`
+
+```yaml
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+# DiT-XL/2 Configuration
+
+model_type: dit
+
+# Architecture: Layers
+num_layers: 28
+
+# Architecture: Dimensions
+hidden_size: 1152
+num_attention_heads: 16
+
+# Input/Output Channels
+in_channels: 4        # VAE latent channels
+out_channels: 4
+
+# Patchification
+patch_size: 2
+
+# Class Conditioning
+num_classes: 1000     # ImageNet classes
+class_dropout_prob: 0.1
+
+# Adaptive LayerNorm
+use_adaptive_layernorm: true
+
+# Precision Settings
+bf16: true
+fp16: false
+
+# Training
+seq_length: 4096
+micro_batch_size: 8
+global_batch_size: 256
+learning_rate: 1.0e-4
+```
+
+### Step 7: Write Tests
+
+**File**: `tests/unit_tests/backends/megatron/diffusion/test_dit_model.py`
+
+```python
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Unit tests for DiT model."""
+
+import pytest
+import torch
+from primus.backends.megatron.core.models.diffusion.dit import DiT, DiTConfig
+
+
+class TestDiTConfig:
+    """Tests for DiT configuration."""
+
+    def test_dit_xl_2_factory(self):
+        """Test DiT-XL/2 configuration factory method."""
+        config = DiTConfig.dit_xl_2()
+
+        assert config.model_type == "dit"
+        assert config.num_layers == 28
+        assert config.hidden_size == 1152
+        assert config.num_attention_heads == 16
+        assert config.patch_size == 2
+
+    def test_dit_config_validation(self):
+        """Test configuration validation."""
+        config = DiTConfig.dit_xl_2()
+        config.validate()  # Should not raise
+
+        # Invalid configuration
+        with pytest.raises(ValueError):
+            config = DiTConfig(num_layers=-1)
+            config.validate()
+
+
+class TestDiTModel:
+    """Tests for DiT model."""
+
+    def test_dit_initialization(self):
+        """Test DiT model initialization."""
+        config = DiTConfig.dit_xl_2()
+        model = DiT(config)
+
+        assert model is not None
+        assert isinstance(model, DiffusionModule)
+
+    def test_dit_forward_shapes(self):
+        """Test forward pass produces correct output shapes."""
+        config = DiTConfig.dit_xl_2()
+        model = DiT(config)
+
+        batch_size = 2
+        latents = torch.randn(batch_size, 4, 32, 32)
+        timesteps = torch.rand(batch_size)
+        class_labels = torch.randint(0, 1000, (batch_size,))
+
+        output = model(latents, timesteps, class_labels=class_labels)
+
+        assert output.shape == latents.shape
+
+### Loss Computation
+
+Use standalone loss functions from `loss_computation.py` instead of implementing loss as a method:
+
+```python
+from primus.backends.megatron.training.diffusion.loss_computation import compute_flow_matching_loss
+
+# In your forward_step_func
+target = noise - clean_latents
+loss = compute_flow_matching_loss(prediction, clean_latents, noise)
+```
+
+Models do NOT implement loss as a method. Loss computation is:
+- Separate from model architecture
+- Reusable across models
+- Testable independently
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+```
+
+### Step 8: Update Documentation
+
+1. Add model to `README.md` supported models list
+2. Update `architecture_overview.md` with model-specific details
+3. Create model-specific training guide (e.g., `dit_training.md`)
+
+### Step 9: Add Example Scripts
+
+**File**: Use `examples/run_pretrain.sh` with appropriate config
+
+```python
+#!/usr/bin/env python3
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Training script for DiT model."""
+
+import argparse
+import yaml
+
+from primus.backends.megatron.core.models.diffusion.dit import DiT, DiTConfig
+from primus.backends.megatron.training.diffusion.schedulers import DDPMScheduler
+from primus.backends.megatron.data.dataloader import MegatronDataloaderWrapper
+# ... other imports
+
+
+def main():
+    # Use examples/run_pretrain.sh with config from examples/megatron/configs/MI300X/diffusion/
+    # MegatronDataloaderWrapper wraps an existing iterable (from dataset provider):
+    #   dataloader = MegatronDataloaderWrapper(energon_loader_or_pytorch_loader)
+    # ...
+
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Example: Adding DiT
+
+See the complete example in the step-by-step guide above.
+
+**Key Files Created**:
+1. `core/models/diffusion/dit/config.py` - DiTConfig
+2. `core/models/diffusion/dit/model.py` - DiT model
+3. `configs/models/megatron/diffusion/dit_xl_2.yaml` - Config file
+4. `tests/unit_tests/backends/megatron/diffusion/test_dit_model.py` - Tests
+5. `examples/run_pretrain.sh` - Use with config from `examples/megatron/configs/MI300X/diffusion/`
+
+---
+
+## Testing Your Model
+
+### Unit Tests
+
+Run tests to verify implementation:
+
+```bash
+# Run all DiT tests
+pytest tests/unit_tests/backends/megatron/diffusion/test_dit_model.py -v
+
+# Run specific test
+pytest tests/unit_tests/backends/megatron/diffusion/test_dit_model.py::TestDiTModel::test_dit_forward_shapes -v
+```
+
+### Integration Tests
+
+Test with actual data:
+
+```bash
+# Small dataset test
+./examples/run_pretrain.sh --config examples/megatron/configs/MI300X/diffusion/flux_535m_pretrain.yaml
+```
+
+### Validation
+
+Compare with reference implementation:
+1. Load reference weights
+2. Run same inputs through both models
+3. Compare outputs (should match within tolerance)
+
+---
+
+## Best Practices
+
+### 1. Code Organization
+- ✅ Separate configuration from model code
+- ✅ Reuse shared components from `common/`
+- ✅ Keep model-specific code minimal
+- ✅ Follow existing naming conventions
+
+### 2. Configuration
+- ✅ Extend `BaseDiffusionConfig`
+- ✅ Add factory methods for common sizes
+- ✅ Implement validation
+- ✅ Document all parameters
+
+### 3. Model Implementation
+- ✅ Extend `DiffusionModule` from `primus.backends.megatron.core.models.common.diffusion_module.diffusion_module`
+- ✅ Implement required method: `forward()`
+- ✅ Use standalone loss functions from `loss_computation.py`
+- ✅ Add comprehensive docstrings
+- ✅ Use type hints
+- ✅ Include `pg_collection` parameter in `__init__` for distributed training
+
+### 4. Testing
+- ✅ Test configuration validation
+- ✅ Test model initialization
+- ✅ Test forward pass shapes
+- ✅ Test loss computation
+- ✅ Test with mock data first
+
+### 5. Documentation
+- ✅ Update README with new model
+- ✅ Document architecture specifics
+- ✅ Provide usage examples
+- ✅ Reference original paper
+
+### 6. Performance
+- ✅ Profile memory usage
+- ✅ Optimize critical paths
+- ✅ Support mixed precision
+- ✅ Enable gradient checkpointing
+
+---
+
+## Common Pitfalls
+
+### 1. Import Errors
+❌ **Wrong**: Absolute imports
+```python
+from primus.backends.megatron.core.models.common.diffusion_module.diffusion_module import DiffusionModule
+```
+
+✅ **Right**: Relative imports
+```python
+from ...common.diffusion_module.diffusion_module import DiffusionModule
+```
+
+### 2. Configuration Validation
+❌ **Wrong**: No validation
+```python
+class DiTConfig(BaseDiffusionConfig):
+    pass  # No validation
+```
+
+✅ **Right**: Validate parameters
+```python
+def validate(self):
+    super().validate()
+    if self.num_layers <= 0:
+        raise ValueError(f"num_layers must be positive")
+```
+
+### 3. Shape Mismatches
+❌ **Wrong**: Assuming fixed shapes
+```python
+def forward(self, x):
+    # Assumes x is always [B, 4, 32, 32]
+    pass
+```
+
+✅ **Right**: Handle variable shapes
+```python
+def forward(self, x):
+    B, C, H, W = x.shape
+    # Handle any valid shape
+    pass
+```
+
+### 4. Testing
+❌ **Wrong**: No tests
+```python
+# Just implement and hope it works
+```
+
+✅ **Right**: Comprehensive tests
+```python
+def test_forward_shapes(self):
+    # Test various input shapes
+    pass
+```
+
+---
+
+## Checklist
+
+Before submitting your new model:
+
+- [ ] Configuration class implemented and validated
+- [ ] Model class extends `DiffusionModule`
+- [ ] Required method implemented: `forward()`
+- [ ] Loss computation uses standalone functions from `loss_computation.py`
+- [ ] Process group support added (`pg_collection` parameter)
+- [ ] YAML configuration files created
+- [ ] Unit tests written and passing
+- [ ] Integration tests run successfully
+- [ ] Documentation updated
+- [ ] Example training script provided
+- [ ] Code follows Primus style guide
+- [ ] No linter errors
+- [ ] PR description includes architecture details
+
+---
+
+## Getting Help
+
+If you encounter issues:
+1. Review existing models (Flux) for patterns
+2. Check documentation in `docs/backends/megatron/diffusion/`
+3. Run tests in debug mode: `pytest --pdb`
+4. Consult architecture overview for design principles
+
+---
+
+**Last Updated**: December 2025

--- a/docs/backends/megatron/diffusion/api_reference.md
+++ b/docs/backends/megatron/diffusion/api_reference.md
@@ -1,0 +1,1059 @@
+# Flux Model API Reference
+
+## Overview
+
+This document provides comprehensive API reference for the Flux diffusion model implementation in Primus. Flux is a flow-based diffusion model that uses MMDiT (Multimodal Diffusion Transformer) architecture for high-quality text-to-image generation.
+
+---
+
+## Base Classes
+
+### DiffusionModule
+
+**Location**: `primus/backends/megatron/core/models/common/diffusion_module/diffusion_module.py`
+
+Base class for all diffusion models, providing Megatron-Core integration.
+
+```python
+from primus.backends.megatron.core.models.common.diffusion_module import DiffusionModule
+```
+
+**Key Features**:
+- Process group management (TP, PP, CP, DP)
+- Attention backend configuration
+- Distributed checkpointing support
+- Common loss computation utilities
+
+**Inherited Methods** (available to all diffusion models):
+- `get_num_params()` - Count trainable/total parameters
+- `set_requires_grad()` - Freeze/unfreeze model
+- `compute_diffusion_loss()` - Common loss helper (MSE, MAE, Huber)
+- `sharded_state_dict()` - Distributed checkpointing
+
+> Note: in-model encoder loading (`load_encoders()`, `get_encoder_by_type()`,
+> `get_encoders_by_type()`) is not implemented and raises `NotImplementedError`.
+> Encode VAE/T5/CLIP inputs via the offline diffusion preprocessing pipeline
+> (`primus.backends.megatron.data.diffusion.preprocessing`) instead.
+
+---
+
+## Model Architecture
+
+### Flux Class
+
+**Location**: `primus/backends/megatron/core/models/diffusion/flux/model.py`
+
+```python
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
+
+# Create model
+config = FluxConfig.flux_535m()
+model = Flux(config)
+```
+
+#### Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                          Flux Model                              │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                   │
+│  Input Processing:                                               │
+│  ┌────────────┐        ┌────────────┐                           │
+│  │ Image      │──┐  ┌──│ Text       │                           │
+│  │ Latents    │  │  │  │ Embeddings │                           │
+│  │ [B,64,H,W] │  │  │  │ [B,S,4096] │                           │
+│  └────────────┘  │  │  └────────────┘                           │
+│                  ▼  ▼                                            │
+│            ┌──────────────┐                                      │
+│            │ Linear Embed │                                      │
+│            └──────┬───────┘                                      │
+│                   │ [B,seq,3072]                                 │
+│                   ▼                                              │
+│            ┌──────────────┐                                      │
+│            │ 3D RoPE      │                                      │
+│            │ Position Emb │                                      │
+│            └──────┬───────┘                                      │
+│                   │                                              │
+│  Conditioning:    │                                              │
+│  ┌────────────┐  │                                              │
+│  │ Timestep   │──┼──┐                                           │
+│  │ Embedding  │  │  │                                           │
+│  └────────────┘  │  │                                           │
+│  ┌────────────┐  │  │                                           │
+│  │ CLIP       │──┼──┤                                           │
+│  │ Pooled     │  │  │ vec_emb [B,3072]                         │
+│  └────────────┘  │  │                                           │
+│  ┌────────────┐  │  │                                           │
+│  │ Guidance   │──┼──┘                                           │
+│  │ (optional) │  │                                              │
+│  └────────────┘  │                                              │
+│                   │                                              │
+│  Double Blocks    │                                              │
+│  (Joint):         │                                              │
+│  ┌────────────────▼──────────┐                                  │
+│  │   MMDiTLayer x N_joint    │ N_joint = 1 (535M), 19 (12B)    │
+│  │  ┌──────────────────────┐ │                                  │
+│  │  │ Joint Self-Attention │ │ (image + text together)         │
+│  │  └──────────────────────┘ │                                  │
+│  │  ┌──────────────────────┐ │                                  │
+│  │  │ Image MLP            │ │                                  │
+│  │  └──────────────────────┘ │                                  │
+│  │  ┌──────────────────────┐ │                                  │
+│  │  │ Text MLP             │ │                                  │
+│  │  └──────────────────────┘ │                                  │
+│  └────────────┬──────────────┘                                  │
+│               │                                                  │
+│  Single Blocks│                                                  │
+│  (Combined):  │                                                  │
+│  ┌────────────▼──────────────┐                                  │
+│  │ FluxSingleTransformer     │ N_single = 1 (535M), 38 (12B)   │
+│  │       Block x N_single    │                                  │
+│  │  ┌──────────────────────┐ │                                  │
+│  │  │ Self-Attention       │ │ (image + text concatenated)     │
+│  │  └──────────────────────┘ │                                  │
+│  │  ┌──────────────────────┐ │                                  │
+│  │  │ MLP                  │ │                                  │
+│  │  └──────────────────────┘ │                                  │
+│  └────────────┬──────────────┘                                  │
+│               │ (extract image tokens)                           │
+│               ▼                                                  │
+│  Output Processing:                                              │
+│  ┌────────────────────────┐                                     │
+│  │ AdaLNContinuous        │                                     │
+│  │ (timestep conditioned) │                                     │
+│  └────────────┬───────────┘                                     │
+│               ▼                                                  │
+│  ┌────────────────────────┐                                     │
+│  │ Linear Projection      │                                     │
+│  └────────────┬───────────┘                                     │
+│               ▼                                                  │
+│         [B,64,H,W]                                               │
+│       Predicted Velocity                                         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+#### Parameter Counts
+
+| Variant | Joint Layers | Single Layers | Total Parameters | Use Case |
+|---------|-------------|---------------|------------------|----------|
+| Flux 535M | 1 | 1 | ~535 million | Testing, debugging, prototyping |
+| Flux 12B | 19 | 38 | ~12 billion | Production training |
+
+---
+
+## Configuration
+
+### FluxConfig
+
+**Location**: `primus/backends/megatron/core/models/diffusion/flux/config.py`
+
+Complete configuration class for Flux models, inheriting from `BaseDiffusionConfig`.
+
+#### Key Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `num_joint_layers` | int | 19 | Number of joint (MMDiT) transformer layers |
+| `num_single_layers` | int | 38 | Number of single transformer layers |
+| `hidden_size` | int | 3072 | Hidden dimension size |
+| `num_attention_heads` | int | 24 | Number of attention heads |
+| `in_channels` | int | 64 | Input channels (VAE latent dimension) |
+| `context_dim` | int | 4096 | Text context dimension (T5-XXL) |
+| `vec_in_dim` | int | 768 | Vector input dimension (CLIP pooled) |
+| `model_channels` | int | 256 | Channels for timestep embedding |
+| `guidance_embed` | bool | False | Enable guidance embedding for CFG |
+| `guidance_scale` | float | 3.5 | Guidance scale for classifier-free guidance |
+| `theta` | int | 10000 | Base for RoPE frequency computation |
+| `axes_dim` | tuple | (16, 56, 56) | Dimensions for 3D RoPE axes |
+| `patch_size` | int | 1 | Patch size for image tokens |
+| `add_qkv_bias` | bool | True | Add bias to QKV projections |
+| `rotary_interleaved` | bool | True | Interleave RoPE dimensions |
+| `layernorm_epsilon` | float | 1e-6 | Epsilon for layer normalization |
+| `hidden_dropout` | float | 0.0 | Hidden layer dropout rate |
+| `attention_dropout` | float | 0.0 | Attention dropout rate |
+
+#### Configuration Examples
+
+**Flux 535M (Testing)**:
+```python
+config = FluxConfig.flux_535m()
+# Equivalent to:
+config = FluxConfig(
+    num_joint_layers=1,
+    num_single_layers=1,
+    hidden_size=3072,
+    num_attention_heads=24,
+)
+```
+
+**Flux 12B (Production)**:
+```python
+config = FluxConfig.flux_12b()
+# Equivalent to:
+config = FluxConfig(
+    num_joint_layers=19,
+    num_single_layers=38,
+    hidden_size=3072,
+    num_attention_heads=24,
+)
+```
+
+**Custom Configuration**:
+```python
+config = FluxConfig(
+    num_joint_layers=4,
+    num_single_layers=8,
+    hidden_size=2048,
+    num_attention_heads=16,
+    guidance_embed=True,
+    patch_size=2,
+)
+```
+
+---
+
+## Components API
+
+### Embeddings
+
+#### TimeStepEmbedder
+
+**Location**: `primus/backends/megatron/core/models/diffusion/common/embeddings.py`
+
+Converts scalar timesteps to high-dimensional embeddings using sinusoidal encoding.
+
+```python
+from primus.backends.megatron.core.models.diffusion.common.embeddings import TimeStepEmbedder
+
+embedder = TimeStepEmbedder(embedding_dim=256, hidden_dim=3072)
+timesteps = torch.tensor([0, 100, 500, 999])  # [B]
+t_emb = embedder(timesteps)  # [B, 3072]
+```
+
+**Input**: Timesteps [B] in range [0, 1000]
+**Output**: Embeddings [B, hidden_dim]
+
+#### MLPEmbedder
+
+Embeds vector conditioning (e.g., CLIP pooled embeddings) via 2-layer MLP.
+
+```python
+from primus.backends.megatron.core.models.diffusion.common.embeddings import MLPEmbedder
+
+embedder = MLPEmbedder(in_dim=768, hidden_dim=3072)
+clip_pooled = torch.randn(4, 768)  # [B, 768]
+embedded = embedder(clip_pooled)  # [B, 3072]
+```
+
+**Input**: Vectors [B, in_dim]
+**Output**: Embeddings [B, hidden_dim]
+
+---
+
+### Normalization
+
+#### AdaLN (Adaptive Layer Normalization)
+
+**Location**: `primus/backends/megatron/core/models/diffusion/common/normalization.py`
+
+Applies layer normalization conditioned on timestep embeddings.
+
+```python
+from megatron.core.transformer.transformer_config import TransformerConfig
+from primus.backends.megatron.core.models.diffusion.common.normalization import AdaLN
+
+config = TransformerConfig(hidden_size=3072)
+adaln = AdaLN(config, n_adaln_chunks=6)
+
+timestep_emb = torch.randn(4, 3072)
+shift, scale, gate, shift_mlp, scale_mlp, gate_mlp = adaln(timestep_emb)
+# Each output: [B, 3072]
+```
+
+**Methods**:
+- `forward(timestep_emb)`: Generate modulation parameters
+- `modulate(x, shift, scale)`: Apply adaptive modulation
+- `scale_add(residual, x, gate)`: Gated residual addition
+
+#### AdaLNContinuous
+
+Continuous variant of AdaLN for Flux output normalization.
+
+```python
+from primus.backends.megatron.core.models.diffusion.common.normalization import AdaLNContinuous
+
+adaln = AdaLNContinuous(config, conditioning_embedding_dim=3072)
+x = torch.randn(4, 256, 3072)  # [B, seq, hidden]
+cond = torch.randn(4, 3072)  # [B, cond_dim]
+x_norm = adaln(x, cond)  # [B, seq, hidden]
+```
+
+#### RMSNorm
+
+Root Mean Square Layer Normalization (simpler, faster than LayerNorm).
+
+```python
+from primus.backends.megatron.core.models.diffusion.common.normalization import RMSNorm
+
+norm = RMSNorm(hidden_size=3072)
+x = torch.randn(4, 256, 3072)
+x_norm = norm(x)
+```
+
+---
+
+### Position Embeddings
+
+#### EmbedND (3D RoPE)
+
+**Location**: `primus/backends/megatron/core/models/diffusion/flux/layers.py`
+
+Multi-dimensional Rotary Position Embedding for image patches.
+
+```python
+from primus.backends.megatron.core.models.diffusion.flux.layers import (
+    EmbedND,
+)
+from primus.backends.megatron.core.models.diffusion.flux.utils import (
+    generate_image_position_ids,
+)
+
+# Initialize
+embed_nd = EmbedND(dim=3072, theta=10000, axes_dim=[16, 56, 56])
+
+# Generate position IDs for 56x56 image patches
+batch_size = 2
+height, width = 112, 112  # Unpacked dimensions (56*2, 56*2)
+img_ids = generate_image_position_ids(batch_size, height, width)
+# img_ids: [B, H*W/4, 3] where dimension 0 is always 0
+
+# Get RoPE frequencies
+rope_freqs = embed_nd(img_ids)  # [3, B, H*W, 3072]
+```
+
+**Axes**:
+- Axis 0: Channel groups (16 for 64 channels)
+- Axis 1: Height positions (56 for 1024px image)
+- Axis 2: Width positions (56 for 1024px image)
+
+---
+
+### Attention Mechanisms
+
+#### JointSelfAttention
+
+**Location**: `primus/backends/megatron/core/models/diffusion/flux/attention.py`
+
+Joint attention over image and text tokens (MMDiT architecture).
+
+```python
+from primus.backends.megatron.core.models.diffusion.flux.attention import (
+    JointSelfAttention,
+    JointSelfAttentionSubmodules,
+)
+
+submodules = JointSelfAttentionSubmodules(...)
+joint_attn = JointSelfAttention(config, submodules, layer_number=0)
+
+# Forward
+img_tokens = torch.randn(3136, 2, 3072)  # [seq_img, B, hidden]
+txt_tokens = torch.randn(512, 2, 3072)   # [seq_txt, B, hidden]
+img_out, txt_out = joint_attn(
+    img_tokens,
+    attention_mask=None,
+    additional_hidden_states=txt_tokens,
+)
+```
+
+**Input**:
+- `hidden_states`: Image tokens [seq_img, B, hidden]
+- `additional_hidden_states`: Text tokens [seq_txt, B, hidden]
+
+**Output**: Tuple of (img_output, txt_output)
+
+#### FluxSingleAttention
+
+Single-stream self-attention for image tokens only.
+
+```python
+from primus.backends.megatron.core.models.diffusion.flux.attention import FluxSingleAttention
+
+single_attn = FluxSingleAttention(config, submodules, layer_number=0)
+
+img_tokens = torch.randn(3136, 2, 3072)
+output = single_attn(img_tokens, attention_mask=None)
+```
+
+---
+
+### Layer Specifications
+
+#### MMDiTLayer
+
+**Location**: `primus/backends/megatron/core/models/diffusion/flux/layer_spec.py`
+
+Joint image-text transformer block.
+
+```python
+from primus.backends.megatron.core.models.diffusion.flux.layer_spec import (
+    MMDiTLayer,
+    get_flux_double_transformer_spec_for_backend,
+)
+
+# Using factory function (recommended)
+spec = get_flux_double_transformer_spec_for_backend(backend)
+mmdit_layer = MMDiTLayer(
+    config=config,
+    submodules=spec.submodules,
+    layer_number=0,
+)
+
+# Forward
+img_tokens = torch.randn(3136, 2, 3072)
+txt_tokens = torch.randn(512, 2, 3072)
+emb = torch.randn(2, 3072)
+img_out, txt_out = mmdit_layer(img_tokens, txt_tokens, emb=emb)
+```
+
+#### FluxSingleTransformerBlock
+
+Image-only transformer block.
+
+```python
+from primus.backends.megatron.core.models.diffusion.flux.layer_spec import (
+    FluxSingleTransformerBlock,
+    get_flux_single_transformer_spec_for_backend,
+)
+
+spec = get_flux_single_transformer_spec_for_backend(backend)
+single_block = FluxSingleTransformerBlock(
+    config=config,
+    submodules=spec.submodules,
+    layer_number=0,
+)
+
+# Forward
+img_tokens = torch.randn(3136, 2, 3072)
+emb = torch.randn(2, 3072)
+output, _ = single_block(img_tokens, emb=emb)
+```
+
+---
+
+## Training Utilities
+
+### Noise Application
+
+**Location**: `primus/backends/megatron/training/diffusion/noise_utils.py`
+
+Pure functions for applying noise according to different diffusion forward processes.
+
+#### apply_flow_matching_noise()
+
+```python
+from primus.backends.megatron.training.diffusion.noise_utils import apply_flow_matching_noise
+
+clean_latents = torch.randn(2, 16, 64, 64)
+noise = torch.randn(2, 16, 64, 64)
+sigma = torch.tensor([0.3, 0.7]).reshape(2, 1, 1, 1)
+
+noisy = apply_flow_matching_noise(clean_latents, noise, sigma)
+# Formula: noisy = (1 - sigma) * clean + sigma * noise
+```
+
+**Parameters**:
+- `clean_latents` (Tensor): Clean latents [any shape]
+- `noise` (Tensor): Sampled noise [same shape as clean_latents]
+- `sigma` (Tensor): Noise schedule values [broadcast compatible], range [0, 1]
+
+**Returns**: Noisy latents [same shape as clean_latents]
+
+**Reference**: [Flow Matching for Generative Modeling](https://arxiv.org/abs/2210.02747)
+
+#### apply_ddpm_noise()
+
+```python
+from primus.backends.megatron.training.diffusion.noise_utils import apply_ddpm_noise
+
+clean = torch.randn(2, 3, 256, 256)
+noise = torch.randn(2, 3, 256, 256)
+alpha_bar = torch.tensor([0.9, 0.5]).reshape(2, 1, 1, 1)
+
+noisy = apply_ddpm_noise(clean, noise, alpha_bar)
+# Formula: noisy = sqrt(alpha_bar) * clean + sqrt(1 - alpha_bar) * noise
+```
+
+**Parameters**:
+- `clean_latents` (Tensor): Clean latents
+- `noise` (Tensor): Sampled noise (same shape)
+- `alpha_bar` (Tensor): Cumulative product of alphas, range (0, 1]
+
+**Returns**: Noisy latents
+
+**Reference**: [Denoising Diffusion Probabilistic Models](https://arxiv.org/abs/2006.11239)
+
+---
+
+### Loss Computation
+
+**Location**: `primus/backends/megatron/training/diffusion/loss_computation.py`
+
+Reusable loss computation logic for different diffusion training objectives.
+
+#### compute_flow_matching_loss()
+
+```python
+from primus.backends.megatron.training.diffusion.loss_computation import compute_flow_matching_loss
+
+prediction = torch.randn(2, 16, 64, 64)  # Model output
+clean = torch.randn(2, 16, 64, 64)
+noise = torch.randn(2, 16, 64, 64)
+
+loss = compute_flow_matching_loss(prediction, clean, noise)
+# Formula: target = noise - clean
+#          loss = MSE(prediction, target)
+```
+
+**Parameters**:
+- `prediction` (Tensor): Model output (predicted velocity) [any shape]
+- `clean_latents` (Tensor): Original clean latents [same shape]
+- `noise` (Tensor): Sampled noise [same shape]
+
+**Returns**: Scalar loss value (mean squared error)
+
+**Used by**: Flux, SD3, video models
+
+#### compute_epsilon_loss()
+
+```python
+from primus.backends.megatron.training.diffusion.loss_computation import compute_epsilon_loss
+
+prediction = torch.randn(2, 3, 256, 256)
+noise = torch.randn(2, 3, 256, 256)
+
+loss = compute_epsilon_loss(prediction, noise)
+# Formula: loss = MSE(prediction, noise)
+```
+
+**Parameters**:
+- `prediction` (Tensor): Model output (predicted noise)
+- `noise` (Tensor): Sampled noise (ground truth)
+
+**Returns**: Scalar loss value
+
+**Used by**: DDPM and older models
+
+#### compute_v_prediction_loss()
+
+```python
+from primus.backends.megatron.training.diffusion.loss_computation import compute_v_prediction_loss
+
+prediction = torch.randn(2, 16, 64, 64)
+clean = torch.randn(2, 16, 64, 64)
+noise = torch.randn(2, 16, 64, 64)
+sigma = torch.tensor([0.3, 0.7]).reshape(2, 1, 1, 1)
+
+loss = compute_v_prediction_loss(prediction, clean, noise, sigma)
+# Formula: v = sigma * noise - (1 - sigma) * clean
+#          loss = MSE(prediction, v)
+```
+
+**Parameters**:
+- `prediction` (Tensor): Model output
+- `clean_latents` (Tensor): Clean latents
+- `noise` (Tensor): Sampled noise
+- `sigma` (Tensor): Noise schedule values [broadcast compatible]
+
+**Returns**: Scalar loss value
+
+**Reference**: [Progressive Distillation for Fast Sampling](https://arxiv.org/abs/2202.00512)
+
+---
+
+### Timestep Sampling
+
+**Location**: `primus/backends/megatron/training/diffusion/timestep_sampling.py`
+
+Sampling strategies for training timesteps (hyperparameter optimization, separate from inference).
+
+#### LogitNormalSampler
+
+```python
+from primus.backends.megatron.training.diffusion.timestep_sampling import LogitNormalSampler
+
+sampler = LogitNormalSampler(mean=0.0, std=1.0)
+timesteps, sigmas = sampler.sample(
+    batch_size=32,
+    device='cuda',
+    scheduler=flow_scheduler
+)
+```
+
+**Description**: Logit-normal distribution sampling, emphasizes boundary timesteps (t≈0 and t≈1000).
+
+**Parameters**:
+- `mean` (float): Mean of normal distribution (default: 0.0)
+- `std` (float): Standard deviation (default: 1.0)
+
+**Returns**: Tuple of (timesteps [B], sigmas [B])
+
+**Reference**: [Stable Diffusion 3](https://arxiv.org/abs/2403.03206v1), Section 3.1
+
+**Used by**: Flux, SD3
+
+#### UniformSampler
+
+```python
+from primus.backends.megatron.training.diffusion.timestep_sampling import UniformSampler
+
+sampler = UniformSampler()
+timesteps, sigmas = sampler.sample(batch_size=32, device='cuda', scheduler=flow_scheduler)
+```
+
+**Description**: Uniform timestep sampling (baseline approach for comparison).
+
+**Returns**: Tuple of (timesteps [B], sigmas [B])
+
+#### ModeSampler
+
+```python
+from primus.backends.megatron.training.diffusion.timestep_sampling import ModeSampler
+
+sampler = ModeSampler(mode_scale=1.29)
+timesteps, sigmas = sampler.sample(batch_size=32, device='cuda', scheduler=flow_scheduler)
+```
+
+**Description**: Mode-based sampling from SD3 paper (alternative to logit-normal).
+
+**Parameters**:
+- `mode_scale` (float): Scaling factor (default: 1.29 from SD3 paper)
+
+**Returns**: Tuple of (timesteps [B], sigmas [B])
+
+#### create_timestep_sampler()
+
+```python
+from primus.backends.megatron.training.diffusion.timestep_sampling import create_timestep_sampler
+
+# Factory function for easy experimentation
+sampler = create_timestep_sampler("logit_normal", mean=0.0, std=1.0)
+sampler = create_timestep_sampler("uniform")
+sampler = create_timestep_sampler("mode", mode_scale=1.5)
+```
+
+**Parameters**:
+- `strategy` (str): Sampling strategy ("logit_normal", "uniform", "mode")
+- `**kwargs`: Additional arguments for the sampler
+
+**Returns**: TimestepSampler instance
+
+---
+
+### Training Workflow Example
+
+Complete training step using the utilities:
+
+```python
+import torch
+from torch.optim import AdamW
+from primus.backends.megatron.core.models.diffusion.flux import Flux, FluxConfig
+from primus.backends.megatron.training.diffusion.noise_utils import apply_flow_matching_noise
+from primus.backends.megatron.training.diffusion.loss_computation import compute_flow_matching_loss
+from primus.backends.megatron.training.diffusion.timestep_sampling import LogitNormalSampler
+from primus.backends.megatron.training.diffusion.schedulers.flow_match_euler import (
+    FlowMatchEulerDiscreteScheduler
+)
+
+# Setup
+config = FluxConfig.flux_535m()
+model = Flux(config).cuda()
+optimizer = AdamW(model.parameters(), lr=1e-4)
+
+# Initialize scheduler and timestep sampler
+scheduler = FlowMatchEulerDiscreteScheduler(num_train_timesteps=1000)
+timestep_sampler = LogitNormalSampler(mean=0.0, std=1.0)
+
+# Training loop
+for batch in dataloader:
+    clean_latents = batch['latents'].cuda()  # [B, 16, 64, 64]
+    txt_embeddings = batch['text'].cuda()     # [B, 512, 4096]
+    clip_pooled = batch['clip'].cuda()        # [B, 768]
+
+    batch_size = clean_latents.shape[0]
+
+    # 1. Sample timesteps
+    timesteps, sigmas = timestep_sampler.sample(
+        batch_size=batch_size,
+        device='cuda',
+        scheduler=scheduler
+    )
+
+    # 2. Sample noise
+    noise = torch.randn_like(clean_latents)
+
+    # 3. Apply noise
+    sigma_reshaped = sigmas.view(-1, 1, 1, 1)
+    noisy_latents = apply_flow_matching_noise(clean_latents, noise, sigma_reshaped)
+
+    # 4. Prepare position IDs
+    img_ids = generate_image_position_ids(batch_size, 128, 128).cuda()
+    txt_ids = torch.zeros(batch_size, 512, 3).cuda()
+
+    # 5. Forward pass
+    predicted_velocity = model(
+        img=noisy_latents,
+        txt=txt_embeddings,
+        y=clip_pooled,
+        timesteps=sigmas,
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+    )
+
+    # 6. Compute loss
+    loss = compute_flow_matching_loss(predicted_velocity, clean_latents, noise)
+
+    # 7. Backward and optimize
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+
+    print(f"Step {step}, Loss: {loss.item():.4f}")
+```
+
+---
+
+## Usage Examples
+
+### Basic Inference
+
+```python
+import torch
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
+from primus.backends.megatron.core.models.diffusion.flux.utils import generate_image_position_ids
+
+# 1. Setup model
+config = FluxConfig.flux_535m()
+model = Flux(config)
+model.eval()
+
+# 2. Prepare inputs
+batch_size = 1
+img_latents = torch.randn(batch_size, 64, 128, 128)  # VAE latents
+txt_embeddings = torch.randn(batch_size, 512, 4096)  # T5-XXL embeddings
+clip_pooled = torch.randn(batch_size, 768)  # CLIP-L pooled
+timesteps = torch.tensor([0.5])  # Diffusion timestep [0, 1]
+
+# 3. Generate position IDs
+img_ids = generate_image_position_ids(batch_size, 256, 256)
+txt_ids = torch.zeros(batch_size, 512, 3)
+
+# 4. Forward pass
+with torch.no_grad():
+    predicted_velocity = model(
+        img=img_latents,
+        txt=txt_embeddings,
+        y=clip_pooled,
+        timesteps=timesteps,
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+    )
+
+print(f"Output shape: {predicted_velocity.shape}")  # [1, 64, 128, 128]
+```
+
+### Training Step
+
+```python
+import torch
+from torch.optim import AdamW
+
+# Setup
+config = FluxConfig.flux_535m()
+model = Flux(config)
+model.train()
+
+optimizer = AdamW(model.parameters(), lr=1e-4, weight_decay=0.01)
+
+# Prepare batch
+batch_size = 4
+img = torch.randn(batch_size, 64, 128, 128)
+txt = torch.randn(batch_size, 512, 4096)
+y = torch.randn(batch_size, 768)
+timesteps = torch.rand(batch_size)
+
+img_ids = generate_image_position_ids(batch_size, 256, 256)
+txt_ids = torch.zeros(batch_size, 512, 3)
+
+# Add noise for flow matching
+original = img.clone()
+noise = torch.randn_like(img)
+t = timesteps.view(-1, 1, 1, 1)
+noisy_img = original + noise * t
+
+# Velocity target for flow matching
+velocity_target = noise - original
+
+# Training step
+optimizer.zero_grad()
+
+# Forward pass
+output = model(noisy_img, txt, y, timesteps, img_ids, txt_ids)
+
+# Loss computation (using standalone function)
+from primus.backends.megatron.training.diffusion.loss_computation import compute_flow_matching_loss
+target = noise - clean_latents
+loss = compute_flow_matching_loss(output, clean_latents, noise)
+
+# Backward pass
+loss.backward()
+
+# Optimizer step
+optimizer.step()
+
+print(f"Loss: {loss.item():.4f}")
+```
+
+### With Guidance (Classifier-Free Guidance)
+
+```python
+# Enable guidance in config
+config = FluxConfig.flux_535m(guidance_embed=True)
+model = Flux(config)
+model.eval()
+
+# Prepare inputs with guidance
+guidance_scale = torch.tensor([3.5])  # Typical guidance scale
+
+with torch.no_grad():
+    output = model(
+        img=img_latents,
+        txt=txt_embeddings,
+        y=clip_pooled,
+        timesteps=timesteps,
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+        guidance=guidance_scale,  # Add guidance
+    )
+```
+
+### Different Resolutions
+
+```python
+# Flux can handle different resolutions
+resolutions = [
+    (64, 64),    # 512x512 pixels
+    (128, 128),  # 1024x1024 pixels
+    (192, 192),  # 1536x1536 pixels
+]
+
+for height, width in resolutions:
+    img = torch.randn(1, 64, height, width)
+    img_ids = generate_image_position_ids(1, height, width)
+
+    with torch.no_grad():
+        output = model(img, txt, y, timesteps, img_ids, txt_ids)
+
+    assert output.shape == img.shape
+```
+
+---
+
+## Methods Reference
+
+### Flux.forward()
+
+```python
+def forward(
+    self,
+    img: Tensor,                    # [B, C, H, W] Image latents from VAE
+    txt: Tensor,                    # [B, S_txt, D_txt] T5-XXL embeddings
+    y: Tensor,                      # [B, D_pool] CLIP pooled embeddings
+    timesteps: Tensor,              # [B] Timesteps in [0, 1]
+    img_ids: Tensor,                # [B, H*W, 3] Image position IDs
+    txt_ids: Tensor,                # [B, S_txt, 3] Text position IDs
+    guidance: Optional[Tensor] = None,  # [B] Guidance scale
+    controlnet_double_block_samples: Optional[Tensor] = None,
+    controlnet_single_block_samples: Optional[Tensor] = None,
+) -> Tensor:                        # Returns: [B, C, H, W] Predicted velocity
+```
+
+## Loss Computation
+
+Loss is computed using standalone functions from `loss_computation.py`:
+
+### compute_flow_matching_loss()
+
+```python
+from primus.backends.megatron.training.diffusion.loss_computation import compute_flow_matching_loss
+
+def compute_flow_matching_loss(
+    prediction: Tensor,                 # [any shape] Model prediction
+    clean_latents: Tensor,              # [same shape] Original clean latents
+    noise: Tensor,                      # [same shape] Sampled noise
+) -> Tensor:                            # Returns: Scalar loss
+```
+
+### Flux.get_num_params()
+
+```python
+def get_num_params(
+    self,
+    trainable_only: bool = True,
+) -> int:                           # Returns: Number of parameters
+```
+
+---
+
+## Testing
+
+### Running Tests
+
+```bash
+# Run all Flux tests
+pytest tests/unit_tests/backends/megatron/diffusion/ -v
+
+# Run specific test files
+pytest tests/unit_tests/backends/megatron/diffusion/test_flux_embeddings.py -v
+pytest tests/unit_tests/backends/megatron/diffusion/test_flux_normalization.py -v
+pytest tests/unit_tests/backends/megatron/diffusion/test_flux_config.py -v
+pytest tests/unit_tests/backends/megatron/diffusion/test_flux_layers.py -v
+pytest tests/unit_tests/backends/megatron/diffusion/test_flux_model.py -v
+pytest tests/unit_tests/backends/megatron/diffusion/test_flux_layer_spec_backend_selection.py -v
+
+# Run with coverage
+pytest tests/unit_tests/backends/megatron/diffusion/ --cov=primus.backends.megatron.core.models.diffusion --cov-report=html
+```
+
+### Test Coverage
+
+- **Component tests**: 80+ tests covering all components
+- **Model tests**: 17+ tests for full model
+- **Integration tests**: 11+ tests for complete workflows
+
+---
+
+## Performance Considerations
+
+### Memory Usage
+
+| Configuration | Model Weights | Training (bf16) | Training (fp32) |
+|--------------|---------------|-----------------|-----------------|
+| Flux 535M | ~2 GB | ~6-8 GB | ~10-12 GB |
+| Flux 12B | ~24 GB | ~60-80 GB | ~100-120 GB |
+
+### Throughput (Estimated)
+
+On MI300X (192GB):
+- **Flux 535M**: ~5-10 samples/sec (depends on resolution)
+- **Flux 12B**: ~0.5-1 samples/sec (requires multi-GPU)
+
+### Optimization Tips
+
+1. **Use mixed precision**: `torch.autocast(device_type='cuda', dtype=torch.bfloat16)`
+2. **Enable CUDA graphs**: Set `enable_cuda_graph=True` in config
+3. **Use Transformer Engine**: Automatically used with factory functions
+4. **Gradient checkpointing**: Can be enabled for memory savings
+
+---
+
+## Common Issues
+
+### Issue: Import Errors
+
+```python
+# Old import style
+from some_other_library import Flux
+
+# Correct Primus import
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+```
+
+### Issue: Position ID Shape Mismatch
+
+```python
+# Position IDs must be [B, seq, 3] for 3D RoPE
+img_ids = generate_image_position_ids(batch_size, height, width)
+# Not: img_ids = torch.randn(batch_size, height * width, 2)  # Wrong!
+```
+
+### Issue: Timestep Range
+
+```python
+# Flux expects timesteps in [0, 1]
+timesteps = torch.rand(batch_size)  # Correct: [0, 1]
+# Not: timesteps = torch.randint(0, 1000, (batch_size,))  # Wrong range!
+```
+
+---
+
+## API Compatibility
+
+### Primus Architecture Features
+
+| Aspect | Primus Implementation |
+|--------|----------------------|
+| Import path | `primus.backends.megatron.core.models.diffusion.flux` |
+| Base class | `DiffusionModule` (extends MegatronModule) |
+| Config parent | `BaseDiffusionConfig` (extends TransformerConfig) |
+| Layer organization | Unified `TransformerBlock` with heterogeneous specs |
+| Checkpoint format | `transformer.layers.{0-56}` unified namespace |
+| Process groups | Via `pg_collection` parameter |
+
+### Key Design Choices
+
+**TransformerBlock Architecture**:
+- Primus uses Megatron-Core's `TransformerBlock` with heterogeneous layer specifications
+- Unified checkpoint format for simpler distributed training
+- Note: pipeline parallelism is not supported for diffusion models (`pipeline_model_parallel_size` must be 1)
+
+**Example Usage**:
+
+```python
+# Primus native approach
+from primus.backends.megatron.core.models.diffusion.flux import Flux, FluxConfig
+
+# Primus
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
+config = FluxConfig()
+model = Flux(config)
+```
+
+For more advanced examples, see `examples/run_pretrain.sh`.
+
+---
+
+## References
+
+### Papers
+- **Flux**: "Flux: A Scalable Diffusion Model for High-Resolution Image Synthesis"
+- **MMDiT**: "Scaling Rectified Flow Transformers for High-Resolution Image Synthesis"
+- **Flow Matching**: "Flow Matching for Generative Modeling"
+- **RoPE**: "RoFormer: Enhanced Transformer with Rotary Position Embedding"
+- **DiT**: "Scalable Diffusion Models with Transformers" (Peebles & Xie, 2023)
+
+### Source Code
+- **Primus Implementation**: `primus/backends/megatron/core/models/diffusion/flux/`
+- **Megatron-Core**: `megatron/core/transformer/`
+- **Official Flux**: Black Forest Labs (HuggingFace)
+
+---
+
+## Version Information
+
+- **Primus Version**: Current
+- **Megatron-Core Version**: Latest
+- **Transformer Engine**: Optional (recommended for performance)
+
+---
+
+## Support
+
+For issues or questions:
+1. Check this API reference
+2. Read architecture guide: `docs/backends/megatron/diffusion/flux_architecture.md`
+3. See examples in docstrings
+4. Check test files for usage patterns

--- a/docs/backends/megatron/diffusion/architecture_overview.md
+++ b/docs/backends/megatron/diffusion/architecture_overview.md
@@ -1,0 +1,497 @@
+# Architecture Overview
+
+This document provides a detailed overview of the diffusion model architecture in Primus, including design decisions, directory structure, and implementation patterns.
+
+---
+
+## Table of Contents
+
+1. [Design Philosophy](#design-philosophy)
+2. [Directory Structure](#directory-structure)
+3. [Architectural Decisions](#architectural-decisions)
+4. [Component Hierarchy](#component-hierarchy)
+5. [Data Flow](#data-flow)
+6. [Comparison with Alternative Implementations](#comparison-with-alternative-implementations)
+
+---
+
+## Design Philosophy
+
+### Core Principles
+
+1. **Megatron-Core Native**: Built on Megatron-Core patterns and conventions
+2. **Extensibility**: Easy to add new models (DiT, MovieGen, custom)
+3. **Clarity**: Clear separation between shared and model-specific code
+4. **Reusability**: Shared components across multiple models
+5. **Performance**: Support for precalculated data and multi-GPU training
+
+### Architectural Advantages
+
+| Aspect | Primus Design Choice |
+|--------|---------------------|
+| Model Location | `core/models/diffusion/` (Megatron-Core convention) |
+| Layer Organization | Unified `TransformerBlock` with heterogeneous specs |
+| Shared Code | Dedicated `common/` directory |
+| Encoders | Hierarchical `encoders/{type}/{variant}/` |
+| Energon | Shared `data/energon/` for all models |
+| Mock Data | Separated in `tests/fixtures/` |
+| Framework | Pure Megatron (no PyTorch Lightning dependency) |
+
+---
+
+## Directory Structure
+
+### High-Level Organization
+
+```
+primus/backends/megatron/
+├── core/models/diffusion/          # Core model implementations
+├── training/diffusion/             # Training utilities (schedulers, etc.)
+└── data/
+    ├── energon/                    # Shared Energon infrastructure
+    └── diffusion/                  # Diffusion-specific data
+```
+
+### Detailed Breakdown
+
+#### 1. Core Models (`core/models/diffusion/`)
+
+Following Megatron-Core convention (`megatron/core/models/gpt/`, `megatron/core/models/multimodal/`):
+
+```
+core/models/diffusion/
+├── common/                         # Shared across all diffusion models
+│   ├── __init__.py
+│   ├── config.py                   # BaseDiffusionConfig
+│   ├── attention.py                # JointSelfAttention, FluxSingleAttention
+│   └── layers.py                   # MMDiTLayer, FluxSingleTransformerBlock
+│
+└── flux/                           # Flux-specific components
+    ├── __init__.py
+    ├── config.py                   # FluxConfig
+    ├── model.py                    # Flux (main model class)
+    └── layers.py                   # EmbedND (3D RoPE), embedders
+```
+
+**Rationale**:
+- `common/`: Shared MMDiT patterns (used by both DiT and Flux)
+- `flux/`: Only truly Flux-specific code (3D RoPE, Flux model class)
+- Clear distinction enables easy DiT implementation (reuse `common/`)
+
+#### 2. Training (`training/diffusion/`)
+
+```
+training/diffusion/
+├── __init__.py
+└── schedulers/
+    ├── __init__.py
+    ├── base.py                     # BaseScheduler
+    ├── flow_matching.py            # FlowMatchEulerDiscreteScheduler
+    ├── ddpm.py                     # [Future] DDPMScheduler
+    ├── edm.py                      # [Future] EDMScheduler
+    └── euler.py                    # [Future] EulerDiscreteScheduler
+```
+
+**Rationale**:
+- Schedulers define noise schedules and training targets
+- Separate from model code for clarity
+- Easy to add new schedulers (DDPM, EDM, etc.)
+
+#### 3. Data Pipeline (`data/`)
+
+```
+data/
+├── energon/                        # Shared Energon utilities
+│   └── __init__.py
+├── dataloader.py                   # MegatronDataloaderWrapper (wraps any iterable)
+│
+└── diffusion/
+    ├── __init__.py
+    ├── encoders/                   # Hierarchical encoder registry
+    │   ├── __init__.py
+    │   ├── registry.py             # EncoderRegistry
+    │   ├── image/
+    │   │   └── vae/
+    │   │       ├── __init__.py
+    │   │       ├── autoencoder_kl.py   # AutoencoderKL
+    │   │       └── vqvae.py            # VQVAE
+    │   └── text/
+    │       ├── t5/
+    │       │   ├── __init__.py
+    │       │   ├── t5_xxl.py           # T5-XXL
+    │       │   └── t5_large.py         # T5-Large
+    │       └── clip/
+    │           ├── __init__.py
+    │           ├── clip_l.py           # CLIP-L
+    │           └── clip_h.py           # CLIP-H
+    │
+    ├── preprocessing/
+    │   ├── __init__.py
+    │   └── image/
+    │       ├── __init__.py
+    │       ├── transforms.py           # Resizing, normalization
+    │       └── augmentation.py         # Data augmentation
+    │
+    └── task_encoders/
+        ├── __init__.py
+        └── image.py  # EncodedDiffusionTaskEncoder
+```
+
+**Rationale**:
+- **Energon shared**: VLM and other models can reuse Energon utilities
+- **Hierarchical encoders**: Organized by modality and variant type
+- **Registry pattern**: Config-driven encoder selection
+- **Preprocessing separated**: Clear pipeline stages
+
+---
+
+## Architectural Decisions
+
+### Decision 1: Models Under `core/models/`
+
+**Choice**: `primus/backends/megatron/core/models/diffusion/`
+**Not**: `primus/backends/megatron/models/diffusion/`
+
+**Reasoning**:
+- Aligns with Megatron-Core structure
+- Easier upstream tracking
+- Clear that these are Megatron-Core compatible
+- Consistent with existing Primus structure (`core/models/gpt/`)
+
+### Decision 2: Separate `common/` Directory
+
+**Choice**: Shared components in `common/`
+**Not**: Everything in `flux/` or flat structure
+
+**Reasoning**:
+- Standard approach puts shared code in model-specific directories
+- Primus: `common/` makes it explicit what's shared
+- Future DiT implementation trivial (reuse from `common/`)
+- Clear contract: if in `common/`, must work for all models
+
+**Shared Components**:
+- `JointSelfAttention`: Used by DiT and Flux joint layers
+- `FluxSingleAttention`: Used by DiT and Flux single layers
+- `MMDiTLayer`: Joint (multimodal) transformer block
+- `FluxSingleTransformerBlock`: Single-modality transformer block
+
+**Flux-Only Components**:
+- `EmbedND`: 3D RoPE position embedding (Flux-specific)
+- `Flux` model class
+
+### Decision 3: Hierarchical Encoder Structure
+
+**Choice**: `encoders/image/vae/`, `encoders/text/t5/`, `encoders/text/clip/`
+**Not**: Flat `encoders/conditioner.py`
+
+**Reasoning**:
+- Traditional approach uses flat structure with all encoders in one file
+- User requirement: support 5+ variants per modality
+- Registry pattern enables config-driven selection
+- Easy to add new encoders without modifying existing files
+
+**Registry Pattern**:
+```python
+from primus.backends.megatron.data.diffusion.encoders import get_encoder
+
+# Config-driven selection
+vae = get_encoder('autoencoder_kl', config=vae_config)
+t5 = get_encoder('t5_xxl', config=t5_config)
+clip = get_encoder('clip_l', config=clip_config)
+```
+
+### Decision 4: Shared Energon Infrastructure
+
+**Choice**: `data/energon/` for shared utilities
+**Not**: Nested under `data/diffusion/`
+
+**Reasoning**:
+- Energon is general-purpose (VLM, diffusion, future models)
+- Traditional approach nests under model-specific directories
+- Megatron-LM has Energon at example level (not in core)
+- Primus approach: shared infra + model-specific TaskEncoders
+
+**Pattern**:
+```python
+# Shared: data/dataloader.py
+# MegatronDataloaderWrapper wraps any iterable (Energon loader, PyTorch DataLoader, etc.)
+wrapper = MegatronDataloaderWrapper(dataloader)
+
+# Model-specific: data/diffusion/task_encoders/image.py
+class EncodedDiffusionTaskEncoder:
+    """Diffusion-specific encoding logic"""
+    pass
+```
+
+### Decision 5: Model Provider at Adapter Level
+
+**Choice**: `diffusion_model_provider.py` at `primus/backends/megatron/`
+**Not**: Under `core/`
+
+**Reasoning**:
+- Follows existing pattern (`primus/backends/megatron/model_provider.py`)
+- Model providers are adapter/wrapper functions
+- Sit above core models to add Primus-specific functionality
+- Example: Wrap model with logit softcapping, custom loss, etc.
+
+### Decision 6: No PyTorch Lightning
+
+**Choice**: Pure Megatron patterns
+**Not**: PyTorch Lightning DataModules
+
+**Reasoning**:
+- Primus doesn't use PyTorch Lightning
+- Framework-specific implementations reduce flexibility
+- Better integration with Megatron training loop
+- Follows Megatron-LM's `MegatronDataloaderWrapper` wrapper pattern
+
+---
+
+## Component Hierarchy
+
+### 1. Model Hierarchy
+
+```
+nn.Module (PyTorch)
+└── MegatronModule
+    └── DiffusionModule (abstract)
+        └── Flux (concrete)
+        ├── Joint layers: MMDiTLayer × num_joint_layers
+        │   └── JointSelfAttention (shared)
+        ├── Single layers: FluxSingleTransformerBlock × num_single_layers
+        │   └── FluxSingleAttention (shared)
+        └── Embeddings:
+            ├── TimeStepEmbedder (shared)
+            ├── MLPEmbedder (shared)
+            └── EmbedND (Flux-specific, 3D RoPE)
+```
+
+### 2. Configuration Hierarchy
+
+```
+TransformerConfig (Megatron-Core)
+└── BaseDiffusionConfig
+    └── FluxConfig
+        ├── flux_535m() factory
+        └── flux_12b() factory
+```
+
+### 3. Scheduler Hierarchy
+
+```
+BaseScheduler (abstract)
+├── FlowMatchEulerDiscreteScheduler (Flux)
+├── DDPMScheduler (future)
+├── EDMScheduler (future)
+└── EulerDiscreteScheduler (future)
+```
+
+### 4. Encoder Hierarchy
+
+```
+BaseEncoder (abstract)
+├── ImageEncoder
+│   └── VAE
+│       ├── AutoencoderKL (Flux)
+│       └── VQVAE (future)
+└── TextEncoder
+    ├── T5
+    │   ├── T5-XXL (Flux)
+    │   └── T5-Large (future)
+    └── CLIP
+        ├── CLIP-L (Flux)
+        └── CLIP-H (future)
+```
+
+---
+
+## Data Flow
+
+### Training Pipeline
+
+```
+Raw Data (images + captions)
+    ↓
+[Optional] Precalculation
+    ├─ VAE → latents [B, 64, H/8, W/8]
+    ├─ T5-XXL → embeddings [B, 512, 4096]
+    └─ CLIP-L → pooled [B, 768]
+    ↓
+WebDataset/Energon Format (.tar files)
+    ↓
+MegatronDataloaderWrapper (from data/dataloader.py)
+    ↓
+EncodedDiffusionTaskEncoder (from data/diffusion/task_encoders/)
+    ├─ Load precalculated data, OR
+    └─ Encode on-the-fly (slower)
+    ↓
+Training Batch:
+    ├─ latents: [B, 64, H, W]
+    ├─ t5_embeddings: [B, S, 4096]
+    └─ clip_pooled: [B, 768]
+    ↓
+FlowMatchEulerDiscreteScheduler
+    ├─ Sample timesteps: t ~ U(0, 1)
+    ├─ Sample noise: ε ~ N(0, I)
+    ├─ Add noise: x_t = (1-t)*ε + t*x_0
+    └─ Compute target: v = x_0 - ε
+    ↓
+Flux Model Forward Pass
+    ├─ Embed timesteps
+    ├─ Embed pooled text (CLIP)
+    ├─ Joint layers (process latents + T5 embeddings)
+    ├─ Single layers (process latents only)
+    └─ Output: v_pred [B, 64, H, W]
+    ↓
+Loss Computation: MSE(v_pred, v_target)
+    ↓
+Backward Pass & Optimizer Step
+```
+
+### Inference Pipeline
+
+```
+Text Prompt
+    ↓
+Text Encoders
+    ├─ T5-XXL → embeddings [1, S, 4096]
+    └─ CLIP-L → pooled [1, 768]
+    ↓
+Initialize Noise: x_0 ~ N(0, I)
+    ↓
+Sampling Loop (t = 1.0 → 0.0)
+    ├─ Model forward: v_t = Flux(x_t, t, embeddings)
+    ├─ Update: x_{t-dt} = x_t + v_t * dt
+    └─ Repeat until t = 0
+    ↓
+Latents: x_0 [1, 64, H, W]
+    ↓
+VAE Decoder
+    ↓
+Generated Image [1, 3, H*8, W*8]
+```
+
+---
+
+## Comparison with Alternative Implementations
+
+### Primus Architectural Advantages
+
+#### 1. TransformerBlock Architecture (Primus Innovation)
+- **Primus**: Unified `TransformerBlock` with heterogeneous layer specs
+- **Others**: Separate `nn.ModuleList` containers for double/single blocks
+- **Benefit**: Better PP slicing, unified checkpointing, future-proof
+
+#### 2. Megatron-Core Native
+- **Primus**: Pure Megatron-Core, no framework dependencies
+- **Others**: Often integrated with PyTorch Lightning or other frameworks
+- **Benefit**: Tighter integration, simpler training loops
+
+#### 3. Checkpoint Format
+- **Primus**: Unified `transformer.layers.{0-56}` structure
+- **Others**: Separate `double_blocks.{i}` and `single_blocks.{j}`
+- **Benefit**: Simpler distributed checkpointing
+
+#### 4. Encoder Architecture
+- **Primus**: Registry-based, hierarchical organization
+- **Others**: Direct imports from monolithic files
+- **Benefit**: Easy extensibility for new encoder variants
+
+### File Organization Comparison
+
+| Component | Standard Location | Primus Location | Improvement |
+|-----------|------------------|-----------------|-------------|
+| Model | `models/diffusion/flux/` | `core/models/diffusion/flux/` | Megatron-Core convention |
+| Layers | Mixed locations | `common/` for shared, `flux/` for specific | Clear boundaries |
+| Encoders | Single file | `data/diffusion/encoders/{type}/{variant}/` | Hierarchical, extensible |
+| Tests | Mixed with code | `tests/unit_tests/backends/megatron/diffusion/` | Proper separation |
+
+---
+
+## Implementation Status
+
+### Core Infrastructure ✅
+- ✅ Directory structure
+- ✅ Base classes (DiffusionModule, BaseDiffusionConfig, BaseScheduler)
+- ✅ DiffusionModule with Megatron-Core integration
+- ✅ FluxConfig with factory methods
+- ✅ FlowMatchEulerDiscreteScheduler implementation
+- ✅ Configuration files (YAML)
+- ✅ Testing framework (290+ tests)
+- ✅ Documentation structure
+
+### Flux Model Implementation ✅
+- ✅ Flux model architecture
+- ✅ MMDiT layers and attention
+- ✅ Embeddings (RoPE, timestep, vector)
+- ✅ Encoder registry and loaders
+- ✅ TaskEncoder for Energon
+- ✅ Data pipeline
+
+---
+
+## Extension Points
+
+### Adding a New Model (e.g., DiT)
+
+1. **Create model directory**: `core/models/diffusion/dit/`
+2. **Add config**: Extend `BaseDiffusionConfig`
+3. **Implement model**: Extend `DiffusionModule` (which extends MegatronModule)
+   - Inherit process group management
+   - Get distributed checkpointing support
+   - Access attention backend configuration
+4. **Reuse shared components**: Import from `common/`
+5. **Add tests**: `tests/unit_tests/backends/megatron/diffusion/test_dit_model.py`
+6. **Update configs**: Add `dit_config.yaml`
+
+### Adding a New Encoder Variant
+
+1. **Create encoder file**: e.g., `data/diffusion/encoders/text/t5/t5_large.py`
+2. **Implement encoder class**: Extend `BaseEncoder`
+3. **Register**: Add to `ENCODER_REGISTRY`
+4. **Add config**: Update `encoders.yaml`
+5. **Add tests**: Test in `tests/unit_tests/backends/megatron/diffusion/data/encoders/`
+
+### Adding a New Scheduler
+
+1. **Create scheduler file**: `training/diffusion/schedulers/ddpm.py`
+2. **Implement**: Extend `BaseScheduler`
+3. **Export**: Add to `__init__.py`
+4. **Add tests**: `tests/unit_tests/backends/megatron/diffusion/training/test_scheduler.py`
+5. **Document**: Update this file and README
+
+---
+
+## Performance Considerations
+
+### Memory Optimization
+- **Precalculated data**: 5-10x faster, lower memory
+- **Frozen encoders**: Only train diffusion model
+- **Gradient checkpointing**: Trade compute for memory
+- **Mixed precision**: bf16 on MI300X (compatible with H100/A100)
+
+### Multi-GPU Scaling
+- **Tensor Parallelism**: Split model across GPUs
+- **Pipeline Parallelism**: Split layers across GPUs
+- **Data Parallelism**: Replicate model, split data
+- **Sequence Parallelism**: For very long sequences
+
+### Best Practices
+1. Use precalculated mode for training
+2. Freeze encoders (standard practice)
+3. Use bf16 on modern hardware
+4. Start with TP=1, PP=1, scale as needed
+5. Profile before optimizing
+
+---
+
+## References
+
+- **Megatron-Core**: [nvidia/Megatron-LM](https://github.com/NVIDIA/Megatron-LM) transformer patterns
+- **Flux**: [black-forest-labs/FLUX.1](https://huggingface.co/black-forest-labs/FLUX.1-dev)
+- **Flow Matching**: Rectified flow and flow matching papers
+- **NeMo**: [nvidia/NeMo](https://github.com/NVIDIA/NeMo) - Alternative diffusion implementation
+
+---
+
+**Last Updated**: December 2025

--- a/docs/backends/megatron/diffusion/data_preprocessing.md
+++ b/docs/backends/megatron/diffusion/data_preprocessing.md
@@ -1,0 +1,629 @@
+# Data Preprocessing Guide
+
+This guide explains how to prepare datasets for Flux and other diffusion models in Primus, including pre-encoding of VAE latents and text embeddings into Energon WebDataset format.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Quick Start](#quick-start)
+3. [Two Pipelines](#two-pipelines)
+4. [Running Preprocessing](#running-preprocessing)
+5. [Configuration](#configuration)
+6. [Authentication](#authentication)
+7. [Finalization](#finalization)
+8. [Output Format](#output-format)
+9. [Validation](#validation)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Diffusion models require three types of encodings:
+1. **VAE latents**: Images encoded to latent space
+2. **Text embeddings**: Captions encoded with T5-XXL (sequence)
+3. **Pooled embeddings**: Captions encoded with CLIP-L (pooled)
+
+### Why Pre-encode?
+
+**Benefits**:
+- 5-10x faster training (no online encoding)
+- Lower GPU memory usage (encoders not loaded during training)
+- Deterministic inputs (same preprocessing for all runs)
+- Eliminates encoder differences as a variable
+
+**When to Use**:
+- Training (highly recommended)
+- Fine-tuning on fixed datasets
+- Benchmarking and reproducibility
+
+**When NOT to Use**:
+- Interactive data augmentation needed
+- Dataset too large to store pre-encoded
+- Rapid prototyping with changing data
+
+---
+
+## Quick Start
+
+Preprocess the Pokemon dataset with a single command:
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --config primus/configs/data/megatron/diffusion/preprocessing/quickstart_pokemon.yaml \
+  --hf-token-file /path/to/.hf_token
+```
+
+This will:
+1. Download the `diffusers/pokemon-gpt4-captions` dataset from HuggingFace
+2. Encode all images with VAE and captions with T5/CLIP
+3. Write Energon WebDataset tar shards to `/workspace/Primus/data/quickstart_pokemon`
+4. Automatically finalize the dataset (create `dataset.yaml`, run `energon prepare`, validate)
+
+The default encoder model (`black-forest-labs/FLUX.1-dev`) is gated and requires a HuggingFace token. Get one at https://huggingface.co/settings/tokens and save it to a file.
+
+---
+
+## Two Pipelines
+
+Primus provides two preprocessing pipelines via the `primus data` CLI:
+
+### `diffusion-encoded` (Recommended for Training)
+
+Pre-encodes images with VAE and text with T5/CLIP. Produces larger datasets but enables faster training since encoders are not needed at training time.
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --config primus/configs/data/megatron/diffusion/preprocessing/example_huggingface.yaml \
+  --hf-token-file /path/to/.hf_token
+```
+
+**Output**: WebDataset shards containing `latents.pth`, `prompt_embeds.pth`, `pooled_prompt_embeds.pth`, `caption.txt`
+
+**Use when**: Training on production datasets, maximum training speed is needed, storage is available.
+
+### `diffusion-raw`
+
+Stores raw images and captions without encoding. Smaller datasets but encoding happens on-the-fly during training (requires GPU + encoders loaded in memory).
+
+```bash
+primus-cli direct -- data diffusion-raw \
+  --source-type huggingface \
+  --hf-dataset diffusers/pokemon-gpt4-captions \
+  --output-dir /workspace/Primus/data/raw_pokemon \
+  --hf-token-file /path/to/.hf_token
+```
+
+**Output**: WebDataset shards containing `jpg` (or `png`/`webp`) and `txt` files.
+
+**Use when**: Storage is limited, experimenting with different encoders, rapid prototyping.
+
+**Note**: `diffusion-raw` does not support `--config` files. All options must be passed as CLI arguments.
+
+---
+
+## Running Preprocessing
+
+### Using a Config File (Recommended)
+
+The `--config` flag is supported by `diffusion-encoded` only. The simplest approach uses a YAML config file:
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --config primus/configs/data/megatron/diffusion/preprocessing/example_huggingface.yaml \
+  --hf-token-file /path/to/.hf_token
+```
+
+Available example configs in `primus/configs/data/megatron/diffusion/preprocessing/`:
+
+| Config | Source | Description |
+|--------|--------|-------------|
+| `quickstart_pokemon.yaml` | HuggingFace | Minimal config, 256px, fast |
+| `example_huggingface.yaml` | HuggingFace | Full example with all options |
+| `example_directory.yaml` | Local directory | Images + captions from disk |
+| `example_webdataset.yaml` | WebDataset | Existing tar archives |
+| `example_base.yaml` | N/A | Comprehensive reference with all fields |
+| `text_to_image_2m_10k.yaml` | HuggingFace | 10K subset of text-to-image-2M (1024px) |
+
+### Using CLI Arguments Directly
+
+All config values can be provided as CLI arguments:
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --source-type huggingface \
+  --hf-dataset diffusers/pokemon-gpt4-captions \
+  --output-dir /workspace/Primus/data/encoded_pokemon \
+  --model-path black-forest-labs/FLUX.1-dev \
+  --batch-size 8 \
+  --precision bf16 \
+  --hf-token-file /path/to/.hf_token
+```
+
+### CLI Overrides Config Values
+
+When using both `--config` and CLI arguments, CLI arguments take priority:
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --config primus/configs/data/megatron/diffusion/preprocessing/example_huggingface.yaml \
+  --hf-token-file /path/to/.hf_token \
+  --output-dir /my/custom/path \
+  --batch-size 16 \
+  --max-samples 1000
+```
+
+Priority order (highest to lowest):
+1. Explicitly provided CLI arguments
+2. YAML config file values
+3. CLI default values
+
+### Multi-GPU Processing
+
+Use `--nproc-per-node` for data-parallel preprocessing across multiple GPUs:
+
+```bash
+primus-cli direct -- --nproc-per-node=8 data diffusion-encoded \
+  --config primus/configs/data/megatron/diffusion/preprocessing/example_huggingface.yaml \
+  --hf-token-file /path/to/.hf_token
+```
+
+Each GPU processes a subset of the data. Shards are named to avoid conflicts across ranks.
+
+---
+
+## Configuration
+
+### YAML Config Structure
+
+Preprocessing configs have four sections:
+
+```yaml
+source:
+  type: huggingface          # huggingface | directory | webdataset
+  hf_dataset: diffusers/pokemon-gpt4-captions
+  hf_split: train
+
+output:
+  output_dir: /workspace/Primus/data/encoded_pokemon
+  shard_size: 1000           # samples per tar shard
+  max_samples: null          # null = process all
+  compress: false
+
+model:
+  model_path: black-forest-labs/FLUX.1-dev   # HF repo or local path
+  precision: bf16            # bf16 | fp16 | fp32
+  batch_size: 8
+  # Optional per-encoder overrides:
+  vae_path: null
+  t5_path: null
+  clip_path: null
+
+image:
+  image_size: 1024
+  center_crop: false
+```
+
+### Source Types
+
+**HuggingFace** (`type: huggingface`):
+```yaml
+source:
+  type: huggingface
+  hf_dataset: diffusers/pokemon-gpt4-captions
+  hf_split: train
+  hf_data_files: null        # optional: specific files within dataset
+```
+
+**Local Directory** (`type: directory`):
+```yaml
+source:
+  type: directory
+  input_dir: /data/my_images
+```
+
+Expected directory structure for `directory` source:
+```
+my_images/
+├── images/
+│   ├── 00001.jpg
+│   ├── 00002.png
+│   └── ...
+└── captions/
+    ├── 00001.txt
+    ├── 00002.txt
+    └── ...
+```
+
+**WebDataset** (`type: webdataset`):
+```yaml
+source:
+  type: webdataset
+  input_path: /data/existing_shards/*.tar
+```
+
+### Model Configuration
+
+The `model_path` defaults to `black-forest-labs/FLUX.1-dev`, which downloads VAE, T5-XXL, and CLIP-L encoders from HuggingFace. This model is gated and requires authentication (see [Authentication](#authentication)).
+
+Individual encoder paths can be overridden:
+
+```yaml
+model:
+  model_path: black-forest-labs/FLUX.1-dev
+  vae_path: /local/models/vae        # use local VAE instead
+  t5_path: null                       # falls back to model_path
+  clip_path: null                     # falls back to model_path
+```
+
+---
+
+## Authentication
+
+The default encoder model (`FLUX.1-dev`) is gated on HuggingFace and requires authentication. Primus supports three authentication methods, checked in priority order:
+
+### 1. Token File (Recommended)
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --config your_config.yaml \
+  --hf-token-file /path/to/.hf_token
+```
+
+The token file must have secure permissions (600 or 400). Create it with:
+
+```bash
+echo "hf_your_token_here" > /path/to/.hf_token
+chmod 600 /path/to/.hf_token
+```
+
+### 2. Environment Variable
+
+```bash
+export HF_TOKEN=hf_your_token_here
+primus-cli direct -- data diffusion-encoded --config your_config.yaml
+```
+
+### 3. HuggingFace CLI Login
+
+```bash
+huggingface-cli login
+primus-cli direct -- data diffusion-encoded --config your_config.yaml
+```
+
+If authentication fails, Primus provides a clear error message indicating which encoder failed and how to fix it.
+
+---
+
+## Finalization
+
+Finalization is **automatic by default**. After preprocessing completes, Primus automatically:
+
+1. **Creates `.nv-meta/dataset.yaml`** with `CrudeWebdataset` sample type and encoding subflavor
+2. **Runs `energon prepare`** to index the tar shards and create split assignments
+3. **Validates the dataset** using Primus's custom validation (metadata checks, sample count verification, energon API spot-check)
+
+### Skipping Finalization
+
+To skip automatic finalization (e.g., for manual post-processing):
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --config your_config.yaml \
+  --hf-token-file /path/to/.hf_token \
+  --no-finalize
+```
+
+### Custom Train/Val/Test Splits
+
+By default, 100% of data goes to the training split. To create validation and test splits:
+
+```bash
+primus-cli direct -- data diffusion-encoded \
+  --config your_config.yaml \
+  --hf-token-file /path/to/.hf_token \
+  --train-split 0.8
+```
+
+This creates an 80% train / 10% val / 10% test split.
+
+---
+
+## Output Format
+
+### Directory Structure
+
+After preprocessing and finalization, the output directory contains:
+
+```
+encoded_pokemon/
+├── 000000.tar              # WebDataset shard
+├── 000001.tar
+├── 000000.tar.idx          # Energon index files
+├── 000001.tar.idx
+└── .nv-meta/               # Energon metadata
+    ├── dataset.yaml         # Dataset type configuration
+    ├── split.yaml           # Train/val/test split assignments
+    └── .info.json           # Shard counts and sample counts
+```
+
+### Pre-encoded Shard Contents (`diffusion-encoded`)
+
+Each tar shard contains samples with these keys:
+
+```
+000000.tar:
+├── 0000000000.latents.pth              # VAE latents tensor
+├── 0000000000.prompt_embeds.pth        # T5-XXL embeddings tensor
+├── 0000000000.pooled_prompt_embeds.pth # CLIP-L pooled embeddings tensor
+├── 0000000000.caption.txt              # Original caption text
+├── 0000000001.latents.pth
+├── 0000000001.prompt_embeds.pth
+├── ...
+```
+
+Tensor shapes:
+- `latents.pth`: `[64, H/8, W/8]` (e.g., `[64, 128, 128]` for 1024x1024 images)
+- `prompt_embeds.pth`: `[seq_len, 4096]` (T5-XXL hidden dim)
+- `pooled_prompt_embeds.pth`: `[768]` (CLIP-L pooled dim)
+
+### Raw Shard Contents (`diffusion-raw`)
+
+```
+000000.tar:
+├── 0000000000.jpg       # Preprocessed image
+├── 0000000000.txt       # Caption text
+├── 0000000001.jpg
+├── 0000000001.txt
+├── ...
+```
+
+### Dataset YAML
+
+The auto-generated `.nv-meta/dataset.yaml` uses `CrudeWebdataset` format:
+
+```yaml
+__module__: megatron.energon
+__class__: CrudeWebdataset
+subflavors:
+  encoding: preencoded    # or 'raw' for diffusion-raw
+```
+
+---
+
+## Validation
+
+### Automatic Validation
+
+Validation runs automatically as part of finalization. It performs four checks:
+
+1. **Metadata check**: Verifies `.nv-meta/` files exist and are valid (`.info.json`, `split.yaml`, `dataset.yaml`)
+2. **Sample count check**: Spot-checks that tar shard entry counts match `.info.json`
+3. **Sample load check**: Loads one sample through Energon's Python API (same code path as training)
+4. **Summary report**: Prints dataset statistics (encoding, total samples, splits, data shapes, size)
+
+### Standalone Validation
+
+To validate a dataset independently:
+
+```bash
+python -m primus.backends.megatron.data.diffusion.preprocessing.validate /path/to/dataset
+
+# For raw datasets:
+python -m primus.backends.megatron.data.diffusion.preprocessing.validate /path/to/dataset --encoding raw
+```
+
+### Programmatic Validation
+
+```python
+from primus.backends.megatron.data.diffusion.preprocessing.validate import validate_energon_dataset
+
+ok = validate_energon_dataset('/path/to/dataset', encoding='preencoded')
+```
+
+### Known Energon CLI Limitations
+
+The standard Energon CLI tools (`energon info`, `energon preview`, `energon lint`) do **not** work correctly with `CrudeWebdataset` format. Primus uses custom validation instead:
+
+- `energon info` raises `KeyError: 'sample_type'`
+- `energon preview` raises `TypeError` (expects dataclass, `CrudeSample` is a dict)
+- `energon lint` raises `AssertionError` (expects registered cookers)
+
+Use Primus's built-in validation or the standalone script above.
+
+---
+
+## Troubleshooting
+
+### HuggingFace Authentication Failure
+
+**Symptoms**: Error mentioning "token", "gated", "401", or "403" when downloading encoders.
+
+**Solutions**:
+1. Provide a token: `--hf-token-file /path/to/.hf_token`
+2. Set environment variable: `export HF_TOKEN=hf_xxx`
+3. Run `huggingface-cli login`
+4. Accept the model's license on https://huggingface.co/black-forest-labs/FLUX.1-dev
+
+### Out of Memory During Preprocessing
+
+**Symptoms**: CUDA out of memory error during encoding.
+
+**Solutions**:
+1. Reduce batch size: `--batch-size 4` or `--batch-size 1`
+2. Use smaller image size: `--image-size 512`
+3. Use fp16 precision: `--precision fp16`
+4. Use multi-GPU to distribute work: `--nproc-per-node=8`
+
+### Missing Dependencies
+
+**Symptoms**: `ModuleNotFoundError` for `webdataset`, `megatron-energon`, `tqdm`, etc.
+
+**Solution**:
+```bash
+pip install -r requirements.txt
+```
+
+Or set `PRIMUS_AUTO_INSTALL=1` in the container to auto-install missing packages.
+
+### Finalization Fails
+
+**Symptoms**: Error during `energon prepare` or validation after preprocessing.
+
+**Solutions**:
+1. Check that tar shards exist in the output directory
+2. Ensure `megatron-energon` is installed (`pip install megatron-energon`)
+3. Re-run with `--no-finalize`, then manually inspect the output before finalizing
+
+### Slow Preprocessing
+
+**Symptoms**: Low throughput (< 10 samples/sec).
+
+**Solutions**:
+1. Increase batch size (limited by VRAM): `--batch-size 16`
+2. Use multiple GPUs: `--nproc-per-node=8`
+3. Use bf16 precision (faster on supported hardware): `--precision bf16`
+4. For raw pipeline, reduce image quality: `--image-quality 85`
+
+---
+
+## Best Practices
+
+1. **Always pre-encode for production training**: 5-10x speedup is worth the storage
+2. **Test on small dataset first**: Use `--max-samples 100` to verify the pipeline works
+3. **Use bf16 precision**: Good balance of speed, storage, and quality
+4. **Start with quickstart_pokemon.yaml**: Verify your setup before processing large datasets
+5. **Keep raw data**: Pre-encoding is a one-way transformation
+6. **Version your configs**: Track which preprocessing config produced each dataset
+
+---
+
+## Flux-Specific Data Preparation (torchrun)
+
+This section covers preparing datasets for Flux training using `torchrun` directly
+inside a Docker container, as an alternative to the `primus-cli` workflow above.
+
+### Prerequisites
+
+Start the container and optionally install requirements:
+
+```bash
+bash tools/docker/start_container.sh
+docker exec dev_primus bash -c 'pip install -r /workspace/Primus/requirements.txt'
+```
+
+This mounts the repository to `/workspace/Primus` inside the container.
+Override the image with `DOCKER_IMAGE`:
+
+```bash
+DOCKER_IMAGE=docker.io/rocm/primus:v26.1 bash tools/docker/start_container.sh
+```
+
+### Input Directory Structure
+
+When using `--source-type directory`, organize your data as follows:
+
+```
+dataset/
+├── images/
+│   ├── 0000000.png
+│   ├── 0000001.png
+│   └── ...
+└── captions/
+    ├── 0000000.txt
+    ├── 0000001.txt
+    └── ...
+```
+
+The file stem links each image to its caption (e.g., `images/0000000.png` pairs
+with `captions/0000000.txt`). Images can be `.jpg`, `.jpeg`, `.png`, or `.webp`.
+Captions must be UTF-8 `.txt` files. Samples without a matching caption are skipped.
+
+Other supported source types:
+- **huggingface** -- Load directly from HuggingFace Hub. Requires `--hf-dataset`.
+- **webdataset** -- Read from existing WebDataset tar archives. Requires `--input-path`.
+
+### Image Sizing
+
+**Fixed size (default):** Every image is resized to `--image-size` pixels square
+(default 1024). Use `--center-crop` to control center-cropping.
+
+**Variable size (`--variable-size`):** Preserves aspect ratio by scaling the
+longest side to `--max-size` (default 1024) and rounding dimensions to multiples
+of 16. Only use this when all images share the same dimensions -- mixed tensor
+sizes cause load imbalance across GPUs.
+
+### Key Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--source-type` | — | `directory`, `huggingface`, or `webdataset` |
+| `--input-dir` | — | Dataset root (for `directory` source) |
+| `--image-size` | 1024 | Square target size |
+| `--variable-size` | off | Preserve aspect ratio |
+| `--max-size` | 1024 | Maximum dimension in variable-size mode |
+| `--model-path` | `black-forest-labs/FLUX.1-dev` | Base model for encoder weights |
+| `--t5-max-length` | 512 | T5 token limit (use 256 for FLUX.1-schnell) |
+| `--batch-size` | 8 | Encoding batch size per GPU |
+| `--output-dir` | — | Destination for encoded WebDataset shards |
+| `--shard-size` | 1000 | Samples per tar shard |
+
+### Examples
+
+**From host (via `docker exec`):**
+
+```bash
+docker exec dev_primus bash -c '\
+  export HF_HOME=/workspace/Primus/checkpoints/flux; \
+PYTHONPATH=/workspace/Primus:/workspace/Primus/third_party/Megatron-LM:$PYTHONPATH \
+  torchrun --nproc_per_node=8 /workspace/Primus/primus/cli/main.py \
+    data diffusion-encoded \
+    --source-type directory \
+    --input-dir /workspace/Primus/data/dataset \
+    --output-dir /workspace/Primus/data/dataset_encoded_256 \
+    --image-size 256  \
+    --t5-max-length 256'
+```
+
+**Inside the container:**
+
+```bash
+export HF_HOME=/workspace/Primus/checkpoints/flux
+PYTHONPATH=/workspace/Primus:/workspace/Primus/third_party/Megatron-LM:$PYTHONPATH \
+  torchrun --nproc_per_node=8 /workspace/Primus/primus/cli/main.py \
+    data diffusion-encoded \
+    --source-type directory \
+    --input-dir /workspace/Primus/data/dataset \
+    --output-dir /workspace/Primus/data/dataset_encoded_256 \
+    --image-size 256 \
+    --t5-max-length 256
+```
+
+Both commands encode a local directory dataset at 256px on 8 GPUs, then create an Energon dataset by default.
+
+### Limitations
+
+**Uniform output size only.** When using `--variable-size`, images may produce
+tensors of different shapes. The current data pipeline does not support mixed
+tensor sizes because samples are distributed evenly across GPUs and unequal
+shapes cause load imbalance and eventual timeout. Use fixed `--image-size` if
+your images have various sizes.
+
+---
+
+## Next Steps
+
+After preprocessing:
+1. **Training**: Use the preprocessed dataset path in your training config
+2. **Validation**: The dataset is ready for training immediately after finalization
+
+See:
+- [Energon Integration](energon_integration.md) for TaskEncoder and dataloader details
+- [Config Directory Guide](../../../../primus/configs/data/megatron/diffusion/README.md) for config file reference
+- Example configs in `primus/configs/data/megatron/diffusion/preprocessing/`
+
+---
+
+**Last Updated**: June 2026

--- a/docs/backends/megatron/diffusion/energon_integration.md
+++ b/docs/backends/megatron/diffusion/energon_integration.md
@@ -1,0 +1,514 @@
+# Energon Integration Guide
+
+This guide explains how Megatron-Energon is integrated with Primus diffusion models, including the Cooker/TaskEncoder pattern, dataloader configuration, and dataset format.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Energon Architecture](#energon-architecture)
+3. [Dataset Format](#dataset-format)
+4. [TaskEncoder and Cooker Pattern](#taskencoder-and-cooker-pattern)
+5. [Dataloader Setup](#dataloader-setup)
+6. [Dataset Configuration](#dataset-configuration)
+7. [Implementation Examples](#implementation-examples)
+8. [Best Practices](#best-practices)
+
+---
+
+## Overview
+
+### What is Megatron-Energon?
+
+Megatron-Energon is NVIDIA's data loading framework for large-scale multimodal training. It provides:
+- **WebDataset integration**: Efficient streaming from .tar archives
+- **Task encoding**: Flexible data transformation pipeline via Cookers
+- **Multi-worker support**: Parallel data loading
+- **Deterministic iteration**: Reproducible training
+- **Checkpoint resumption**: Resume from any step
+
+### Why Energon for Diffusion?
+
+- **Proven at scale**: Used by NVIDIA for LLM and multimodal training
+- **Flexible**: Supports various data formats and transformations
+- **Efficient**: Optimized for multi-GPU training
+- **Compatible**: Works with Megatron parallelism (TP, PP, DP)
+
+### Primus Integration Strategy
+
+```
+Shared Infrastructure (data/)
+  ├─ MegatronDataloaderWrapper
+  ├─ Dataset configuration parsers
+  └─ Common utilities
+      ↓
+Model-Specific TaskEncoders (data/diffusion/task_encoders/)
+  ├─ EncodedDiffusionTaskEncoder (preencoded data)
+  ├─ RawDiffusionTaskEncoder (raw images + text)
+  └─ Custom task encoders
+```
+
+**Key Principle**: Share infrastructure, separate domain logic.
+
+---
+
+## Energon Architecture
+
+### Component Stack
+
+```
+Training Loop
+    ↓
+MegatronDataloaderWrapper (Primus wrapper, cyclic iteration)
+    ↓
+Megatron-Energon Core
+    ├─ WebDataset Reader (reads .tar shards)
+    ├─ Cooker (transforms raw dict → typed Sample)
+    ├─ TaskEncoder.batch() (stacks samples → batch)
+    └─ Worker Pool
+    ↓
+.tar Shards (CrudeWebdataset format)
+```
+
+### Data Flow
+
+```
+1. Load from .tar shard
+   → raw_dict = {'__key__': '0000000000',
+                  'latents.pth': bytes,
+                  'prompt_embeds.pth': bytes,
+                  'pooled_prompt_embeds.pth': bytes,
+                  'caption.txt': bytes}
+
+2. Cooker function (e.g., cook_preencoded_diffusion)
+   → Deserializes bytes to tensors
+   → Returns typed DiffusionSample dataclass
+   → DiffusionSample(latents=Tensor[64,128,128],
+                      prompt_embeds=Tensor[512,4096],
+                      pooled_prompt_embeds=Tensor[768],
+                      caption="a photo of...")
+
+3. TaskEncoder.batch()
+   → Stacks list of DiffusionSample into batch dict
+   → batch = {'latents': [B, 64, H, W],
+              'prompt_embeds': [B, seq_len, 4096],
+              'pooled_prompt_embeds': [B, 768]}
+
+4. Return to training loop via MegatronDataloaderWrapper
+   → Forward pass, loss, backprop
+```
+
+---
+
+## Dataset Format
+
+### CrudeWebdataset
+
+Primus uses Energon's `CrudeWebdataset` format for preprocessed datasets. This is the simplest Energon format -- it stores raw key-value pairs in tar shards without requiring a strict schema.
+
+The dataset type is configured in `.nv-meta/dataset.yaml`:
+
+```yaml
+__module__: megatron.energon
+__class__: CrudeWebdataset
+subflavors:
+  encoding: preencoded    # or 'raw'
+```
+
+The `subflavors.encoding` field tells the TaskEncoder which Cooker to use:
+- `preencoded`: Uses `cook_preencoded_diffusion` -- loads pre-encoded tensors
+- `raw`: Uses `cook_raw_images` -- loads raw images and text
+
+### Pre-encoded Shard Contents
+
+Each tar shard contains samples with these keys:
+
+| Key | Type | Shape | Description |
+|-----|------|-------|-------------|
+| `latents.pth` | Tensor | `[64, H/8, W/8]` | VAE-encoded image latents |
+| `prompt_embeds.pth` | Tensor | `[seq_len, 4096]` | T5-XXL text embeddings |
+| `pooled_prompt_embeds.pth` | Tensor | `[768]` | CLIP-L pooled embeddings |
+| `caption.txt` | str | N/A | Original caption text |
+
+### Raw Shard Contents
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `jpg` / `png` / `webp` | bytes | Preprocessed image |
+| `txt` | str | Caption text |
+
+### Known Energon CLI Limitations
+
+The standard Energon CLI tools have issues with `CrudeWebdataset`:
+- `energon info` raises `KeyError: 'sample_type'`
+- `energon preview` raises `TypeError` (expects dataclass, `CrudeSample` is a dict)
+- `energon lint` raises `AssertionError` (expects registered cookers)
+
+Primus includes custom validation (`primus.backends.megatron.data.diffusion.preprocessing.validate`) as a replacement. See the [Data Preprocessing Guide](data_preprocessing.md#validation) for details.
+
+---
+
+## TaskEncoder and Cooker Pattern
+
+Primus uses Energon's Cooker pattern rather than the older `encode_sample()` approach. Cookers are `@stateless` functions that transform raw sample dicts into typed dataclass instances, dispatched based on `subflavors`.
+
+### DiffusionSample Dataclass
+
+Location: `primus/backends/megatron/data/diffusion/task_encoders/image.py`
+
+```python
+# (imports like torch omitted for brevity)
+from dataclasses import dataclass
+from megatron.energon import Sample
+
+@dataclass
+class DiffusionSample(Sample):
+    """
+    Diffusion training sample with framework-standard field names.
+
+    Inherits from megatron.energon.Sample to ensure __key__, __restore_key__,
+    and __subflavors__ are properly tracked for deterministic training resumption.
+    """
+    latents: torch.Tensor              # [C, H, W] VAE latents
+    prompt_embeds: torch.Tensor        # [seq_len, hidden_dim] T5 embeddings
+    pooled_prompt_embeds: torch.Tensor # [hidden_dim] CLIP pooled
+    caption: str = ""
+```
+
+### Cooker Functions
+
+Cookers are `@stateless` functions registered with a `Cooker` wrapper that specifies which `subflavors` they handle:
+
+```python
+# (imports like torch, io omitted for brevity)
+from megatron.energon import Cooker, basic_sample_keys, stateless
+
+@stateless
+def cook_preencoded_diffusion(sample: dict) -> DiffusionSample:
+    """Load precalculated VAE latents and text embeddings from disk."""
+
+    def load_tensor(data):
+        if isinstance(data, bytes):
+            return torch.load(io.BytesIO(data), map_location='cpu')
+        return data
+
+    latents = load_tensor(sample.get('latents.pth'))
+    prompt_embeds = load_tensor(sample.get('prompt_embeds.pth'))
+    pooled_prompt_embeds = load_tensor(sample.get('pooled_prompt_embeds.pth'))
+
+    caption = sample.get('caption.txt', b'')
+    if isinstance(caption, bytes):
+        caption = caption.decode('utf-8')
+
+    return DiffusionSample(
+        **basic_sample_keys(sample),
+        latents=latents,
+        prompt_embeds=prompt_embeds,
+        pooled_prompt_embeds=pooled_prompt_embeds,
+        caption=caption,
+    )
+
+
+@stateless
+def cook_raw_images(sample: dict) -> Dict[str, Any]:
+    """Load raw images and text -- NO encoding, just data loading."""
+    return {
+        **basic_sample_keys(sample),
+        'images': sample.get('images'),
+        'txt': sample.get('txt'),
+    }
+```
+
+The cooker code above is simplified for clarity. See `primus/backends/megatron/data/diffusion/task_encoders/image.py` for the full implementation, which includes additional input type handling and validation.
+
+### EncodedDiffusionTaskEncoder
+
+The TaskEncoder registers Cookers and provides the `batch()` method:
+
+```python
+from megatron.energon import DefaultTaskEncoder, SampleDecoder, Cooker, WorkerConfig
+
+class EncodedDiffusionTaskEncoder(DefaultTaskEncoder[DiffusionSample, DiffusionSample, dict, dict]):
+    """TaskEncoder for PRE-ENCODED diffusion data."""
+
+    decoder = SampleDecoder(image_decode="pil")
+
+    cookers = [
+        Cooker(cook_preencoded_diffusion, has_subflavors={"encoding": "preencoded"}),
+    ]
+
+    def __init__(self, worker_config: Optional[WorkerConfig] = None):
+        super().__init__()
+        self.worker_config = worker_config
+
+    def batch(self, samples: List[DiffusionSample]) -> Dict[str, torch.Tensor]:
+        return {
+            'latents': torch.stack([s.latents for s in samples]),
+            'prompt_embeds': torch.stack([s.prompt_embeds for s in samples]),
+            'pooled_prompt_embeds': torch.stack([s.pooled_prompt_embeds for s in samples]),
+        }
+```
+
+### RawDiffusionTaskEncoder
+
+For raw (on-the-fly encoding) datasets:
+
+```python
+class RawDiffusionTaskEncoder(DefaultTaskEncoder):
+    """TaskEncoder for RAW diffusion data (images and text)."""
+
+    decoder = SampleDecoder(image_decode="pil")
+
+    cookers = [
+        Cooker(cook_raw_images, has_subflavors={"encoding": "raw"}),
+    ]
+
+    def __init__(self, worker_config: Optional[WorkerConfig] = None):
+        super().__init__()
+        self.worker_config = worker_config
+
+    def batch(self, samples: List[Dict]) -> Dict[str, Any]:
+        return {
+            'images': [s['images'] for s in samples],
+            'txt': [s['txt'] for s in samples],
+        }
+```
+
+### How Cooker Dispatch Works
+
+The Cooker framework matches samples to cooker functions based on `subflavors`:
+
+1. `dataset.yaml` specifies `subflavors: { encoding: preencoded }`
+2. Energon reads a sample from the tar shard
+3. The `has_subflavors` on each `Cooker` is checked against the sample's subflavors
+4. The matching cooker function is called to transform the raw dict into a typed sample
+5. `TaskEncoder.batch()` stacks multiple samples into a training batch
+
+This decouples data format (what's in the tar) from data loading logic (how to interpret it).
+
+---
+
+## Dataloader Setup
+
+### MegatronDataloaderWrapper
+
+Location: `primus/backends/megatron/data/dataloader.py`
+
+The `MegatronDataloaderWrapper` is a generic wrapper that makes any iterable compatible with Megatron's training loop. It provides:
+- Cyclic iteration (never raises StopIteration)
+- Optional checkpoint support via duck typing (`save_state_rank()` / `restore_state_rank()`)
+- Works with PyTorch DataLoader, Energon loaders, and synthetic data
+
+```python
+from primus.backends.megatron.data.dataloader import MegatronDataloaderWrapper
+
+wrapper = MegatronDataloaderWrapper(pytorch_or_energon_loader)
+```
+
+Note: Originally named `EnergonDataloader`, renamed to `MegatronDataloaderWrapper` to reflect its generic nature (it has no Energon dependencies). The old name is available as a deprecated alias.
+
+### Usage Example
+
+```python
+from primus.backends.megatron.data.dataloader import MegatronDataloaderWrapper
+
+# Create Energon loader (with TaskEncoder configured)
+energon_loader = get_loader(...)
+dataloader = MegatronDataloaderWrapper(energon_loader)
+
+# Use in training loop
+for batch in dataloader:
+    latents = batch['latents']                          # [B, 64, H, W]
+    prompt_embeds = batch['prompt_embeds']              # [B, seq_len, 4096]
+    pooled_prompt_embeds = batch['pooled_prompt_embeds'] # [B, 768]
+
+    output = model(latents, timesteps, prompt_embeds, pooled_prompt_embeds)
+    loss = criterion(output, target)
+    loss.backward()
+```
+
+---
+
+## Dataset Configuration
+
+### Per-Dataset dataset.yaml
+
+Each dataset directory has a `.nv-meta/dataset.yaml` that specifies the Energon dataset type:
+
+```yaml
+__module__: megatron.energon
+__class__: CrudeWebdataset
+subflavors:
+  encoding: preencoded
+```
+
+This file is auto-generated by Primus during finalization. See [Data Preprocessing Guide](data_preprocessing.md#finalization).
+
+### Metadataset (Multi-Dataset Mixing)
+
+For combining multiple datasets with different weights:
+
+```yaml
+__module__: megatron.energon
+__class__: Metadataset
+
+splits:
+  train:
+    datasets:
+      - weight: 0.7
+        path: /data/laion_precalculated/
+      - weight: 0.3
+        path: /data/coco_precalculated/
+```
+
+Energon samples proportionally to weights (70% from LAION, 30% from COCO).
+
+---
+
+## Implementation Examples
+
+### Example 1: Pre-encoded Training
+
+```python
+from primus.backends.megatron.data.dataloader import MegatronDataloaderWrapper
+from primus.backends.megatron.data.diffusion.task_encoders import EncodedDiffusionTaskEncoder
+
+# TaskEncoder is configured by the dataset provider
+# The cooker automatically handles subflavors dispatch
+energon_loader = get_loader(...)
+dataloader = MegatronDataloaderWrapper(energon_loader)
+
+for batch in dataloader:
+    output = model(
+        batch['latents'],
+        batch['prompt_embeds'],
+        batch['pooled_prompt_embeds'],
+    )
+```
+
+### Example 2: Raw Data Training (On-the-Fly Encoding)
+
+```python
+from primus.backends.megatron.data.diffusion.task_encoders import RawDiffusionTaskEncoder
+
+# Raw TaskEncoder passes through images and text without encoding
+# Encoding happens in the model's forward_step
+energon_loader = get_loader(...)
+dataloader = MegatronDataloaderWrapper(energon_loader)
+
+for batch in dataloader:
+    images = batch['images']   # List of PIL Images
+    captions = batch['txt']    # List of caption strings
+    # Model handles VAE/T5/CLIP encoding in forward_step
+```
+
+### Example 3: Multi-GPU Training
+
+```python
+import torch.distributed as dist
+
+dist.init_process_group(backend='nccl')
+
+energon_loader = get_loader(...)
+dataloader = MegatronDataloaderWrapper(energon_loader)
+
+for batch in dataloader:
+    output = model(batch['latents'], ...)
+```
+
+---
+
+## Best Practices
+
+### 1. Pre-encoded Mode
+- **Always use for production training**: 5-10x faster
+- **Validate first**: Test with small dataset using `quickstart_pokemon.yaml`
+- **Version datasets**: Track which preprocessing config produced each dataset
+
+### 2. Cooker Design
+- **Use `@stateless`**: Cookers must be stateless and side-effect-free
+- **Use `basic_sample_keys()`**: Always forward `__key__`, `__restore_key__`, `__subflavors__`
+- **Keep it simple**: Cookers should only deserialize and restructure data, not transform it
+- **Use subflavors for dispatch**: Let the framework choose the right cooker
+
+### 3. TaskEncoder Design
+- **Single responsibility**: One task encoder per data format family
+- **Minimal `batch()`**: Only stack tensors, avoid computation in the batch method
+- **Separate concerns**: Data loading in Cooker, encoding in model forward_step
+
+### 4. Dataloader Configuration
+- **Num workers**: Match CPU cores (typically 4-8)
+- **Batch size**: Max out GPU memory
+- **Shuffle**: Always true for training
+- **Drop last**: True to avoid irregular batches
+
+### 5. Debugging
+- **Small dataset**: Test with 100 samples first (`--max-samples 100`)
+- **Single worker**: Set `num_workers=1` for debugging
+- **Validate**: Run `python -m primus.backends.megatron.data.diffusion.preprocessing.validate /path/to/dataset`
+
+---
+
+## Customization Patterns
+
+### Custom Cooker Function
+
+Add a new cooker for a different data format:
+
+```python
+from megatron.energon import Cooker, basic_sample_keys, stateless
+
+@stateless
+def cook_my_custom_format(sample: dict) -> DiffusionSample:
+    """Custom cooker for a different data layout."""
+    latents = torch.load(io.BytesIO(sample['vae_output.pth']), map_location='cpu')
+    prompt = torch.load(io.BytesIO(sample['text_embed.pth']), map_location='cpu')
+    pooled = torch.load(io.BytesIO(sample['clip_embed.pth']), map_location='cpu')
+
+    return DiffusionSample(
+        **basic_sample_keys(sample),
+        latents=latents,
+        prompt_embeds=prompt,
+        pooled_prompt_embeds=pooled,
+    )
+
+class CustomDiffusionTaskEncoder(DefaultTaskEncoder[DiffusionSample, DiffusionSample, dict, dict]):
+    decoder = SampleDecoder(image_decode="pil")
+    cookers = [
+        Cooker(cook_my_custom_format, has_subflavors={"encoding": "custom_v2"}),
+    ]
+
+    def batch(self, samples):
+        return {
+            'latents': torch.stack([s.latents for s in samples]),
+            'prompt_embeds': torch.stack([s.prompt_embeds for s in samples]),
+            'pooled_prompt_embeds': torch.stack([s.pooled_prompt_embeds for s in samples]),
+        }
+```
+
+### Multiple Cookers in One TaskEncoder
+
+A single TaskEncoder can register multiple cookers for different subflavors:
+
+```python
+class MultiFormatTaskEncoder(DefaultTaskEncoder[DiffusionSample, DiffusionSample, dict, dict]):
+    cookers = [
+        Cooker(cook_preencoded_diffusion, has_subflavors={"encoding": "preencoded"}),
+        Cooker(cook_my_custom_format, has_subflavors={"encoding": "custom_v2"}),
+    ]
+```
+
+---
+
+## References
+
+- **Megatron-Energon**: [nvidia/Megatron-LM](https://github.com/NVIDIA/Megatron-LM) multimodal examples
+- **WebDataset**: [webdataset/webdataset](https://github.com/webdataset/webdataset)
+- **NeMo Implementation**: `nemo/collections/diffusion/data/`
+- **Primus TaskEncoders**: `primus/backends/megatron/data/diffusion/task_encoders/image.py`
+- **Primus Dataloader**: `primus/backends/megatron/data/dataloader.py`
+
+---
+
+**Last Updated**: March 2026

--- a/docs/backends/megatron/diffusion/flux_architecture.md
+++ b/docs/backends/megatron/diffusion/flux_architecture.md
@@ -1,0 +1,926 @@
+# Flux Architecture Deep Dive
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture Principles](#architecture-principles)
+3. [Model Components](#model-components)
+4. [Data Flow](#data-flow)
+5. [Mathematical Formulation](#mathematical-formulation)
+6. [Implementation Details](#implementation-details)
+7. [Megatron-Core Integration](#megatron-core-integration)
+8. [Performance Optimizations](#performance-optimizations)
+
+---
+
+## Overview
+
+Flux is a **flow-based diffusion model** for high-quality text-to-image generation. It uses an innovative **MMDiT (Multimodal Diffusion Transformer)** architecture that jointly processes image and text tokens through shared transformer blocks.
+
+### Key Innovations
+
+1. **Flow Matching**: Uses rectified flow instead of traditional diffusion
+2. **MMDiT Architecture**: Joint image-text attention in early layers
+3. **3D RoPE**: Multi-dimensional rotary position embeddings for spatial awareness
+4. **Two-Stage Processing**: Joint layers followed by image-only layers
+
+### Model Variants
+
+| Variant | Joint Layers | Single Layers | Parameters | Use Case |
+|---------|--------------|---------------|------------|----------|
+| Flux 535M | 1 | 1 | ~535M | Development, testing |
+| Flux 12B | 19 | 38 | ~12B | Production deployment |
+
+---
+
+## Architecture Principles
+
+### 1. Flow Matching Framework
+
+Unlike traditional diffusion (which adds Gaussian noise), Flux uses **rectified flow**:
+
+```
+Forward process:  z_t = (1-t) * z_0 + t * z_1
+where:
+  - z_0 = original image (latent)
+  - z_1 = random noise
+  - t ∈ [0, 1] is the flow timestep
+```
+
+The model predicts the **velocity field** v_θ:
+
+```
+v_θ(z_t, t, c) ≈ z_1 - z_0
+```
+
+**Advantages**:
+- Straight-line interpolation paths (more efficient than diffusion curves)
+- Faster sampling (fewer steps needed)
+- Better training stability
+
+### 2. MMDiT (Multimodal Diffusion Transformer)
+
+Traditional DiT processes image tokens independently. MMDiT jointly processes image and text:
+
+```
+┌─────────────┐     ┌─────────────┐
+│ Image Tokens│     │ Text Tokens │
+└──────┬──────┘     └──────┬──────┘
+       │                   │
+       └───────┬───────────┘
+               │
+        ┌──────▼──────┐
+        │ Joint Attn  │ ← Cross-attend image ↔ text
+        └──────┬──────┘
+               │
+        ┌──────▼──────┐
+        │   Split     │
+        └──┬───────┬──┘
+           │       │
+   ┌───────▼──┐ ┌─▼────────┐
+   │ Image MLP│ │ Text MLP │ ← Separate processing
+   └──────────┘ └──────────┘
+```
+
+**Benefits**:
+- Better text-image alignment
+- Richer cross-modal interactions
+- Improved compositional understanding
+
+### 3. Two-Stage Processing
+
+Flux uses a unique two-stage architecture:
+
+**Stage 1: Joint Processing (Double Blocks)**
+- Both image and text tokens
+- Multi-modal attention
+- Rich semantic understanding
+
+**Stage 2: Image Refinement (Single Blocks)**
+- Image tokens only (text concatenated but not separated)
+- Focus on spatial coherence
+- Fine-grained detail generation
+
+---
+
+## Model Components
+
+### 1. Input Embeddings
+
+#### Image Path
+
+```
+Image (RGB) → VAE Encoder → Latents [B, 64, H/8, W/8]
+                           ↓
+                    Patchify + Linear
+                           ↓
+              Image Tokens [B, H*W, 3072]
+```
+
+**VAE**: AutoencoderKL (8x downsampling)
+- Input: 1024×1024 RGB image
+- Output: 64×128×128 latent
+
+**Linear Projection**: Maps 64 channels → 3072 hidden dim
+
+#### Text Path
+
+```
+Caption → T5-XXL Encoder → Embeddings [B, S, 4096]
+                          ↓
+                    Linear Projection
+                          ↓
+              Text Tokens [B, S, 3072]
+
+Caption → CLIP-L Encoder → Pooled [B, 768]
+                          ↓
+                    MLP Embedder
+                          ↓
+                Vector Embedding [B, 3072]
+```
+
+**T5-XXL**: Context-rich text embeddings (max 512 tokens)
+**CLIP-L**: Global style/semantic vector (768 dim)
+
+#### Conditioning
+
+```
+Timestep t ∈ [0, 1] → Sinusoidal Encoding → [B, 256]
+                                            ↓
+                                          MLP
+                                            ↓
+                              Timestep Embedding [B, 3072]
+
+(Optional) Guidance scale g → Linear → [B, 3072]
+```
+
+**Combined Conditioning Vector**:
+```
+vec = timestep_emb + clip_pooled_emb + [guidance_emb]
+```
+
+### 2. Position Embeddings (3D RoPE)
+
+Flux uses **3D Rotary Position Embeddings** for spatial awareness:
+
+**Axes**:
+1. **Axis 0**: Channel groups (16 groups for 64 channels)
+2. **Axis 1**: Height positions (e.g., 128 for 1024px)
+3. **Axis 2**: Width positions (e.g., 128 for 1024px)
+
+**Implementation**:
+```python
+# Generate position IDs for each axis
+pos_ids = [
+    (h * W + w) // (16 * patch_size),  # Axis 0: channel group
+    h,                                  # Axis 1: height
+    w,                                  # Axis 2: width
+]
+
+# Compute frequencies for each axis
+theta_i = theta ^ (2i / dim_axis)
+freqs = pos_id / theta_i
+
+# Apply RoPE rotation
+cos_freq = cos(freqs)
+sin_freq = sin(freqs)
+```
+
+**Advantages**:
+- Encodes spatial structure (height × width)
+- Encodes channel relationships
+- Works for any resolution (generalization)
+
+### 3. MMDiT Layer (Double Block)
+
+Each MMDiT layer performs:
+
+```
+Input: img [B, H*W, D], txt [B, S, D], vec [B, D]
+
+1. Pre-normalization (AdaLN with timestep conditioning)
+   img_norm = AdaLN(img, vec)
+   txt_norm = AdaLN(txt, vec)
+
+2. Joint Self-Attention
+   img_qkv = Linear(img_norm)  # [B, H*W, 3*D]
+   txt_qkv = Linear(txt_norm)  # [B, S, 3*D]
+
+   # Concatenate for joint attention
+   joint_qkv = concat([img_qkv, txt_qkv], dim=1)  # [B, H*W+S, 3*D]
+
+   # Apply attention
+   joint_out = Attention(joint_qkv)  # [B, H*W+S, D]
+
+   # Split back
+   img_attn, txt_attn = split(joint_out, [H*W, S])
+
+3. Gated Residual Addition
+   img = img + gate_img * img_attn
+   txt = txt + gate_txt * txt_attn
+
+4. Feed-Forward Networks (separate for img and txt)
+   img_mlp = AdaLN(img, vec) → Linear → GELU → Linear
+   txt_mlp = AdaLN(txt, vec) → Linear → GELU → Linear
+
+   img = img + gate_img_mlp * img_mlp
+   txt = txt + gate_txt_mlp * txt_mlp
+
+Output: img [B, H*W, D], txt [B, S, D]
+```
+
+**Key Features**:
+- **Shared attention space**: Image and text attend to each other
+- **Adaptive gating**: Timestep-conditioned residual connections
+- **Separate MLPs**: Modality-specific processing
+
+### 4. Flux Single Block
+
+After joint processing, image tokens go through single blocks:
+
+```
+Input: img [B, H*W, D], txt [B, S, D], vec [B, D]
+
+1. Concatenate (but don't split later)
+   combined = concat([img, txt], dim=1)  # [B, H*W+S, D]
+
+2. Pre-normalization (AdaLN)
+   combined_norm = AdaLN(combined, vec)
+
+3. Self-Attention
+   qkv = Linear(combined_norm)  # [B, H*W+S, 3*D]
+   attn_out = Attention(qkv)     # [B, H*W+S, D]
+
+4. Gated Residual
+   combined = combined + gate * attn_out
+
+5. Feed-Forward
+   mlp_norm = AdaLN(combined, vec)
+   mlp_out = Linear → GELU → Linear
+   combined = combined + gate_mlp * mlp_out
+
+6. Extract image tokens
+   img = combined[:, :H*W, :]  # Only use image part
+
+Output: img [B, H*W, D]  (text tokens discarded)
+```
+
+**Rationale**:
+- Text still influences attention (as keys/values)
+- Output focuses on image generation
+- More efficient than full joint processing
+
+### 5. Output Processing
+
+```
+Image Tokens [B, H*W, D]
+        ↓
+    AdaLNContinuous(vec)  ← Final timestep conditioning
+        ↓
+    Linear Projection
+        ↓
+     [B, H*W, 64]
+        ↓
+    Reshape
+        ↓
+  [B, 64, H, W]  ← Predicted velocity field
+```
+
+---
+
+## Data Flow
+
+### Complete Forward Pass
+
+```
+                            Input
+                              │
+          ┌───────────────────┼───────────────────┐
+          │                   │                   │
+        Image               Text               Timestep
+    [B,64,H,W]           [B,S,4096]             [B]
+          │                   │                   │
+          ▼                   ▼                   ▼
+     img_linear          txt_linear          time_emb
+          │                   │                   │
+          ├─────── + ─────────┴─────── vec ──────┤
+          │              (conditioning)           │
+          ▼                                       │
+    img [B,H*W,3072]                             │
+    txt [B,S,3072]                               │
+          │                                       │
+          │              ┌──────────┐            │
+          └──────────────► MMDiT    ├────◄───────┤
+          ┌──────────────◄ Layer 1  ├────────────┘
+          │              └──────────┘
+          │              ┌──────────┐
+          └──────────────► MMDiT    ├────◄───────┐
+          ┌──────────────◄ Layer 2  ├────────────┤
+          │              └──────────┘            │
+          ...                                    vec
+          │              ┌──────────┐            │
+          └──────────────► MMDiT    ├────◄───────┘
+          ┌──────────────◄ Layer N  ├────────────┐
+          │              └──────────┘            │
+          │                                       │
+    img [B,H*W,3072]                             │
+    txt [B,S,3072]                               │
+          │                                       │
+          │              ┌──────────┐            │
+          └──────────────► Single   ├────◄───────┤
+          ┌──────────────◄ Block 1  ├────────────┘
+          │              └──────────┘
+          │              ┌──────────┐
+          └──────────────► Single   ├────◄───────┐
+          ┌──────────────◄ Block 2  ├────────────┤
+          │              └──────────┘            │
+          ...                                    vec
+          │              ┌──────────┐            │
+          └──────────────► Single   ├────◄───────┘
+          ┌──────────────◄ Block M  ├────────────┐
+          │              └──────────┘            │
+          │                                       │
+    img [B,H*W,3072]                             │
+          │                                       │
+          ▼                                       │
+    AdaLNContinuous ◄───────────────────────────┘
+          │
+          ▼
+    Linear Projection
+          │
+          ▼
+    Reshape to [B,64,H,W]
+          │
+          ▼
+   Predicted Velocity
+```
+
+### Training Data Flow
+
+```
+Original Image
+      │
+      ▼
+   VAE Encode → z_0 [B,64,H,W]
+      │
+      ├─────────────┐
+      │             │
+      ▼             ▼
+   z_0        Sample Noise → z_1
+      │             │
+      │    Sample t ~ Uniform(0,1)
+      │             │
+      └──────┬──────┘
+             │
+        z_t = (1-t)*z_0 + t*z_1  ← Noisy latent
+             │
+             ▼
+      Flux Model(z_t, text, t)
+             │
+             ▼
+       v_pred [B,64,H,W]  ← Predicted velocity
+             │
+             ▼
+    Loss = MSE(v_pred, z_1 - z_0)  ← Flow matching loss
+```
+
+---
+
+## Mathematical Formulation
+
+### Flow Matching Objective
+
+**Forward Process**:
+```
+z_t = (1 - t) * z_0 + t * z_1,  where t ~ Uniform(0, 1)
+```
+
+**Velocity Target**:
+```
+v* = dz_t/dt = z_1 - z_0
+```
+
+**Training Loss**:
+```
+L = E_{z_0, z_1, t, c} [ ||v_θ(z_t, t, c) - (z_1 - z_0)||² ]
+
+where:
+  z_0 = VAE(image)                    # Original latent
+  z_1 ~ N(0, I)                       # Random noise
+  c = (text_emb, clip_pooled)         # Conditioning
+  v_θ = Flux model                    # Predicted velocity
+```
+
+### Sampling (Inference)
+
+**Euler Integration** (first-order ODE solver):
+```
+z_0 = z_1  # Start from noise
+for t in [1.0, 0.9, ..., 0.1, 0.0]:
+    v_t = Flux(z_t, t, c)
+    z_{t-Δt} = z_t - Δt * v_t
+```
+
+**Higher-Order Solvers** (optional):
+- Heun's method (2nd order)
+- DPM-Solver (adaptive)
+
+### Classifier-Free Guidance
+
+During inference, use guidance scale `w`:
+
+```
+v_guided = v_uncond + w * (v_cond - v_uncond)
+
+where:
+  v_cond = Flux(z_t, t, c_text)       # With text
+  v_uncond = Flux(z_t, t, c_empty)    # Without text (null prompt)
+  w = guidance scale (typically 3-5)
+```
+
+**Implementation**: Use guidance embedding in config:
+```python
+config = FluxConfig(guidance_embed=True, guidance_scale=3.5)
+```
+
+### 3D RoPE Mathematics
+
+For position `(h, w)` in image:
+
+**Position IDs**:
+```
+pid = [floor((h*W + w) / 16), h, w]  # [channel_group, height, width]
+```
+
+**Frequencies**:
+```
+θ_i = θ_base ^ (2i / d_axis),  for i = 0, ..., d_axis/2
+
+freq_{axis,i} = pid[axis] / θ_i
+```
+
+**RoPE Rotation**:
+```
+q_rot = [q[:d/2] * cos(freq) - q[d/2:] * sin(freq),
+         q[:d/2] * sin(freq) + q[d/2:] * cos(freq)]
+
+k_rot = [k[:d/2] * cos(freq) - k[d/2:] * sin(freq),
+         k[:d/2] * sin(freq) + k[d/2:] * cos(freq)]
+```
+
+---
+
+## Implementation Details
+
+### Memory Layout
+
+Megatron-Core uses **sequence-first format**: `[seq, batch, hidden]`
+
+**Conversions**:
+```python
+# User format: [B, C, H, W]
+img_latents = torch.randn(B, 64, H, W)
+
+# Reshape to [B, H*W, 64]
+img_seq = rearrange(img_latents, 'b c h w -> b (h w) c')
+
+# Project to hidden_size
+img_tokens = linear(img_seq)  # [B, H*W, 3072]
+
+# Convert to Megatron format: [seq, batch, hidden]
+img_megatron = rearrange(img_tokens, 'b s d -> s b d')
+```
+
+### Adaptive Layer Normalization
+
+**Standard AdaLN**:
+```python
+class AdaLN:
+    def forward(self, timestep_emb):
+        modulation = MLP(SiLU(timestep_emb))
+        shift, scale, gate = split(modulation, 3)
+        return shift, scale, gate
+
+    @staticmethod
+    def modulate(x, shift, scale):
+        return LayerNorm(x) * (1 + scale) + shift
+```
+
+**Usage in Layer**:
+```python
+shift, scale, gate = adaln(timestep_emb)
+x_norm = AdaLN.modulate(x, shift, scale)
+x_attn = attention(x_norm)
+x = x + gate * x_attn  # Gated residual
+```
+
+### Attention Implementation
+
+**Using Megatron SelfAttention**:
+```python
+from megatron.core.transformer.attention import SelfAttention
+
+attn = SelfAttention(
+    config=config,
+    submodules=submodules,
+    layer_number=layer_idx,
+    attn_mask_type=AttnMaskType.no_mask,  # Flux uses no mask
+)
+
+# Megatron expects [seq, batch, hidden]
+output = attn(hidden_states)
+```
+
+**Joint Attention Trick**:
+```python
+# Concatenate image and text
+combined = torch.cat([img, txt], dim=0)  # [seq_img+seq_txt, batch, hidden]
+
+# Single attention call processes both
+joint_output = attention(combined)
+
+# Split back
+img_out = joint_output[:seq_img]
+txt_out = joint_output[seq_img:]
+```
+
+---
+
+## Megatron-Core Integration
+
+### TransformerConfig
+
+Flux uses Megatron's `TransformerConfig`:
+
+```python
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+config = TransformerConfig(
+    num_layers=19 + 38,  # joint + single
+    hidden_size=3072,
+    num_attention_heads=24,
+    ffn_hidden_size=3072 * 4,  # Standard 4x expansion
+    layernorm_epsilon=1e-6,
+    hidden_dropout=0.0,
+    attention_dropout=0.0,
+    add_qkv_bias=True,
+    # ... other Megatron params
+)
+```
+
+### Layer Specs
+
+Flux provides factory functions for layer specs:
+
+```python
+from primus.backends.megatron.core.models.diffusion.flux.layer_spec import (
+    get_flux_double_transformer_spec_for_backend,
+    get_flux_single_transformer_spec_for_backend,
+    get_flux_layer_spec,
+)
+
+# For MMDiT layers (pass backend from config)
+double_spec = get_flux_double_transformer_spec_for_backend(backend)
+
+# For single blocks
+single_spec = get_flux_single_transformer_spec_for_backend(backend)
+
+# Or use high-level API for full TransformerBlock
+layer_specs = get_flux_layer_spec(config, backend=backend)
+```
+
+### Distributed Training Support
+
+Flux inherits Megatron's parallelism:
+
+**Tensor Parallelism** (TP):
+```python
+config = TransformerConfig(
+    tensor_model_parallel_size=8,  # 8-way TP
+    sequence_parallel=True,        # Sequence parallelism
+)
+```
+
+**Pipeline Parallelism** (PP): not supported for diffusion models. The forward
+path runs embeddings/output head on every rank and does not relay activations
+between stages, so `pipeline_model_parallel_size` must be 1 (PP > 1 is rejected
+at config construction).
+
+**Data Parallelism**: Handled automatically by trainer
+
+---
+
+## Performance Optimizations
+
+### 1. Transformer Engine
+
+Flux uses NVIDIA Transformer Engine for FP8 training:
+
+```python
+from megatron.core.extensions.transformer_engine import (
+    TELayerNormColumnParallelLinear,
+    TERowParallelLinear,
+)
+
+# Automatically used in layer specs
+linear_qkv = TELayerNormColumnParallelLinear(...)
+linear_proj = TERowParallelLinear(...)
+```
+
+**Benefits**:
+- FP8 matmul (faster, less memory)
+- Fused operations (LayerNorm + Linear)
+- Automatic scaling for numerical stability
+
+### 2. Flash Attention
+
+Enabled via Megatron:
+
+```python
+config = TransformerConfig(
+    attention_type='flash_attention',  # Use Flash Attention 2
+)
+```
+
+**Speedup**: 2-3x faster attention, 4x less memory
+
+### 3. Gradient Checkpointing
+
+For large models:
+
+```python
+config = TransformerConfig(
+    recompute_granularity='selective',  # Checkpoint expensive ops
+    recompute_method='uniform',
+    recompute_num_layers=19,  # Checkpoint all joint layers
+)
+```
+
+**Memory Savings**: ~40% reduction, ~20% slower
+
+### 4. Fused Operations
+
+```python
+config = TransformerConfig(
+    bias_activation_fusion=True,      # Fuse bias + activation
+    masked_softmax_fusion=True,       # Fuse mask + softmax
+    gradient_accumulation_fusion=True, # Fuse grad accumulation
+)
+```
+
+### 5. Mixed Precision
+
+```python
+from primus.backends.megatron.training.diffusion.loss_computation import compute_flow_matching_loss
+
+# Using PyTorch autocast
+with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+    output = model(img, txt, y, timesteps, img_ids, txt_ids)
+    target = noise - clean_latents
+    loss = compute_flow_matching_loss(output, clean_latents, noise)
+
+# Backward pass (handled automatically)
+scaler = torch.cuda.amp.GradScaler()
+scaler.scale(loss).backward()
+scaler.step(optimizer)
+scaler.update()
+```
+
+---
+
+## Comparison with Other Models
+
+### Flux vs DiT
+
+| Aspect | DiT | Flux |
+|--------|-----|------|
+| Architecture | Image-only transformer | MMDiT (image + text joint) |
+| Conditioning | AdaLN (injected) | Joint attention |
+| Position Encoding | Learned 2D | 3D RoPE |
+| Diffusion Type | DDPM | Flow matching |
+
+### Flux vs Stable Diffusion
+
+| Aspect | Stable Diffusion (UNet) | Flux (Transformer) |
+|--------|-------------------------|---------------------|
+| Backbone | UNet with ResNet blocks | Full transformer |
+| Text Integration | Cross-attention | Joint self-attention |
+| Scalability | Limited (U-Net bottleneck) | Excellent (transformer scaling) |
+| Efficiency | Fast (fewer params) | Slower but higher quality |
+
+---
+
+## Design Decisions
+
+### Why Two-Stage (Joint + Single)?
+
+**Joint Blocks**:
+- Deep semantic understanding
+- Text-image alignment
+- Compositional reasoning
+
+**Single Blocks**:
+- Spatial refinement
+- Detail generation
+- Efficient (no text processing)
+
+**Alternative**: All joint blocks → slower, marginal quality gain
+
+### Why Flow Matching?
+
+**Advantages over DDPM**:
+1. **Simpler training**: Straight-line interpolation (no schedule design)
+2. **Faster sampling**: Fewer steps (10-20 vs 50-100)
+3. **Better mode coverage**: Straighter paths → less error accumulation
+
+**Math**: Rectified flow is ODE-based (vs SDE for DDPM)
+
+### Why 3D RoPE?
+
+**Advantages**:
+1. **Spatial awareness**: Encodes (height, width) structure
+2. **Resolution flexibility**: Works for any image size
+3. **Channel grouping**: Models relationships between channels
+
+**Alternative**: Learned absolute embeddings → less flexible
+
+---
+
+## Primus Implementation Highlights
+
+### TransformerBlock Architecture
+
+Primus's key architectural enhancement is the use of Megatron-Core's **TransformerBlock with heterogeneous layer specifications**:
+
+```mermaid
+graph TD
+    subgraph traditional[Traditional Approach]
+        A[Model] --> B[double_blocks: ModuleList]
+        A --> C[single_blocks: ModuleList]
+        B --> D[Manual iteration]
+        C --> D
+        D --> E[Manual PP splitting]
+    end
+
+    subgraph primus[Primus Approach]
+        F[Model] --> G[transformer: TransformerBlock]
+        G --> H[layer_specs: heterogeneous]
+        H --> J[Unified checkpoint format]
+    end
+```
+
+**Benefits**:
+1. **Unified Checkpointing**: Single `transformer.layers.{0-56}` namespace
+2. **Future-Proof**: Native support for new Megatron-Core features
+3. **Cleaner Code**: No manual iteration over separate block lists
+
+### Layer Specification Pattern
+
+```python
+# Primus approach
+layer_specs = get_flux_layer_spec(config, backend=backend)
+# Or manually:
+# layer_specs = [
+#     *[get_flux_double_transformer_spec_for_backend(backend) for _ in range(19)],
+#     *[get_flux_single_transformer_spec_for_backend(backend) for _ in range(38)],
+# ]
+
+transformer = TransformerBlock(
+    config=config,
+    spec=TransformerBlockSubmodules(layer_specs=layer_specs)
+)
+
+# Automatic PP slicing handled by TransformerBlock
+# No manual offset calculation needed
+```
+
+### Checkpoint Format Comparison
+
+**Traditional Format**:
+```
+double_blocks.0.attn.qkv.weight
+double_blocks.18.mlp.fc2.bias
+single_blocks.0.attn.qkv.weight
+single_blocks.37.mlp.fc2.bias
+```
+
+**Primus Format** (TransformerBlock):
+```
+transformer.layers.0.self_attention.linear_qkv.weight   # Joint layer 0
+transformer.layers.18.mlp.linear_fc2.bias               # Joint layer 18
+transformer.layers.19.self_attention.linear_qkv.weight  # Single layer 0
+transformer.layers.56.mlp.linear_fc2.bias               # Single layer 37
+```
+
+Benefits: Simpler distributed checkpointing, easier layer inspection, consistent with Megatron GPT models.
+
+---
+
+## Future Enhancements
+
+### Planned Features
+
+1. **ControlNet Support**:
+   - Spatial conditioning (pose, depth, edges)
+   - Residual connections from control encoder
+
+2. **Multi-Resolution Training**:
+   - Dynamic image sizes during training
+   - Aspect ratio bucketing
+
+3. **Efficient Sampling**:
+   - DPM-Solver integration
+   - Distillation for 1-step generation
+
+4. **LoRA Fine-Tuning**:
+   - Low-rank adaptation for custom styles
+   - Efficient personalization
+
+### Research Directions
+
+- **Sparse Attention**: Reduce quadratic complexity for high-res
+- **Mixture of Experts**: Conditional computation for efficiency
+- **3D Extension**: Video generation with Flux architecture
+
+---
+
+## References
+
+### Papers
+
+1. **Flow Matching**: Lipman et al., "Flow Matching for Generative Modeling", 2022
+2. **Rectified Flow**: Liu et al., "Flow Straight and Fast: Learning to Generate and Transfer Data with Rectified Flow", 2022
+3. **DiT**: Peebles & Xie, "Scalable Diffusion Models with Transformers", 2023
+4. **RoPE**: Su et al., "RoFormer: Enhanced Transformer with Rotary Position Embedding", 2021
+5. **Transformer Engine**: NVIDIA, "Transformer Engine: Accelerating Transformer Training", 2022
+
+### Code References
+
+- **Primus Flux**: `primus/backends/megatron/core/models/diffusion/flux/`
+- **Megatron-Core**: `megatron/core/transformer/`
+- **Transformer Engine**: `transformer_engine/pytorch/`
+- **Official Flux**: Black Forest Labs (HuggingFace)
+
+---
+
+## Appendix: Hyperparameters
+
+### Flux 535M Training
+
+```yaml
+model:
+  num_joint_layers: 1
+  num_single_layers: 1
+  hidden_size: 3072
+  num_attention_heads: 24
+
+training:
+  batch_size: 256  # global
+  learning_rate: 1e-4
+  weight_decay: 0.01
+  lr_schedule: cosine
+  warmup_steps: 10000
+  total_steps: 500000
+
+optimization:
+  optimizer: AdamW
+  beta1: 0.9
+  beta2: 0.999
+  epsilon: 1e-8
+  gradient_clip: 1.0
+```
+
+### Flux 12B Training
+
+```yaml
+model:
+  num_joint_layers: 19
+  num_single_layers: 38
+  hidden_size: 3072
+  num_attention_heads: 24
+
+training:
+  batch_size: 2048  # global, multi-node
+  learning_rate: 1e-4
+  weight_decay: 0.01
+  lr_schedule: cosine
+  warmup_steps: 10000
+  total_steps: 1000000
+
+optimization:
+  optimizer: AdamW
+  beta1: 0.9
+  beta2: 0.95
+  epsilon: 1e-8
+  gradient_clip: 1.0
+
+parallelism:
+  tensor_parallel: 8
+  pipeline_parallel: 4
+  data_parallel: 8
+  sequence_parallel: True
+```
+
+---
+
+*For API usage, see [api_reference.md](api_reference.md).*

--- a/docs/backends/megatron/diffusion/fp8_training.md
+++ b/docs/backends/megatron/diffusion/fp8_training.md
@@ -1,0 +1,514 @@
+# FP8 Training for Flux Models
+
+Complete guide for training Flux diffusion models with FP8 (8-bit floating point) precision on AMD MI300X GPUs using Transformer Engine's delayed scaling recipe.
+
+## Overview
+
+FP8 training provides significant memory and speed improvements while maintaining numerical stability through delayed scaling:
+
+- **~2x memory reduction** (activations and weights)
+- **1.5-2x training speedup** on AMD MI300X
+- **Maintains numerical stability** via delayed scaling
+- **Enables larger batch sizes** or higher resolutions
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [Performance Benchmarks](#performance-benchmarks)
+- [Troubleshooting](#troubleshooting)
+- [Best Practices](#best-practices)
+- [AMD MI300X Specific](#amd-mi300x-specific)
+
+---
+
+## Prerequisites
+
+### Hardware Requirements
+
+- **AMD MI300X GPUs** with ROCm 6.0+ support
+- **Minimum GPUs:**
+  - Flux 535M: 1x MI300X (testing)
+  - Flux 12B: 2x MI300X with TP=2 (can train with FP8)
+
+### Software Requirements
+
+1. **ROCm 6.0+** with FP8 tensor core support
+2. **Transformer Engine 2.1.0+** with ROCm backend
+3. **PyTorch** with ROCm support
+4. **Megatron-LM** (included in Primus)
+
+### Verification
+
+Verify your environment has:
+- Transformer Engine 2.1.0+ with ROCm backend
+- FP8 support (run `python3 -c "import transformer_engine.pytorch as te; print(te.fp8.is_fp8_available())"`)
+
+---
+
+## Quick Start
+
+### Test FP8 with Flux 535M (Recommended First Step)
+
+```bash
+# 1. Prepare test dataset (or use existing)
+# See primus/configs/data/megatron/diffusion/README.md
+
+# 2. Train Flux 535M with FP8
+EXP=examples/megatron/configs/MI300X/diffusion/flux_535m_pretrain_fp8.yaml \
+GPUS_PER_NODE=1 \
+bash examples/run_pretrain.sh
+```
+
+### Production Training with Flux 12B
+
+```bash
+# After validating with 535M, scale to 12B (TransformerEngine FP8)
+EXP=examples/megatron/configs/MI300X/diffusion/flux_12b_ddp_energon_schnell_resample_te_spec_fp8.yaml \
+GPUS_PER_NODE=8 \
+NNODES=4 \
+bash examples/run_slurm_pretrain.sh
+
+# Or local-spec FP8 (no TransformerEngine dependency)
+EXP=examples/megatron/configs/MI300X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_fp8.yaml \
+GPUS_PER_NODE=8 \
+NNODES=4 \
+bash examples/run_slurm_pretrain.sh
+```
+
+---
+
+## Configuration
+
+### FP8 Model Configuration
+
+FP8 is configured at the model level. Two pre-configured files are available:
+
+- `primus/configs/models/megatron/diffusion/flux_535m_fp8.yaml`
+- `primus/configs/models/megatron/diffusion/flux_12b_fp8.yaml`
+
+**Key FP8 Parameters:**
+
+```yaml
+# Enable FP8
+fp8: "e4m3"  # E4M3 format (recommended)
+             # Alternative: "hybrid" (E4M3 activations + E5M2 gradients)
+
+# FP8 Recipe
+fp8_recipe: "delayed"  # Delayed scaling (most stable)
+                       # Alternatives: "tensorwise", "blockwise", "mxfp8"
+
+# Scaling Configuration
+fp8_margin: 0  # Margin for scaling factor (0 = no margin)
+fp8_amax_history_len: 1024  # History window for delayed scaling
+                            # Larger = more stable, smaller = adapts faster
+fp8_amax_compute_algo: "most_recent"  # or "max"
+
+# Gradient Precision
+fp8_wgrad: true  # Enable FP8 for weight gradients (recommended)
+
+# Attention Precision
+fp8_dot_product_attention: false  # Keep attention in higher precision
+fp8_multi_head_attention: false   # Keep MHA in higher precision
+```
+
+### Training Configuration Adjustments
+
+**Batch Sizes with FP8:**
+
+```yaml
+# Flux 12B - can increase batch size with FP8 memory savings
+micro_batch_size: 2  # vs 1 for BF16
+global_batch_size: 256  # same as BF16
+
+# Flux 535M - can increase significantly
+micro_batch_size: 4  # vs 2 for BF16
+global_batch_size: 32
+```
+
+**Optimizer Settings (Same as BF16):**
+
+```yaml
+optimizer: adamw
+lr: 1.0e-4
+min_lr: 1.0e-5
+weight_decay: 0.01
+clip_grad: 1.0  # Gradient clipping still important!
+```
+
+**Parallelism with FP8:**
+
+```yaml
+# Flux 12B - can potentially reduce TP with FP8
+tensor_model_parallel_size: 2  # or reduce to 1 with FP8
+pipeline_model_parallel_size: 1
+context_parallel_size: 1
+```
+
+---
+
+## Performance Benchmarks
+
+### Memory Usage
+
+| Model | Precision | Memory/GPU | Batch Size | Notes |
+|-------|-----------|------------|------------|-------|
+| Flux 535M | BF16 | ~7-10GB | 2 | Baseline |
+| Flux 535M | FP8 | ~3-5GB | 4 | ~50% reduction |
+| Flux 12B | BF16 | ~40-50GB | 1 | TP=2 required |
+| Flux 12B | FP8 | ~20-25GB | 2 | TP=2, ~50% reduction |
+
+### Training Speed
+
+| Model | Precision | Steps/sec | Speedup | Hardware |
+|-------|-----------|-----------|---------|----------|
+| Flux 535M | BF16 | ~20-30 | 1.0x | 1x MI300X |
+| Flux 535M | FP8 | ~30-50 | 1.5-2x | 1x MI300X |
+| Flux 12B | BF16 | ~0.5-1.0 | 1.0x | 32x MI300X |
+| Flux 12B | FP8 | ~0.8-1.5 | 1.5-2x | 32x MI300X |
+
+### Expected Results
+
+- **Memory:** ~50% reduction vs BF16
+- **Speed:** 1.5-2x faster training
+- **Quality:** Loss curves within 5% of BF16
+- **Convergence:** Similar or faster than BF16
+
+---
+
+## Troubleshooting
+
+### NaN or Inf in Losses
+
+**Problem:** Training becomes unstable with NaN/Inf values
+
+**Solutions:**
+
+1. **Increase scaling history:**
+   ```yaml
+   fp8_amax_history_len: 2048  # or 4096
+   ```
+
+2. **Disable FP8 for weight gradients:**
+   ```yaml
+   fp8_wgrad: false
+   ```
+
+3. **Use more conservative scaling:**
+   ```yaml
+   fp8_amax_compute_algo: "max"  # instead of "most_recent"
+   ```
+
+4. **Add scaling margin:**
+   ```yaml
+   fp8_margin: 1  # or 2
+   ```
+
+5. **Keep first/last layers in BF16:**
+   ```yaml
+   first_last_layers_bf16: true
+   num_layers_at_start_in_bf16: 2
+   num_layers_at_end_in_bf16: 2
+   ```
+
+### Out of Memory Even with FP8
+
+**Problem:** Still hitting OOM errors with FP8 enabled
+
+**Solutions:**
+
+1. **Reduce micro batch size:**
+   ```yaml
+   micro_batch_size: 1  # back to minimum
+   ```
+
+2. **Enable gradient checkpointing:**
+   ```yaml
+   recompute_granularity: "selective"  # or "full"
+   recompute_method: "block"
+   ```
+
+3. **Increase tensor parallelism:**
+   ```yaml
+   tensor_model_parallel_size: 4  # distribute more
+   ```
+
+4. **Reduce sequence length:**
+   ```yaml
+   seq_length: 2048  # if applicable
+   ```
+
+### FP8 Not Available
+
+**Problem:** Setup script shows "FP8 not available"
+
+**Checks:**
+
+1. **Verify GPU model:**
+   ```bash
+   rocm-smi --showproductname
+   # Should show MI300X
+   ```
+
+2. **Check ROCm version:**
+   ```bash
+   rocm-smi --showversion
+   # Should be 6.0+
+   ```
+
+3. **Verify Transformer Engine:**
+   ```bash
+   python3 -c "import transformer_engine; print(transformer_engine.__version__)"
+   # Should be 2.1.0+
+   ```
+
+4. **Test FP8 directly:**
+   ```python
+   import transformer_engine.pytorch as te
+   print(te.fp8.is_fp8_available())  # Should be True
+   ```
+
+### Slower Than Expected
+
+**Problem:** FP8 training is not faster than BF16
+
+**Checks:**
+
+1. **Verify FP8 is actually enabled:**
+   - Check logs for FP8 context messages
+   - Run with `NCCL_DEBUG=INFO` to see precision info
+
+2. **Check batch size:**
+   - Ensure you increased micro_batch_size with FP8
+   - Small batches may not show speedup
+
+3. **Verify tensor cores:**
+   - FP8 requires tensor core support
+   - Check ROCm driver configuration
+
+4. **Profile training:**
+   ```yaml
+   log_timers_to_tensorboard: true
+   ```
+   - Compare FP8 vs BF16 step times
+
+---
+
+## Best Practices
+
+### Recommended Workflow
+
+1. **Start with 535M:**
+   - Validate FP8 works correctly
+   - Test for 100-1000 steps
+   - Verify no NaN/Inf
+
+2. **Validate on small 12B run:**
+   - Train for 1000-5000 steps
+   - Compare loss with BF16 baseline
+   - Check memory and speed improvements
+
+3. **Production training:**
+   - Monitor closely for first 10K steps
+   - Watch for numerical issues
+   - Compare checkpoints with BF16
+
+### Training Configuration
+
+**Conservative (stable):**
+```yaml
+fp8_recipe: "delayed"
+fp8_amax_history_len: 2048
+fp8_amax_compute_algo: "max"
+fp8_wgrad: false
+```
+
+**Balanced (recommended):**
+```yaml
+fp8_recipe: "delayed"
+fp8_amax_history_len: 1024
+fp8_amax_compute_algo: "most_recent"
+fp8_wgrad: true
+```
+
+**Aggressive (maximum performance):**
+```yaml
+fp8_recipe: "tensorwise"  # Requires TE 2.2.0+
+fp8_amax_history_len: 512
+fp8_amax_compute_algo: "most_recent"
+fp8_wgrad: true
+```
+
+### Monitoring
+
+**Key metrics to watch:**
+
+1. **Loss curves:**
+   - Should be smooth (no spikes)
+   - Should decrease normally
+   - Compare with BF16 baseline
+
+2. **Gradient norms:**
+   - Should be stable
+   - No sudden jumps to infinity
+
+3. **Memory usage:**
+   - Should be ~50% of BF16
+   - Check with `rocm-smi`
+
+4. **Training speed:**
+   - Should be 1.5-2x faster
+   - Measure steps/second
+
+### Checkpointing
+
+- **FP8 checkpoints are compatible with BF16**
+- Can switch between FP8/BF16 training
+- Optimizer state includes FP8 scaling factors
+- Checkpoints are same size as BF16
+
+---
+
+## Autotune (Local Spec FP8)
+
+> **Scope:** This section covers the **local-spec** FP8 path (`PrimusTurboFloat8LocalSpecProvider`, no TransformerEngine), e.g. `flux_12b_ddp_energon_schnell_resample_local_spec_fp8.yaml`. The TransformerEngine prerequisites and checks elsewhere in this guide (`te.fp8.is_fp8_available()`, "FP8 Not Available") do **not** apply here -- this path quantizes via Primus Turbo directly.
+
+### Enable autotune (and do not pin the FP8 GEMM backend)
+
+The local-spec FP8 kernels benefit from the Primus-Turbo autotuner, which picks the best backend per GEMM shape. Enable it with `PRIMUS_TURBO_AUTO_TUNE=1`.
+
+`PRIMUS_TURBO_AUTO_TUNE=1` is necessary but **not sufficient**: an explicit `PRIMUS_TURBO_GEMM_BACKEND` short-circuits autotune (the FP8 kernel dispatcher returns the user-specified backend before the autotune step), so it must be unset (or scoped so it does not cover FP8) for autotune to engage.
+
+**Note:** some base images bake `PRIMUS_TURBO_GEMM_BACKEND` as an *empty string* rather than leaving it unset. An empty value is not treated as "unset" and can raise `KeyError ''` on the first FP8 GEMM. If you hit this, `unset PRIMUS_TURBO_GEMM_BACKEND` before launching.
+
+```bash
+unset PRIMUS_TURBO_GEMM_BACKEND          # or scope it so it does not cover FP8
+export PRIMUS_TURBO_AUTO_TUNE=1
+
+EXP=examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_fp8.yaml \
+  bash examples/run_pretrain.sh
+```
+
+### Contrast with MXFP4
+
+For MXFP4/FP4 + AITER with a tuned CSV, do the **opposite**: leave `PRIMUS_TURBO_AUTO_TUNE` unset, because autotune disables the AITER preshuffle fast path. See the [MXFP4 Training Guide](mxfp4_training.md) ("Preshuffle fast path"). Do not copy the MXFP4 env recipe for FP8.
+
+---
+
+## AMD MI300X Specific
+
+### Environment Variables
+
+```bash
+# Optional: set for better performance
+export HSA_FORCE_FINE_GRAIN_PCIE=1  # Better PCIe performance
+export NCCL_DEBUG=INFO  # For debugging
+export HSA_ENABLE_SDMA=0  # Disable SDMA for stability
+```
+
+### ROCm Optimization
+
+1. **HipBLASLt tuning:**
+   ```bash
+   # Generate optimal GEMM kernels for your hardware
+   # See ROCm documentation for details
+   ```
+
+2. **NCCL configuration:**
+   ```bash
+   export NCCL_IB_DISABLE=0  # Enable InfiniBand if available
+   export NCCL_NET_GDR_LEVEL=3  # GPU Direct RDMA
+   ```
+
+3. **Memory management:**
+   ```bash
+   export HSA_OVERRIDE_GFX_VERSION=9.4.2  # For MI300X
+   ```
+
+### Known Issues
+
+1. **Transformer Engine ROCm support:**
+   - Verify TE version supports ROCm FP8
+   - Some recipes may require specific TE versions
+
+2. **Numerical stability:**
+   - MI300X may require longer history (fp8_amax_history_len)
+   - Start conservative and tune
+
+3. **Multi-node training:**
+   - Ensure RCCL/NCCL properly configured
+   - Test single-node first
+
+---
+
+## Testing
+
+### Integration Test
+
+```bash
+# Quick 100-step validation run
+EXP=examples/megatron/configs/MI300X/diffusion/flux_535m_pretrain_fp8.yaml \
+GPUS_PER_NODE=1 \
+bash examples/run_pretrain.sh
+```
+
+### Convergence Test
+
+1. Train both BF16 and FP8 for 5000 steps
+2. Compare loss curves (should be within 5%)
+3. Generate images from checkpoints
+4. Compare quality visually
+
+---
+
+## Numerical verification status
+
+To set expectations for external users, the precision/convergence claims in this
+codebase fall into two tiers:
+
+- **Backed by in-repo tests** (CI-runnable on supported hardware): structural and
+  convention checks — attention TE-vs-local-spec equivalence, RNG/seed
+  determinism, chimera init, VAE resample reproducibility, fused delayed-scale
+  update, and MLPerf warmup FP8 state.
+- **Asserted, not yet backed by an in-repo test:** end-to-end *tensor parity*
+  against HuggingFace/Diffusers FLUX from a real checkpoint, and the exact MLPerf
+  v5.1 eval sample-count / validation-timestep semantics. These are validated by
+  internal reference runs but no committed test reproduces them.
+
+Tracked follow-ups (file as public-repo issues):
+
+1. A real-checkpoint forward-parity test (535M minimum) comparing Primus Flux
+   against HF/Diffusers within a documented tolerance.
+2. A robustness test for the MLPerf validation-timestep fallback path.
+
+Treat any "bit-exact / matches NeMo / matches MLPerf / within X%" statement in
+source comments as *asserted, unverified* until the parity test above lands.
+
+## References
+
+- [Transformer Engine Documentation](https://docs.nvidia.com/deeplearning/transformer-engine/)
+- [AMD ROCm Documentation](https://rocm.docs.amd.com/)
+- [Megatron-LM FP8 Guide](https://github.com/NVIDIA/Megatron-LM/blob/main/docs/llm/fp8.md)
+- [FP8 Formats Explained (E4M3 vs E5M2)](https://arxiv.org/abs/2209.05433)
+
+---
+
+## Support
+
+For issues or questions:
+
+1. Check this guide first
+2. Verify Transformer Engine and FP8 support (see Prerequisites)
+3. Review logs for error messages
+4. File issue with:
+   - Hardware specs (GPU model, ROCm version)
+   - Software versions (TE, PyTorch, Megatron-LM)
+   - Config files used
+   - Error logs
+
+---
+
+**Happy FP8 Training! 🚀**
+
+*Last updated: 2026-01-10*

--- a/docs/backends/megatron/diffusion/mxfp4_training.md
+++ b/docs/backends/megatron/diffusion/mxfp4_training.md
@@ -1,0 +1,210 @@
+# MXFP4 Training for Flux Models
+
+Guide for training Flux diffusion models in **MXFP4** (E2M1 mantissa + E8M0 block-of-32 scales) on AMD MI355X GPUs using Primus's local-spec MXFP4 implementation backed by Primus-Turbo and AITER.
+
+## Overview
+
+MXFP4 stores activations and weights in 4-bit microscale floating-point with one E8M0 exponent shared per block of 32 elements. The Primus integration:
+
+- Uses a **local spec** (`PrimusTurboMXFP4LocalSpecProvider`) with **no Transformer Engine dependency** — MXFP4 linear layers are self-contained autograd `Function`s that call Primus-Turbo's `gemm_fp4_impl` directly, so the path is `torch.compile`-friendly with minimal graph breaks.
+- Keeps **attention, optimizer state / main params, and inter-rank communication in BF16**. Only the MMA inputs of the column- and row-parallel linears are quantized.
+- Supports two backward modes via `mxfp4_backward_precision`: pure **MXFP4** (default) or **FP8** hybrid (E5M2 backward with tensorwise scaling on HipBLASLt).
+- Dispatches the FP4 GEMM through Primus-Turbo's pluggable backend layer, which can route to either AITER (recommended for MI355X) or HipBLASLt.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [Primus-Turbo Backend Selection](#primus-turbo-backend-selection)
+- [Tuned GEMMs](#tuned-gemms)
+- [Troubleshooting](#troubleshooting)
+- [Verification Status](#verification-status)
+
+---
+
+## Prerequisites
+
+### Hardware
+
+- **AMD Instinct MI355X** (gfx950) with FP4 tensor-core support. The MXFP4 linear-layer modules assert `check_mxfp4_support()` at construction and will refuse to initialize on unsupported devices ([`primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py`](../../../../primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py)).
+- Single node (the local-spec layers require `tensor_model_parallel_size: 1`).
+
+### Software
+
+- ROCm-compatible install of `aiter` (provides `aiter.gemm_a4w4` and the tuned-config loader in `aiter/jit/core.py`).
+- Primus-Turbo with FP4 backend registered (`primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl`).
+- `enable_primus_turbo: true` and `use_turbo_attention: true` in the training config.
+
+---
+
+## Quick Start
+
+The verified MXFP4 config is `examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml`. Launch with the AITER backend and the pre-tuned GEMM CSV:
+
+```bash
+# Path to a checkout of the `tuned_gemm_configs` directory.
+# Set TUNED_GEMM_DIR to wherever you have the tuned configs available.
+export TUNED_GEMM_DIR=${TUNED_GEMM_DIR:-/path/to/tuned_gemm_configs}
+
+export EXP=examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml
+export PRIMUS_TURBO_GEMM_BACKEND=FP4:AITER
+export AITER_CONFIG_GEMM_A4W4=$TUNED_GEMM_DIR/mi355x/flux_12b.csv
+export AITER_LOG_TUNED_CONFIG=1   # recommended: confirms each shape hits the CSV
+
+bash examples/run_pretrain.sh
+```
+
+The pre-tuned CSV is distributed via an internal tuned-config source (`tuned_gemm_configs/mi355x/flux_12b.csv`). If you do not have access, omit `AITER_CONFIG_GEMM_A4W4` and AITER will fall back to its bundled `a4w4_blockscale_tuned_gemm.csv` (slower for Flux 12B shapes).
+
+---
+
+## Configuration
+
+The relevant overrides in [`examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml`](../../../../examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml):
+
+```yaml
+# MXFP4 precision
+fp4: "mxfp4"
+fp4_recipe: "mxfp4"              # default is "nvfp4" in trainer_base.yaml; must override
+mxfp4_backward_precision: "mxfp4"  # "mxfp4" (pure) or "fp8" (hybrid)
+
+# Local spec + Primus-Turbo
+transformer_impl: "local"
+enable_primus_turbo: true
+use_turbo_attention: true
+
+# Required by the MXFP4 linear-layer modules
+tensor_model_parallel_size: 1
+gradient_accumulation_fusion: false
+# sequence_parallel must remain false
+```
+
+### Knob semantics
+
+| Knob | Values | Notes |
+|------|--------|-------|
+| `fp4` | `"mxfp4"` | Top-level switch to enable FP4. |
+| `fp4_recipe` | `"mxfp4"` for this guide | Default in [`primus/configs/modules/megatron/trainer_base.yaml`](../../../../primus/configs/modules/megatron/trainer_base.yaml) is `nvfp4`; the MXFP4 config overrides it. |
+| `mxfp4_backward_precision` | `"mxfp4"` or `"fp8"` | Exhaustive set (checked by branch in [`primus_turbo_mxfp4_local.py`](../../../../primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py)). `"fp8"` uses E5M2 with tensorwise HipBLASLt for backward. |
+| `mxfp4_gradient_stochastic_rounding` | `true` / `false` | Optional. Enables SR on FP4 gradient quantization. |
+
+---
+
+## Primus-Turbo Backend Selection
+
+The FP4 GEMM call is routed by `GEMMFP4KernelDispatcher` in `Primus-Turbo/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py`. Backends are selected with the precision-scoped env var `PRIMUS_TURBO_GEMM_BACKEND` (declared in `Primus-Turbo/primus_turbo/common/constants.py`):
+
+```bash
+# Single backend for every precision:
+export PRIMUS_TURBO_GEMM_BACKEND=AITER
+
+# Precision-scoped (recommended): route FP4 GEMMs to AITER, leave others to defaults:
+export PRIMUS_TURBO_GEMM_BACKEND=FP4:AITER
+
+# Per-precision routing:
+export PRIMUS_TURBO_GEMM_BACKEND=FP4:AITER,FP8:HIPBLASLT
+```
+
+The dispatcher (`GlobalBackendManager` / `AutoKernelDispatcher.dispatch` in `Primus-Turbo/primus_turbo/pytorch/core/backend.py`) resolves the backend in this order: **explicit env > code-set > auto-tune > registered default > fallback**.
+
+### Preshuffle fast path
+
+When **all** of the following are true, MXFP4 GEMMs take the preshuffled fast path with no per-call shuffle overhead:
+
+- `PRIMUS_TURBO_GEMM_BACKEND=FP4:AITER` (or `AITER`) is set.
+- `PRIMUS_TURBO_AUTO_TUNE` is unset or `0`.
+
+The `_enable_preshuffle()` helper in `primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py` returns `True` under these conditions (FP4 backend pinned to AITER and auto-tune off), and the call becomes `aiter.gemm_a4w4(..., bpreshuffle=True)`. This helper reproduces the upstream `enable_preshuffle()` that Primus-Turbo removed in PR #383 ("refactor preshuffle ..."), which moved per-call preshuffle control onto `Float4QuantConfig.use_preshuffle`; Primus keeps the runtime probe locally because `MXFP4LinearFunction` passes a plain `bool` into its custom ops.
+
+> **Do not combine `PRIMUS_TURBO_AUTO_TUNE=1` with a tuned CSV.** Auto-tune disables the preshuffle fast path, so each call pays the shuffle cost while AITER still picks the same kernel internally. For production runs, leave `PRIMUS_TURBO_AUTO_TUNE` unset.
+
+---
+
+## Tuned GEMMs
+
+AITER reads its tuned-GEMM CSV from the `AITER_CONFIG_GEMM_A4W4` env var (handled in `aiter/jit/core.py`; the default is the bundled `aiter/configs/a4w4_blockscale_tuned_gemm.csv`). Each row maps `(cu_num, M, N, K)` to a profiled kernel and split-K factor.
+
+For Flux 12B on MI355X, the pre-tuned CSV is provided by an internal tuned-config source (`tuned_gemm_configs/mi355x/flux_12b.csv`). See that directory's `README.md` for the tuning runbook, CSV schema, ASM-vs-CK kernel distinction, and re-tuning triggers.
+
+### Verifying the CSV is being used
+
+Set `AITER_LOG_TUNED_CONFIG=1`. AITER will log one line per **hit**:
+
+```
+shape is M:16384, N:9216, K:3072, found padded_M: 16384, N:9216, K:3072 is tuned on cu_num = 256 in /path/to/tuned_gemm_configs/mi355x/flux_12b.csv, kernel name is _ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E, splitK is 0!
+```
+
+**Miss** lines are printed unconditionally (no env var required) and look like:
+
+```
+shape is M:..., N:..., K:..., not found tuned config in /path/to/flux_12b.csv, will use default config!
+```
+
+Any miss line means the CSV needs re-tuning for that shape — follow the runbook in `tuned_gemm_configs/README.md`.
+
+### First-run JIT compile
+
+The two `a4w4_blockscale_*_intrawave_v3` CK kernels are JIT-compiled on first use (~2-5 min). Subsequent runs reuse the cached `.so` files. The ASM `f4gemm_bf16_per1x32Fp4_BpreShuffle_*` kernels are pre-compiled blobs shipped with AITER and incur no JIT cost.
+
+---
+
+## Troubleshooting
+
+### `not found tuned config in {file}, will use default config!`
+
+The (M, N, K) shape is missing from your CSV. AITER will fall back to its compiled-in default, which is typically slow. Re-tune for that shape per the internal `tuned_gemm_configs/README.md` runbook (capture the shape via the same log line, append to the untuned CSV, re-run the AITER tuner, commit the new CSV).
+
+### Slow first iteration (~minutes), normal afterwards
+
+Expected — the first call to a CK-based `a4w4_blockscale_*` kernel triggers JIT compilation. Cached `.so` files are reused on subsequent starts.
+
+### `User specified backend AITER cannot handle the given inputs`
+
+Raised by `AutoKernelDispatcher.dispatch` when `GEMMFP4AITERBackend.can_handle` rejects the input. Common causes:
+
+- `M` not a multiple of 16, or `N` not a multiple of 16 (constants `AITER_FP4GEMM_M_MULTIPLE` / `AITER_FP4GEMM_N_MULTIPLE` in `gemm_fp4_impl.py`).
+- Unsupported dtype combination (only `(float4_e2m1fn_x2, float4_e2m1fn_x2, fp16/bf16)` is supported).
+- Non-NT layout (`trans_a=False, trans_b=True, trans_c=False`).
+
+Workaround: switch to `PRIMUS_TURBO_GEMM_BACKEND=FP4:HIPBLASLT` for unsupported shapes, or pad/reshape inputs.
+
+### `MXFP4ColumnParallelLinear requires tensor_model_parallel_size=1`
+
+The MXFP4 linear-layer modules assert on `tensor_model_parallel_size == 1`, `gradient_accumulation_fusion == False`, and `sequence_parallel == False` ([`primus_turbo_mxfp4_local.py`](../../../../primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py)). Adjust the config accordingly.
+
+### NaN losses
+
+Switch to the hybrid backward mode, which keeps the FP4 forward but does the gradient GEMM in FP8 (E5M2 tensorwise on HipBLASLt):
+
+```yaml
+mxfp4_backward_precision: "fp8"
+```
+
+If NaNs persist, also try `mxfp4_gradient_stochastic_rounding: true`.
+
+---
+
+## Verification Status
+
+The public config has been smoke-tested end-to-end: 1000 iters on 8x MI355X (single node, micro-batch 64 / global 512, sequence length 512) completes in ~16-20 minutes with `PRIMUS_TURBO_GEMM_BACKEND=FP4:AITER` and the tuned CSV. No errors across ranks; `pretrain() completed successfully`.
+
+Formal A/B benchmarks vs BF16 and FP8 (delayed and tensorwise) are pending and will be published once a representative suite is run; do not rely on the wall-clock numbers above as performance characterizations.
+
+---
+
+## Source Code Pointers
+
+- MXFP4 spec provider: [`primus/backends/megatron/core/extensions/primus_turbo_local_spec.py`](../../../../primus/backends/megatron/core/extensions/primus_turbo_local_spec.py) (`PrimusTurboMXFP4LocalSpecProvider`).
+- MXFP4 linear-layer autograd / fwd-bwd: [`primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py`](../../../../primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py).
+- Config schema defaults: [`primus/configs/modules/megatron/trainer_base.yaml`](../../../../primus/configs/modules/megatron/trainer_base.yaml).
+- Dataclass field `mxfp4_backward_precision`: [`primus/backends/megatron/core/models/diffusion/common/config.py`](../../../../primus/backends/megatron/core/models/diffusion/common/config.py).
+- FP4 backend selection (Primus-Turbo): `primus_turbo/common/constants.py`, `primus_turbo/pytorch/core/backend.py`, `primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py`.
+- AITER tuned-config loader: `aiter/jit/core.py` (`AITER_CONFIG_GEMM_A4W4`).
+- AITER A4W4 dispatch + hit/miss logging: `aiter/ops/gemm_op_a4w4.py`.
+
+## Related Documentation
+
+- [FP8 Training Guide](fp8_training.md) — companion guide for FP8.
+- [Diffusion Architecture / Developer Guide](README.md).
+- [Diffusion Examples README](../../../../examples/megatron/diffusion/README.md).

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -43,6 +43,22 @@ If you're running from the Primus repo root (after `git clone ... && cd Primus`)
 primus-cli direct -- benchmark gemm -M 4096 -N 4096 -K 4096
 ```
 
+### Data Preparation Commands
+
+```bash
+# Prepare a raw WebDataset (smaller, on-the-fly encoding during training)
+primus-cli direct -- data diffusion-raw \
+  --config primus/configs/data/megatron/diffusion/preprocessing/example_huggingface.yaml
+
+# Prepare a pre-encoded dataset from HuggingFace
+primus-cli direct -- data diffusion-encoded \
+  --config primus/configs/data/megatron/diffusion/preprocessing/example_huggingface.yaml
+
+# Ingest MLPerf Flux1 pre-encoded data (streaming download + conversion)
+primus-cli direct -- data diffusion-ingest \
+  --config primus/configs/data/megatron/diffusion/preprocessing/mlperf_flux1.yaml
+```
+
 ## 🎯 Three Execution Modes
 
 | Mode | Use Case | Command Example |

--- a/examples/README.md
+++ b/examples/README.md
@@ -208,6 +208,13 @@ The following models are supported out of the box via provided configuration fil
 | Mixtral-8x7B-v0.1 | [mistralai/Mixtral-8x7B-v0.1 ](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)           | [mixtral_8x7B_v0.1-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/mixtral_8x7B_v0.1-BF16-pretrain.yaml)           | |
 | Mixtral-8x22B-v0.1 | [mistralai/Mixtral-8x22B-v0.1 ](https://huggingface.co/mistralai/Mixtral-8x22B-v0.1)           | [mixtral_8x22B_v0.1-BF16-pretrain.yaml](https://github.com/AMD-AGI/Primus/blob/main/examples/megatron/configs/MI300X/mixtral_8x22B_v0.1-BF16-pretrain.yaml)           | |
 
+### Diffusion Models
+
+- **Flux** - Flow-based diffusion model for text-to-image generation
+  - Training guide: [examples/megatron/diffusion/README.md](megatron/diffusion/README.md) (Flux 535M and 12B)
+  - Architecture & developer docs: [docs/backends/megatron/diffusion/README.md](../docs/backends/megatron/diffusion/README.md)
+  - FP8 training: [docs/backends/megatron/diffusion/fp8_training.md](../docs/backends/megatron/diffusion/fp8_training.md)
+
 ---
 
 ### 🏃‍♂️ How to Run a Supported Model

--- a/examples/megatron/diffusion/README.md
+++ b/examples/megatron/diffusion/README.md
@@ -1,0 +1,317 @@
+# Flux Diffusion Model Training Examples
+
+Training examples for Flux diffusion models with Primus-Megatron on AMD GPUs.
+
+## Related Documentation
+
+- **Architecture & Developer Guide:** [docs/backends/megatron/diffusion/README.md](../../../docs/backends/megatron/diffusion/README.md)
+- **API Reference:** [docs/backends/megatron/diffusion/api_reference.md](../../../docs/backends/megatron/diffusion/api_reference.md)
+- **FP8 Training Guide:** [docs/backends/megatron/diffusion/fp8_training.md](../../../docs/backends/megatron/diffusion/fp8_training.md)
+- **MXFP4 Training Guide:** [docs/backends/megatron/diffusion/mxfp4_training.md](../../../docs/backends/megatron/diffusion/mxfp4_training.md)
+- **Dataset Preparation:** [primus/configs/data/megatron/diffusion/README.md](../../../primus/configs/data/megatron/diffusion/README.md)
+- **Tests:** [tests/unit_tests/backends/megatron/diffusion/](../../../tests/unit_tests/backends/megatron/diffusion/)
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- AMD Instinct GPU(s) (MI300X, MI325X, MI355X)
+- Docker or Podman with ROCm support
+- Primus Docker image: `docker.io/rocm/primus:v26.1`
+- Prepared dataset (see [Dataset Preparation](../../../primus/configs/data/megatron/diffusion/README.md))
+
+### 5-Minute Test Run
+
+1. **Prepare a small test dataset:**
+
+```bash
+mkdir -p /tmp/flux_test_data/raw && cd /tmp/flux_test_data/raw
+
+for i in {000..099}; do
+    convert -size 512x512 xc:blue sample_${i}.jpg
+    echo "A blue square" > sample_${i}.txt
+done
+
+tar -cf train-000000.tar sample_*.jpg sample_*.txt
+
+cat > dataset.yaml << 'EOF'
+__module__: megatron.energon
+__class__: CrudeWebdataset
+subflavors:
+  encoding: raw
+EOF
+
+energon prepare . --num-workers 4
+```
+
+2. **Launch training:**
+
+```bash
+EXP=examples/megatron/configs/MI300X/diffusion/flux_535m_pretrain.yaml \
+DATA_PATH=/tmp/flux_test_data \
+GPUS_PER_NODE=1 \
+bash examples/run_pretrain.sh
+```
+
+---
+
+## Model Variants
+
+| Feature | Flux 535M | Flux 12B |
+|---------|-----------|----------|
+| Parameters | 535M | 12B |
+| Joint Layers | 1 | 19 |
+| Single Layers | 1 | 38 |
+| Min GPUs | 1 | 8 (FSDP2 / DDP) |
+| Recommended GPUs | 1-8 | 8-64 |
+| Sharding | DP | FSDP2 (ZeRO-2/3) or DDP + distributed optimizer |
+| Best For | Testing | Production |
+
+---
+
+## Available Configurations
+
+The same configs are provided for both MI300X (`examples/megatron/configs/MI300X/diffusion/`)
+and MI355X (`examples/megatron/configs/MI355X/diffusion/`). The only differences
+are hardware-tuned batch sizes (MI300X has 192GB HBM3, MI355X has 256GB), so MI300X
+uses smaller default micro/global batch sizes on the 12B DDP configs.
+
+### Shared (MI300X and MI355X)
+
+| Config | Description |
+|--------|-------------|
+| `flux_535m_pretrain.yaml` | Flux 535M, BF16, single/multi-GPU |
+| `flux_535m_pretrain_fp8.yaml` | Flux 535M with FP8 precision |
+| `flux_535m_with_guidance_embed.yaml` | Flux 535M with guidance embedding |
+| `flux_12b_fsdp2_energon_schnell_resample_local_spec.yaml` | Flux 12B, FSDP2, BF16, local spec |
+| `flux_12b_fsdp2_energon_schnell_resample_local_spec_fp8.yaml` | Flux 12B, FSDP2, FP8, local spec |
+| `flux_12b_ddp_energon_schnell_resample_local_spec_fp8.yaml` | Flux 12B, DDP, FP8, local spec (delayed scaling) |
+| `flux_12b_ddp_energon_schnell_resample_te_spec.yaml` | Flux 12B, DDP, BF16, TransformerEngine spec |
+| `flux_12b_ddp_energon_schnell_resample_te_spec_fp8.yaml` | Flux 12B, DDP, FP8, TransformerEngine spec |
+
+### MI355X only
+
+| Config | Description |
+|--------|-------------|
+| `flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml` | Flux 12B, DDP, MXFP4, local spec |
+| `flux_12b_ddp_energon_schnell_resample_local_spec_fp8_mlperf.yaml` | MLPerf benchmark reproduction (local spec FP8) |
+| `flux_12b_ddp_energon_schnell_resample_te_spec_fp8_mlperf.yaml` | MLPerf benchmark reproduction (TE spec FP8) |
+
+> The `*_mlperf.yaml` configs reproduce the MLPerf Training Flux.1 benchmark
+> (MLPerf logging + convergence target). Use the non-MLPerf configs above for
+> general training.
+
+---
+
+## Training Modes
+
+### Single-Node Training
+
+```bash
+# Flux 535M (1-8 GPUs)
+EXP=examples/megatron/configs/MI300X/diffusion/flux_535m_pretrain.yaml \
+GPUS_PER_NODE=8 \
+bash examples/run_pretrain.sh
+
+# Flux 12B (FSDP2, BF16, 8 GPUs)
+EXP=examples/megatron/configs/MI300X/diffusion/flux_12b_fsdp2_energon_schnell_resample_local_spec.yaml \
+GPUS_PER_NODE=8 \
+bash examples/run_pretrain.sh
+```
+
+### Multi-Node Training (SLURM)
+
+```bash
+export DOCKER_IMAGE="docker.io/rocm/primus:v26.1"
+export NNODES=8
+export GPUS_PER_NODE=8
+
+EXP=examples/megatron/configs/MI300X/diffusion/flux_12b_fsdp2_energon_schnell_resample_local_spec.yaml \
+bash examples/run_slurm_pretrain.sh
+```
+
+### MLPerf Benchmark Reproduction (MI355X)
+
+The `*_mlperf.yaml` configs reproduce the MLPerf Training Flux.1 benchmark and are
+intended for benchmark reproduction rather than general training.
+
+```bash
+# Step 1: Ingest MLPerf data
+primus-cli direct -- data diffusion-ingest \
+  --config primus/configs/data/megatron/diffusion/preprocessing/mlperf_flux1.yaml
+
+# Step 2: Train (configs already set vae_latent_mode: resample, vae_scale: 0.3611, vae_shift: 0.1159)
+EXP=examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_fp8_mlperf.yaml \
+GPUS_PER_NODE=8 \
+bash examples/run_pretrain.sh
+```
+
+---
+
+## FP8 Training
+
+FP8 provides ~2x memory reduction and 1.5-2x training speedup on AMD MI300X/MI355X GPUs.
+
+```bash
+# Quick validation with 535M
+EXP=examples/megatron/configs/MI300X/diffusion/flux_535m_pretrain_fp8.yaml \
+GPUS_PER_NODE=1 \
+bash examples/run_pretrain.sh
+
+# Production with 12B (TransformerEngine FP8)
+EXP=examples/megatron/configs/MI300X/diffusion/flux_12b_ddp_energon_schnell_resample_te_spec_fp8.yaml \
+GPUS_PER_NODE=8 NNODES=4 \
+bash examples/run_slurm_pretrain.sh
+
+# Production with 12B (local-spec FP8, no TransformerEngine dependency)
+EXP=examples/megatron/configs/MI300X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_fp8.yaml \
+GPUS_PER_NODE=8 NNODES=4 \
+bash examples/run_slurm_pretrain.sh
+```
+
+| Model | Precision | Memory/GPU | Batch Size | Speed |
+|-------|-----------|------------|------------|-------|
+| Flux 535M | BF16 | ~7-10GB | 2 | 1.0x |
+| Flux 535M | FP8 | ~3-5GB | 4 | 1.5-2x |
+| Flux 12B | BF16 | ~40-50GB | 1 | 1.0x |
+| Flux 12B | FP8 | ~20-25GB | 2 | 1.5-2x |
+
+For configuration details, tuning recipes, benchmarks, and troubleshooting, see the [FP8 Training Guide](../../../docs/backends/megatron/diffusion/fp8_training.md).
+
+---
+
+## MXFP4 Training
+
+MXFP4 (E2M1 + E8M0 block-of-32 scales) Flux 12B training on MI355X is supported via the local-spec provider (`PrimusTurboMXFP4LocalSpecProvider`, no TransformerEngine dependency). Forward and weight GEMMs run in FP4 through Primus-Turbo + AITER; attention, the optimizer state, and inter-rank communication stay in BF16.
+
+```bash
+# Path to a checkout of the `tuned_gemm_configs` directory.
+# Set TUNED_GEMM_DIR to wherever you have the tuned configs available.
+export TUNED_GEMM_DIR=${TUNED_GEMM_DIR:-/path/to/tuned_gemm_configs}
+
+EXP=examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml \
+PRIMUS_TURBO_GEMM_BACKEND=FP4:AITER \
+AITER_CONFIG_GEMM_A4W4=$TUNED_GEMM_DIR/mi355x/flux_12b.csv \
+AITER_LOG_TUNED_CONFIG=1 \
+bash examples/run_pretrain.sh
+```
+
+For configuration knobs, backend-selector semantics, tuned-GEMM verification, and troubleshooting, see the [MXFP4 Training Guide](../../../docs/backends/megatron/diffusion/mxfp4_training.md).
+
+---
+
+## Converting HuggingFace Checkpoints
+
+Convert pre-trained HuggingFace Flux checkpoints to Primus/Megatron-Core format:
+
+```bash
+python tools/checkpoint_conversion/convert_flux_hf_to_primus.py \
+    --input black-forest-labs/FLUX.1-dev \
+    --output checkpoints/primus_flux_12b.safetensors \
+    --variant flux_12b
+```
+
+Supported variants: `flux_535m`, `flux_12b`, `custom` (with `--num-joint-layers` / `--num-single-layers`).
+
+For gated models (FLUX.1-dev), set `export HF_TOKEN="your_token"` or run `huggingface-cli login`.
+
+Primus also auto-detects tokens from `.hf_token` at the project root or `~/.cache/huggingface/token`.
+
+---
+
+## Configuration Reference
+
+### Key Training Parameters
+
+```yaml
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    model: diffusion/flux_535m.yaml
+    trainer_class: FluxPretrainTrainer
+
+    overrides:
+      train_iters: 100000
+      micro_batch_size: 2
+      global_batch_size: 16
+      lr: 1.0e-4
+      min_lr: 1.0e-5
+      weight_decay: 0.01
+      clip_grad: 1.0
+      lr_decay_style: cosine
+      lr_warmup_iters: 1000
+```
+
+### Parallelism
+
+The Flux 12B configs scale with FSDP2 (ZeRO-2/3) or DDP + distributed optimizer
+rather than tensor/pipeline parallelism.
+
+| Setting | Flux 535M | Flux 12B |
+|---------|-----------|----------|
+| `tensor_model_parallel_size` | 1 | 1 |
+| `pipeline_model_parallel_size` | 1 | 1 |
+| `context_parallel_size` | 1 | 1 |
+| Sharding | DP | FSDP2 (`use_torch_fsdp2: true`) or DDP (`use_distributed_optimizer: true`) |
+
+### Memory Optimization
+
+```yaml
+modules:
+  pre_trainer:
+    overrides:
+      recompute_granularity: selective  # or 'full'
+      recompute_method: block
+      sequence_parallel: false
+```
+
+---
+
+## Troubleshooting
+
+### Dataset Not Found
+
+Verify `data_path` in your config, ensure `energon prepare` was run, and check that `dataset.yaml` exists.
+
+### Out of Memory (OOM)
+
+Reduce `micro_batch_size`, increase `tensor_model_parallel_size`, enable `recompute_granularity: full`, or switch to pre-encoded data mode.
+
+### NaN Loss
+
+Reduce learning rate to `1.0e-5`, ensure `clip_grad: 1.0`, increase `lr_warmup_iters`, check dataset for corruption.
+
+### NaN Loss with MLPerf Data
+
+Ensure config includes the required normalization constants:
+
+```yaml
+vae_latent_mode: resample
+vae_scale: 0.3611
+vae_shift: 0.1159
+```
+
+### Encoder Download Fails
+
+Set `export HF_TOKEN=your_token` or use a local model path via `encoder_model_path` in config overrides.
+
+### Slow Training
+
+Use pre-encoded data (2-3x faster), increase `num_workers`, enable `use_flash_attn: true`.
+
+---
+
+## Source Code Pointers
+
+- **Model Architecture:** `primus/backends/megatron/core/models/diffusion/flux/`
+- **Trainer:** `primus/modules/trainer/megatron/diffusion/flux_pretrain_trainer.py`
+- **Data Pipeline:** `primus/backends/megatron/data/diffusion/`
+- **Model Configs:** `primus/configs/models/megatron/diffusion/`
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/AMD-AGI/Primus/issues)
+- [GitHub Discussions](https://github.com/AMD-AGI/Primus/discussions)

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -89,6 +89,7 @@ PRIMUS_PATH=$(realpath "$(dirname "$0")/..")
 export DATA_PATH=${DATA_PATH:-"${PRIMUS_PATH}/data"}
 export HF_HOME=${HF_HOME:-"${DATA_PATH}/huggingface"}
 
+# shellcheck source=/dev/null
 source "${PRIMUS_PATH}/runner/helpers/envs/path_utils.sh"
 
 LOG_INFO_RANK0 "Pip installing required packages ..."
@@ -117,7 +118,14 @@ if [ ! -f "${EXP}" ]; then
     exit 1
 fi
 
-TRAIN_LOG=${TRAIN_LOG:-"output/log_mp_pretrain_$(basename "$EXP" .yaml).txt"}
+if [ -z "${TRAIN_LOG:-}" ]; then
+    RUN_FOLDER=$(python3 -c "
+import yaml, sys
+d = yaml.safe_load(open(sys.argv[1]))
+print(f\"{d.get('workspace','./output')}/{d.get('work_group','default')}/{d.get('user_name','unknown')}/{d.get('exp_name','experiment')}\")
+" "$EXP" 2>/dev/null || echo "output")
+    TRAIN_LOG="${RUN_FOLDER}/train.log"
+fi
 
 LOG_INFO_RANK0 "==========Training info=========="
 LOG_INFO_RANK0 "EXP: $EXP"

--- a/runner/helpers/hooks/05_check_primus_requirements.sh
+++ b/runner/helpers/hooks/05_check_primus_requirements.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+# Check that Primus requirements.txt packages are installed.
+# Warns on missing packages by default. Set PRIMUS_STRICT_REQUIREMENTS=1 to
+# make it a fatal error.
+###############################################################################
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMUS_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+REQ_FILE="${PRIMUS_ROOT}/requirements.txt"
+
+if [[ ! -f "$REQ_FILE" ]]; then
+    exit 0
+fi
+
+MISSING=$(python3 - "$REQ_FILE" << 'PYEOF'
+import importlib.metadata, re, sys, pathlib
+
+req_file = pathlib.Path(sys.argv[1])
+missing = []
+
+for line in req_file.read_text().splitlines():
+    line = line.strip()
+    if not line or line.startswith("#") or line.startswith("-"):
+        continue
+    pkg = re.split(r"[><=!;\[\s]", line)[0].strip()
+    if not pkg:
+        continue
+    normalized = re.sub(r"[-_.]+", "-", pkg).lower()
+    try:
+        importlib.metadata.distribution(normalized)
+    except importlib.metadata.PackageNotFoundError:
+        missing.append(pkg)
+
+for m in missing:
+    print(m)
+PYEOF
+)
+
+if [[ -n "$MISSING" ]]; then
+    echo ""
+    echo "[WARN] Primus requirements not satisfied. Missing packages:"
+    while IFS= read -r pkg; do
+        echo "         - $pkg"
+    done <<< "$MISSING"
+    echo ""
+    echo "       To install:  pip install -r ${REQ_FILE}"
+    echo ""
+
+    if [[ "${PRIMUS_STRICT_REQUIREMENTS:-0}" == "1" ]]; then
+        echo "[ERROR] PRIMUS_STRICT_REQUIREMENTS=1 — aborting. Install missing packages first."
+        exit 1
+    fi
+
+    if [[ "${PRIMUS_AUTO_INSTALL:-0}" == "1" ]]; then
+        echo "[INFO] PRIMUS_AUTO_INSTALL=1 — installing missing packages..."
+        if pip install -r "${REQ_FILE}" --quiet; then
+            echo "[INFO] Successfully installed missing packages."
+        else
+            echo "[ERROR] Failed to install packages. Please install manually."
+            exit 1
+        fi
+    fi
+fi

--- a/runner/helpers/hooks/train/pretrain/megatron/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/megatron/prepare.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -103,11 +103,41 @@ def prepare_dataset(
 
 def prepare_dataset_if_needed(primus_config: PrimusConfig, data_path: Path, env=None):
     pre_trainer_cfg = primus_config.get_module_config("pre_trainer")
+
+    # Skip dataset preparation if train_data_path is explicitly set
     if pre_trainer_cfg.train_data_path is not None:
         return
 
-    tokenizer_type = pre_trainer_cfg.tokenizer_type
-    tokenizer_model = pre_trainer_cfg.tokenizer_model
+    # Check if this is a diffusion model (uses Energon datasets, not tokenized datasets)
+    model_type = getattr(pre_trainer_cfg, "model_type", None)
+    trainer_class = getattr(pre_trainer_cfg, "trainer_class", None)
+    data_path_config = getattr(pre_trainer_cfg, "data_path", None)
+
+    # Determine if this is a diffusion model
+    is_diffusion = False
+    if model_type == "diffusion_model":
+        is_diffusion = True
+    elif trainer_class and ("Flux" in str(trainer_class) or "Diffusion" in str(trainer_class)):
+        is_diffusion = True
+    elif hasattr(model_type, "name") and "DIFFUSION" in model_type.name:
+        is_diffusion = True
+
+    # For diffusion models with data_path set, skip tokenization (they use Energon)
+    if is_diffusion and data_path_config:
+        log_info("=" * 80)
+        log_info("Diffusion model detected with data_path configured.")
+        log_info("Skipping tokenization (diffusion models use Energon datasets).")
+        log_info(f"Data will be loaded from: {data_path_config}")
+        log_info("=" * 80)
+        return
+
+    # For language models, proceed with tokenization
+    tokenizer_type = getattr(pre_trainer_cfg, "tokenizer_type", None)
+    if not tokenizer_type:
+        log_info("No tokenizer_type found, skipping dataset preparation.")
+        return
+
+    tokenizer_model = getattr(pre_trainer_cfg, "tokenizer_model", None)
     default_tokenized_path = Path(data_path) / f"bookcorpus/{tokenizer_type}/bookcorpus_text_sentence"
     tokenized_data_path = Path(os.environ.get("TOKENIZED_DATA_PATH", str(default_tokenized_path)))
 
@@ -119,6 +149,12 @@ def prepare_dataset_if_needed(primus_config: PrimusConfig, data_path: Path, env=
             hf_token = os.environ.get("HF_TOKEN")
             if not hf_token:
                 log_error_and_exit("Environment variable HF_TOKEN must be set.")
+
+            if not tokenizer_model:
+                log_error_and_exit(
+                    "tokenizer_model not found in configuration. "
+                    "This is required for language model tokenization."
+                )
 
             log_info(f"TOKENIZED_DATA_PATH is {tokenized_data_path}")
 
@@ -179,9 +215,7 @@ def build_megatron_helper(megatron_path: Path):
     dataset_cpp_dir = megatron_path / "megatron/core/datasets"
     log_info(f"Building Megatron dataset helper in {dataset_cpp_dir}")
 
-    # `-s` silences make's "Nothing to be done"/recipe echo on no-op rebuilds;
-    # real compiler errors still surface and are handled below.
-    ret = subprocess.run(["make", "-s"], cwd=dataset_cpp_dir)
+    ret = subprocess.run(["make"], cwd=dataset_cpp_dir)
     if ret.returncode != 0:
         log_error_and_exit("Building Megatron C++ helper failed.")
 


### PR DESCRIPTION
**Important:** The content of this PR was approved and merged https://github.com/AMD-AGI/Primus/pull/823, but not to main (auto-target to main was not triggered and the lesson was taken into account for further PRs).
The purpose of this PR is to finalize the merge to main and not to introduce any new changes.

Part of an 18-PR series splitting the Flux diffusion-training feature (training Flux, a DiT text-to-image diffusion model, on Primus/Megatron) out of one large branch for reviewability. Content-independent — can review/merge in any order. Cut from `feat/flux/ci-env` (so its head carries the draft guard) and targets that branch; it auto-retargets to `main` when the CI-pins PR merges.

## What this changes
The diffusion documentation set: the `docs/backends/megatron/diffusion/*` pages, the CLI / top-level / examples READMEs, the example `run_pretrain.sh`, and the requirement-check runner hook. Content reflects the current curated layout (rewritten fp8/mxfp4/structure/data docs).

## Dependencies
No content parents (docs-only); cut from `feat/flux/ci-env` only to carry the draft guard, with no functional dependency on the turbo bump.

## Test plan
Lint/pre-commit plus a link / relocated-path check; no runtime tests.

## Files
17 (diffusion docs, READMEs, example launcher, requirement-check hook).