### PR TITLE
opt: remove grouped mlp d2h sync

### DIFF
--- a/primus/backends/megatron/core/transformer/experts.py
+++ b/primus/backends/megatron/core/transformer/experts.py
@@ -77,6 +77,18 @@ class PrimusGroupedMLP(TEGroupedMLP):
             # use the original bias_act_func from TEGroupedMLP, ignore the tokens_per_experts
             return self.bias_act_func(intermediate_parallel, bias_parallel, permuted_probs)
 
+    @staticmethod
+    def _apply_bias(intermediate_parallel, bias_parallel, tokens_per_expert, permuted_probs):
+        if bias_parallel is None:
+            return intermediate_parallel
+
+        # NOTE: tokens_per_expert is on GPU, so we need to convert it to a list of ints.
+        tokens_per_expert_cpu = tokens_per_expert.tolist()
+
+        return super()._apply_bias(
+            intermediate_parallel, bias_parallel, tokens_per_expert_cpu, permuted_probs
+        )
+
     def forward(
         self,
         permuted_local_hidden_states: torch.Tensor,
@@ -151,8 +163,7 @@ class PrimusGroupedMLP(TEGroupedMLP):
         # to make sure the fc1_output is reloaded to GPU before recomputing moe_act.
         if self.offload_moe_act:
             output = off_interface.group_commit(output, name="moe_act", forced_released_tensors=[fc1_output])
-        # NOTE: tokens_per_expert is on GPU, so we need to convert it to a list of ints.
-        output = self._apply_bias(output, output_bias, tokens_per_expert.tolist(), permuted_probs)
+        output = self._apply_bias(output, output_bias, tokens_per_expert, permuted_probs)
 
         # upad and concat the output
         if not self.moe_router_padding_for_quantization and (self.config.fp8 or self.config.fp4):


### PR DESCRIPTION
# Description

This PR removes an unnecessary GPU-to-CPU (d2h) synchronization in `PrimusGroupedMLP.forward()` when applying the final expert output bias.

Previously, `tokens_per_expert.tolist()` was called unconditionally at the end of `forward()` before `_apply_bias`, forcing a device sync on every MoE forward pass even when `output_bias` is `None` (the common case when bias is already fused into TE GroupedLinear output).

The fix overrides `_apply_bias` to defer the `.tolist()` conversion until bias application is actually needed, and to skip it entirely when `bias_parallel` is `None`.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add a `PrimusGroupedMLP._apply_bias` static override that returns early when `bias_parallel` is `None`, avoiding the d2h sync in the no-bias path.
- Move `tokens_per_expert.tolist()` from `forward()` into `_apply_bias`, so the CPU conversion only runs when bias must be applied.
- Update the `forward()` call site to pass the GPU `tokens_per_expert` tensor directly to `_apply_bias` instead of a pre-materialized Python list.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
