### PR TITLE
fix: remove duplicated flag use_turbo_fp4_autocast

### DIFF
--- a/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/llama3.1_8B-MXFP4-pretrain.yaml
@@ -110,7 +110,6 @@ modules:
       # --- Primus Turbo Config ---
       enable_primus_turbo: true
       use_turbo_attention: true
-      use_turbo_fp4_autocast: false                 # TE mxfp4 recipe should set it to false
       use_turbo_gemm: false              # can't use together with delayed recipe
       use_turbo_grouped_gemm: false
       moe_use_fused_router_with_aux_score: false

--- a/primus/backends/megatron/core/fp4_utils.py
+++ b/primus/backends/megatron/core/fp4_utils.py
@@ -45,8 +45,7 @@ def _primus_turbo_enabled() -> bool:
 
         args = get_args()
         enable_primus_turbo = bool(getattr(args, "enable_primus_turbo", False))
-        use_turbo_fp4_autocast = bool(getattr(args, "use_turbo_fp4_autocast", False))
-        return enable_primus_turbo and use_turbo_fp4_autocast
+        return enable_primus_turbo
     except Exception:
         return False
 

--- a/primus/configs/modules/megatron/primus_turbo.yaml
+++ b/primus/configs/modules/megatron/primus_turbo.yaml
@@ -1,8 +1,6 @@
 # ===== Global =====
 # main control flag
 enable_primus_turbo: false
-# use primus_turbo_fp4_autocast instead of TE fp8_autocast for FP4 (requires enable_primus_turbo)
-use_turbo_fp4_autocast: false
 
 # ===== Attention =====
 # operator switch


### PR DESCRIPTION
# Description

This PR removes the redundant `use_turbo_fp4_autocast` flag and simplifies FP4 autocast routing in Megatron.

Previously, enabling Primus-Turbo FP4 autocast required both `enable_primus_turbo` and `use_turbo_fp4_autocast` to be set. Actually the Primus-Turbo autocast is compatible with TE autocast. That duplicated control was confusing and easy to misconfigure (e.g. Turbo GEMM/attention enabled while FP4 still fell back to Transformer Engine).

With this change, MXFP4 training uses the Primus-Turbo FP4 autocast path whenever `enable_primus_turbo` is enabled, which aligns FP4 behavior with other Primus-Turbo features.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Remove `use_turbo_fp4_autocast` from `primus/configs/modules/megatron/primus_turbo.yaml`.
- Update `_primus_turbo_enabled()` in `fp4_utils.py` to gate the Turbo FP4 path on `enable_primus_turbo` only, instead of requiring both `enable_primus_turbo` and `use_turbo_fp4_autocast`.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
