### PR TITLE
fix(diffusion): repoint module_utils import to primus.core

### DIFF
--- a/primus/backends/diffusion/diffusion_adapter.py
+++ b/primus/backends/diffusion/diffusion_adapter.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from primus.backends.diffusion.argument_builder import WanArgBuilder
 from primus.core.backend.backend_adapter import BackendAdapter
-from primus.modules.module_utils import log_rank_0
+from primus.core.utils.module_utils import log_rank_0
 
 
 class DiffusionAdapter(BackendAdapter):

--- a/primus/backends/diffusion/diffusion_pretrain_trainer.py
+++ b/primus/backends/diffusion/diffusion_pretrain_trainer.py
@@ -10,8 +10,8 @@ import importlib.util
 from typing import Any
 
 from primus.core.trainer.base_trainer import BaseTrainer
+from primus.core.utils.module_utils import log_rank_0
 from primus.core.utils.yaml_utils import nested_namespace_to_dict
-from primus.modules.module_utils import log_rank_0
 
 
 class DiffusionPretrainTrainer(BaseTrainer):

--- a/primus/backends/megatron/core/utils.py
+++ b/primus/backends/megatron/core/utils.py
@@ -9,7 +9,7 @@ from typing import Any, List
 import torch
 from megatron.core import parallel_state
 
-from primus.modules.module_utils import log_rank_0
+from primus.core.utils.module_utils import log_rank_0
 
 
 @lru_cache


### PR DESCRIPTION
## Summary
Fix `ModuleNotFoundError: No module named 'primus.modules'` that currently breaks test collection / `import primus` on `main`.

An earlier refactor removed `primus/modules` and migrated the logging helpers to `primus.core.utils.module_utils`. Independently-merged diffusion and flux changes still imported `log_rank_0` from the old `primus.modules.module_utils` path, which now no longer exists — so importing the diffusion backend (e.g. `tests/unit_tests/backends/diffusion/test_wan_argument_builder.py`) fails at collection.

## Changes
Repoint the three remaining offenders to the migrated location (`primus.modules.module_utils` → `primus.core.utils.module_utils`):
- `primus/backends/diffusion/diffusion_adapter.py`
- `primus/backends/diffusion/diffusion_pretrain_trainer.py`
- `primus/backends/megatron/core/utils.py`

The repo is now free of `primus.modules` references (grep-clean).

## Verification
- `pre-commit run --all-files`: all hooks pass.
- Import smoke: `import primus.backends.diffusion.argument_builder`, `primus.cli.main`, `train_runtime`, megatron/torchtitan adapters all OK.
- `pytest tests/unit_tests/backends/diffusion/`: 8 passed (including the previously-failing `test_wan_argument_builder.py`).
- Core unit subset (adapter/runtime/backend/config/base_trainer): 48 passed, no new failures.