### PR TITLE
feat: remove extra htod when enable turbo grouped gemm

### DIFF
--- a/primus/backends/megatron/patches/moe_patches/moe_alltoall_dtoh_patches.py
+++ b/primus/backends/megatron/patches/moe_patches/moe_alltoall_dtoh_patches.py
@@ -1,0 +1,85 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Primus MoE All-to-All dispatcher D2H patch.
+
+Patches ``MoEAlltoAllTokenDispatcher._maybe_dtoh_and_synchronize`` so that when
+``use_turbo_grouped_gemm`` is enabled, ``tokens_per_expert`` is kept on-device
+(PrimusTurbo grouped gemm consumes it on the GPU) instead of being copied to the
+host. All other splits are still moved to CPU and the stream sync is unchanged.
+"""
+
+import torch
+
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.core.utils.module_utils import log_rank_0
+
+
+@register_patch(
+    "megatron.moe_alltoall_dtoh_turbo_grouped_gemm",
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Skip tokens_per_expert D2H copy in MoEAlltoAllTokenDispatcher "
+        "when PrimusTurbo grouped gemm is enabled"
+    ),
+    condition=lambda ctx: getattr(get_args(ctx), "use_turbo_grouped_gemm", False),
+)
+def patch_moe_alltoall_dtoh(ctx: PatchContext):
+    """Replace ``MoEAlltoAllTokenDispatcher._maybe_dtoh_and_synchronize``."""
+    from megatron.core.transformer.moe import token_dispatcher
+
+    cls = token_dispatcher.MoEAlltoAllTokenDispatcher
+
+    def _maybe_dtoh_and_synchronize(self, point, tokens_per_expert=None):
+        """
+        Move all possible GPU tensors to CPU and make a synchronization at the expected point.
+        """
+        maybe_move_tensor_to_cpu = token_dispatcher.maybe_move_tensor_to_cpu
+
+        if not self.drop_and_pad:
+            if point == self.cuda_dtoh_point:
+                # Move all possible GPU tensors to CPU at self.cuda_dtoh_point.
+                on_side_stream = torch.cuda.current_stream() != self.cuda_dtoh_stream
+                if on_side_stream:
+                    self.cuda_dtoh_stream.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(self.cuda_dtoh_stream):
+                    # NOTE: PrimusTurbo grouped gemm consumes tokens_per_expert on device,
+                    # so keep it on the GPU and skip the D2H copy when enabled.
+                    # tokens_per_expert = maybe_move_tensor_to_cpu(
+                    #     tokens_per_expert, record_stream=on_side_stream
+                    # )
+                    self.input_splits = maybe_move_tensor_to_cpu(
+                        self.input_splits, as_numpy=True, record_stream=on_side_stream
+                    )
+                    self.output_splits = maybe_move_tensor_to_cpu(
+                        self.output_splits, as_numpy=True, record_stream=on_side_stream
+                    )
+                    self.output_splits_tp = maybe_move_tensor_to_cpu(
+                        self.output_splits_tp, as_numpy=True, record_stream=on_side_stream
+                    )
+                    self.num_out_tokens = maybe_move_tensor_to_cpu(
+                        self.num_out_tokens, record_stream=on_side_stream
+                    )
+                    if self.num_local_experts > 1 and not self.config.moe_permute_fusion:
+                        self.num_global_tokens_per_local_expert = maybe_move_tensor_to_cpu(
+                            self.num_global_tokens_per_local_expert, record_stream=on_side_stream
+                        )
+                self.d2h_event = self.cuda_dtoh_stream.record_event()
+
+            if point == self.cuda_sync_point:
+                # Synchronize with the DtoH stream at self.cuda_sync_point.
+                self.d2h_event.synchronize()
+
+        return tokens_per_expert
+
+    cls._maybe_dtoh_and_synchronize = _maybe_dtoh_and_synchronize
+
+    log_rank_0(
+        "[Patch:megatron.moe_alltoall_dtoh_turbo_grouped_gemm]   Patched "
+        "MoEAlltoAllTokenDispatcher._maybe_dtoh_and_synchronize "
+    )


### PR DESCRIPTION
# Description

When `use_turbo_grouped_gemm` is enabled, the MoE All-to-All token dispatcher still copies `tokens_per_expert` from device to host (D2H) inside `_maybe_dtoh_and_synchronize`.
However, PrimusTurbo grouped gemm consumes `tokens_per_expert` directly on the GPU, so this D2H copy is redundant.
This extra copy introduces an unnecessary device-to-host transfer and stream synchronization overhead on the critical path.

This PR adds a `before_train` patch that replaces `MoEAlltoAllTokenDispatcher._maybe_dtoh_and_synchronize` so that `tokens_per_expert` is kept on-device when PrimusTurbo grouped gemm is enabled.
All other splits (`input_splits`, `output_splits`, `output_splits_tp`, `num_out_tokens`, `num_global_tokens_per_local_expert`) are still moved to CPU, and the DtoH stream synchronization behavior is unchanged.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `primus/backends/megatron/patches/moe_patches/moe_alltoall_dtoh_patches.py`, registering the `megatron.moe_alltoall_dtoh_turbo_grouped_gemm` patch.
- The patch is applied at the `before_train` phase and is only active when `use_turbo_grouped_gemm` is set (guarded by a `condition`).
- Override `MoEAlltoAllTokenDispatcher._maybe_dtoh_and_synchronize` to skip the `tokens_per_expert` D2H copy while keeping all other splits' CPU migration and the DtoH stream sync unchanged.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
