### PR TITLE
fix(mlperf): dataset prep no longer deletes sibling files in data_dir

### DIFF
--- a/primus/backends/megatron_bridge/recipes/mlperf_llama2_70b/convert_dataset.py
+++ b/primus/backends/megatron_bridge/recipes/mlperf_llama2_70b/convert_dataset.py
@@ -1,3 +1,5 @@
+# Modifications Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
 # Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +25,7 @@ if str(_RECIPE_DIR) not in sys.path:
 
 import numpy as np
 import pandas as pd
-from dataset_hash import hash_directory
+from dataset_hash import hash_files
 
 
 def convert(data_dir, split):
@@ -54,5 +56,7 @@ if __name__ == "__main__":
         executable="/bin/bash",
         check=True,
     )
-    directory_hash = hash_directory(args.data_dir)
+    # Verify only the produced files, so other content in data_dir does not
+    # affect the hash.
+    directory_hash = hash_files([f"{args.data_dir}/train.npy", f"{args.data_dir}/validation.npy"])
     print(f"Succesfully converted dataset with hash {directory_hash}")

--- a/primus/backends/megatron_bridge/recipes/mlperf_llama2_70b/dataset_hash.py
+++ b/primus/backends/megatron_bridge/recipes/mlperf_llama2_70b/dataset_hash.py
@@ -1,3 +1,5 @@
+# Modifications Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +15,6 @@
 # limitations under the License.
 
 import hashlib
-import os
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -29,15 +30,15 @@ def hash_file_md5(file_path, chunk_size=4194304):  # Default chunk size 4MB.
     return md5_hash.hexdigest()
 
 
-def hash_directory(path):
-    """Hashes all files in a directory in parallel using MD5."""
+def hash_files(file_paths):
+    """Hashes an explicit list of files in parallel using MD5.
+
+    Only the given files are considered, so unrelated content in the same
+    directory (e.g. checkpoints) does not affect the result.
+    """
     hashes = []
     with ThreadPoolExecutor() as executor:
-        futures = [
-            executor.submit(hash_file_md5, os.path.join(root, file))
-            for root, dirs, files in os.walk(path)
-            for file in files
-        ]
+        futures = [executor.submit(hash_file_md5, p) for p in file_paths]
         for future in futures:
             file_hash = future.result()
             if file_hash:

--- a/primus/backends/megatron_bridge/recipes/mlperf_llama2_70b/download_dataset.py
+++ b/primus/backends/megatron_bridge/recipes/mlperf_llama2_70b/download_dataset.py
@@ -1,3 +1,5 @@
+# Modifications Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
 # Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import glob
 import subprocess
 import sys
 from pathlib import Path
@@ -21,7 +24,7 @@ _RECIPE_DIR = Path(__file__).resolve().parent
 if str(_RECIPE_DIR) not in sys.path:
     sys.path.insert(0, str(_RECIPE_DIR))
 
-from dataset_hash import hash_directory
+from dataset_hash import hash_files
 from huggingface_hub import snapshot_download
 
 parser = argparse.ArgumentParser()
@@ -37,14 +40,20 @@ snapshot_download(
     max_workers=16,
     repo_type="dataset",
 )
+
+# Move the dataset parquets up and remove only HF's own artifacts. Do NOT
+# blanket-delete data_dir: it may hold a sibling checkpoint (the old
+# `find <data_dir> ! -name '*.parquet' -exec rm -rf` wiped it).
 subprocess.run(
-    f"mv {args.data_dir}/data/* {args.data_dir}/ && find {args.data_dir} -mindepth 1 ! -name '*.parquet' -exec rm -rf {{}} +",
+    f"mv {args.data_dir}/data/*.parquet {args.data_dir}/ && rm -rf {args.data_dir}/data {args.data_dir}/.cache",
     shell=True,
     executable="/bin/bash",
     check=True,
 )
 
-directory_hash = hash_directory(args.data_dir)
+# Verify only the downloaded parquets, so other content in data_dir does not
+# affect the hash.
+directory_hash = hash_files(sorted(glob.glob(f"{args.data_dir}/*.parquet")))
 assert (
     directory_hash == "682a5f40b790a56751bf8303554efc08"
 ), f"Expected hash 682a5f40b790a56751bf8303554efc08, but got {directory_hash}"


### PR DESCRIPTION
## Problem

MLPerf llama2-70b post-training failed with:

```
ValueError: Invalid pretrained checkpoint directory found: /data/megatron_checkpoints/Llama-2-70b-hf
```

The dataset prep script `download_dataset.py` ran `find <data_dir> ! -name '*.parquet' -exec rm -rf` over the whole `data_dir` and hashed the whole dir, assuming it holds only the dataset. But the converted checkpoint lives in the same `data_dir`, so it got deleted (and the same blanket delete can wipe unrelated data on a shared/mounted dir).

## Fix

- `download_dataset.py`: move only the dataset parquets and remove only HF's own artifacts; verify via `hash_files`.
- `convert_dataset.py`: verify via `hash_files` over the produced `.npy` (no longer walks the large checkpoint).
- `dataset_hash.py`: replace `hash_directory` with `hash_files` (hash an explicit file list).

Modified NVIDIA-origin (Apache-2.0) files carry an added AMD 'Modifications Copyright' line.

## Verification

Reproduced the failure, then confirmed the fix end-to-end in a container: prep completes, the checkpoint is preserved, training loads it and proceeds; dataset hashes unchanged. pre-commit passes.