### PR TITLE
feat: add use_turbo_autotune flag and refine moe_router_force_load_balancing_type flag

### DIFF
--- a/docs/03-configuration-reference/megatron-parameters.md
+++ b/docs/03-configuration-reference/megatron-parameters.md
@@ -597,6 +597,8 @@ models:
 | `disable_primus_topk_router` | `false` | *Primus:* disable Primus top-k router patch. |
 | `moe_router_force_load_balancing` | `false` | *Primus:* force load-balanced routing. |
 | `use_deprecated_20241209_moe_layer` | `false` | *Primus:* legacy MoE layer implementation. |
+| `moe_router_force_load_balancing_type` | `even` | *Primus:* Control the force load balancing type for the MoE router. Choices: even, uniform. |
+
 
 ### 10.7 Logit softcapping (Primus / Grok-style)
 
@@ -625,7 +627,8 @@ models:
 | `use_sink_attention` | `false` | GPT-OSS-style learned sink attention. |
 | `sink_sliding_window` | `0` | Sliding-window size for sink attention (GPT-OSS uses `128`). |
 | `sink_window_even_layers_only` | `true` | Apply the sliding window only to even layers (GPT-OSS pattern). |
-| `use_turbo_parallel_linear` | `false` | Turbo parallel linear layers. |
+| `use_turbo_gemm` | `false` | Active Turbo GEMM flag for Dense paths. |
+| `use_turbo_parallel_linear` | *(removed)* | Removed—use `use_turbo_gemm`. Passing this key now raises an assertion error (`use_turbo_parallel_linear has been removed; please use use_turbo_gemm instead`). |
 | `use_turbo_grouped_gemm` | `false` | Active Turbo grouped GEMM flag for MoE paths. |
 | `use_turbo_grouped_mlp` | *(removed)* | Removed—use `use_turbo_grouped_gemm`. Passing this key now raises an assertion error (`use_turbo_grouped_mlp has been removed; please use use_turbo_grouped_gemm instead`). |
 | `moe_use_fused_router_with_aux_score` | `false` | Fused MoE router with auxiliary scores. |

--- a/primus/backends/megatron/patches/args/rocm_arg_validation.py
+++ b/primus/backends/megatron/patches/args/rocm_arg_validation.py
@@ -98,6 +98,12 @@ def validate_fsdp2_optimizer_exclusivity(args) -> None:
 
 
 def validate_args_on_rocm(args):
+    # Primus-Turbo auto-tuning
+    use_turbo_autotune = getattr(args, "use_turbo_autotune", False)
+    if use_turbo_autotune:
+        # NOTE: Set PRIMUS_TURBO_AUTO_TUNE to 1 to enable turbo auto-tuning.
+        os.environ["PRIMUS_TURBO_AUTO_TUNE"] = "1"
+
     # Deterministic mode
     if args.deterministic_mode:
         # NOTE: Some environment variables affect deterministic mode on ROCm. Need to do extra check.

--- a/primus/configs/models/megatron/primus_megatron_model.yaml
+++ b/primus/configs/models/megatron/primus_megatron_model.yaml
@@ -13,10 +13,3 @@ router_logit_softcapping: null # float
 lfm_layer_types: null # list[str]
 conv_L_cache: 3 # int
 conv_bias: false # bool
-
-
-# Primus patch option
-# Control the force load balancing type for the MoE router.
-# If set to "even", the router will force the load balancing to be even.
-# If set to "uniform", the router will force the load balancing to be uniform. (Megatron-LM original behavior)
-moe_router_force_load_balancing_type: "even"

--- a/primus/configs/modules/megatron/primus_megatron_module.yaml
+++ b/primus/configs/modules/megatron/primus_megatron_module.yaml
@@ -96,3 +96,8 @@ recompute_layer_ids: null # int list; global layer ids, range from 0 to (num_lay
 
 # dataloader
 dataloader_mp_context: null # "forkserver" | "spawn" | "fork" | null
+
+# Control the force load balancing type for the MoE router.
+# If set to "even", the router will force the load balancing to be even.
+# If set to "uniform", the router will force the load balancing to be uniform. (Megatron-LM original behavior)
+moe_router_force_load_balancing_type: "even"

--- a/primus/configs/modules/megatron/primus_turbo.yaml
+++ b/primus/configs/modules/megatron/primus_turbo.yaml
@@ -2,6 +2,10 @@
 # main control flag
 enable_primus_turbo: false
 
+# ===== AutoTune =====
+# enable turbo auto-tuning
+use_turbo_autotune: false
+
 # ===== Attention =====
 # operator switch
 use_turbo_attention: false


### PR DESCRIPTION
# Description

This PR introduces a new `use_turbo_autotune` flag to enable Primus-Turbo auto-tuning, and refines the MoE router force load balancing configuration by moving the `moe_router_force_load_balancing_type` flag to a more appropriate module config.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `use_turbo_autotune` flag to `primus_turbo.yaml` (default `false`), which sets the `PRIMUS_TURBO_AUTO_TUNE=1` environment variable during ROCm arg validation to enable Primus-Turbo auto-tuning.
- Refine the `moe_router_force_load_balancing_type` flag by moving it from `primus_megatron_model.yaml` to `primus_megatron_module.yaml`.
- Update `docs/03-configuration-reference/megatron-parameters.md` to document the `moe_router_force_load_balancing_type` flag and clarify Turbo GEMM flags.

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
