### PR TITLE
docs: editorial improvements from user review pass

### DIFF
--- a/docs/01-getting-started/overview.md
+++ b/docs/01-getting-started/overview.md
@@ -2,7 +2,7 @@
 
 ## Executive summary
 
-**Primus** is a YAML-driven training framework for large-scale foundation model work on AMD GPUs. It targets **machine learning engineers**, **researchers**, and **platform/operations teams** who need reproducible, multi-backend training pipelines on AMD Instinct™ hardware. Within the broader Primus ecosystem, this repository is the training component, sometimes referred to as **Primus-LM** (see [Primus ecosystem](#primus-ecosystem) below).
+**Primus** is a YAML-driven training framework for large-scale foundation model work on AMD GPUs. It targets **machine learning engineers**, **researchers**, and **platform/operations teams** who need reproducible, multi-backend training pipelines on AMD Instinct™ hardware. This project, also referred to as **Primus-LM**, serves as the training component within the broader [Primus ecosystem](#primus-ecosystem).
 
 **Repository:** [https://github.com/AMD-AGI/Primus](https://github.com/AMD-AGI/Primus)
 
@@ -25,7 +25,7 @@ Workflows span **pretraining** and **post-training** (including SFT and LoRA). S
 
 ## Primus ecosystem
 
-The training component (Primus-LM) sits between the stability/platform services above it and the low-level operator libraries below it:
+The training component (Primus-LM) serves as the layer between the stability and platform services above it and the low-level operator libraries below it:
 
 ```
                     +------------------+
@@ -63,7 +63,7 @@ The training component (Primus-LM) sits between the stability/platform services 
 | **Megatron Bridge** | Post-training and bridge workflows on top of Megatron-related stacks. |
 | **HummingbirdXT** | Additional integrated training path when enabled by your deployment. |
 
-Backend choice is expressed in the configuration YAML and resolved through Primus’s adapter layer (see [glossary](./glossary.md)).
+Backend choice is specified in the configuration YAML and resolved through Primus’s adapter layer (see [glossary](./glossary.md)).
 
 ---
 

--- a/docs/02-user-guide/README.md
+++ b/docs/02-user-guide/README.md
@@ -8,8 +8,10 @@ Core workflows and day-to-day usage.
 - [Pretraining](pretraining.md): pretraining **concepts**: backends, YAML structure, parallelism, configuration inventory
 - [Backend training recipes](training-recipes.md): pretraining **commands**: copy-paste, GPU-arch-specific run commands
 - [Post-training](posttraining.md): SFT and LoRA fine-tuning via Megatron Bridge
-- [Benchmarking](benchmarking.md): GEMM, RCCL, and dense-GEMM benchmark suites
+- [Node-smoke test instruction](node-smoke-test-instruction.md): screen a cluster fast and exclude bad nodes before launching a real training job  
 - [Preflight](preflight.md): cluster diagnostics and environment validation
+- [Run preflight without a container](preflight-without-container.md): run cluster-diagnostic tool directly on the host
+- [Benchmarking](benchmarking.md): GEMM, RCCL, and dense-GEMM benchmark suites
 - [Projection](projection.md): memory and performance projection tools
 - [Tuning agent](tuning-agent.md): LLM-driven search for an optimal training configuration (uses projection as an oracle)
 

--- a/docs/02-user-guide/benchmarking.md
+++ b/docs/02-user-guide/benchmarking.md
@@ -1,6 +1,6 @@
 # Benchmark suite
 
-Primus ships microbenchmarks for GPU compute and distributed communication. They are exposed as the `benchmark` subcommand of the Primus CLI. Use them to sanity-check a node or cluster before long training jobs.
+Primus ships microbenchmarks for GPU compute and distributed communication. They are exposed as the `benchmark` subcommand of the Primus CLI. Use them to validate a node or cluster before long training jobs.
 
 **Implementation:** `primus/cli/subcommands/benchmark.py` (initializes distributed execution, runs the selected suite, then finalizes).
 

--- a/docs/02-user-guide/cli-reference.md
+++ b/docs/02-user-guide/cli-reference.md
@@ -14,7 +14,7 @@ primus-cli [global-options] <mode> [mode-args] -- [command]
 - **Mode** is one of `direct`, `container`, or `slurm`.
 - **`--` (required)** separates launcher options from the Primus Python CLI. Everything after the first `--` is passed to `primus/cli/main.py` (or another script if you override it in direct mode).
 
-From the repository root, invoke the launcher as `./runner/primus-cli` (or install/link it as `primus-cli` on your `PATH`).
+From the repository root, invoke the launcher as `./runner/primus-cli` (or install or link it as `primus-cli` on your `PATH`).
 
 ---
 

--- a/docs/02-user-guide/preflight-without-container.md
+++ b/docs/02-user-guide/preflight-without-container.md
@@ -1,4 +1,4 @@
-# Run Preflight Without a Container
+# Run preflight without a container
 
 > ⚠ **Run the [node-smoke test](./node-smoke-test-instruction.md) first.** `preflight` opens a global `torch.distributed` rendezvous, so a single sick node (wedged driver, leaked rank holding HBM, partial NIC enumeration, time-sync drift, etc.) can stall the whole job for up to `--dist-timeout-sec` seconds — long before any cross-node bandwidth number is produced. The node-smoke test catches those exact failure modes *without* a rendezvous in ~30–60 s and emits a SLURM-ready `failing_nodes.txt` you can pipe straight into `srun --exclude=`. Treat node-smoke as a hard prerequisite; only run `preflight` on the nodes node-smoke marked PASS. See [§0 "Which test should I run?"](#0-which-test-should-i-run) for the side-by-side comparison and the recommended 3-step workflow.
 

--- a/docs/02-user-guide/pretraining.md
+++ b/docs/02-user-guide/pretraining.md
@@ -249,7 +249,7 @@ Set `mock_data: true` (Megatron/TorchTitan) or synthetic dataset settings (MaxTe
 
 Export `HF_TOKEN` on the host before launching **container** mode; `runner/.primus.yaml` lists `HF_TOKEN` under `container.options.env` so it can be forwarded into the container. MaxText configurations may reference `${HF_TOKEN:""}` directly.
 
-### HipBLASLt autotuning (three stages)
+### hipBLASLt autotuning (three stages)
 
 Controlled with `PRIMUS_HIPBLASLT_TUNING_STAGE` (see `examples/README.md`):
 

--- a/docs/02-user-guide/projection.md
+++ b/docs/02-user-guide/projection.md
@@ -143,7 +143,7 @@ primus-cli [global-options] <mode> [mode-args] -- projection {memory,performance
 ### Assumptions (performance projection)
 
 1. **Data-parallel scaling**—Compute time scales with ideal weak-scaling assumptions versus data-parallel width.
-2. **Communication Model**—Uses simplified bandwidth and latency models (defaults such as efficiency factors may apply).
+2. **Communication model**—Uses simplified bandwidth and latency models (defaults such as efficiency factors may apply).
 3. **Pipeline scheduling**—Bubble and overlap behavior is modeled with fixed splits; real frameworks may differ.
 4. **Gradients and MoE**—Gradient all-reduce overlap and MoE all-to-all behavior follow the implemented model (for example overlap flags, EP scaling).
 

--- a/docs/02-user-guide/training-recipes.md
+++ b/docs/02-user-guide/training-recipes.md
@@ -65,7 +65,7 @@ These apply across all backends. Set them up before running the recipes below.
 export HF_TOKEN=<your_hf_token>
 ```
 
-`runner/.primus.yaml` forwards `HF_TOKEN` into the container automatically. MaxText configurations may also read `${HF_TOKEN:""}` directly.
+`runner/.primus.yaml` forwards `HF_TOKEN` into the container automatically. MaxText configurations might also read `${HF_TOKEN:""}` directly.
 
 ### Mock vs. real data
 
@@ -136,7 +136,7 @@ Switch model or precision by changing the config filename (e.g. `llama3.1_70B-FP
 **Model-specific notes:**
 
 - **Zebra-Llama** (hybrid Mamba+MLA) pretrain presets ship at `examples/megatron/configs/<ARCH>/zebra_llama_{1B,3B,8B}-pretrain.yaml` and run via the standard core runtime; Megatron Bridge SFT variants live under `examples/megatron_bridge/configs/<ARCH>/`.
-- **MoE models** (DeepSeek-V2-Lite, Mixtral) may need extra grouped-GEMM or router flags; [Training with Primus + Megatron-LM](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/primus-megatron.html) lists the exact flags per model.
+- **MoE models** (DeepSeek-V2-Lite, Mixtral) might need extra grouped-GEMM or router flags; [Training with Primus + Megatron-LM](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/benchmark-docker/primus-megatron.html) lists the exact flags per model.
 
 ### 3. Multi-node (Slurm mode)
 

--- a/docs/03-configuration-reference/environment-variables.md
+++ b/docs/03-configuration-reference/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment variables reference
 
-This document catalogs the main environment variables you may encounter when running Primus on AMD GPUs: distributed launchers, Primus runners and CLI, YAML substitution, libraries (NCCL/RCCL, ROCm, PyTorch, JAX), and optional integrations (Hugging Face, WandB, MLflow). It is a practical reference, not a complete list of every variable accepted by upstream libraries.
+This document catalogs the main environment variables you might encounter when running Primus on AMD GPUs: distributed launchers, Primus runners and CLI, YAML substitution, libraries (NCCL/RCCL, ROCm, PyTorch, JAX), and optional integrations (Hugging Face, WandB, MLflow). It is a practical reference, not a complete list of every variable accepted by upstream libraries.
 
 **Legend**
 
@@ -152,7 +152,7 @@ Primus seeds many of these in `runner/helpers/envs/base_env.sh`. RCCL honors NCC
 | `HF_TOKEN` | (unset) | User, container passthrough | Hugging Face Hub | Auth for gated models. **Required** for private/gated assets. |
 | `TORCH_HOME` | under workspace | `primus/core/utils/env_setup.py` | PyTorch Hub | Torch Hub cache root. |
 | `TRANSFORMERS_CACHE` | aligned with HF layout | `primus/core/utils/env_setup.py` | `transformers` | Model cache for Transformers. |
-| `WANDB_API_KEY` | (unset) | User, container passthrough | WandB client, Megatron trainer checks | API key for logging. **Required** for WandB when enabled. |
+| `WANDB_API_KEY` | (unset) | User, container passthrough | Weights & Biases client, Megatron trainer checks | API key for logging. **Required** for Weights & Biases when enabled. |
 | `WANDB_PROJECT` | (unset) | User / TorchTitan patch | `primus/backends/torchtitan/patches/wandb_patches.py` | Project name. |
 | `WANDB_RUN_NAME` | (unset) | User / patches | Same | Run display name. |
 | `WANDB_TEAM` | (unset) | User | TorchTitan metrics (entity) | WandB team/entity. |
@@ -165,15 +165,15 @@ Primus seeds many of these in `runner/helpers/envs/base_env.sh`. RCCL honors NCC
 
 ---
 
-## 9. HipBLASLt tuning
+## 9. hipBLASLt tuning
 
 | Variable | Default | Where set | Where used | Description |
 |----------|---------|-----------|------------|-------------|
 | `PRIMUS_HIPBLASLT_TUNING` | `0` | User | `examples/run_pretrain.sh` | **Master switch** for the HipBLASLt tuning flow (`1` enables). Must be set before `PRIMUS_HIPBLASLT_TUNING_STAGE` takes effect, and is mutually exclusive with deterministic mode (`PRIMUS_DETERMINISTIC=1`). |
 | `PRIMUS_HIPBLASLT_TUNING_STAGE` | `0` | User | `examples/run_pretrain.sh` | Stages `0` off, `1` dump shapes, `2` offline tune, `3` apply tuned kernels. |
 | `HIPBLASLT_TUNING_OVERRIDE_FILE` | (unset) | User / tuning scripts | `examples/run_pretrain.sh` | Path to tuned-kernel override file for stage `3`. |
-| `TE_HIPBLASLT_TUNING_RUN_COUNT` | varies | User | `examples/run_pretrain.sh` | Number of benchmark runs per shape during TE HipBLASLt tuning. |
-| `TE_HIPBLASLT_TUNING_ALGO_COUNT` | varies | User | `examples/run_pretrain.sh` | Transformer Engine HipBLASLt search breadth. |
+| `TE_HIPBLASLT_TUNING_RUN_COUNT` | varies | User | `examples/run_pretrain.sh` | Number of benchmark runs per shape during TE hipBLASLt tuning. |
+| `TE_HIPBLASLT_TUNING_ALGO_COUNT` | varies | User | `examples/run_pretrain.sh` | Transformer Engine hipBLASLt search breadth. |
 | `TE_HIPBLASLT_TUNING_ALGO_FILE` | (unset) | User | TE + HipBLASLt | Algorithm file for TE tuning flows. |
 | `TE_HIPBLASLT_TUNING` | (unset) | User | `examples/run_pretrain.sh` | When set, interacts with deterministic mode and tuning stages (disable conflicting modes per script comments). |
 | `HIPBLASLT_LOG_LEVEL` | (unset) | User | HipBLASLt | Library log level. |
@@ -195,7 +195,7 @@ Primus seeds many of these in `runner/helpers/envs/base_env.sh`. RCCL honors NCC
 
 ## 11. Container passthrough
 
-`runner/.primus.yaml` lists names forwarded from the host into training containers (`container.options.env`). Primus does not assign values here; it only whitelists keys for `--env` forwarding.
+`runner/.primus.yaml` lists names forwarded from the host into training containers (`container.options.env`). Primus does not assign values here; it only allowlists keys for `--env` forwarding.
 
 Forwarded keys:
 
@@ -209,7 +209,7 @@ Forwarded keys:
 |----------|---------|-----------|------------|-------------|
 | `SLURM_NNODES` / `SLURM_JOB_NUM_NODES` | job-dependent | Slurm | `primus-cli-slurm-entry.sh` (`NNODES` export), preflight probes | Node count for the allocation. |
 | `SLURM_NODEID` | job-dependent | Slurm | Mapped to `NODE_RANK` in `primus-cli-slurm-entry.sh` | Node index. |
-| `SLURM_PROCID` | job-dependent | Slurm | Fallback for `NODE_RANK` when `SLURM_NODEID` is unset | Process id within the Slurm step (entry script). |
+| `SLURM_PROCID` | job-dependent | Slurm | Fallback for `NODE_RANK` when `SLURM_NODEID` is unset | Process ID within the Slurm step (entry script). |
 | `SLURM_JOB_ID` | job-dependent | Slurm | `primus/tools/preflight/host/host_probe.py` | Job identifier string. |
 
 ---
@@ -236,4 +236,4 @@ Primus MaxText hooks print recommended values in `runner/helpers/hooks/train/pre
 | `DUMP_HLO_DIR` | `${PRIMUS_PATH}/output/xla_dump_hlo` (example) | User | XLA via `XLA_FLAGS` composition | Directory for HLO dumps when enabled. |
 | `DUMP_HLO` | `0` | User | Prepare hook → XLA flags | Gate HLO dumping (`1` enables in hook samples). |
 
-**Note:** MaxText also propagates many knobs through `XLA_FLAGS` and `LIBTPU_INIT_ARGS` upstream; see MaxText sources for the full matrix.
+**Note:** MaxText also propagates many knobs through `XLA_FLAGS` and `LIBTPU_INIT_ARGS` upstream; see MaxText sources for the full list.

--- a/docs/03-configuration-reference/maxtext-parameters.md
+++ b/docs/03-configuration-reference/maxtext-parameters.md
@@ -61,7 +61,7 @@ From `pre_trainer.yaml` (extends `trainer_base.yaml`).
 
 ## 4. Checkpointing
 
-These are Primus overlay defaults. MaxText also loads upstream `base.yml` at runtime through `base_config: "base.yml"`, where upstream checkpoint defaults may differ. When debugging effective behavior, distinguish the Primus YAML written by the adapter from the upstream MaxText defaults loaded afterward.
+These are Primus overlay defaults. MaxText also loads upstream `base.yml` at runtime through `base_config: "base.yml"`, where upstream checkpoint defaults might differ. When debugging effective behavior, distinguish the Primus YAML written by the adapter from the upstream MaxText defaults loaded afterward.
 
 
 | Parameter              | Default | Description                                                        |

--- a/docs/03-configuration-reference/megatron-bridge-parameters.md
+++ b/docs/03-configuration-reference/megatron-bridge-parameters.md
@@ -152,7 +152,7 @@ Model YAML files (`qwen3_8b.yaml`, `qwen3_32b.yaml`, `llama31_70b.yaml`) supply:
 | `hf_path` | `Qwen/Qwen3-8B`, `meta-llama/Meta-Llama-3.1-70B` | Hugging Face model id for weights/tokenizer flows. |
 | `dataset` | nested | Example: `dataset_name: "rajpurkar/squad"` for SQuAD-style fine-tuning. |
 
-**Logging (optional overrides in examples):** `wandb_project`, `wandb_entity`, `wandb_exp_name` may be set under `overrides` for experiment tracking when Weights & Biases is configured.
+**Logging (optional overrides in examples):** `wandb_project`, `wandb_entity`, `wandb_exp_name` might be set under `overrides` for experiment tracking when Weights & Biases is configured.
 
 ---
 

--- a/docs/04-technical-guides/checkpoint-management.md
+++ b/docs/04-technical-guides/checkpoint-management.md
@@ -113,7 +113,7 @@ TorchTitan also defines `activation_checkpoint` (activation recomputation) separ
 
 ## 4. MaxText checkpoint configuration
 
-MaxText (JAX) uses configuration keys surfaced in Primus documentation and MaxText configs under `third_party/maxtext`. Primus overlay presets set the defaults shown below, while upstream MaxText `base.yml` is still loaded at runtime via `base_config: "base.yml"` and may define different upstream defaults. Typical training flags:
+MaxText (JAX) uses configuration keys surfaced in Primus documentation and MaxText configs under `third_party/maxtext`. Primus overlay presets set the defaults shown below, while upstream MaxText `base.yml` is still loaded at runtime via `base_config: "base.yml"` and might define different upstream defaults. Typical training flags:
 
 | Parameter | Typical default | Description |
 |-----------|-----------------|-------------|
@@ -129,7 +129,7 @@ See `docs/03-configuration-reference/maxtext-parameters.md` for the full MaxText
 | Format | Behavior | Notes |
 |--------|----------|--------|
 | `torch` | Classic PyTorch save/load; often **one file per rank** in distributed settings. | Simple but less flexible for topology changes. |
-| `torch_dist` | **Distributed** checkpoint format with **resharding** support (e.g., changing tensor/pipeline parallel degree between save and load). | **Recommended** for many production flows that may change parallelism. |
+| `torch_dist` | **Distributed** checkpoint format with **resharding** support (e.g., changing tensor/pipeline parallel degree between save and load). | **Recommended** for many production flows that might change parallelism. |
 | `zarr` | Zarr-backed checkpoint storage. | Useful when the stack and storage backend support it. |
 
 **Recommendation:** Prefer `torch_dist` for production when you need **flexibility across parallel layouts** and scalable I/O (see `ckpt_fully_parallel_save` / `ckpt_fully_parallel_load` in Megatron config).

--- a/docs/04-technical-guides/collective-operations.md
+++ b/docs/04-technical-guides/collective-operations.md
@@ -200,9 +200,9 @@ The following appear in ROCm / AMD deployments and partner integrations; availab
 
 | Feature | Notes |
 |---------|--------|
-| **MSCCL** | Microsoft Collective Communication Library: **custom algorithms** and patterns; may be used when the stack is built and configured for them. |
+| **MSCCL** | Microsoft Collective Communication Library: **custom algorithms** and patterns; might be used when the stack is built and configured for them. |
 | **MSCCL++** | User-space collective paths aimed at **lower latency** for specific patterns and hardware. |
-| **ANP (AMD Network Plugin)** | Network backend integration (e.g. **AINIC**-oriented paths). Example: `NCCL_NET_PLUGIN` may point to `librccl-anp.so` or similar when installed (see Primus `examples/run_pretrain.sh` patterns). |
+| **ANP (AMD Network Plugin)** | Network backend integration (e.g. **AINIC**-oriented paths). Example: `NCCL_NET_PLUGIN` might point to `librccl-anp.so` or similar when installed (see Primus `examples/run_pretrain.sh` patterns). |
 
 ### Environment variables
 

--- a/docs/04-technical-guides/data-preparation.md
+++ b/docs/04-technical-guides/data-preparation.md
@@ -153,7 +153,7 @@ See MaxText’s data input documentation for Grain and TFDS specifics.
 
 ## Summary
 
-1. Use **mock** / **synthetic** data to validate configs and performance before investing in large preprocessing jobs.
+1. Use **mock or synthetic** data to validate configs and performance before investing in large preprocessing jobs.
 2. For **Megatron**, convert JSON/JSONL to `.bin`/`.idx` with `preprocess_data.py` and point `data_path` or split paths at the outputs.
 3. For **TorchTitan**, set `training.dataset` / `dataset_path` and run **`examples/torchtitan/prepare.py`** to fetch tokenizer assets.
 4. For **MaxText**, configure `dataset_type` and `per_device_batch_size` per upstream `base.yml` and model YAMLs.

--- a/docs/04-technical-guides/determinism-and-reproducibility.md
+++ b/docs/04-technical-guides/determinism-and-reproducibility.md
@@ -32,7 +32,7 @@ export PRIMUS_TURBO_AUTO_TUNE=0            # disable Primus-Turbo autotuning (st
 
 Additionally, **HipBLASLt autotuning is disabled** in deterministic mode: tuning only runs when `PRIMUS_DETERMINISTIC != 1` *and* `PRIMUS_HIPBLASLT_TUNING=1` (`examples/run_pretrain.sh`). This prevents run-to-run kernel-selection differences. See [Performance tuning](./performance-tuning.md).
 
-`PRIMUS_DETERMINISTIC` is on the container passthrough whitelist (`runner/.primus.yaml`), so it reaches the training container. See [Environment variables](../03-configuration-reference/environment-variables.md).
+`PRIMUS_DETERMINISTIC` is on the container passthrough allowlist (`runner/.primus.yaml`), so it reaches the training container. See [Environment variables](../03-configuration-reference/environment-variables.md).
 
 ```bash
 export PRIMUS_DETERMINISTIC=1

--- a/docs/04-technical-guides/logging-and-experiment-tracking.md
+++ b/docs/04-technical-guides/logging-and-experiment-tracking.md
@@ -16,11 +16,11 @@ disable_wandb: true
 disable_mlflow: true
 ```
 
-Set the relevant `disable_*` to `false` to enable a tracker. Primus performs sanity checks at startup—e.g. it warns if WandB is enabled but `WANDB_API_KEY` is unset (`primus/backends/megatron/patches/args/wandb_config_patches.py`). MLflow logging is initialized in `primus/backends/megatron/training/global_vars.py`; Databricks-hosted MLflow additionally requires `DATABRICKS_HOST` (read by the `mlflow` client).
+Set the relevant `disable_*` to `false` to enable a tracker. Primus performs validation checks at startup—e.g. it warns if WandB is enabled but `WANDB_API_KEY` is unset (`primus/backends/megatron/patches/args/wandb_config_patches.py`). MLflow logging is initialized in `primus/backends/megatron/training/global_vars.py`; Databricks-hosted MLflow additionally requires `DATABRICKS_HOST` (read by the `mlflow` client).
 
 ---
 
-## 2. Console / step logging (Megatron)
+## 2. Console and step logging (Megatron)
 
 Core logging cadence and content (`trainer_base.yaml`, overridden by `pre_trainer.yaml`):
 
@@ -78,7 +78,7 @@ export WANDB_RUN_NAME=...    # optional
 export WANDB_TEAM=...        # optional (entity)
 ```
 
-`WANDB_API_KEY` is on the container passthrough whitelist (`runner/.primus.yaml`), so it propagates into the training container.
+`WANDB_API_KEY` is on the container passthrough allowlist (`runner/.primus.yaml`), so it propagates into the training container.
 
 ---
 
@@ -95,7 +95,7 @@ Enable with `disable_mlflow: false`. Run identification and upload behavior:
 | `mlflow_upload_performance_metrics` | `false` | Upload the comprehensive perf/memory/utilization metric set (implicitly enables throughput calc). |
 | `mlflow_upload_tracelens_report` | `false` | Generate + upload TraceLens reports (see [Profiling & observability](./profiling-and-observability.md)). |
 
-**Credentials / endpoints:**
+**Credentials and endpoints:**
 
 ```bash
 export MLFLOW_TRACKING_URI=...     # tracking server URI
@@ -151,7 +151,7 @@ MaxText logging cadence is controlled by `log_period` (`primus/configs/modules/m
 1. **Local-only:** enable TensorBoard (`disable_tensorboard: false`, set `tensorboard_dir`)—no credentials required.
 2. **Team tracking:** enable WandB (`disable_wandb: false`) + export `WANDB_API_KEY` and `wandb_project`/`wandb_entity`.
 3. **Enterprise / scaling studies:** enable MLflow (`disable_mlflow: false`) + `MLFLOW_TRACKING_URI` (or Databricks host/token), and turn on `mlflow_upload_performance_metrics` for throughput/memory/utilization dashboards.
-4. **Keep `WANDB_API_KEY` and tokens out of YAML**—pass them as environment variables (whitelisted for container passthrough). See [Security](../05-operations/security.md).
+4. **Keep `WANDB_API_KEY` and tokens out of YAML**—pass them as environment variables (allowlisted for container passthrough). See [Security](../05-operations/security.md).
 
 ---
 

--- a/docs/04-technical-guides/multi-node-networking.md
+++ b/docs/04-technical-guides/multi-node-networking.md
@@ -63,7 +63,7 @@ RoCE reuses much of the **IB verb** stack; the same **`NCCL_IB_*`** knobs apply.
 |----------|-------------|
 | `NCCL_IB_ROCE_VERSION_NUM` | RoCE version (commonly **2** for RoCE v2). |
 
-GID selection (`NCCL_IB_GID_INDEX`) and traffic classes (`NCCL_IB_TC`, `NCCL_IB_FIFO_TC`) remain important on RoCE fabrics. Follow your network team’s mapping (often **GID index 1** for RoCE v2 vs **3** for some IB fabrics—your site may differ).
+GID selection (`NCCL_IB_GID_INDEX`) and traffic classes (`NCCL_IB_TC`, `NCCL_IB_FIFO_TC`) remain important on RoCE fabrics. Follow your network team’s mapping (often **GID index 1** for RoCE v2 vs **3** for some IB fabrics—your site might differ).
 
 ---
 
@@ -129,7 +129,7 @@ CPU-side and fallback socket traffic uses interface selection:
 |----------|--------------------------|---------|
 | `NCCL_PXN_DISABLE` | `1` | **PXN disabled** by default (saves GPU memory per comment in `base_env.sh`). |
 
-When **`NCCL_PXN_DISABLE=0`**, **PCIe cross-NIC** is enabled: GPUs may use NICs attached to **other** PCIe switches, which can improve **multi-rail** bandwidth at the cost of **higher GPU memory** use. `runner/use_ainic.yaml` sets `NCCL_PXN_DISABLE=0` for AINIC-oriented runs.
+When **`NCCL_PXN_DISABLE=0`**, **PCIe cross-NIC** is enabled: GPUs might use NICs attached to **other** PCIe switches, which can improve **multi-rail** bandwidth at the cost of **higher GPU memory** use. `runner/use_ainic.yaml` sets `NCCL_PXN_DISABLE=0` for AINIC-oriented runs.
 
 ---
 

--- a/docs/04-technical-guides/parallelism-configuration.md
+++ b/docs/04-technical-guides/parallelism-configuration.md
@@ -156,7 +156,7 @@ Consult MaxText’s mesh documentation and your chosen model YAML for valid comb
 | Goal | What to change |
 |------|----------------|
 | Increase global batch without more per-GPU memory | Increase `gradient_accumulation_steps` (Megatron) or increase accumulation / GBS while keeping MBS fixed. |
-| Increase throughput per step | Increase `micro_batch_size` if memory allows; may require lowering accumulation to keep GBS fixed. |
+| Increase throughput per step | Increase `micro_batch_size` if memory allows; might require lowering accumulation to keep GBS fixed. |
 | Scale to more GPUs | Increase world size; often increase DP; keep GBS stable by adjusting accumulation. |
 
 ### Memory and convergence

--- a/docs/04-technical-guides/parallelism-strategies.md
+++ b/docs/04-technical-guides/parallelism-strategies.md
@@ -10,7 +10,7 @@ For Megatron YAML flags and environment tuning, see [Megatron parameters](../03-
 
 ### Why parallelism is needed
 
-Modern foundation models often exceed the memory of a single accelerator: parameters, activations, optimizer states, and KV caches cannot all reside on one device at useful batch sizes. Even when a model *fits*, training throughput may be too low without scaling across many GPUs. Parallelism splits the problem along several independent **dimensions** so that:
+Modern foundation models often exceed the memory of a single GPU: parameters, activations, optimizer states, and KV caches cannot all reside on one device at useful batch sizes. Even when a model *fits*, training throughput might be too low without scaling across many GPUs. Parallelism splits the problem along several independent **dimensions** so that:
 
 - **Memory** is shared across devices (sharding, pipeline stages, sequence splits).
 - **Compute** is scaled by processing more data in parallel or by overlapping communication with computation.
@@ -21,7 +21,7 @@ Modern foundation models often exceed the memory of a single accelerator: parame
 |-----------|----------------|--------------|
 | **Data parallelism (DP)** | Input batches | Throughput; same model on each GPU |
 | **FSDP / ZeRO** | Parameters, gradients, optimizer (by stage) | Memory; keep DP semantics |
-| **Tensor parallelism (TP)** | Individual weight matrices / matmuls | Memory per layer; needs fast links |
+| **Tensor parallelism (TP)** | Individual weight matrices and matmuls | Memory per layer; needs fast links |
 | **Sequence parallelism (SP)** | Sequence in non-TP regions | Activation memory with TP |
 | **Pipeline parallelism (PP)** | Layer groups across stages | Memory; depth-wise split |
 | **Context parallelism (CP)** | Sequence for attention (e.g. ring) | Very long contexts |
@@ -170,7 +170,7 @@ Typical **transformer block** pattern: **column-parallel** for the first project
 **Interaction with TP**
 
 - After a **column-parallel** region, partial activations can be **ReduceScatter**d along the sequence.
-- Before a **row-parallel** region, activations may be **AllGather**d along the sequence.
+- Before a **row-parallel** region, activations might be **AllGather**d along the sequence.
 
 So SP trades **extra collectives** for **lower per-rank activation footprint** on long sequences.
 
@@ -203,7 +203,7 @@ If a stage waits for input while other stages compute, **idle time** appears (**
 |----------|------|
 | **1F1B** | One forward, one backward; classic **warmup / steady / cooldown** phases |
 | **1F1B interleaved (VPP)** | **Virtual pipeline** stages: multiple chunks per device to improve utilization |
-| **Zero-bubble (ZB)** | Reorders / splits backward so **forward and backward** hide each other better; may separate **input-gradient** vs **weight-gradient** phases |
+| **Zero-bubble (ZB)** | Reorders / splits backward so **forward and backward** hide each other better; might separate **input-gradient** vs **weight-gradient** phases |
 | **V-Schedule / V-Half / V-Min** | Variants reducing bubbles further (names vary by codebase) |
 | **DualPipe** | Bidirectional pipeline scheduling (e.g. DeepSeek-style) to overlap forward/backward paths |
 

--- a/docs/04-technical-guides/performance-tuning.md
+++ b/docs/04-technical-guides/performance-tuning.md
@@ -162,7 +162,7 @@ From `primus/configs/models/megatron/language_model.yaml`:
 |-----------|----------------|-------|
 | `recompute_granularity` | `full`, `selective` | `full` recomputes more; max memory savings. |
 | `recompute_method` | `uniform`, `block` | How recomputation is distributed. |
-| `recompute_num_layers` | integer | Layers to recompute when using selective/uniform strategies. |
+| `recompute_num_layers` | integer | Layers to recompute when using selective or uniform strategies. |
 | `recompute_layer_ids` | list or null | Primus extension: **global** layer indices from `0` to `num_layers - 1` (the patch resolves block-local indices to global ids via `layer_offset`). Use with `recompute_granularity: full` and supported recompute methods. |
 
 ### TorchTitan
@@ -195,7 +195,7 @@ From `trainer_base.yaml` and model settings:
 
 ### Environment
 
-`CUDA_DEVICE_MAX_CONNECTIONS=1` is commonly required for **correct** overlap behavior in TP/PP stacks (see `docs/03-configuration-reference/environment-variables.md` and Megatron tests). Primus launch scripts or your cluster setup may set this.
+`CUDA_DEVICE_MAX_CONNECTIONS=1` is commonly required for **correct** overlap behavior in TP/PP stacks (see `docs/03-configuration-reference/environment-variables.md` and Megatron tests). Primus launch scripts or your cluster setup might set this.
 
 ---
 

--- a/docs/04-technical-guides/profiling-and-observability.md
+++ b/docs/04-technical-guides/profiling-and-observability.md
@@ -132,7 +132,7 @@ Project resource usage **before** launching, without consuming a full cluster. E
 ./primus-cli direct -- projection performance --config <exp>.yaml --target-nodes 4
 ```
 
-Memory projection breaks VRAM down across parameters, gradients, activations, optimizer states, and mixed-precision overhead—invaluable for MoE/ultra-large models where activations dominate. See [Projection](../02-user-guide/projection.md) for the full reference.
+Memory projection breaks VRAM down across parameters, gradients, activations, optimizer states, and mixed-precision overhead—invaluable for MoE and ultra-large models where activations dominate. See [Projection](../02-user-guide/projection.md) for the full reference.
 
 ---
 

--- a/docs/05-operations/deployment.md
+++ b/docs/05-operations/deployment.md
@@ -225,7 +225,7 @@ Required variables for distributed training:
 | Shared data | Paths visible and consistent on all nodes |
 | Hugging Face | Set `HF_TOKEN` if using gated models |
 | Checkpoints | Save directory on shared or replicated storage with sufficient space |
-| Monitoring | Configure WandB or TensorBoard (see [Monitoring and Logging](./monitoring-logging.md)) |
+| Monitoring | Configure Weights & Biases or TensorBoard (see [Monitoring and Logging](./monitoring-logging.md)) |
 | Resources | Slurm time limits, partitions, and GPU counts match your YAML and hardware |
 
 ---

--- a/docs/05-operations/monitoring-logging.md
+++ b/docs/05-operations/monitoring-logging.md
@@ -1,6 +1,6 @@
 # Monitoring and logging
 
-This page summarizes how Primus configures application logging, experiment tracking (Weights and Biases, TensorBoard, MLflow), training metrics, profilers, ROCm memory probes, and how to capture a reproducible configuration snapshot.
+This page summarizes how Primus configures application logging, experiment tracking (Weights & Biases, TensorBoard, MLflow), training metrics, profilers, ROCm memory probes, and how to capture a reproducible configuration snapshot.
 
 ---
 
@@ -21,7 +21,7 @@ Primus uses **loguru** for structured logging. Initialization wires **file sinks
 | `file_sink_level` | `DEBUG` | Minimum level for file sinks when `sink_level` is unset. |
 | `stderr_sink_level` | `INFO` | Minimum level for stderr when `sink_level` is unset. |
 
-`init_worker_logger` in `primus/core/runtime/logging.py` reads `sink_level`, `file_sink_level`, and `stderr_sink_level` from the merged module config. The Megatron trainer maps `stderr_sink_level` to Megatron’s numeric `logging_level` (deprecated `logging_level` in `trainer_base.yaml` is replaced by this mapping).
+`init_worker_logger` in `primus/core/runtime/logging.py` reads `sink_level`, `file_sink_level`, and `stderr_sink_level` from the merged module config. The Megatron trainer maps `stderr_sink_level` to Megatron’s numeric `logging_level` (the `logging_level` field in `trainer_base.yaml` is deprecated; this mapping supersedes it)..
 
 **Shell / runner environment** (see `docs/03-configuration-reference/environment-variables.md`)
 
@@ -37,25 +37,29 @@ Primus uses **loguru** for structured logging. Initialization wires **file sinks
 
 ---
 
-## 2. Weights and biases
+## 2. Weights & Biases
 
-### Megatron (`primus/configs/modules/megatron/trainer_base.yaml`, `primus_megatron_module.yaml`)
+### Megatron
 
-Defaults in `primus_megatron_module.yaml` disable WandB; trainer fields in `trainer_base.yaml` supply names and paths when enabled.
+Configuration files: `primus/configs/modules/megatron/trainer_base.yaml` and `primus_megatron_module.yaml`.
+
+Defaults in `primus_megatron_module.yaml` disable Weights & Biases; trainer fields in `trainer_base.yaml` supply names and paths when enabled.
 
 | Parameter | Default (module / trainer) | Description |
 |-----------|----------------------------|-------------|
 | `disable_wandb` | `true` (`primus_megatron_module.yaml`) | Master switch; when `false`, Primus sets paths and default project/run names from experiment metadata. |
-| `wandb_project` | `null` | If unset when WandB is enabled, defaults to `{work_group}_{user_name}`. |
+| `wandb_project` | `null` | If unset when Weights & Biases is enabled, defaults to `{work_group}_{user_name}`. |
 | `wandb_exp_name` | `null` | If unset, defaults to `exp_name`. |
 | `wandb_entity` | `null` | Optional WandB entity/team. |
 | `wandb_save_dir` | `null` | Deprecated in favor of `{exp_root}`; artifacts use `{exp_root}/wandb`. |
 
 **Environment**
 
-- `WANDB_API_KEY` is **required** when WandB is enabled; Primus emits a warning if it is missing (`primus/backends/megatron/patches/args/wandb_config_patches.py`).
+- `WANDB_API_KEY` is **required** when Weights & Biases is enabled; Primus emits a warning if it is missing (`primus/backends/megatron/patches/args/wandb_config_patches.py`).
 
-### TorchTitan (`primus/configs/modules/torchtitan/pre_trainer.yaml`)
+### TorchTitan
+
+Configuration file: `primus/configs/modules/torchtitan/pre_trainer.yaml`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -69,13 +73,17 @@ When enabled, `primus/backends/torchtitan/patches/wandb_patches.py` can set `WAN
 
 ### Megatron
 
-**Module toggles** (`primus_megatron_module.yaml`)
+**Module toggles**
+
+Configuration file: `primus_megatron_module.yaml`
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `disable_tensorboard` | `true` | When `false`, TensorBoard output is placed under `{exp_root}/tensorboard` (Primus overrides deprecated `tensorboard_dir` with this path). |
 
-**Trainer** (`trainer_base.yaml`)
+**Trainer**
+
+Configuration file: `trainer_base.yaml`
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -92,7 +100,9 @@ When enabled, `primus/backends/torchtitan/patches/wandb_patches.py` can set `WAN
 
 **Note:** Enabling Megatron **profiling** (`profile: true`) forces `disable_tensorboard` off in `update_primus_config` so TensorBoard is available for profile-related views.
 
-### TorchTitan (`pre_trainer.yaml`)
+### TorchTitan
+
+Configuration file: `pre_trainer.yaml`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -113,7 +123,9 @@ Point `<path>` at the Megatron `tensorboard` directory under the experiment root
 
 MLflow integration is **Megatron-only** in the paths described here.
 
-**Module** (`primus_megatron_module.yaml`)
+**Module**
+
+Configuration file: `primus_megatron_module.yaml`
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -121,7 +133,9 @@ MLflow integration is **Megatron-only** in the paths described here.
 | `mlflow_run_name` | `null` | If unset when enabled, defaults to `{work_group}_{user_name}`. |
 | `mlflow_experiment_name` | `null` | Passed to `mlflow.set_experiment` when set. |
 
-**Startup behavior** (`primus/backends/megatron/training/global_vars.py`)
+**Startup behavior**
+
+Configuration file: `primus/backends/megatron/training/global_vars.py`
 
 - Logs training `args` as parameters.
 - Logs filtered environment variables with an `env__` prefix.
@@ -139,7 +153,9 @@ MLflow integration is **Megatron-only** in the paths described here.
 
 ## 5. Training metrics
 
-### Megatron (`trainer_base.yaml`)
+### Megatron
+
+Configuration file: `trainer_base.yaml`
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -153,7 +169,9 @@ MLflow integration is **Megatron-only** in the paths described here.
 | `timing_log_level` | `0` | Timing log verbosity. |
 | `timing_log_option` | `minmax` | Timing aggregation option. |
 
-### TorchTitan (`pre_trainer.yaml`)
+### TorchTitan
+
+Configuration file: `pre_trainer.yaml`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -165,7 +183,9 @@ MLflow integration is **Megatron-only** in the paths described here.
 
 ## 6. Profiling
 
-### Megatron (`trainer_base.yaml`, `primus_megatron_module.yaml`)
+### Megatron
+
+Configuration files: `trainer_base.yaml` and `primus_megatron_module.yaml`
 
 | Parameter | Source | Default | Description |
 |-----------|--------|---------|-------------|
@@ -181,7 +201,9 @@ MLflow integration is **Megatron-only** in the paths described here.
 | `torch_profiler_with_stack` | `primus_megatron_module.yaml` | `true` | Capture Python stacks. |
 | `torch_profiler_use_gzip` | `primus_megatron_module.yaml` | `false` | Gzip profiler traces. |
 
-### TorchTitan (`pre_trainer.yaml`)
+### TorchTitan
+
+Configuration file: `pre_trainer.yaml`.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|

--- a/docs/05-operations/troubleshooting.md
+++ b/docs/05-operations/troubleshooting.md
@@ -163,7 +163,7 @@ Installation and container-oriented setup are covered in [Installation](../01-ge
 
 | Area | Action |
 |------|--------|
-| GEMM / kernels | Enable **HipBLASLt tuning** (multi-stage workflow—see [Performance tuning](../04-technical-guides/performance-tuning.md)). |
+| GEMM / kernels | Enable **hipBLASLt tuning** (multi-stage workflow—see [Performance tuning](../04-technical-guides/performance-tuning.md)). |
 | Primus stack | Enable **`enable_primus_turbo: true`** where supported. |
 | Communication overlap | **`overlap_grad_reduce: true`**, **`overlap_param_gather: true`** (when applicable to your backend). |
 | MoE / scratch | Confirm **`HSA_NO_SCRATCH_RECLAIM=1`** when recommended for your model class. |

--- a/docs/06-developer-guide/adding-models.md
+++ b/docs/06-developer-guide/adding-models.md
@@ -110,7 +110,7 @@ position_embedding_type: rope
 
 **4. Point an experiment at the new model**
 
-Copy an existing experiment (for example `examples/megatron/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml`) and set `model:` to your preset. Use **mock data** first for a quick sanity check:
+Copy an existing experiment (for example `examples/megatron/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml`) and set `model:` to your preset. Use **mock data** first for a quick smoke test:
 
 ```yaml
 work_group: ${PRIMUS_TEAM:amd}

--- a/docs/06-developer-guide/contributing.md
+++ b/docs/06-developer-guide/contributing.md
@@ -1,6 +1,6 @@
 # Contributing guide
 
-This guide summarizes how to set up a development environment, follow project conventions, run checks locally, and align with the CI pipeline. For test commands and layout, see [Testing Guide](testing.md). The repository root [CONTRIBUTING.md](../../CONTRIBUTING.md) repeats branch naming, commit style, and pull request steps in short form.
+This guide summarizes how to set up a development environment, follow project conventions, run checks locally, and align with the CI pipeline. For test commands and layout, see [Testing Guide](testing.md). The repository root [CONTRIBUTING.md](../../CONTRIBUTING.md) summarizes key contribution guidelines, such as branch naming conventions, commit message style, and pull request requirements.
 
 ## 1. Development setup
 

--- a/docs/06-developer-guide/testing.md
+++ b/docs/06-developer-guide/testing.md
@@ -54,7 +54,7 @@ bash ./tests/runner/run_all_tests.sh
 pytest tests/unit_tests/ --maxfail=1 -s
 ```
 
-**Trainer integration tests** (GPU and data; may require Hugging Face access):
+**Trainer integration tests** (GPU and data; might require Hugging Face access):
 
 ```bash
 # Megatron

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Primus documentation
 
-Production documentation for **Primus**, a large-scale foundation model training framework for AMD GPUs.
+Documentation for **Primus**, a large-scale foundation model training framework for AMD GPUs.
 
 ---
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -20,24 +20,28 @@ subtrees:
 
   - caption: User guide
     entries:
-      - file: 02-user-guide/pretraining.md
-        title: Pretraining workflows
-      - file: 02-user-guide/posttraining.md
-        title: Post-training workflows
-      - file: 02-user-guide/training-recipes.md
-        title: Backend training recipes
-      - file: 02-user-guide/cli-reference.md
-        title: CLI reference
-      - file: 02-user-guide/preflight.md
-        title: Preflight diagnostics
-      - file: 02-user-guide/configuration-system.md
-        title: Configuration system
-      - file: 02-user-guide/projection.md
-        title: Memory and performance projection
-      - file: 02-user-guide/benchmarking.md
-        title: Benchmark suite
       - file: 02-user-guide/primus-tools.md
         title: Primus tools
+      - file: 02-user-guide/cli-reference.md
+        title: CLI reference
+      - file: 02-user-guide/configuration-system.md
+        title: Configuration system
+      - file: 02-user-guide/pretraining.md
+        title: Pretraining workflows
+      - file: 02-user-guide/training-recipes.md
+        title: Backend training recipes
+      - file: 02-user-guide/posttraining.md
+        title: Post-training workflows
+      - file: 02-user-guide/node-smoke-test-instruction.md
+        title: Node-smoke test instruction
+      - file: 02-user-guide/preflight.md
+        title: Preflight diagnostics
+      - file: 02-user-guide/preflight-without-container.md
+        title: Run preflight without a container
+      - file: 02-user-guide/benchmarking.md
+        title: Benchmark suite
+      - file: 02-user-guide/projection.md
+        title: Memory and performance projection      
       - file: 02-user-guide/tuning-agent.md
         title: Tuning agent
 


### PR DESCRIPTION
## Summary

Applies the subset of editorial changes from my earlier review pass (PR #866) that were **not** already incorporated into main by the final review pass (commit \`4089c3a3\`).

- **"WandB" → "Weights & Biases"** in deployment.md and monitoring-logging.md
- **"whitelist" → "allowlist"** in determinism-and-reproducibility, environment-variables, logging-and-experiment-tracking (inclusive language)
- **"HipBLASLt" → "hipBLASLt"** in pretraining, troubleshooting, environment-variables section heading (correct product casing)
- **"sanity check/checks" → "validate"/"validation checks"** in benchmarking and logging-and-experiment-tracking
- **"sanity check" → "smoke test"** in adding-models
- **Slash "/" → "or"/"and"** in training-recipes, cli-reference, parallelism-strategies, data-preparation, profiling-and-observability
- **"accelerator" → "GPU"** in parallelism-strategies intro
- **"may" → "might"** across 16 locations (style consistency)
- **monitoring-logging.md**: heading and wording cleanup, structural subheading improvements
- Misc sentence-level improvements in contributing.md, training-recipes.md, cli-reference.md, projection.md

## Test plan

- [x] All modified files are Markdown documentation only — no code changes
- [ ] Verify rendered output looks correct in the documentation site

🤖 Generated with [Claude Code](https://claude.ai/claude-code)