### PR TITLE
fix(fsdp2): skip explicit forward prefetch when activation recompute …

### DIFF
--- a/primus/backends/megatron/core/distributed/torch_fully_sharded_data_parallel.py
+++ b/primus/backends/megatron/core/distributed/torch_fully_sharded_data_parallel.py
@@ -323,10 +323,16 @@ class PrimusTorchFullyShardedDataParallel(_BaseDataParallel):
         log_rank_0(f"FSDP2: wrapped {len(wrapped_list)} inner modules + root")
 
         prefetch_depth = getattr(self.config, "fsdp_prefetch_depth", 1)
+        recompute_on = getattr(self.config, "recompute_granularity", None) is not None
         for i, mod in enumerate(wrapped_list):
-            fwd_targets = wrapped_list[i + 1 : i + 1 + prefetch_depth]
-            if fwd_targets:
-                mod.set_modules_to_forward_prefetch(fwd_targets)
+            # With activation recompute enabled, the recomputed forward pass triggers
+            # wrong-direction forward-prefetch all-gathers that expose communication and
+            # inflate peak memory (matches Megatron upstream, which only sets backward
+            # prefetch when recompute is on). Skip explicit forward prefetch in that case.
+            if not recompute_on:
+                fwd_targets = wrapped_list[i + 1 : i + 1 + prefetch_depth]
+                if fwd_targets:
+                    mod.set_modules_to_forward_prefetch(fwd_targets)
 
             bwd_start = max(0, i - prefetch_depth)
             bwd_targets = list(reversed(wrapped_list[bwd_start:i]))


### PR DESCRIPTION
Fixes a ~50% FSDP2 throughput regression (llama3.1-70B, MI355X) introduced in #808. The rewritten PrimusTorchFullyShardedDataParallel set explicit forward prefetch unconditionally; with activation recompute on, the recomputed forward triggers wrong-direction all-gathers that expose communication and inflate memory. Fix: skip explicit forward prefetch when recompute is enabled, matching Megatron upstream. Verified on 8×MI355X: ~1026 → ~2026 toks/s/gpu, iter-1 reserved 249GB → 201GB.