### PR TITLE
Support Crusoe (Spur) cluster for DeepSeek-V4 multi-node runs

### DIFF
--- a/examples/deepseek-v4/run_deepseek_v4.sh
+++ b/examples/deepseek-v4/run_deepseek_v4.sh
@@ -25,7 +25,7 @@ export NNODES=${NNODES:-1}
 export TRAIN_ITERS=${TRAIN_ITERS:-20}
 
 export DOCKER_IMAGE=${DOCKER_IMAGE:-"tasimage/primus:pr-715-ainic"}
-export SLURM_PARTITION=Compute-DCPT
+export SLURM_PARTITION=${SLURM_PARTITION:-Compute-DCPT}
 export SLURM_NODELIST="${SLURM_NODELIST:-smci355-ccs-aus-n01-21,smci355-ccs-aus-n01-33,smci355-ccs-aus-n02-21,smci355-ccs-aus-n02-25,smci355-ccs-aus-n02-29,smci355-ccs-aus-n02-33,smci355-ccs-aus-n03-33,smci355-ccs-aus-n04-21,smci355-ccs-aus-n04-25,smci355-ccs-aus-n04-29,smci355-ccs-aus-n04-33,smci355-ccs-aus-n05-21,smci355-ccs-aus-n05-29,smci355-ccs-aus-n05-33,smci355-ccs-aus-n06-25,smci355-ccs-aus-n06-33,smci355-ccs-aus-n10-29}"
 export MASTER_PORT=${MASTER_PORT:-29500}
 
@@ -230,6 +230,10 @@ export BACKEND_PATH=${BACKEND_PATH:-"$(pwd)/third_party/Megatron-LM"}
 export PRIMUS_TEAM=${PRIMUS_TEAM:-amd}
 export PRIMUS_USER=${PRIMUS_USER:-tas-mi355x-$(date +%Y%m%d)}
 export PRIMUS_EXP_NAME=${PRIMUS_EXP_NAME:-deepseek_v4_smoke_${PRECISION_TYPE}_MBS${MBS}_GBS${GBS}_PP${PRIMUS_PP}_EP${PRIMUS_EP}}
+# Host-side directory for the launcher's aggregated log. Defaults to the
+# canonical "output" tree; override when that tree is not writable by the
+# invoking user (e.g. it was created by an earlier root/sudo run).
+export PRIMUS_OUTPUT_ROOT=${PRIMUS_OUTPUT_ROOT:-output}
 
 if [ ! -d "$BACKEND_PATH" ] || [ -z "$(ls -A "$BACKEND_PATH" 2>/dev/null)" ]; then
   echo "[ERROR] BACKEND_PATH does not exist or is empty: $BACKEND_PATH"
@@ -237,7 +241,7 @@ if [ ! -d "$BACKEND_PATH" ] || [ -z "$(ls -A "$BACKEND_PATH" 2>/dev/null)" ]; th
   exit 1
 fi
 
-mkdir -p "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
+mkdir -p "$PRIMUS_OUTPUT_ROOT/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME"
 
 export PRIMUS_EXIT_FAST=1
 
@@ -311,4 +315,4 @@ fi
   --profile_step_end 7 \
   --profile_step_start 6 \
   --bias_swiglu_fusion "$PRIMUS_BIAS_SWIGLU_FUSION" \
-  2>&1 | tee "output/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME/log_node_${NODE_RANK:-0}.txt"
+  2>&1 | tee "$PRIMUS_OUTPUT_ROOT/$PRIMUS_TEAM/$PRIMUS_USER/$PRIMUS_EXP_NAME/log_node_${NODE_RANK:-0}.txt"

--- a/examples/deepseek-v4/run_deepseek_v4_flash.sh
+++ b/examples/deepseek-v4/run_deepseek_v4_flash.sh
@@ -7,7 +7,7 @@ export PRIMUS_NUM_EXPERTS=${PRIMUS_NUM_EXPERTS:-256}
 export PRIMUS_MOE_TOPK=${PRIMUS_MOE_TOPK:-6}
 export PRIMUS_MOE_FFN_HIDDEN_SIZE=${PRIMUS_MOE_FFN_HIDDEN_SIZE:-2048}
 export PRIMUS_INDEX_TOPK=${PRIMUS_INDEX_TOPK:-512}
-export PRIMUS_COMPRESS_RATIOS=${PRIMUS_COMPRESS_RATIOS:-'"[0, 0, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 0]"'}
+export PRIMUS_COMPRESS_RATIOS=${PRIMUS_COMPRESS_RATIOS:-'[0, 0, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 0]'}
 export MTP_NUM_LAYERS=${MTP_NUM_LAYERS:-1}
 
 export NNODES=${NNODES:-8}
@@ -18,9 +18,9 @@ if [ "$NNODES" -eq 8 ]; then
     export PRIMUS_EP=${PRIMUS_EP:-8}
     export PRIMUS_RECOMPUTE_LAYERS=0
     if [ "$MTP_NUM_LAYERS" -eq 1 ]; then
-      export PRIMUS_PP_LAYOUT='"Et*4|t*5|(t*6|)*5,t*4mL"'
+      export PRIMUS_PP_LAYOUT='Et*4|t*5|(t*6|)*5,t*4mL'
     else
-      export PRIMUS_PP_LAYOUT='"Et*4|t*5|(t*6|)*5,t*4L"'
+      export PRIMUS_PP_LAYOUT='Et*4|t*5|(t*6|)*5,t*4L'
     fi
 elif [ "$NNODES" -eq 4 ]; then
     export PRIMUS_TP=${PRIMUS_TP:-1}
@@ -28,9 +28,9 @@ elif [ "$NNODES" -eq 4 ]; then
     export PRIMUS_EP=${PRIMUS_EP:-8}
     export PRIMUS_RECOMPUTE_LAYERS=3
     if [ "$MTP_NUM_LAYERS" -eq 1 ]; then
-      export PRIMUS_PP_LAYOUT='"Et*10|t*11|t*11|t*11mL"'
+      export PRIMUS_PP_LAYOUT='Et*10|t*11|t*11|t*11mL'
     else
-      export PRIMUS_PP_LAYOUT='"Et*10|t*11|t*11|t*11L"'
+      export PRIMUS_PP_LAYOUT='Et*10|t*11|t*11|t*11L'
     fi
 fi
 

--- a/runner/primus-cli-slurm-entry.sh
+++ b/runner/primus-cli-slurm-entry.sh
@@ -118,18 +118,59 @@ if [[ -z "${SLURM_NODELIST:-}" ]]; then
     exit 2
 fi
 
-# Get all node hostnames (sorted, as needed). Prefer scontrol, which correctly
-# expands compressed nodelists (e.g. "node[01-04]"). When scontrol is
-# unavailable -- CI containers / dev VMs without the Slurm client tools -- fall
-# back to parsing SLURM_NODELIST directly. This mirrors the scontrol-optional
-# handling in primus-cli-direct.sh so every launcher behaves consistently
-# off-cluster (range expansion is skipped in the fallback, which is fine for the
-# single-host / comma-list forms used in CI and single-node runs).
+# Pure-bash expander for a SLURM/Spur nodelist. Handles comma-separated lists
+# and bracket forms like "prefix[01-04,06]" / "prefix[030,058]" (optional
+# suffix). Used as the portable fallback below.
+_expand_nodelist() {
+    local nl="$1"
+    local seg="" depth=0 i ch
+    local -a segs=()
+    for (( i=0; i<${#nl}; i++ )); do
+        ch="${nl:i:1}"
+        if [[ "$ch" == "[" ]]; then depth=$((depth+1)); seg+="$ch"
+        elif [[ "$ch" == "]" ]]; then depth=$((depth-1)); seg+="$ch"
+        elif [[ "$ch" == "," && $depth -eq 0 ]]; then segs+=("$seg"); seg=""
+        else seg+="$ch"; fi
+    done
+    [[ -n "$seg" ]] && segs+=("$seg")
+
+    local s pre body suf tok a b width n
+    for s in "${segs[@]}"; do
+        [[ -n "$s" ]] || continue
+        if [[ "$s" == *"["* ]]; then
+            pre="${s%%[*}"
+            body="${s#*[}"; body="${body%%]*}"
+            suf="${s#*]}"
+            local OLD_IFS="$IFS"; IFS=','
+            for tok in $body; do
+                if [[ "$tok" == *-* ]]; then
+                    a="${tok%%-*}"; b="${tok##*-}"; width=${#a}
+                    for (( n=10#$a; n<=10#$b; n++ )); do
+                        printf "%s%0*d%s\n" "$pre" "$width" "$n" "$suf"
+                    done
+                else
+                    printf "%s%s%s\n" "$pre" "$tok" "$suf"
+                fi
+            done
+            IFS="$OLD_IFS"
+        else
+            printf "%s\n" "$s"
+        fi
+    done
+}
+
+# Get all node hostnames. Prefer `scontrol show hostnames`, which correctly
+# expands compressed nodelists on stock Slurm. Some Slurm-compatible schedulers
+# (e.g. Spur) lack that subcommand, and CI containers / dev VMs may lack the
+# client entirely -- in both cases fall back to the pure-bash expander above so
+# every launcher behaves consistently, including bracket-range expansion.
+NODE_ARRAY=()
 if command -v scontrol >/dev/null 2>&1; then
-    readarray -t NODE_ARRAY < <(scontrol show hostnames "$SLURM_NODELIST")
-else
-    LOG_WARN "[slurm-entry] scontrol not found; parsing SLURM_NODELIST without range expansion"
-    readarray -t NODE_ARRAY < <(tr ',' '\n' <<< "$SLURM_NODELIST")
+    readarray -t NODE_ARRAY < <(scontrol show hostnames "$SLURM_NODELIST" 2>/dev/null || true)
+fi
+if [[ ${#NODE_ARRAY[@]} -eq 0 ]]; then
+    LOG_WARN "[slurm-entry] 'scontrol show hostnames' unavailable; expanding SLURM_NODELIST locally"
+    readarray -t NODE_ARRAY < <(_expand_nodelist "$SLURM_NODELIST")
 fi
 SLURM_MASTER_ADDR="${NODE_ARRAY[0]:-}"
 if [[ -z "$SLURM_MASTER_ADDR" ]]; then
@@ -139,7 +180,11 @@ fi
 
 if [[ -z "${MASTER_ADDR:-}" ]]; then
     MASTER_ADDR="$SLURM_MASTER_ADDR"
-elif [[ "$MASTER_ADDR" != "$SLURM_MASTER_ADDR" ]]; then
+elif [[ "${MASTER_ADDR%%.*}" != "${SLURM_MASTER_ADDR%%.*}" ]]; then
+    # Compare only the leading hostname label so a scheduler-provided FQDN
+    # (e.g. Spur exports MASTER_ADDR=node.crusoe.amd.com) still matches the
+    # short name produced by nodelist expansion. A genuine mismatch (a
+    # different node entirely) is still caught.
     LOG_ERROR "[slurm-entry] MASTER_ADDR must match the first host in SLURM_NODELIST."
     LOG_ERROR "[slurm-entry] MASTER_ADDR=$MASTER_ADDR, expected=$SLURM_MASTER_ADDR"
     exit 2


### PR DESCRIPTION
### Summary
Enables the DeepSeek-V4 flash example to launch multi-node training on the Crusoe cluster, which runs the **Spur** scheduler (a SLURM-compatible controller) with `ionic` (AINIC) RDMA NICs. Getting a 4-node run off the ground surfaced several launcher/config issues that also affect any non-stock-SLURM cluster; this PR fixes them.

### Changes

**`runner/primus-cli-slurm-entry.sh`**
- Add a pure-bash `SLURM_NODELIST` expander used as a fallback when `scontrol show hostnames` is unavailable. Spur's `scontrol` only supports `job/node/partition/reservation/federation/config`, so the previous `command -v scontrol` gate still took the broken path and failed to resolve the master host. The expander handles comma lists and bracket forms (`prefix[01-04,06]`, `prefix[030,058]`).
- Match only the leading hostname label in the `MASTER_ADDR` consistency check, so a scheduler-provided FQDN (Spur exports `MASTER_ADDR=<node>.crusoe.amd.com`) is accepted against the short name produced by nodelist expansion. A genuine mismatch is still caught.

**`examples/deepseek-v4/run_deepseek_v4_flash.sh`**
- Remove the literal double-quotes wrapping `PRIMUS_PP_LAYOUT` and `PRIMUS_COMPRESS_RATIOS`. The quotes were passed through verbatim as CLI overrides, and Megatron's pipeline-layout parser rejected them (`AssertionError: Invalid layer character: "`). This only triggered for multi-stage PP layouts (`NNODES=4/8`), so single-stage smoke runs never hit it. Values are still single-quoted in bash to protect `|`, `*`, `(`, `)`, and spaces.

**`examples/deepseek-v4/run_deepseek_v4.sh`**
- Make `SLURM_PARTITION` overridable via env (was hard-coded to `Compute-DCPT`).
- Add `PRIMUS_OUTPUT_ROOT` (default `output`) for the host-side launcher log directory, so runs work when the canonical `output/` tree is owned by root from earlier privileged runs.

### Notes for reviewers
- No behavior change for stock-SLURM clusters: `scontrol show hostnames` is still preferred when it works, and all new env knobs default to the previous values.
- For multi-node runs on Spur nodes, the socket bootstrap interface must be a routable NIC; pass `NCCL_SOCKET_IFNAME`/`GLOO_SOCKET_IFNAME=ens3` (the script otherwise falls back to `lo`).

### Testing
- Verified nodelist expansion for comma / bracket-list / bracket-range / mixed forms.
- Launched a 4-node DeepSeek-V4 flash run on `amd-spur`: passes scheduler launch, master resolution, layout parsing, NCCL init, model build, and dataset setup. (A separate image-side stall during optimizer/DeepEP setup with `tasimage/primus:pr-862` is still under investigation and is out of scope for this launcher/config PR.)

---

Want me to create the PR into `main` with this description?