### PR TITLE
fix(maxtext): handle v26.5 2-value initialize()/run() API

### DIFF
--- a/primus/backends/maxtext/maxtext_pretrain_trainer.py
+++ b/primus/backends/maxtext/maxtext_pretrain_trainer.py
@@ -84,6 +84,9 @@ class MaxTextPretrainTrainer(BaseTrainer):
         self.train_config: Optional[Any] = None
         self.recorder: Optional[Any] = None
         self.diagnostic_config: Optional[Any] = None
+        # Raw tuple returned by MaxText's initialize(); forwarded verbatim to
+        # run() so we stay agnostic to its return arity across MaxText versions.
+        self._init_result: tuple = ()
 
         log_rank_0("Initialized MaxTextPretrainTrainer")
 
@@ -126,12 +129,26 @@ class MaxTextPretrainTrainer(BaseTrainer):
         yaml_path = export_params_to_yaml(params_dict)
         try:
             argv = [module_name, yaml_path]
-            self.train_config, self.recorder, self.diagnostic_config = initialize(argv, **override_model_args)
+            init_result = initialize(argv, **override_model_args)
         finally:
             try:
                 os.unlink(yaml_path)
             except OSError as e:
                 error_rank_0(f"MaxTextPretrainTrainer: Failed to delete temporary YAML at {yaml_path}: {e}")
+
+        # MaxText's ``initialize()`` return arity changed across versions:
+        #   - v26.4 and earlier: ``(config, recorder, diagnostic_config)``
+        #   - v26.5+:            ``(config, recorder)`` (diagnostic_config dropped)
+        # Keep the raw tuple so ``train()`` can forward it verbatim to ``run()``,
+        # whose parameter count matches ``initialize()``'s arity in the same
+        # version. Unpacking a fixed number of names here is what previously
+        # crashed on v26.5 with "not enough values to unpack (expected 3, got 2)".
+        if not isinstance(init_result, tuple):
+            init_result = (init_result,)
+        self._init_result = init_result
+        self.train_config = init_result[0] if len(init_result) > 0 else None
+        self.recorder = init_result[1] if len(init_result) > 1 else None
+        self.diagnostic_config = init_result[2] if len(init_result) > 2 else None
 
         self._update_logger_rank()
         log_rank_0("MaxText training components initialized successfully")
@@ -212,6 +229,9 @@ class MaxTextPretrainTrainer(BaseTrainer):
 
         _, run, _ = _resolve_maxtext_train()
 
-        run(self.train_config, self.recorder, self.diagnostic_config)
+        # Forward the exact tuple returned by initialize(); run()'s signature
+        # matches initialize()'s arity within a given MaxText version (3 args on
+        # v26.4 with diagnostic_config, 2 args on v26.5+).
+        run(*self._init_result)
 
         log_rank_0("MaxText pretrain execution completed.")


### PR DESCRIPTION
### Summary
Fixes MaxText **v26.5** pretraining via Primus, which currently exits silently
right after JAX initializes the GPUs. Makes `MaxTextPretrainTrainer` agnostic to
MaxText's `initialize()`/`run()` return arity, so it works on v26.5 and stays
backward compatible with v26.4/v26.3.

### Problem
`#906` bumped `third_party/maxtext` to v26.5 but did not update the pretrain
trainer, so on `main` this fails:

    ./primus-cli ... train pretrain --config examples/maxtext/configs/MI300X/llama2_7B-pretrain.yaml

The run dies immediately after the "System Information / devices" block with no
visible error (the launcher swallows the traceback).

### Root cause
MaxText v26.5 dropped `diagnostic_config` and moved to a 2-value API:
- v26.3 / v26.4: `initialize()` -> `(config, recorder, diagnostic_config)`, `run(config, recorder, diagnostic_config)`
- v26.5+:        `initialize()` -> `(config, recorder)`, `run(config, recorder)`

The trainer unpacked a fixed 3 values and called `run()` with 3 args, so on
v26.5 it raised `ValueError: not enough values to unpack (expected 3, got 2)`.

### Fix
Keep the tuple returned by `initialize()` and forward it verbatim to `run()`
instead of unpacking a fixed arity:

    init_result = initialize(argv, **override_model_args)
    self._init_result = init_result
    self.train_config      = init_result[0] if len(init_result) > 0 else None
    self.recorder          = init_result[1] if len(init_result) > 1 else None
    self.diagnostic_config = init_result[2] if len(init_result) > 2 else None
    ...
    run(*self._init_result)

`initialize` and `run` are resolved from the same MaxText module, so `run`'s
arity always matches `initialize()`'s return — making this correct on every
version (and forward compatible).

### Backward compatibility
- v26.4 / v26.3: 3-value tuple -> `run(config, recorder, diagnostic_config)` (unchanged).
- v26.5+: 2-value tuple, `diagnostic_config = None` -> `run(config, recorder)`.
- Fields are still populated by index, so the `if self.train_config is None`
  guard is unchanged. No other MaxText path assumes 3 values.

### How to verify
v26.5 (the fix) — short pretrain should now train past init:

    ./primus-cli container -- train pretrain \
      --config examples/maxtext/configs/MI300X/llama2_7B-pretrain.yaml --steps 5


v26.4 (backward compat) — with the maxtext submodule pinned to `release/v26.4`,
the same command still trains end-to-end.