### PR TITLE
ci: chown root-owned E2E leftovers back to runner user in Clean step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -233,6 +233,32 @@ jobs:
     # runs-on: [primus-lm-cicd-v26.3-crusoe-m2m-321]
     steps:
       - run: echo "🎉 Begin Primus Unit Test (containerized)."
+      - name: Pre-checkout cleanup of root-owned leftovers
+        # Safety net for when a PREVIOUS run never reached its Clean step (runner
+        # crash/reboot/OOM, or cancellation past the grace period): it can leave
+        # root-owned files (E2E data/, output/, pp_simulation_result/,
+        # .pytest_cache, ...) in the workspace, and actions/checkout then fails
+        # with EACCES while deleting them ("Deleting the contents of ..."). Fix
+        # ownership here BEFORE checkout so the current run self-heals regardless
+        # of how the previous one ended. Runs as root via docker because the
+        # runner user cannot chown root-owned files. Best-effort (never fails).
+        run: |
+          WS="${GITHUB_WORKSPACE}"
+          CWS="$WS"; [[ "$WS" == /apps/* ]] && CWS="/mnt/apps_proxy${WS#/apps}"
+          if [ ! -d "$CWS" ]; then echo "Workspace $CWS not present yet; nothing to clean."; exit 0; fi
+          owner="$(stat -c '%u:%g' "$CWS")"
+          echo "Workspace=$CWS owner=$owner root-owned-before=$(find "$CWS" -user 0 2>/dev/null | wc -l)"
+          FIX="find '$CWS' -user 0 -exec chown $owner {} + 2>/dev/null; true"
+          if [ "$(docker inspect -f '{{.State.Running}}' "${UT_CONTAINER}" 2>/dev/null)" = "true" ]; then
+            echo "Fixing ownership via running container ${UT_CONTAINER}."
+            docker exec "${UT_CONTAINER}" bash -lc "$FIX" || true
+          else
+            IMG="$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -m1 -E 'tasimage/primus|rocm/primus' || true)"
+            [ -n "$IMG" ] || IMG="${BASE_IMAGE}"
+            echo "Fixing ownership via throwaway container from image: $IMG"
+            docker run --rm -v /mnt/apps_proxy:/mnt/apps_proxy "$IMG" bash -lc "$FIX" || true
+          fi
+          echo "root-owned-after=$(find "$CWS" -user 0 2>/dev/null | wc -l)"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: recursive

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -574,11 +574,13 @@ jobs:
         run: |
           # The container steps run as ROOT and write root-owned files into the
           # mounted GITHUB_WORKSPACE (__pycache__, .pytest_cache/, .hypothesis/,
-          # logs/, test-reports/, ut_out/, .coverage*). The next run's
-          # actions/checkout runs as the runner user and cannot delete those, so
-          # it fails at "Deleting the contents of ...".
-          # Remove them here AS ROOT (via the container) so the workspace is left
-          # clean for the next checkout. Artifacts have already been uploaded by the
+          # logs/, test-reports/, ut_out/, .coverage*, plus E2E-generated dirs like
+          # data/, output/, pp_simulation_result/). The next run's actions/checkout
+          # runs as the runner user and cannot delete those, so it fails at
+          # "Deleting the contents of ..." (e.g. EACCES on data/huggingface).
+          # Remove the well-known artifacts here AS ROOT (via the container), then
+          # chown whatever root-owned files remain back to the runner user so the
+          # next checkout can clean them. Artifacts have already been uploaded by the
           # preceding upload steps. The container is left running for reuse.
           docker exec -i -e GITHUB_WORKSPACE="${CWS}" "${UT_CONTAINER}" bash -s <<'IN' || true
           set +e
@@ -590,6 +592,12 @@ jobs:
           find . -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null
           # Coverage subprocess-injection .pth in site-packages.
           SP=$(python -c "import site; print(site.getsitepackages()[0])" 2>/dev/null) && rm -f "$SP/primus_e2e_coverage.pth"
+          # Safety net: hand any remaining root-owned files (E2E-generated data/,
+          # output/, pp_simulation_result/, .git internals, ...) back to the runner
+          # user so the next actions/checkout can delete them instead of hitting
+          # EACCES. Owner is taken from GITHUB_WORKSPACE itself (the runner user).
+          owner="$(stat -c '%u:%g' "${GITHUB_WORKSPACE}" 2>/dev/null)"
+          [ -n "$owner" ] && find "${GITHUB_WORKSPACE}" -user 0 -exec chown "$owner" {} + 2>/dev/null
           IN
 
   run-unittest-jax:


### PR DESCRIPTION
The containerized E2E steps run as root and create root-owned dirs in the mounted workspace beyond the fixed rm list (data/ incl. data/huggingface, output/, pp_simulation_result/, .git internals). The next run's actions/checkout runs as the runner user and fails with EACCES while deleting them (e.g. rmdir data/huggingface). After the existing rm/find cleanup, chown any remaining root-owned files back to the runner user so the next checkout can remove them.