### PR TITLE
fix(flux): cast Q/K to value dtype before core attention

### DIFF
--- a/primus/backends/megatron/core/models/diffusion/flux/attention.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/attention.py
@@ -390,6 +390,12 @@ class JointSelfAttention(Attention):
             query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
             key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
 
+        # Q/K RMSNorm (for_qk) can leave Q/K in fp32 while V stays bf16; AITER
+        # FlashAttention requires Q, K, V to share one dtype. Align Q/K to V at the
+        # attention-kernel boundary (covers both RMSNorm and RoPE promotion).
+        query = query.to(value.dtype)
+        key = key.to(value.dtype)
+
         # Core attention computation
         if self.checkpoint_core_attention and self.training:
             core_attn_out = self._checkpointed_attention_forward(
@@ -565,6 +571,12 @@ class FluxSingleAttention(SelfAttention):
 
             query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
             key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
+
+        # Q/K RMSNorm (for_qk) can leave Q/K in fp32 while V stays bf16; AITER
+        # FlashAttention requires Q, K, V to share one dtype. Align Q/K to V at the
+        # attention-kernel boundary (covers both RMSNorm and RoPE promotion).
+        query = query.to(value.dtype)
+        key = key.to(value.dtype)
 
         # Core attention computation
         if self.checkpoint_core_attention and self.training:


### PR DESCRIPTION
## Summary

The Flux joint and single self-attention forwards can reach the core attention call with Q/K in fp32 while V is bf16: the Q/K RMSNorm (`for_qk`) and RoPE promote Q/K to fp32, but V is left untouched. AITER FlashAttention requires Q, K and V to share one dtype and otherwise raises `FlashAttention only support fp16, bf16 and fp8_e4m3`, so the Flux 12B local-spec / MXFP4 recipes cannot reach iteration 1 on `rocm/primus:v26.4`.

Fix: cast `query`/`key` to `value.dtype` at the attention-kernel boundary in both `JointSelfAttention.forward` and `FluxSingleAttention.forward` — right after RoPE, before the core attention computation. This covers both the RMSNorm and RoPE promotion paths and is a no-op when the dtypes already match.

### Changed
- `primus/backends/megatron/core/models/diffusion/flux/attention.py` — cast Q/K → `value.dtype` in both forwards.

## Test plan

- [x] 2-step smoke of `flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml` on 8 GPUs with `rocm/primus:v26.4`: exits `rc=0` with finite loss and no NaN; the attention forward runs (previously crashed before iteration 1).
- [ ] Maintainer review of the cast placement.