### PR TITLE
feat(runner): auto docker login before container image pull

### DIFF
--- a/examples/deepseek-v4/run_deepseek_v4.sh
+++ b/examples/deepseek-v4/run_deepseek_v4.sh
@@ -24,7 +24,7 @@ export WANDB_API_KEY="${WANDB_API_KEY:-your_wandb_api_key}"
 export NNODES=${NNODES:-1}
 export TRAIN_ITERS=${TRAIN_ITERS:-20}
 
-export DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/tasimage/primus:pr-882-ainic"}
+export DOCKER_IMAGE=${DOCKER_IMAGE:-"docker.io/tasimage/primus:pr-898-ainic"}
 export SLURM_PARTITION=${SLURM_PARTITION:-Compute-DCPT}
 export SLURM_NODELIST="${SLURM_NODELIST-smci355-ccs-aus-n01-21,smci355-ccs-aus-n01-33,smci355-ccs-aus-n02-21,smci355-ccs-aus-n02-25,smci355-ccs-aus-n02-29,smci355-ccs-aus-n02-33,smci355-ccs-aus-n03-33,smci355-ccs-aus-n04-21,smci355-ccs-aus-n04-25,smci355-ccs-aus-n04-29,smci355-ccs-aus-n04-33,smci355-ccs-aus-n05-21,smci355-ccs-aus-n05-29,smci355-ccs-aus-n05-33,smci355-ccs-aus-n06-25,smci355-ccs-aus-n06-33,smci355-ccs-aus-n10-29}"
 export MASTER_PORT=${MASTER_PORT:-29500}

--- a/examples/deepseek-v4/run_deepseek_v4_flash.sh
+++ b/examples/deepseek-v4/run_deepseek_v4_flash.sh
@@ -22,6 +22,16 @@ if command -v spur >/dev/null 2>&1; then
     export NCCL_DEBUG="${NCCL_DEBUG:-}"
     export GLOO_SOCKET_IFNAME=ens3
     export NCCL_SOCKET_IFNAME=ens3
+    # Docker Hub login for pulling the private tasimage/primus image. On each node
+    # primus-cli-container.sh runs `docker login` before the image pull; spur
+    # sbatch --export=ALL propagates these to every node, so training auto-logs-in
+    # and pulls without a manual `docker login`. Defaults are empty (login is
+    # skipped when DOCKER_LOGIN_KEY is unset): export DOCKER_LOGIN_USER and
+    # DOCKER_LOGIN_KEY (Docker Hub PAT) in your environment to enable it -- this
+    # keeps the secret out of this git-tracked file.
+    export DOCKER_LOGIN_USER="${DOCKER_LOGIN_USER:-}"
+    export DOCKER_LOGIN_KEY="${DOCKER_LOGIN_KEY:-}"
+    export DOCKER_IMAGE="${DOCKER_IMAGE:-docker.io/tasimage/primus:pr-898-ainic}"
 fi
 
 export PRIMUS_TOTAL_LAYERS=${PRIMUS_TOTAL_LAYERS:-43}
@@ -64,8 +74,10 @@ export PRIMUS_SEQ_LENGTH=${PRIMUS_SEQ_LENGTH:-4096}
 export PRIMUS_MAX_POSITION_EMBEDDINGS=${PRIMUS_MAX_POSITION_EMBEDDINGS:-${PRIMUS_SEQ_LENGTH}}
 
 export USE_V4_FP8_INDEXER=${USE_V4_FP8_INDEXER:-True}
-export USE_V4_ATTENTION_BACKEND=${USE_V4_ATTENTION_BACKEND:-triton_v2}
-export USE_V4_CSA_ATTENTION_BACKEND=${USE_V4_CSA_ATTENTION_BACKEND:-triton_v2}
+# V4 attention backend: default to PrimusTurbo native-FlyDSL sparse-MLA ("turbo")
+# for both the dense/HCA path and the CSA path.
+export USE_V4_ATTENTION_BACKEND=${USE_V4_ATTENTION_BACKEND:-turbo}
+export USE_V4_CSA_ATTENTION_BACKEND=${USE_V4_CSA_ATTENTION_BACKEND:-turbo}
 export USE_TURBO_DEEPEP=${USE_TURBO_DEEPEP:-True}
 export TURBO_USE_GROUPED_MLP=${TURBO_USE_GROUPED_MLP:-True}
 export USE_V4_COMPILED_SINKHORN=${USE_V4_COMPILED_SINKHORN:-True}

--- a/runner/primus-cli-container.sh
+++ b/runner/primus-cli-container.sh
@@ -541,5 +541,28 @@ if [[ "$DRY_RUN_MODE" == "true" ]]; then
     exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# Optional: authenticate to the container registry before the implicit pull.
+# On clusters whose compute nodes are not pre-logged-in, a private image
+# (e.g. docker.io/tasimage/primus:*) cannot be pulled and `docker run` fails
+# with "Unable to find image '<image>' locally" followed by a pull-access
+# error. Export DOCKER_LOGIN_USER and DOCKER_LOGIN_KEY (e.g. a Docker Hub PAT)
+# and the scheduler propagates them to every node (spur sbatch --export=ALL),
+# so the login+pull happens automatically at launch. DOCKER_LOGIN_REGISTRY is
+# optional and defaults to Docker Hub.
+# ---------------------------------------------------------------------------
+if [[ -n "${DOCKER_LOGIN_KEY:-}" ]]; then
+    if [[ -z "${DOCKER_LOGIN_USER:-}" ]]; then
+        LOG_ERROR "[container] DOCKER_LOGIN_KEY is set but DOCKER_LOGIN_USER is empty."
+        exit 1
+    fi
+    LOG_INFO_RANK0 "[container] Logging in to registry ${DOCKER_LOGIN_REGISTRY:-docker.io} as ${DOCKER_LOGIN_USER}..."
+    if ! printf '%s' "${DOCKER_LOGIN_KEY}" | \
+        "$CONTAINER_RUNTIME" login ${DOCKER_LOGIN_REGISTRY:+"$DOCKER_LOGIN_REGISTRY"} -u "${DOCKER_LOGIN_USER}" --password-stdin; then
+        LOG_ERROR "[container] Registry login failed for user ${DOCKER_LOGIN_USER}."
+        exit 1
+    fi
+fi
+
 LOG_INFO "[container] Executing command..."
 "${CMD[@]}"


### PR DESCRIPTION
- primus-cli-container.sh: run `docker login` on each node before `docker run` when DOCKER_LOGIN_USER/DOCKER_LOGIN_KEY are set (spur sbatch --export=ALL propagates them), so private-image pulls work on nodes not pre-logged-in.
- run_deepseek_v4_flash.sh: wire DOCKER_LOGIN_USER/KEY (empty defaults) and DOCKER_IMAGE in the spur block; default V4 attention backend to 'turbo'.
- run_deepseek_v4.sh: default image -> pr-898-ainic.