### PR TITLE
fix(ci): stop anchore/sbom-action from double-uploading SBOM to releases

### DIFF
--- a/.github/workflows/release-build-wheel.yml
+++ b/.github/workflows/release-build-wheel.yml
@@ -149,6 +149,12 @@ jobs:
           format: spdx-json
           artifact-name: primus-sbom.spdx.json
           output-file: dist/primus-sbom.spdx.json
+          # The "Attach wheel to release" step below is the single place that
+          # uploads release assets (with clobber semantics it controls). Let
+          # this action only produce the SBOM as a workflow artifact, so it
+          # doesn't race that step by also auto-uploading to the release on
+          # `release` events -- that always fails with "asset already exists".
+          upload-release-assets: false
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
## Summary
- `anchore/sbom-action` defaults to `upload-release-assets: true`, so on a `release` event it auto-attaches `primus-sbom.spdx.json` to the GitHub Release.
- The later "Attach wheel to release" step then re-uploads the same filename without `--clobber` (release events never clobber), which fails with `asset under the same name already exists` and aborts the entire `gh release upload` batch — so the wheel, sdist, and `SHA256SUMS` never land on the release either.
- This is exactly what happened on the [v26.5.0 release run](https://github.com/AMD-AGI/Primus/actions/runs/30036562282/job/89305868922): only `primus-sbom.spdx.json` made it onto the release; the wheel/tar.gz/SHA256SUMS are still missing.
- Fix: set `upload-release-assets: false` on the SBOM step so release-asset uploads are handled solely by the existing, clobber-aware "Attach wheel to release" step. The SBOM is still produced and still uploaded as a workflow artifact — nothing is lost.

## Root cause history
- Introduced in #780 ("ci: supply-chain hardening"), which added the SBOM step and also started listing `dist/primus-sbom.spdx.json` in the explicit `gh release upload` call in the same PR.