### PR TITLE
[CP] Support maxtext v26.5 release (#906)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 [submodule "third_party/maxtext"]
 	path = third_party/maxtext
 	url = https://github.com/ROCm/maxtext.git
-	branch = release/v26.4
+	branch = release/v26.5
 [submodule "third_party/Emerging-Optimizers"]
 	path = third_party/Emerging-Optimizers
 	url = https://github.com/NVIDIA-NeMo/Emerging-Optimizers.git

--- a/primus/_thirdparty.lock
+++ b/primus/_thirdparty.lock
@@ -16,7 +16,7 @@
       "name": "maxtext",
       "path": "third_party/maxtext",
       "url": "https://github.com/ROCm/maxtext.git",
-      "commit": "80f431d0ebbf6465257e2a5d931046dfb0b465b0"
+      "commit": "a7c6c7e5377cce39be51cbe2a48fe0f86fbab8dc"
     },
     {
       "name": "Emerging-Optimizers",

--- a/primus/configs/modules/maxtext/pre_trainer.yaml
+++ b/primus/configs/modules/maxtext/pre_trainer.yaml
@@ -21,7 +21,7 @@ packing: true
 # 32 matches upstream MaxText GPU model configs and is harmless on v26.3.
 max_segments_per_seq: 32
 
-shardy: false
+shardy: true
 
 remat_policy: 'full'
 optimizer_memory_host_offload: false

--- a/runner/helpers/envs/MI355X.sh
+++ b/runner/helpers/envs/MI355X.sh
@@ -30,5 +30,8 @@ LOG_INFO_RANK0 "Loading MI355X-specific optimizations..."
 # APU may have different interconnect characteristics
 # Keep common_network.sh settings unless testing shows otherwise
 
+# Disable RCCL warp-speed auto-tuning on gfx950 (MI355X)
+export RCCL_WARP_SPEED_AUTO=${RCCL_WARP_SPEED_AUTO:-0}
+
 # log_exported_vars "MI355X-specific optimizations" \
-#     HSA_XNACK HSA_ENABLE_INTERRUPT GPU_MAX_HEAP_SIZE HSA_KERNARG_POOL_SIZE
+#     HSA_XNACK HSA_ENABLE_INTERRUPT GPU_MAX_HEAP_SIZE HSA_KERNARG_POOL_SIZE RCCL_WARP_SPEED_AUTO


### PR DESCRIPTION
Config changes:
- JAX 0.10 requires `shardy: true`
- For NaN mitigation, set `RCCL_WARP_SPEED_AUTO=0`

---------