### PR TITLE
fix(megatron): restore "compute per GPU" TFLOP label and make log parsers robust

### DIFF
--- a/benchmark/megatron/model/benchmark_report.py
+++ b/benchmark/megatron/model/benchmark_report.py
@@ -13,15 +13,21 @@ from typing import Dict
 
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
 ARG_PATTERN = re.compile(r"\]:\s+([a-zA-Z0-9_]+)\s+\.{3,}\s+(.*)$")
+# Field order matches the current Megatron training-log line, where the memory
+# segment is appended last (after tokens) rather than sitting between elapsed and
+# throughput as in the old format. Groups: elapsed inst/avg, tflops inst/avg,
+# tokens inst/avg, memory.
 ITERATION_PATTERN = re.compile(
     r"iteration\s+\d+/.*?elapsed time per iteration \(ms\): ([\d.]+)/([\d.]+).*?"
-    r"mem usages: ([\d.]+).*?"
     # Compute (TFLOP/s/GPU) accepts both the current "compute per GPU (...): X (avg Y)"
     # label and the legacy "throughput per GPU (...): X/Y" label.
     r"(?:compute|throughput) per GPU \(TFLOP/s/GPU\): ([\d.]+)(?:/| \(avg )([\d.]+)\)?.*?"
     # Tokens accepts both the current "tokens/s/GPU inst/harmonic mean: X/Y" label
     # and the legacy "tokens per GPU (tokens/s/GPU): X/Y" label.
-    r"(?:tokens per GPU \(tokens/s/GPU\)|tokens/s/GPU inst/harmonic mean): ([\d.]+)/([\d.]+)",
+    r"(?:tokens per GPU \(tokens/s/GPU\)|tokens/s/GPU inst/harmonic mean): ([\d.]+)/([\d.]+).*?"
+    # Memory accepts both the current "hip mem usage/free/total/usage_ratio: X GB/..."
+    # segment and the legacy "mem usages: X" segment. Only the used value is captured.
+    r"(?:hip mem usage/free/total/usage_ratio:\s*|mem usages:\s*)([\d.]+)(?:\s*G(?:i)?B)?",
     re.DOTALL,
 )
 
@@ -53,9 +59,9 @@ def parse_last_metrics_from_log(file_path: str) -> Dict[str, float]:
 
     last = matches[-1]
     step_time_s = (float(last[0]) + float(last[1])) / 2000
-    mem_usage = float(last[2])
-    tflops = max(float(last[3]), float(last[4]))
-    tokens_per_gpu = (float(last[5]) + float(last[6])) / 2
+    tflops = max(float(last[2]), float(last[3]))
+    tokens_per_gpu = (float(last[4]) + float(last[5])) / 2
+    mem_usage = float(last[6])
 
     return {
         "TFLOP/s/GPU": round(tflops, 2),

--- a/benchmark/megatron/model/benchmark_report.py
+++ b/benchmark/megatron/model/benchmark_report.py
@@ -20,8 +20,9 @@ ARG_PATTERN = re.compile(r"\]:\s+([a-zA-Z0-9_]+)\s+\.{3,}\s+(.*)$")
 ITERATION_PATTERN = re.compile(
     r"iteration\s+\d+/.*?elapsed time per iteration \(ms\): ([\d.]+)/([\d.]+).*?"
     # Compute (TFLOP/s/GPU) accepts both the current "compute per GPU (...): X (avg Y)"
-    # label and the legacy "throughput per GPU (...): X/Y" label.
-    r"(?:compute|throughput) per GPU \(TFLOP/s/GPU\): ([\d.]+)(?:/| \(avg )([\d.]+)\)?.*?"
+    # label and the legacy "throughput per GPU (...): X/Y" label. The space before
+    # "(avg" is optional (some log sinks drop it).
+    r"(?:compute|throughput) per GPU \(TFLOP/s/GPU\): ([\d.]+)(?:/|\s*\(avg\s*)([\d.]+)\)?.*?"
     # Tokens accepts both the current "tokens/s/GPU inst/harmonic mean: X/Y" label
     # and the legacy "tokens per GPU (tokens/s/GPU): X/Y" label.
     r"(?:tokens per GPU \(tokens/s/GPU\)|tokens/s/GPU inst/harmonic mean): ([\d.]+)/([\d.]+).*?"

--- a/benchmark/megatron/model/benchmark_report.py
+++ b/benchmark/megatron/model/benchmark_report.py
@@ -16,8 +16,12 @@ ARG_PATTERN = re.compile(r"\]:\s+([a-zA-Z0-9_]+)\s+\.{3,}\s+(.*)$")
 ITERATION_PATTERN = re.compile(
     r"iteration\s+\d+/.*?elapsed time per iteration \(ms\): ([\d.]+)/([\d.]+).*?"
     r"mem usages: ([\d.]+).*?"
-    r"throughput per GPU \(TFLOP/s/GPU\): ([\d.]+)/([\d.]+).*?"
-    r"tokens per GPU \(tokens/s/GPU\): ([\d.]+)/([\d.]+)",
+    # Compute (TFLOP/s/GPU) accepts both the current "compute per GPU (...): X (avg Y)"
+    # label and the legacy "throughput per GPU (...): X/Y" label.
+    r"(?:compute|throughput) per GPU \(TFLOP/s/GPU\): ([\d.]+)(?:/| \(avg )([\d.]+)\)?.*?"
+    # Tokens accepts both the current "tokens/s/GPU inst/harmonic mean: X/Y" label
+    # and the legacy "tokens per GPU (tokens/s/GPU): X/Y" label.
+    r"(?:tokens per GPU \(tokens/s/GPU\)|tokens/s/GPU inst/harmonic mean): ([\d.]+)/([\d.]+)",
     re.DOTALL,
 )
 

--- a/primus/backends/megatron/patches/training_log/print_rank_last_patches.py
+++ b/primus/backends/megatron/patches/training_log/print_rank_last_patches.py
@@ -12,7 +12,7 @@ to inject additional information into Megatron training logs:
 
     - ROCm/HIP memory stats.
     - Running average elapsed time per iteration (ms).
-    - Running average throughput per GPU (TFLOP/s/GPU).
+    - Running average compute per GPU (TFLOP/s/GPU).
     - Running average token throughput per GPU (tokens/s/GPU) (language models only).
     - Diffusion-specific metrics (diffusion models only):
       * Images per GPU (images/s/GPU): instant/average
@@ -461,7 +461,7 @@ class ThroughputAverageExtension:
                 idx = parsed.throughput_index
                 if idx is not None and 0 <= idx < len(parsed.segments):
                     parsed.segments[idx] = (
-                        f"throughput per GPU (TFLOP/s/GPU): {tflops_value:.1f}/{avg_tflops:.1f}"
+                        f"compute per GPU (TFLOP/s/GPU): {tflops_value:.1f} (avg {avg_tflops:.1f})"
                     )
 
     def inject(self, log_string: str, parsed: Optional[TrainingLogInfo] = None) -> str:
@@ -469,9 +469,9 @@ class ThroughputAverageExtension:
         Update ``parsed`` with running-average TFLOP and token throughput.
 
         - TFLOPs are rendered inline as:
-              throughput per GPU (TFLOP/s/GPU): inst/avg
-        - Tokens are appended as a new segment immediately after throughput:
-              tokens per GPU (tokens/s/GPU): inst/avg
+              compute per GPU (TFLOP/s/GPU): inst (avg <mean>)
+        - Tokens are appended to the same segment immediately after compute:
+              tokens/s/GPU inst/harmonic mean: inst/<harmonic mean>
         """
         try:
             # If no parsed info is provided (e.g., unit tests calling this

--- a/tools/auto_benchmark/metrics.py
+++ b/tools/auto_benchmark/metrics.py
@@ -84,8 +84,13 @@ MEGATRON_METRIC_VALUE = rf"({MEGATRON_NUM})(?:\s*/\s*{MEGATRON_NUM})?"
 MEGATRON_ITERATION_REGEX = re.compile(
     rf"iteration\s+(\d+)/\s*\d+.*?"
     rf"elapsed time per iteration \(ms\):\s*{MEGATRON_METRIC_VALUE}.*?"
-    rf"throughput per GPU \(TFLOP/s/GPU\):\s*{MEGATRON_METRIC_VALUE}.*?"
-    rf"(?:tokens per GPU \(tokens/s/GPU\):\s*{MEGATRON_METRIC_VALUE}.*?)?"
+    # Compute (TFLOP/s/GPU) accepts both the current "compute per GPU (...)" label
+    # and the legacy "throughput per GPU (...)" label. Only the instantaneous value
+    # is captured; the "(avg Y)" / "/Y" suffix is absorbed by the trailing ".*?".
+    rf"(?:compute|throughput) per GPU \(TFLOP/s/GPU\):\s*{MEGATRON_METRIC_VALUE}.*?"
+    # Tokens accepts both the current "tokens/s/GPU inst/harmonic mean:" label and
+    # the legacy "tokens per GPU (tokens/s/GPU):" label.
+    rf"(?:(?:tokens per GPU \(tokens/s/GPU\)|tokens/s/GPU inst/harmonic mean):\s*{MEGATRON_METRIC_VALUE}.*?)?"
     rf"global batch size:\s*(\d+)",
     re.IGNORECASE,
 )

--- a/tools/auto_benchmark/metrics.py
+++ b/tools/auto_benchmark/metrics.py
@@ -82,8 +82,7 @@ MEGATRON_NUM = r"[\d,]+(?:\.\d+)?"
 MEGATRON_METRIC_VALUE = rf"({MEGATRON_NUM})(?:\s*/\s*{MEGATRON_NUM})?"
 
 MEGATRON_ITERATION_REGEX = re.compile(
-    rf"iteration\s+(\d+)/\s*\d+.*?"
-    rf"elapsed time per iteration \(ms\):\s*{MEGATRON_METRIC_VALUE}.*?"
+    rf"iteration\s+(\d+)/\s*\d+.*?" rf"elapsed time per iteration \(ms\):\s*{MEGATRON_METRIC_VALUE}.*?"
     # Compute (TFLOP/s/GPU) accepts both the current "compute per GPU (...)" label
     # and the legacy "throughput per GPU (...)" label. Only the instantaneous value
     # is captured; the "(avg Y)" / "/Y" suffix is absorbed by the trailing ".*?".

--- a/tools/daily/daily_report.py
+++ b/tools/daily/daily_report.py
@@ -17,8 +17,15 @@ ANSI_ESCAPE_PATTERN = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
 MEGATRON_ITERATION_PATTERN = re.compile(
     r"iteration\s+\d+\s*/\s*\d+.*?"
     r"elapsed time per iteration\s*\(ms\):\s*(?P<elapsed_ms>[\d.]+)(?:/(?P<elapsed_ms_avg>[\d.]+))?.*?"
-    r"throughput per GPU\s*\(TFLOP/s/GPU\):\s*(?P<tflops>[\d.]+)/(?P<tflops_avg>[\d.]+).*?"
-    r"tokens per GPU\s*\(tokens/s/GPU\):\s*(?P<tokens>[\d.]+)/(?P<tokens_avg>[\d.]+).*?"
+    # Compute (TFLOP/s/GPU) accepts both the current "compute per GPU (...): X (avg Y)"
+    # label and the legacy "throughput per GPU (...): X/Y" label. The average is
+    # optional so raw (un-averaged) Megatron lines still parse.
+    r"(?:compute|throughput) per GPU\s*\(TFLOP/s/GPU\):\s*(?P<tflops>[\d.]+)"
+    r"(?:\s*(?:/|\(avg\s*)\s*(?P<tflops_avg>[\d.]+)\)?)?.*?"
+    # Tokens accepts both the current "tokens/s/GPU inst/harmonic mean: X/Y" label
+    # and the legacy "tokens per GPU (tokens/s/GPU): X/Y" label.
+    r"(?:tokens per GPU\s*\(tokens/s/GPU\)|tokens/s/GPU\s+inst/harmonic mean):\s*"
+    r"(?P<tokens>[\d.]+)(?:\s*/\s*(?P<tokens_avg>[\d.]+))?.*?"
     r"hip mem usage/free/total/usage_ratio:\s*"
     r"(?P<hip_used>[\d.]+)\s*G(?:i)?B/(?P<hip_free>[\d.]+)\s*G(?:i)?B/(?P<hip_total>[\d.]+)\s*G(?:i)?B/(?P<hip_ratio>[\d.]+)%",
     re.DOTALL,
@@ -138,10 +145,12 @@ def parse_last_metrics_from_log(file_path: str) -> Dict[str, float]:
     if not last_m:
         raise ValueError(f"No valid iteration metrics found in {file_path}")
     metric = last_m.groupdict()
-    step_time_s_avg = float(metric["elapsed_ms_avg"]) / 1000.0
+    # Averages are optional in the pattern (raw Megatron lines omit them); fall
+    # back to the instantaneous value when an average is not present.
+    step_time_s_avg = float(metric["elapsed_ms_avg"] or metric["elapsed_ms"]) / 1000.0
     mem_usage = float(metric["hip_used"])
-    tflops_avg = float(metric["tflops_avg"])
-    tokens_avg = float(metric["tokens_avg"])
+    tflops_avg = float(metric["tflops_avg"] or metric["tflops"])
+    tokens_avg = float(metric["tokens_avg"] or metric["tokens"])
 
     return {
         "TFLOP/s/GPU": round(tflops_avg, 2),


### PR DESCRIPTION
## Summary

Restores the `compute per GPU (TFLOP/s/GPU)` training-log label (from #842) that
was inadvertently reverted by the Flux MLPerf logging refactor (#820), and updates
the three Megatron log parsers so both the current and legacy log formats parse
correctly.

## Background

- #842 relabeled the per-GPU FLOP rate from `throughput per GPU (TFLOP/s/GPU): X/Y`
  to `compute per GPU (TFLOP/s/GPU): X (avg Y)`. "Throughput" is ambiguous next to
  the tokens/s line; `compute` describes a FLOP rate unambiguously.
- #820 extracted a shared `_inject_tflops()` helper for the diffusion path and, in
  the process, reverted that label back to `throughput per GPU`. The harmonic-mean
  token change from #842 was left intact.
- The newest docs (`examples/odc/README.md`, added after #820) already document the
  log as `compute per GPU (TFLOP/s/GPU)`, so the code had drifted from the docs.

## What changed

**`primus/backends/megatron/patches/training_log/print_rank_last_patches.py`**
- Restore the `compute per GPU (TFLOP/s/GPU): X (avg Y)` label in `_inject_tflops()`.
- Refresh the module/render docstrings to match the actual output
  (`compute per GPU ...` and `tokens/s/GPU inst/harmonic mean: ...`).

**Log parsers** — `tools/daily/daily_report.py`, `tools/auto_benchmark/metrics.py`,
`benchmark/megatron/model/benchmark_report.py`
- Accept both the current labels (`compute per GPU`, `tokens/s/GPU inst/harmonic mean`)
  and the legacy ones (`throughput per GPU`, `tokens per GPU (tokens/s/GPU)`), using
  non-capturing alternations so positional group indices are unchanged.
- `benchmark_report`: the memory segment is now appended **last** (as
  `hip mem usage/free/total/usage_ratio: X GB/...`) rather than sitting between
  elapsed and throughput as `mem usages: X`; reorder the pattern/group indices and
  accept both memory labels.
- Tolerate the optional space before `(avg` (real logs can render `X(avg Y)`), and
  fall back to the instantaneous value when a running average is absent (raw
  warmup lines).

## Why the parsers were already broken

The token label from #842 (`tokens/s/GPU inst/harmonic mean`) never matched the
parsers' `tokens per GPU (tokens/s/GPU)` regex, and `benchmark_report` expected a
`mem usages:` segment that current logs no longer emit. This PR realigns all three
with the current log format while staying backward-compatible.

## Test plan

- [x] `pytest tests/unit_tests/backends/megatron/test_training_log_patches.py` — 7 passed
- [x] End-to-end: drove the real `ThroughputAverageExtension`/`ElapsedAverageExtension`
      across multiple iterations, rendered the line, and confirmed all three parsers
      extract correct inst/avg TFLOP, tokens, and memory values.
- [x] Validated all three parsers against **real** pre-train logs
      (`llama2_7B-BF16-pretrain`, MI300X): current + legacy + raw-warmup lines all parse.
- [x] No new lint errors.