### PR TITLE
fix(deepseek-v4): align Flash attention math with the released reference implementation

### DIFF
--- a/examples/deepseek-v4/run_deepseek_v4.sh
+++ b/examples/deepseek-v4/run_deepseek_v4.sh
@@ -166,8 +166,8 @@ export USE_V4_FP8_INDEXER=${USE_V4_FP8_INDEXER:-False}
 
 # Indexer distillation loss coefficient (CSA selector training). 0 keeps the
 # loss off and the indexer frozen -- correct when loading an already-trained
-# indexer. A from-scratch pretrain needs it ON (Megatron's Flash recipe uses
-# 1e-2), which also unfreezes the indexer params.
+# indexer. A from-scratch pretrain needs it ON (1e-2 is a reasonable starting
+# value), which also unfreezes the indexer params.
 export PRIMUS_V4_INDEXER_DISTILL_LOSS_COEFF=${PRIMUS_V4_INDEXER_DISTILL_LOSS_COEFF:-0.0}
 
 # Plan-5 P29 (RESCOPED): wrap sinkhorn_normalize in HyperMixer with a

--- a/examples/deepseek-v4/run_deepseek_v4.sh
+++ b/examples/deepseek-v4/run_deepseek_v4.sh
@@ -164,6 +164,12 @@ export USE_V4_CSA_ATTENTION_BACKEND=${USE_V4_CSA_ATTENTION_BACKEND:-triton_v2}
 # in-container config regardless of env propagation.
 export USE_V4_FP8_INDEXER=${USE_V4_FP8_INDEXER:-False}
 
+# Indexer distillation loss coefficient (CSA selector training). 0 keeps the
+# loss off and the indexer frozen -- correct when loading an already-trained
+# indexer. A from-scratch pretrain needs it ON (Megatron's Flash recipe uses
+# 1e-2), which also unfreezes the indexer params.
+export PRIMUS_V4_INDEXER_DISTILL_LOSS_COEFF=${PRIMUS_V4_INDEXER_DISTILL_LOSS_COEFF:-0.0}
+
 # Plan-5 P29 (RESCOPED): wrap sinkhorn_normalize in HyperMixer with a
 # cached torch.compile build. Default OFF here; the proxy script
 # (run_deepseek_v4_flash_proxy.sh) flips it ON. After G32 + G33b are
@@ -298,6 +304,7 @@ fi
   --use_v4_attention_backend "$USE_V4_ATTENTION_BACKEND" \
   --use_v4_csa_attention_backend "$USE_V4_CSA_ATTENTION_BACKEND" \
   --use_v4_fp8_indexer "$USE_V4_FP8_INDEXER" \
+  --v4_indexer_distill_loss_coeff "$PRIMUS_V4_INDEXER_DISTILL_LOSS_COEFF" \
   --use_v4_compiled_sinkhorn "$USE_V4_COMPILED_SINKHORN" \
   --use_turbo_deepep "$USE_TURBO_DEEPEP" \
   "${TURBO_DEEPEP_CLI_ARGS[@]}" \

--- a/examples/deepseek-v4/run_deepseek_v4_flash.sh
+++ b/examples/deepseek-v4/run_deepseek_v4_flash.sh
@@ -74,12 +74,12 @@ export PRIMUS_SEQ_LENGTH=${PRIMUS_SEQ_LENGTH:-4096}
 export PRIMUS_MAX_POSITION_EMBEDDINGS=${PRIMUS_MAX_POSITION_EMBEDDINGS:-${PRIMUS_SEQ_LENGTH}}
 
 # Keep the indexer QK in high precision. The indexer decides which 512
-# compressed KV entries each query attends to, so quantization error there
-# changes the selection itself; the Megatron-LM reference deliberately runs the
-# CSA compressor and indexer under get_fp8_disabled_context even when the rest
-# of the layer is FP8. Note this knob is a *fake* quant (quantize/dequantize
-# around a BF16 GEMM), so leaving it off also removes pure overhead. Set
-# USE_V4_FP8_INDEXER=True to opt back in for QAT experiments.
+# compressed KV entries each query attends to, so quantization error there does
+# not merely perturb a value -- it changes the selection itself, which is a
+# numerics change and should not be a silent default. Note this knob is also a
+# *fake* quant (quantize/dequantize around a BF16 GEMM), so leaving it off
+# removes pure overhead as well. Set USE_V4_FP8_INDEXER=True to opt back in for
+# QAT experiments.
 export USE_V4_FP8_INDEXER=${USE_V4_FP8_INDEXER:-False}
 # V4 attention backend: default to PrimusTurbo native-FlyDSL sparse-MLA ("turbo")
 # for both the dense/HCA path and the CSA path.

--- a/examples/deepseek-v4/run_deepseek_v4_flash.sh
+++ b/examples/deepseek-v4/run_deepseek_v4_flash.sh
@@ -73,7 +73,14 @@ export TRAIN_ITERS=${TRAIN_ITERS:-10}
 export PRIMUS_SEQ_LENGTH=${PRIMUS_SEQ_LENGTH:-4096}
 export PRIMUS_MAX_POSITION_EMBEDDINGS=${PRIMUS_MAX_POSITION_EMBEDDINGS:-${PRIMUS_SEQ_LENGTH}}
 
-export USE_V4_FP8_INDEXER=${USE_V4_FP8_INDEXER:-True}
+# Keep the indexer QK in high precision. The indexer decides which 512
+# compressed KV entries each query attends to, so quantization error there
+# changes the selection itself; the Megatron-LM reference deliberately runs the
+# CSA compressor and indexer under get_fp8_disabled_context even when the rest
+# of the layer is FP8. Note this knob is a *fake* quant (quantize/dequantize
+# around a BF16 GEMM), so leaving it off also removes pure overhead. Set
+# USE_V4_FP8_INDEXER=True to opt back in for QAT experiments.
+export USE_V4_FP8_INDEXER=${USE_V4_FP8_INDEXER:-False}
 # V4 attention backend: default to PrimusTurbo native-FlyDSL sparse-MLA ("turbo")
 # for both the dense/HCA path and the CSA path.
 export USE_V4_ATTENTION_BACKEND=${USE_V4_ATTENTION_BACKEND:-turbo}

--- a/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
+++ b/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
@@ -115,9 +115,8 @@ class DeepSeekV4TransformerConfig(MLATransformerConfig):
     # ``topk`` is not differentiable, so the CSA lightning indexer only learns
     # through an auxiliary objective: KL between the indexer's score
     # distribution and the distribution the real attention places over the same
-    # compressed entries (DeepSeek-V3.2 2.1; Megatron's
-    # ``compute_dsa_indexer_loss`` / ``dsa_indexer_loss_coeff``, whose Flash
-    # recipe uses 1e-2).
+    # compressed entries (DeepSeek-V3.2 section 2.1). ``1e-2`` is a reasonable
+    # starting value.
     #
     # ``0.0`` (the default) disables the loss AND keeps the indexer parameters
     # frozen, which is the right setting when loading an already-trained

--- a/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
+++ b/primus/backends/megatron/core/models/deepseek_v4/deepseek_v4_transformer_config.py
@@ -111,6 +111,22 @@ class DeepSeekV4TransformerConfig(MLATransformerConfig):
     # ``PRIMUS_USE_V4_FP8_INDEXER`` (see run_deepseek_v4.sh / flash yaml).
     use_v4_fp8_indexer: bool = False
 
+    # ---- DeepSeek-V4 indexer distillation loss (CSA selector training) ----
+    # ``topk`` is not differentiable, so the CSA lightning indexer only learns
+    # through an auxiliary objective: KL between the indexer's score
+    # distribution and the distribution the real attention places over the same
+    # compressed entries (DeepSeek-V3.2 2.1; Megatron's
+    # ``compute_dsa_indexer_loss`` / ``dsa_indexer_loss_coeff``, whose Flash
+    # recipe uses 1e-2).
+    #
+    # ``0.0`` (the default) disables the loss AND keeps the indexer parameters
+    # frozen, which is the right setting when loading an already-trained
+    # indexer: frozen params stay out of the distributed-optimizer grad buckets
+    # so ``overlap_grad_reduce`` keeps working. Set > 0 to unfreeze the indexer
+    # and train it -- required for a from-scratch pretrain, where a frozen
+    # randomly-initialised indexer selects essentially at random.
+    v4_indexer_distill_loss_coeff: float = 0.0
+
     # ---- DeepSeek-V4 attention backend selection (unified string selectors) ----
     # ``use_v4_attention_backend`` selects the dense (cr=0) / HCA (cr=128) kernel;
     # ``use_v4_csa_attention_backend`` selects the CSA (cr=4) kernel:

--- a/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
+++ b/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
@@ -1207,6 +1207,50 @@ class DeepseekV4Attention(MLASelfAttention):
         B, S, H, Dh = attn.shape
         return _projection_forward(self.linear_proj, attn.reshape(B, S, H * Dh))
 
+    def _apply_inverse_rope(self, attn: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        """De-rotate the core-attention output (RoPE at ``position = -t``).
+
+        V4 shares a single latent between K and V, so the values entering the
+        softmax are already rotated and the naive output
+
+            ``o_t = sum_s P[t,s] * R(s) v_s``
+
+        carries *absolute* positions. Rotating it by ``-t`` turns every
+        contribution into ``R(s - t) v_s``, i.e. the relative encoding the
+        model expects. The released ``inference/model.py`` does exactly this
+        with ``apply_rotary_emb(o[..., -rd:], freqs_cis, inverse=True)`` right
+        before ``wo_a``, and the inverse rotation must use the *same* per-layer
+        RoPE base that Q / KV were rotated with.
+
+        Implemented as a negated sine (``R(-t) == R(t)^T``) so the existing
+        eager and Triton kernels are reused unchanged. Returns a new tensor:
+        ``attn`` is what the attention backward saved and must not be mutated.
+        """
+        if self.rotary_dim == 0:
+            return attn
+        rope = self.rope.get_rope(compress_ratio=self.compress_ratio)
+        cos, sin = rope(position_ids)
+        cos = cos[..., : self.rotary_dim // 2]
+        sin = sin[..., : self.rotary_dim // 2]
+        # The Triton path reshapes cos/sin to [prod(attn.shape[:-2]), rd/2],
+        # so a 1-D ``position_ids`` must be broadcast over the batch first.
+        lead = attn.shape[:-2]
+        if tuple(cos.shape[:-1]) != tuple(lead):
+            cos = cos.expand(*lead, -1)
+            sin = sin.expand(*lead, -1)
+        return apply_interleaved_partial_rope(attn, cos, -sin, rotary_dim=self.rotary_dim)
+
+    def _project_output(self, attn: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        """Inverse-RoPE then O projection -- the single exit for every branch.
+
+        Kept as one helper so no attention path can reach the O projection
+        without de-rotating first.
+        """
+        attn = self._apply_inverse_rope(attn, position_ids)
+        if self.linear_o_a is not None:
+            return self._grouped_o_projection(attn)
+        return self._flat_o_projection(attn)
+
     # ------------------------------------------------------------------
     # compressed branches (HCA / CSA)
     # ------------------------------------------------------------------
@@ -1595,9 +1639,7 @@ class DeepseekV4Attention(MLASelfAttention):
             out_bh = self._attention_forward_via_core(q, kv)
             out = out_bh.transpose(1, 2).contiguous()  # [B, S, H, head_dim]
             out = out.to(dtype=dtype)
-            if self.linear_o_a is not None:
-                return self._grouped_o_projection(out)
-            return self._flat_o_projection(out)
+            return self._project_output(out, position_ids)
 
         # Broadcast K / V across the H query-head axis.
         k_h = kv.expand(B, S, self.num_heads, self.head_dim)
@@ -1652,9 +1694,7 @@ class DeepseekV4Attention(MLASelfAttention):
         out = out_bh.transpose(1, 2).contiguous()  # [B, S, H, head_dim]
         out = out.to(dtype=dtype)
 
-        if self.linear_o_a is not None:
-            return self._grouped_o_projection(out)
-        return self._flat_o_projection(out)
+        return self._project_output(out, position_ids)
 
 
 __all__ = [

--- a/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
+++ b/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
@@ -937,9 +937,15 @@ class DeepseekV4Attention(MLASelfAttention):
         return self._rope[0]
 
     def _attention_scale(self) -> float:
-        base = 1.0 / math.sqrt(self.head_dim)
-        rope_scale = self.rope.attn_scale(compress_ratio=self.compress_ratio)
-        return base * rope_scale
+        """Softmax temperature for every branch: plain ``1 / sqrt(head_dim)``.
+
+        V4 keeps attention logits in range via the Q / KV RMSNorms, so the
+        YaRN magnitude factor (``m_scale``) is deliberately NOT folded in here
+        -- ``inference/model.py`` uses ``self.softmax_scale = head_dim ** -0.5``
+        for both the core attention and the indexer. The YaRN *frequency*
+        interpolation on ``inv_freq`` is unaffected.
+        """
+        return 1.0 / math.sqrt(self.head_dim)
 
     def _apply_q(self, hidden: torch.Tensor) -> torch.Tensor:
         """``[B, S, D]`` → ``[B, S, H, head_dim]`` (Q after q_norm + q_rms)."""

--- a/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
+++ b/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
@@ -1220,10 +1220,15 @@ class DeepseekV4Attention(MLASelfAttention):
         pooled = self.compressor(hidden)  # [B, P, head_dim]
         B, P = pooled.shape[0], pooled.shape[1]
 
-        # Compress-base partial RoPE on compressed indices [0..P). Positions are
-        # the deterministic arange(P), so use the cached table instead of
-        # rebuilding arange -> outer -> cos/sin every forward.
-        cos, sin = self.rope.compress_rope.forward_arange(P, device)
+        # Compress-base partial RoPE. Compressed entry ``s`` stands for the
+        # window starting at original token ``s * compress_ratio``, so it is
+        # rotated at that position -- not at the bare block index ``s``. The
+        # queries are rotated at their own original positions, so using block
+        # indices here would put the two sides on different coordinate systems.
+        # Matches inference/model.py (``freqs_cis[:cutoff:ratio]``) and
+        # Megatron's ``cos[:total:ratio]``. Positions stay deterministic, so
+        # the cached table is still reused every forward.
+        cos, sin = self.rope.compress_rope.forward_arange(P, device, stride=self.compress_ratio)
         cos = cos[..., : self.rotary_dim // 2]
         sin = sin[..., : self.rotary_dim // 2]
         cos = cos.unsqueeze(0).expand(B, -1, -1)

--- a/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
+++ b/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
@@ -1285,9 +1285,10 @@ class DeepseekV4Attention(MLASelfAttention):
         # rotated at that position -- not at the bare block index ``s``. The
         # queries are rotated at their own original positions, so using block
         # indices here would put the two sides on different coordinate systems.
-        # Matches inference/model.py (``freqs_cis[:cutoff:ratio]``) and
-        # Megatron's ``cos[:total:ratio]``. Positions stay deterministic, so
-        # the cached table is still reused every forward.
+        # Matches inference/model.py, which slices ``freqs_cis[:cutoff:ratio]``
+        # for prefill and indexes ``start_pos + 1 - ratio`` for decode -- both
+        # land on the window's first token. Positions stay deterministic, so the
+        # cached table is still reused every forward.
         cos, sin = self.rope.compress_rope.forward_arange(P, device, stride=self.compress_ratio)
         cos = cos[..., : self.rotary_dim // 2]
         sin = sin[..., : self.rotary_dim // 2]

--- a/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
+++ b/primus/backends/megatron/core/transformer/deepseek_v4_attention.py
@@ -77,6 +77,10 @@ from primus.backends.megatron.core.transformer.dual_rope import (
     apply_interleaved_partial_rope,
 )
 from primus.backends.megatron.core.transformer.indexer import Indexer
+from primus.backends.megatron.core.transformer.indexer_distill_loss import (
+    V4IndexerLossAutoScaler,
+    compute_indexer_distill_loss,
+)
 from primus.backends.megatron.core.transformer.local_rmsnorm import LocalRMSNorm
 from primus.backends.megatron.core.transformer.sliding_window_kv import (
     sliding_window_causal_mask,
@@ -648,25 +652,27 @@ class DeepseekV4Attention(MLASelfAttention):
         # ---- compressor / indexer (compressed branches only) ----
         self.compressor: Optional[nn.Module] = None
         self.indexer: Optional[nn.Module] = None
+        # Last indexer distillation loss (detached), for logging. None until a
+        # training step runs with the loss enabled.
+        self.last_indexer_distill_loss: Optional[torch.Tensor] = None
         if self.compress_ratio > 0:
             self.compressor = self._build_compressor(submodules.compressor)
             if self.compress_ratio == 4:
                 self.indexer = self._build_indexer(submodules.indexer)
-                # The Indexer is a non-differentiable top-K *selector*: the only
-                # consumed output is ``topk_idxs`` (argTopK indices); its scores
-                # are discarded (``topk_idxs, _ = self.indexer(...)`` in forward)
-                # and this model has no indexer auxiliary/distillation loss, so
-                # none of the Indexer's params can ever receive a gradient.
-                # Leaving them trainable inserts permanently-dead params into the
-                # distributed-optimizer grad buckets, which both wastes grad /
-                # optimizer state + cross-node grad-sync bandwidth AND trips
+                # ``topk`` is not differentiable and the forward only consumes
+                # ``topk_idxs``, so the Indexer can only learn through the
+                # distillation loss (see ``indexer_distill_loss``). Without it,
+                # leaving the params trainable inserts permanently-dead params
+                # into the distributed-optimizer grad buckets: that wastes grad /
+                # optimizer state plus cross-node grad-sync bandwidth AND trips
                 # Megatron's overlap_grad_reduce invariant (every bucket param
-                # must fire its grad-ready backward hook) -- the latter is what
-                # forced overlap_grad_reduce/param_gather OFF and crippled
-                # cross-node DP scaling. Freeze them so Megatron excludes them
-                # from the grad buckets entirely. Set PRIMUS_V4_INDEXER_TRAINABLE=1
-                # to re-enable (e.g. once an indexer aux loss is added).
-                if os.environ.get("PRIMUS_V4_INDEXER_TRAINABLE", "0") != "1":
+                # must fire its grad-ready backward hook), which is what forced
+                # overlap_grad_reduce / param_gather OFF and crippled cross-node
+                # DP scaling. So freeze unless the loss is actually enabled.
+                # PRIMUS_V4_INDEXER_TRAINABLE=1 still forces trainable.
+                if not self.indexer_distill_enabled and (
+                    os.environ.get("PRIMUS_V4_INDEXER_TRAINABLE", "0") != "1"
+                ):
                     for _indexer_param in self.indexer.parameters():
                         _indexer_param.requires_grad_(False)
 
@@ -935,6 +941,16 @@ class DeepseekV4Attention(MLASelfAttention):
     @property
     def rope(self) -> DualRoPE:
         return self._rope[0]
+
+    @property
+    def indexer_distill_coeff(self) -> float:
+        """Coefficient of the indexer distillation loss (``0`` = disabled)."""
+        return float(getattr(self.config, "v4_indexer_distill_loss_coeff", 0.0) or 0.0)
+
+    @property
+    def indexer_distill_enabled(self) -> bool:
+        """True when this layer trains its indexer via the distillation loss."""
+        return self.compress_ratio == 4 and self.indexer_distill_coeff > 0.0
 
     def _attention_scale(self) -> float:
         """Softmax temperature for every branch: plain ``1 / sqrt(head_dim)``.
@@ -1375,7 +1391,26 @@ class DeepseekV4Attention(MLASelfAttention):
         P = pool.shape[1]
 
         # 2) Indexer top-K per query.
-        topk_idxs, _ = self.indexer(hidden)  # [B, S, K]
+        topk_idxs, topk_scores = self.indexer(hidden)  # [B, S, K]
+
+        # 2b) Indexer distillation. argTopK is not differentiable and the
+        # scores are otherwise discarded, so this loss is the indexer's only
+        # learning signal. It is attached to ``pool`` -- which every CSA
+        # backend consumes -- so the aux gradient is seeded no matter which
+        # kernel the layer dispatches to, without threading a second return
+        # value through all of them.
+        if self.indexer_distill_enabled and self.training and torch.is_grad_enabled():
+            indexer_loss = compute_indexer_distill_loss(
+                index_topk_scores=topk_scores,
+                topk_idxs=topk_idxs,
+                query=q_bh,
+                pool=pool,
+                softmax_scale=self._attention_scale(),
+                loss_coeff=self.indexer_distill_coeff,
+            )
+            self.last_indexer_distill_loss = indexer_loss.detach()
+            pool = V4IndexerLossAutoScaler.apply(pool, indexer_loss)
+
         # Dispatch on ``use_v4_csa_attention_backend``. gluon / triton_v2 /
         # triton_v1 consume (pool, topk) directly; eager / triton_v0 / flydsl_v0
         # use the per-query gathered [B, S, K, Dh] representation.

--- a/primus/backends/megatron/core/transformer/dual_rope.py
+++ b/primus/backends/megatron/core/transformer/dual_rope.py
@@ -146,7 +146,11 @@ class RoPECache(nn.Module):
         )
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
-        # YaRN's m_scale; exposed for the caller to multiply attention scale.
+        # YaRN's m_scale, kept for reference / diagnostics only. V4 does NOT
+        # fold it into the attention softmax temperature -- the released
+        # ``inference/model.py`` uses a plain ``head_dim ** -0.5`` and relies on
+        # the Q / KV RMSNorms to keep logits in range. Only the ``inv_freq``
+        # interpolation above is part of the model contract.
         self.attn_scale: float = _yarn_attn_scale(self.yarn_factor)
 
         # Memo of (cos, sin) tables keyed by (n, device) for arange(n) positions;
@@ -349,8 +353,8 @@ class DualRoPE(nn.Module):
         rope = self.get_rope(compress_ratio=compress_ratio)
         return apply_rope_from_positions(x, position_ids, rope.inv_freq, rotary_dim=self.rotary_dim)
 
-    # Convenience accessors for callers who need the YaRN m_scale (e.g. to
-    # adjust attention softmax scale on compressed layers).
+    # Diagnostic accessor for the YaRN m_scale. Not used by the attention
+    # softmax scale -- see the note on ``RoPECache.attn_scale``.
     def attn_scale(self, *, compress_ratio: int) -> float:
         return self.get_rope(compress_ratio=compress_ratio).attn_scale
 

--- a/primus/backends/megatron/core/transformer/dual_rope.py
+++ b/primus/backends/megatron/core/transformer/dual_rope.py
@@ -15,8 +15,13 @@ V4 layers fall into two RoPE regimes, decided per-layer by
 * ``compress_ratio == 0`` (dense / SWA layers): use the **main** RoPE base
   (``rope_theta = 10000``), **no YaRN**.
 * ``compress_ratio != 0`` (CSA / HCA layers): use the **compress** RoPE
-  base (``compress_rope_theta = 160000``) **with YaRN scaling**
+  base (``compress_rope_theta``; 40000 for V4-Flash, 160000 for V4-Pro)
+  **with YaRN scaling**
   (``factor=16, beta_fast=32, beta_slow=1, original_max_position_embeddings=65536``).
+
+Compressed KV entries are rotated at their **original-sequence** positions
+(entry ``s`` covers the window starting at token ``s * compress_ratio``), so
+they share the query coordinate system -- see ``forward_arange(..., stride=)``.
 
 Two important corrections over the HF Llama-style RoPE that V4 inherits
 from the released weights:
@@ -153,8 +158,9 @@ class RoPECache(nn.Module):
         # interpolation above is part of the model contract.
         self.attn_scale: float = _yarn_attn_scale(self.yarn_factor)
 
-        # Memo of (cos, sin) tables keyed by (n, device) for arange(n) positions;
-        # see forward_arange. Not a buffer (recomputable, device-keyed).
+        # Memo of (cos, sin) tables keyed by (n, stride, device) for
+        # ``arange(n) * stride`` positions; see forward_arange. Not a buffer
+        # (recomputable, device-keyed).
         self._arange_cache: dict = {}
 
     def forward(self, position_ids: torch.Tensor) -> tuple:
@@ -172,23 +178,35 @@ class RoPECache(nn.Module):
         sin = freqs.sin()
         return cos, sin
 
-    def forward_arange(self, n: int, device) -> tuple:
-        """``(cos, sin)`` for positions ``torch.arange(n)`` -- cached.
+    def forward_arange(self, n: int, device, *, stride: int = 1) -> tuple:
+        """``(cos, sin)`` for positions ``torch.arange(n) * stride`` -- cached.
 
-        Equivalent to ``self.forward(torch.arange(n, device=device))``, but
-        memoised by ``(n, device)``. The compressed-branch RoPE is always
-        evaluated at the deterministic positions ``arange(P)``
-        (``P = S // compress_ratio``, fixed per run), so the table is identical
-        every forward; caching it skips the ``arange -> outer-product ->
-        cos/sin`` recompute each step (and per compressed layer). Set
+        Equivalent to ``self.forward(torch.arange(n, device=device) * stride)``,
+        but memoised by ``(n, stride, device)``.
+
+        The compressed branch evaluates its RoPE at deterministic positions
+        (``P = S // compress_ratio`` entries, fixed per run), so the table is
+        identical every forward; caching it skips the ``arange ->
+        outer-product -> cos/sin`` recompute each step (and per compressed
+        layer). ``stride`` carries the compression ratio so the compressed
+        entries land on their *original-sequence* coordinates
+        (``0, ratio, 2*ratio, ...``) rather than on bare block indices. Set
         ``PRIMUS_COMPRESS_ROPE_CACHE=0`` to disable the cache.
         """
+        stride = int(stride)
+
+        def _build():
+            positions = torch.arange(n, device=device)
+            if stride != 1:
+                positions = positions * stride
+            return self.forward(positions)
+
         if os.environ.get("PRIMUS_COMPRESS_ROPE_CACHE", "1") == "0":
-            return self.forward(torch.arange(n, device=device))
-        key = (int(n), str(device))
+            return _build()
+        key = (int(n), stride, str(device))
         hit = self._arange_cache.get(key)
         if hit is None:
-            hit = self.forward(torch.arange(n, device=device))
+            hit = _build()
             self._arange_cache[key] = hit
         return hit
 

--- a/primus/backends/megatron/core/transformer/indexer_distill_loss.py
+++ b/primus/backends/megatron/core/transformer/indexer_distill_loss.py
@@ -11,22 +11,22 @@ query attends to. ``topk`` is not differentiable, so without an auxiliary
 objective the indexer never receives a gradient and a from-scratch run selects
 essentially at random.
 
-DeepSeek-V3.2 (and Megatron-LM's DSv4 port, ``compute_dsa_indexer_loss`` in
-``experimental_attention_variant/dsa.py``) trains it by distillation: the
-indexer's score distribution is pulled towards the distribution the *real*
-attention places over the same entries, via ``KL(attention || indexer)``.
+DeepSeek-V3.2 (section 2.1) trains it by distillation: the indexer's score
+distribution is pulled towards the distribution the *real* attention places over
+the same entries, via ``KL(attention || indexer)``.
 
 This module implements the sparse variant -- the loss is evaluated only on the
-entries the indexer actually selected, which is what Megatron's Flash recipe
-uses (``dsa_indexer_use_sparse_loss: true``). Because those entries are already
-gathered per query, the computation stays in the ``[B, S, K]`` top-k space and
+entries the indexer actually selected. That keeps the objective consistent with
+what the forward pass actually consumes, and because those entries are already
+gathered per query the computation stays in the ``[B, S, K]`` top-k space and
 never materialises the dense ``[B, H, S, P]`` score tensor.
 
-The loss is attached to the autograd graph with :class:`V4IndexerLossAutoScaler`
-(the same trick Megatron uses for MoE aux losses and MTP): it passes a tensor
-through untouched in forward and seeds the auxiliary loss with a gradient of
-one in backward, so the aux objective backpropagates without having to be
-threaded through every forward return signature.
+The loss is attached to the autograd graph with :class:`V4IndexerLossAutoScaler`,
+the same aux-loss autoscaler pattern this training stack already uses for the
+MoE auxiliary loss and the MTP loss: it passes a tensor through untouched in
+forward and seeds the auxiliary loss with a gradient of one in backward, so the
+aux objective backpropagates without having to be threaded through every forward
+return signature.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ __all__ = [
     "compute_indexer_distill_loss",
 ]
 
-# Guard for log(0) / division by zero; matches Megatron's constant.
+# Guard for log(0) / division by zero.
 _EPS = 1e-10
 
 
@@ -47,8 +47,8 @@ class V4IndexerLossAutoScaler(torch.autograd.Function):
 
     ``forward`` returns ``output`` unchanged; ``backward`` seeds ``aux_loss``
     with ``main_loss_backward_scale`` so its subgraph is differentiated as part
-    of the main backward. Mirrors Megatron's ``MoEAuxLossAutoScaler`` /
-    ``MTPLossAutoScaler``.
+    of the main backward. Same shape as the autoscalers already used for the MoE
+    auxiliary loss and the MTP loss.
     """
 
     main_loss_backward_scale: torch.Tensor = torch.tensor(1.0)

--- a/primus/backends/megatron/core/transformer/indexer_distill_loss.py
+++ b/primus/backends/megatron/core/transformer/indexer_distill_loss.py
@@ -1,0 +1,136 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Indexer distillation loss for DeepSeek-V4 CSA layers.
+
+The CSA lightning indexer picks which ``index_topk`` compressed KV entries each
+query attends to. ``topk`` is not differentiable, so without an auxiliary
+objective the indexer never receives a gradient and a from-scratch run selects
+essentially at random.
+
+DeepSeek-V3.2 (and Megatron-LM's DSv4 port, ``compute_dsa_indexer_loss`` in
+``experimental_attention_variant/dsa.py``) trains it by distillation: the
+indexer's score distribution is pulled towards the distribution the *real*
+attention places over the same entries, via ``KL(attention || indexer)``.
+
+This module implements the sparse variant -- the loss is evaluated only on the
+entries the indexer actually selected, which is what Megatron's Flash recipe
+uses (``dsa_indexer_use_sparse_loss: true``). Because those entries are already
+gathered per query, the computation stays in the ``[B, S, K]`` top-k space and
+never materialises the dense ``[B, H, S, P]`` score tensor.
+
+The loss is attached to the autograd graph with :class:`V4IndexerLossAutoScaler`
+(the same trick Megatron uses for MoE aux losses and MTP): it passes a tensor
+through untouched in forward and seeds the auxiliary loss with a gradient of
+one in backward, so the aux objective backpropagates without having to be
+threaded through every forward return signature.
+"""
+
+from __future__ import annotations
+
+import torch
+
+__all__ = [
+    "V4IndexerLossAutoScaler",
+    "compute_indexer_distill_loss",
+]
+
+# Guard for log(0) / division by zero; matches Megatron's constant.
+_EPS = 1e-10
+
+
+class V4IndexerLossAutoScaler(torch.autograd.Function):
+    """Attach an auxiliary loss to an existing tensor's backward pass.
+
+    ``forward`` returns ``output`` unchanged; ``backward`` seeds ``aux_loss``
+    with ``main_loss_backward_scale`` so its subgraph is differentiated as part
+    of the main backward. Mirrors Megatron's ``MoEAuxLossAutoScaler`` /
+    ``MTPLossAutoScaler``.
+    """
+
+    main_loss_backward_scale: torch.Tensor = torch.tensor(1.0)
+
+    @staticmethod
+    def forward(ctx, output: torch.Tensor, aux_loss: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        ctx.save_for_backward(aux_loss)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):  # type: ignore[override]
+        (aux_loss,) = ctx.saved_tensors
+        scale = V4IndexerLossAutoScaler.main_loss_backward_scale.to(
+            device=aux_loss.device, dtype=aux_loss.dtype
+        )
+        return grad_output, torch.ones_like(aux_loss) * scale
+
+    @staticmethod
+    def set_loss_scale(scale: torch.Tensor) -> None:
+        """Set the gradient seeded into the auxiliary loss.
+
+        Pipeline / gradient-accumulation schedules use this to keep the aux
+        loss on the same scale as the main loss.
+        """
+        V4IndexerLossAutoScaler.main_loss_backward_scale = scale
+
+
+def compute_indexer_distill_loss(
+    *,
+    index_topk_scores: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    query: torch.Tensor,
+    pool: torch.Tensor,
+    softmax_scale: float,
+    loss_coeff: float,
+) -> torch.Tensor:
+    """``KL(attention || indexer)`` over the selected compressed entries.
+
+    Args:
+        index_topk_scores: indexer scores at the selected slots, ``[B, S, K]``.
+            Invalid slots are ``-inf`` (fewer than K legal entries exist for
+            early queries).
+        topk_idxs: selected pool indices, ``[B, S, K]``; ``-1`` marks invalid.
+        query: post-RoPE queries, ``[B, H, S, head_dim]``.
+        pool: compressed KV pool, ``[B, P, head_dim]``.
+        softmax_scale: the attention softmax temperature (``1/sqrt(head_dim)``).
+        loss_coeff: scaling applied to the KL.
+
+    Returns:
+        Scalar loss (fp32). Rows with no legal entry contribute nothing, so a
+        fully-masked row can never produce NaN.
+    """
+    B, H, S, _ = query.shape
+    valid = topk_idxs >= 0  # [B, S, K]
+    row_valid = valid.any(dim=-1)  # [B, S]
+
+    # Gather the selected pool entries: [B, S, K, head_dim]. Clamp the -1
+    # sentinels to a legal index first; they are masked out below.
+    batch_idx = torch.arange(B, device=pool.device).view(B, 1, 1)
+    gathered = pool[batch_idx, topk_idxs.clamp_min(0)]
+
+    # True attention logits over exactly the selected entries.
+    attn_logits = torch.einsum("bhsd,bskd->bhsk", query.float(), gathered.float()) * softmax_scale
+    attn_logits = attn_logits.masked_fill(~valid.unsqueeze(1), float("-inf"))
+    idx_logits = index_topk_scores.float()
+
+    # Rows with zero legal entries would softmax over all -inf and yield NaN.
+    # Neutralise their logits before the softmax and drop their contribution
+    # after it, so no NaN is ever produced (and no gradient flows from them).
+    attn_row_mask = row_valid.view(B, 1, S, 1)
+    idx_row_mask = row_valid.view(B, S, 1)
+    attn_logits = attn_logits.masked_fill(~attn_row_mask, 0.0)
+    idx_logits = idx_logits.masked_fill(~idx_row_mask, 0.0)
+
+    attn_probs = torch.softmax(attn_logits, dim=-1, dtype=torch.float32) * attn_row_mask.to(torch.float32)
+    idx_probs = torch.softmax(idx_logits, dim=-1, dtype=torch.float32) * idx_row_mask.to(torch.float32)
+
+    # The indexer emits one distribution per query while attention has H heads,
+    # so aggregate the heads and renormalise to a distribution (L1 is enough --
+    # softmax outputs are already non-negative).
+    target = attn_probs.sum(dim=1)  # [B, S, K]
+    target = target / target.sum(dim=-1, keepdim=True).clamp(min=_EPS)
+
+    kl_per_row = (target * (torch.log(target + _EPS) - torch.log(idx_probs + _EPS))).sum(dim=-1)
+    return kl_per_row.mean() * loss_coeff

--- a/primus/configs/models/megatron/deepseek_v4_base.yaml
+++ b/primus/configs/models/megatron/deepseek_v4_base.yaml
@@ -39,6 +39,9 @@ mtp_use_separate_hc_head: true
 hybrid_attention_enabled: true
 compress_ratios: null            # provided by the per-variant yaml (Flash / Pro);
                                  # entries: 0 = dense+SWA, 4 = CSA, 128 = HCA
+# RoPE base for the CSA / HCA (compressed) branches. 160000 is the V4-Pro
+# value; V4-Flash overrides this to 40000 in deepseek_v4_flash.yaml to match
+# the released DeepSeek-V4-Flash inference/model.py.
 compress_rope_theta: 160000.0
 index_topk: 512
 index_head_dim: 128

--- a/primus/configs/models/megatron/deepseek_v4_base.yaml
+++ b/primus/configs/models/megatron/deepseek_v4_base.yaml
@@ -64,6 +64,15 @@ use_v4_csa_attention_backend: triton_v1
 # top-k path is preserved). Surface via PRIMUS_USE_V4_FP8_INDEXER.
 use_v4_fp8_indexer: false
 
+# Indexer distillation loss (CSA selector training). argTopK is not
+# differentiable, so the lightning indexer only learns through this auxiliary
+# KL against the real attention distribution. 0.0 keeps the loss off AND the
+# indexer frozen (correct when loading an already-trained indexer, and it keeps
+# the params out of the grad buckets so overlap_grad_reduce stays usable).
+# A from-scratch pretrain needs this on; Megatron's Flash recipe uses 1e-2.
+# Surface via PRIMUS_V4_INDEXER_DISTILL_LOSS_COEFF (see run_deepseek_v4.sh).
+v4_indexer_distill_loss_coeff: 0.0
+
 # Plan-5 P29 (RESCOPED): wrap ``sinkhorn_normalize`` (the doubly-stochastic
 # projection inside HyperMixer.compute_weights) with a cached
 # ``torch.compile(fullgraph=True, dynamic=False)`` build. Collapses the

--- a/primus/configs/models/megatron/deepseek_v4_base.yaml
+++ b/primus/configs/models/megatron/deepseek_v4_base.yaml
@@ -69,7 +69,7 @@ use_v4_fp8_indexer: false
 # KL against the real attention distribution. 0.0 keeps the loss off AND the
 # indexer frozen (correct when loading an already-trained indexer, and it keeps
 # the params out of the grad buckets so overlap_grad_reduce stays usable).
-# A from-scratch pretrain needs this on; Megatron's Flash recipe uses 1e-2.
+# A from-scratch pretrain needs this on; 1e-2 is a reasonable starting value.
 # Surface via PRIMUS_V4_INDEXER_DISTILL_LOSS_COEFF (see run_deepseek_v4.sh).
 v4_indexer_distill_loss_coeff: 0.0
 

--- a/primus/configs/models/megatron/deepseek_v4_flash.yaml
+++ b/primus/configs/models/megatron/deepseek_v4_flash.yaml
@@ -31,6 +31,11 @@ moe_router_topk_scaling_factor: 1.5
 # Indexer / Compressor
 index_topk: 512
 
+# RoPE base for the compressed (CSA / HCA) branches. The released
+# DeepSeek-V4-Flash inference/model.py uses compress_rope_theta = 40000.0;
+# the 160000 inherited from deepseek_v4_base.yaml is the V4-Pro value.
+compress_rope_theta: 40000.0
+
 # Per-layer compression schedule (from config.json:compress_ratios)
 # 0   = uncompressed dense layer (full attention with SWA)
 # 4   = CSA branch (overlap mode; per-query top-K from compressed pool via Indexer)

--- a/tests/unit_tests/backends/megatron/test_rope_arange_cache.py
+++ b/tests/unit_tests/backends/megatron/test_rope_arange_cache.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
 """Parity + caching test for ``RoPECache.forward_arange``.
 
-The compressed-branch RoPE is evaluated at the deterministic positions
-``arange(P)`` every forward; ``forward_arange`` caches that table. This asserts
-the cached table is bit-identical to recomputing ``forward(arange(n))`` and that
-the cache actually memoises (and that ``PRIMUS_COMPRESS_ROPE_CACHE=0`` bypasses it).
+The compressed-branch RoPE is evaluated at deterministic positions every
+forward (``arange(P) * compress_ratio``); ``forward_arange`` caches that table.
+This asserts the cached table is bit-identical to recomputing
+``forward(arange(n) * stride)``, that ``stride`` is honoured and part of the
+cache key, and that the cache actually memoises (with
+``PRIMUS_COMPRESS_ROPE_CACHE=0`` bypassing it).
 """
 from __future__ import annotations
 
@@ -45,3 +47,34 @@ def test_cache_disabled_recomputes(monkeypatch):
     b = rc.forward_arange(128, "cpu")
     assert a[0] is not b[0]
     torch.testing.assert_close(a[0], b[0], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("stride", [4, 128])
+def test_forward_arange_stride_uses_original_positions(stride):
+    """``stride`` evaluates at ``arange(n) * stride``, not at block indices.
+
+    Compressed KV entry ``s`` covers the window starting at original token
+    ``s * compress_ratio`` and must be rotated at that position so it shares
+    the query coordinate system.
+    """
+    n = 16
+    rc = _rope()
+    cos_a, sin_a = rc.forward_arange(n, "cpu", stride=stride)
+    cos_e, sin_e = rc.forward(torch.arange(n, device="cpu") * stride)
+    torch.testing.assert_close(cos_a, cos_e, rtol=0, atol=0)
+    torch.testing.assert_close(sin_a, sin_e, rtol=0, atol=0)
+
+    # Guard against a silently-ignored stride.
+    cos_blocks, _ = rc.forward_arange(n, "cpu", stride=1)
+    assert not torch.allclose(cos_a, cos_blocks)
+
+
+def test_forward_arange_stride_is_part_of_cache_key():
+    """Different strides must not collide in the memo table."""
+    rc = _rope()
+    cos_s1, _ = rc.forward_arange(32, "cpu", stride=1)
+    cos_s4, _ = rc.forward_arange(32, "cpu", stride=4)
+    torch.testing.assert_close(cos_s4, rc.forward(torch.arange(32) * 4)[0], rtol=0, atol=0)
+    torch.testing.assert_close(cos_s1, rc.forward(torch.arange(32))[0], rtol=0, atol=0)
+    # And each stride still memoises independently.
+    assert rc.forward_arange(32, "cpu", stride=4)[0] is cos_s4

--- a/tests/unit_tests/configs/test_deepseek_v4_yaml.py
+++ b/tests/unit_tests/configs/test_deepseek_v4_yaml.py
@@ -226,6 +226,32 @@ def test_yaml_does_not_set_retired_fields(parse_yaml_fn, yaml_name: str) -> None
 
 
 # ---------------------------------------------------------------------------
+# Compressed-branch RoPE base is variant-specific
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("yaml_name", "expected_theta"),
+    [
+        # The released DeepSeek-V4-Flash inference/model.py ships
+        # ``compress_rope_theta: float = 40000.0``; Megatron-LM's Flash recipe
+        # agrees (``csa_compress_rotary_base: 40000``). 160000 is the Pro value.
+        ("deepseek_v4_flash.yaml", 40000.0),
+        ("deepseek_v4_pro.yaml", 160000.0),
+        ("deepseek_v4_base.yaml", 160000.0),
+    ],
+)
+def test_compress_rope_theta_matches_variant(parse_yaml_fn, yaml_name: str, expected_theta: float) -> None:
+    """Each variant pins the compressed-branch RoPE base it was trained with.
+
+    Getting this wrong silently de-tunes every CSA / HCA layer's positional
+    phase, so it is worth a hard assertion rather than relying on inheritance.
+    """
+    parsed = parse_yaml_fn(str(_YAML_DIR / yaml_name))
+    assert float(parsed["compress_rope_theta"]) == pytest.approx(expected_theta)
+
+
+# ---------------------------------------------------------------------------
 # V4-specific schema fields the runtime depends on (D5 / D6 hygiene)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit_tests/configs/test_deepseek_v4_yaml.py
+++ b/tests/unit_tests/configs/test_deepseek_v4_yaml.py
@@ -234,8 +234,8 @@ def test_yaml_does_not_set_retired_fields(parse_yaml_fn, yaml_name: str) -> None
     ("yaml_name", "expected_theta"),
     [
         # The released DeepSeek-V4-Flash inference/model.py ships
-        # ``compress_rope_theta: float = 40000.0``; Megatron-LM's Flash recipe
-        # agrees (``csa_compress_rotary_base: 40000``). 160000 is the Pro value.
+        # ``compress_rope_theta: float = 40000.0``. 160000 is the Pro value, and
+        # inheriting it in the Flash config was the bug this pins down.
         ("deepseek_v4_flash.yaml", 40000.0),
         ("deepseek_v4_pro.yaml", 160000.0),
         ("deepseek_v4_base.yaml", 160000.0),

--- a/tests/unit_tests/examples/test_deepseek_v4_run_script_defaults.py
+++ b/tests/unit_tests/examples/test_deepseek_v4_run_script_defaults.py
@@ -9,10 +9,11 @@
 The Flash launcher overrides a handful of knobs on top of ``run_deepseek_v4.sh``.
 One of them -- ``USE_V4_FP8_INDEXER`` -- silently changes model numerics rather
 than just performance: the indexer picks which compressed KV entries each query
-attends to, so quantizing its QK inputs perturbs the selection itself. The
-Megatron-LM reference keeps the CSA compressor and indexer in high precision
-even under FP8 training (``get_fp8_disabled_context``), so Primus should not
-enable the fake-quant path by default either.
+attends to, so quantizing its QK inputs changes the selection itself. On top of
+that the knob is a fake quant (quantize/dequantize around a BF16 GEMM), so it
+costs throughput without buying any. Low-precision indexer QK is a legitimate
+thing to explore, but it should be opt-in rather than on by default in one
+launcher only.
 
 These tests parse the scripts as text: they need neither torch nor a GPU, so
 they run in any environment.
@@ -50,9 +51,9 @@ def test_fp8_indexer_defaults_off(script: Path) -> None:
     assert default is not None, f"{script.name} must define USE_V4_FP8_INDEXER with a ${{VAR:-...}} default"
     assert default == "False", (
         f"{script.name} defaults USE_V4_FP8_INDEXER to {default!r}. The indexer selects which "
-        "compressed KV entries each query sees, and the Megatron-LM reference keeps it in high "
-        "precision under FP8 training; enabling the fake-quant path by default changes model "
-        "numerics (and costs throughput, since the GEMM stays BF16)."
+        "compressed KV entries each query sees, so enabling the fake-quant path by default "
+        "changes model numerics -- and costs throughput while doing so, since the GEMM stays "
+        "BF16. Keep it opt-in."
     )
 
 

--- a/tests/unit_tests/examples/test_deepseek_v4_run_script_defaults.py
+++ b/tests/unit_tests/examples/test_deepseek_v4_run_script_defaults.py
@@ -1,0 +1,74 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Default-value gate for the DeepSeek-V4 run scripts.
+
+The Flash launcher overrides a handful of knobs on top of ``run_deepseek_v4.sh``.
+One of them -- ``USE_V4_FP8_INDEXER`` -- silently changes model numerics rather
+than just performance: the indexer picks which compressed KV entries each query
+attends to, so quantizing its QK inputs perturbs the selection itself. The
+Megatron-LM reference keeps the CSA compressor and indexer in high precision
+even under FP8 training (``get_fp8_disabled_context``), so Primus should not
+enable the fake-quant path by default either.
+
+These tests parse the scripts as text: they need neither torch nor a GPU, so
+they run in any environment.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_EXAMPLES = _REPO_ROOT / "examples" / "deepseek-v4"
+
+_FLASH_SCRIPT = _EXAMPLES / "run_deepseek_v4_flash.sh"
+_BASE_SCRIPT = _EXAMPLES / "run_deepseek_v4.sh"
+
+
+def _default_of(script: Path, var: str) -> str | None:
+    """Return the default in ``export VAR=${VAR:-default}``, or None.
+
+    The last assignment wins, mirroring shell semantics.
+    """
+    pattern = re.compile(rf"^\s*export\s+{re.escape(var)}=\$\{{{re.escape(var)}:-([^}}]*)\}}", re.MULTILINE)
+    matches = pattern.findall(script.read_text(encoding="utf-8"))
+    return matches[-1] if matches else None
+
+
+@pytest.mark.parametrize("script", [_FLASH_SCRIPT, _BASE_SCRIPT], ids=["flash", "base"])
+def test_fp8_indexer_defaults_off(script: Path) -> None:
+    """Both launchers must leave the indexer QK in high precision by default."""
+    assert script.is_file(), f"missing run script: {script}"
+    default = _default_of(script, "USE_V4_FP8_INDEXER")
+    assert default is not None, f"{script.name} must define USE_V4_FP8_INDEXER with a ${{VAR:-...}} default"
+    assert default == "False", (
+        f"{script.name} defaults USE_V4_FP8_INDEXER to {default!r}. The indexer selects which "
+        "compressed KV entries each query sees, and the Megatron-LM reference keeps it in high "
+        "precision under FP8 training; enabling the fake-quant path by default changes model "
+        "numerics (and costs throughput, since the GEMM stays BF16)."
+    )
+
+
+def test_fp8_indexer_stays_overridable() -> None:
+    """The knob keeps the ``${VAR:-default}`` form so QAT runs can opt back in."""
+    text = _FLASH_SCRIPT.read_text(encoding="utf-8")
+    assert "USE_V4_FP8_INDEXER=${USE_V4_FP8_INDEXER:-" in text
+
+
+def test_flash_defaults_agree_with_base_script() -> None:
+    """Flash must not silently disagree with the generic launcher on this knob.
+
+    The Flash script is a thin wrapper that execs ``run_deepseek_v4.sh``; a
+    divergent default here is exactly how the FP8 indexer ended up enabled in
+    production while the yaml and the generic script both said otherwise.
+    """
+    assert _default_of(_FLASH_SCRIPT, "USE_V4_FP8_INDEXER") == _default_of(
+        _BASE_SCRIPT, "USE_V4_FP8_INDEXER"
+    )

--- a/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
+++ b/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
@@ -64,6 +64,35 @@ def _rms_norm_per_head(x: torch.Tensor, eps: float) -> torch.Tensor:
     return (x32 * rms).to(in_dtype)
 
 
+def _inverse_rope_reference(
+    out: torch.Tensor,
+    *,
+    position_ids: torch.Tensor,
+    rope: DualRoPE,
+    rotary_dim: int,
+    compress_ratio: int = 0,
+) -> torch.Tensor:
+    """Reference de-rotation of the attention output (RoPE at ``-t``).
+
+    Mirrors ``apply_rotary_emb(o[..., -rd:], freqs_cis, inverse=True)`` from
+    the released ``inference/model.py``: the conjugate rotation, expressed
+    here by negating the sine.
+    """
+    from primus.backends.megatron.core.transformer.dual_rope import (
+        apply_interleaved_partial_rope,
+    )
+
+    cache = rope.get_rope(compress_ratio=compress_ratio)
+    cos, sin = cache(position_ids)
+    cos = cos[..., : rotary_dim // 2]
+    sin = sin[..., : rotary_dim // 2]
+    lead = out.shape[:-2]
+    if tuple(cos.shape[:-1]) != tuple(lead):
+        cos = cos.expand(*lead, -1)
+        sin = sin.expand(*lead, -1)
+    return apply_interleaved_partial_rope(out, cos, -sin, rotary_dim=rotary_dim)
+
+
 def _reference_v4_attention_forward(
     *,
     hidden: torch.Tensor,  # [B, S, D]
@@ -141,6 +170,10 @@ def _reference_v4_attention_forward(
         probs = probs[..., :-1].to(v_bh.dtype)
     out = torch.matmul(probs, v_bh.float()).to(hidden.dtype)
     out = out.transpose(1, 2).contiguous()  # [B, S, H, head_dim]
+
+    # Inverse RoPE (position = -t) on the output tail: K == V, so the output
+    # carries absolute positions until it is de-rotated.
+    out = _inverse_rope_reference(out, position_ids=position_ids, rope=rope, rotary_dim=rotary_dim)
 
     # Grouped low-rank O.
     out_g = out.reshape(B, S, o_groups, (n_heads * head_dim) // o_groups)
@@ -678,6 +711,15 @@ def _reference_hca_forward(
     out = torch.matmul(probs, v_bh.float()).to(hidden.dtype)
     out = out.transpose(1, 2).contiguous()  # [B, S, H, Dh]
 
+    # Inverse RoPE (position = -t) using this layer's compress-base RoPE.
+    out = _inverse_rope_reference(
+        out,
+        position_ids=position_ids,
+        rope=attn.rope,
+        rotary_dim=rotary_dim,
+        compress_ratio=ratio,
+    )
+
     # Grouped low-rank O.
     G, r = attn.o_groups, attn.o_lora_rank
     out_g = out.reshape(B, S, G, (H * Dh) // G)
@@ -725,6 +767,121 @@ def test_hca_forward_matches_inline_reference():
 
     diff = (ours - ref).abs().max().item()
     assert diff < 1e-3, f"HCA forward mismatch: max abs diff = {diff:.3e}"
+
+
+def test_inverse_rope_round_trips():
+    """``R(-t)`` exactly undoes ``R(t)`` on the rotated tail.
+
+    Pure math property of the helper, independent of any attention branch.
+    """
+    torch.manual_seed(0)
+    # H must be a power of two: the Triton RoPE kernel tiles the head axis with
+    # BLOCK_H = _pick_block_h(H) and feeds it to tl.arange, which rejects
+    # non-power-of-2 ranges. Production runs H=64 (Q) / H=1 (KV), so this only
+    # ever bites contrived test shapes.
+    B, S, H, Dh, rotary_dim = 2, 6, 4, 16, 8
+    config = _make_v4_config(
+        hidden_size=64,
+        num_heads=H,
+        head_dim=Dh,
+        rotary_dim=rotary_dim,
+        q_lora_rank=32,
+        o_groups=1,
+        o_lora_rank=8,
+        attn_sink=False,
+    )
+    attn = _make_attention(config).to(_TEST_DTYPE)
+
+    x = torch.randn(B, S, H, Dh, dtype=_TEST_DTYPE)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, S)
+
+    rotated = attn.rope.apply_rope(x, position_ids=position_ids, compress_ratio=0)
+    restored = attn._apply_inverse_rope(rotated, position_ids)
+
+    torch.testing.assert_close(restored, x, rtol=1e-5, atol=1e-5)
+    # The rotation must be non-trivial, otherwise the round-trip is vacuous.
+    assert not torch.allclose(rotated, x, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("compress_ratio", [0, 4, 128])
+def test_output_is_derotated_before_o_projection(compress_ratio):
+    """Every branch de-rotates the attention output before ``wo_a``.
+
+    Guards the wiring rather than the math: ``_project_output`` must apply the
+    inverse rotation, so feeding it a tensor and comparing against an explicit
+    de-rotate + O projection has to agree, and skipping the de-rotation must
+    not.
+    """
+    torch.manual_seed(0)
+    B, S = 2, 8
+    config = _make_v4_config(
+        hidden_size=64,
+        num_heads=4,
+        head_dim=16,
+        rotary_dim=8,
+        q_lora_rank=32,
+        o_groups=2,
+        o_lora_rank=8,
+        attn_sink=True,
+    )
+    config.index_topk = 2
+    config.index_head_dim = 16
+    config.index_n_heads = 2
+
+    if compress_ratio:
+        attn = _make_compressed_attention(config=config, compress_ratio=compress_ratio)
+    else:
+        attn = _make_attention(config)
+    attn = attn.to(_TEST_DTYPE)
+
+    core_out = torch.randn(B, S, attn.num_heads, attn.head_dim, dtype=_TEST_DTYPE)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, S)
+
+    with torch.no_grad():
+        ours = attn._project_output(core_out, position_ids)
+
+        derotated = _inverse_rope_reference(
+            core_out,
+            position_ids=position_ids,
+            rope=attn.rope,
+            rotary_dim=attn.rotary_dim,
+            compress_ratio=compress_ratio,
+        )
+        expected = attn._grouped_o_projection(derotated)
+        without_fix = attn._grouped_o_projection(core_out)
+
+    torch.testing.assert_close(ours, expected, rtol=1e-4, atol=1e-4)
+    assert not torch.allclose(ours, without_fix, rtol=1e-3, atol=1e-3)
+
+
+def test_inverse_rope_does_not_mutate_core_attention_output():
+    """De-rotation is out-of-place.
+
+    The attention backward keeps a reference to the core output, so mutating
+    it in place would corrupt the gradient.
+    """
+    torch.manual_seed(0)
+    config = _make_v4_config(
+        hidden_size=64,
+        num_heads=4,
+        head_dim=16,
+        rotary_dim=8,
+        q_lora_rank=32,
+        o_groups=2,
+        o_lora_rank=8,
+        attn_sink=False,
+    )
+    attn = _make_attention(config).to(_TEST_DTYPE)
+
+    core_out = torch.randn(2, 5, attn.num_heads, attn.head_dim, dtype=_TEST_DTYPE)
+    before = core_out.clone()
+    position_ids = torch.arange(5).unsqueeze(0).expand(2, 5)
+
+    with torch.no_grad():
+        rotated = attn._apply_inverse_rope(core_out, position_ids)
+
+    assert rotated is not core_out
+    torch.testing.assert_close(core_out, before, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize(("compress_ratio", "num_pool_entries"), [(4, 4), (128, 2)])

--- a/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
+++ b/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
@@ -891,7 +891,8 @@ def test_compressed_pool_rope_uses_original_sequence_positions(compress_ratio, n
     The queries are rotated at their own original positions, so rotating the
     compressed KV at bare block indices would put the two sides on different
     coordinate systems. ``inference/model.py`` slices ``freqs_cis[:cutoff:ratio]``
-    and Megatron slices ``cos[:total:ratio]``; both land on ``s * ratio``.
+    for prefill and indexes ``start_pos + 1 - ratio`` for decode; both land on
+    ``s * ratio``.
     """
     from primus.backends.megatron.core.transformer.dual_rope import (
         apply_interleaved_partial_rope,

--- a/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
+++ b/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
@@ -631,7 +631,9 @@ def _reference_hca_forward(
     # Compressed pool from the attention's own Compressor + compress-base RoPE.
     pool = attn.compressor(hidden)  # [B, P, Dh]
     P = pool.shape[1]
-    comp_pos = torch.arange(P, device=hidden.device)
+    # Compressed entry s stands for the window starting at original token
+    # s * ratio, so it is rotated at that position (not at the block index).
+    comp_pos = torch.arange(P, device=hidden.device) * ratio
     cos, sin = attn.rope.compress_rope(comp_pos)
     cos = cos[..., : rotary_dim // 2]
     sin = sin[..., : rotary_dim // 2]
@@ -723,6 +725,65 @@ def test_hca_forward_matches_inline_reference():
 
     diff = (ours - ref).abs().max().item()
     assert diff < 1e-3, f"HCA forward mismatch: max abs diff = {diff:.3e}"
+
+
+@pytest.mark.parametrize(("compress_ratio", "num_pool_entries"), [(4, 4), (128, 2)])
+def test_compressed_pool_rope_uses_original_sequence_positions(compress_ratio, num_pool_entries):
+    """Compressed entry ``s`` is rotated at original token ``s * ratio``.
+
+    The queries are rotated at their own original positions, so rotating the
+    compressed KV at bare block indices would put the two sides on different
+    coordinate systems. ``inference/model.py`` slices ``freqs_cis[:cutoff:ratio]``
+    and Megatron slices ``cos[:total:ratio]``; both land on ``s * ratio``.
+    """
+    from primus.backends.megatron.core.transformer.dual_rope import (
+        apply_interleaved_partial_rope,
+    )
+
+    torch.manual_seed(0)
+    S = compress_ratio * num_pool_entries
+    config = _make_v4_config(
+        hidden_size=64,
+        num_heads=4,
+        head_dim=16,
+        rotary_dim=8,
+        q_lora_rank=32,
+        o_groups=2,
+        o_lora_rank=8,
+        attn_sink=True,
+    )
+    config.index_topk = 2
+    config.index_head_dim = 16
+    config.index_n_heads = 2
+
+    attn = _make_compressed_attention(config=config, compress_ratio=compress_ratio).to(_TEST_DTYPE)
+    hidden = torch.randn(1, S, config.hidden_size, dtype=_TEST_DTYPE)
+
+    with torch.no_grad():
+        pooled_raw = attn.compressor(hidden)  # [B, P, Dh], pre-RoPE
+        ours = attn._build_compressed_pool(hidden)
+
+    P = pooled_raw.shape[1]
+    assert P == num_pool_entries, f"expected P={num_pool_entries}, got {P}"
+    rotary_dim = attn.rotary_dim
+
+    def _rope_at(positions: torch.Tensor) -> torch.Tensor:
+        cos, sin = attn.rope.compress_rope(positions)
+        cos = cos[..., : rotary_dim // 2].unsqueeze(0)
+        sin = sin[..., : rotary_dim // 2].unsqueeze(0)
+        rotated = apply_interleaved_partial_rope(
+            pooled_raw.unsqueeze(2), cos, sin, rotary_dim=rotary_dim
+        )
+        return rotated.squeeze(2)
+
+    block_idx = torch.arange(P, device=hidden.device)
+    expected = _rope_at(block_idx * compress_ratio)
+    torch.testing.assert_close(ours, expected, rtol=1e-4, atol=1e-4)
+
+    # The two conventions must actually differ, or the assertion above is
+    # vacuous (they coincide only at P == 1, which is why P > 1 here).
+    wrong = _rope_at(block_idx)
+    assert not torch.allclose(expected, wrong, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("compress_ratio", [0, 4, 128])

--- a/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
+++ b/tests/unit_tests/megatron/transformer/deepseek_v4/test_deepseek_v4_attention.py
@@ -658,7 +658,9 @@ def _reference_hca_forward(
     k_bh = k_full.transpose(1, 2)
     v_bh = v_full.transpose(1, 2)
 
-    scale = 1.0 / math.sqrt(Dh) * attn.rope.attn_scale(compress_ratio=ratio)
+    # Plain 1/sqrt(head_dim): the YaRN magnitude factor is not part of the
+    # softmax temperature (``inference/model.py`` uses ``head_dim ** -0.5``).
+    scale = 1.0 / math.sqrt(Dh)
     logits = torch.matmul(q_bh.float(), k_bh.float().transpose(-2, -1)) * scale
     logits = logits + full_mask
 
@@ -721,6 +723,55 @@ def test_hca_forward_matches_inline_reference():
 
     diff = (ours - ref).abs().max().item()
     assert diff < 1e-3, f"HCA forward mismatch: max abs diff = {diff:.3e}"
+
+
+@pytest.mark.parametrize("compress_ratio", [0, 4, 128])
+def test_attention_scale_is_pure_inv_sqrt_head_dim(compress_ratio):
+    """Softmax temperature is ``1/sqrt(head_dim)`` on every branch.
+
+    The released ``inference/model.py`` sets ``softmax_scale = head_dim ** -0.5``
+    unconditionally; the YaRN magnitude factor (``m_scale``) must not be folded
+    into the attention temperature even on the compressed layers, which run
+    with a YaRN-scaled RoPE. A non-unit ``yarn_factor`` is used here on purpose
+    so the assertion fails if ``m_scale`` ever leaks back in.
+    """
+    head_dim = 16
+    config = _make_v4_config(
+        hidden_size=64,
+        num_heads=4,
+        head_dim=head_dim,
+        rotary_dim=8,
+        q_lora_rank=32,
+        o_groups=2,
+        o_lora_rank=8,
+        attn_sink=True,
+    )
+    config.index_topk = 2
+    config.index_head_dim = 16
+    config.index_n_heads = 2
+
+    yarn_factor = 16.0
+    rope = DualRoPE(
+        rotary_dim=config.qk_pos_emb_head_dim,
+        rope_theta=config.rotary_base,
+        compress_rope_theta=config.compress_rope_theta,
+        yarn_factor=yarn_factor,
+        original_max_position_embeddings=config.original_max_position_embeddings,
+    )
+    attn = DeepseekV4Attention(
+        config,
+        rope=rope,
+        compress_ratio=compress_ratio,
+        submodules=None,
+    )
+
+    expected = 1.0 / math.sqrt(head_dim)
+    assert attn._attention_scale() == pytest.approx(expected, rel=1e-12)
+
+    if compress_ratio:
+        # Guard the regression directly: the compressed RoPE really does carry
+        # a non-unit m_scale, so the assertion above is not vacuous.
+        assert rope.attn_scale(compress_ratio=compress_ratio) > 1.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/megatron/transformer/deepseek_v4/test_v4_indexer_distill_loss.py
+++ b/tests/unit_tests/megatron/transformer/deepseek_v4/test_v4_indexer_distill_loss.py
@@ -24,7 +24,7 @@ torch = pytest.importorskip("torch")
 
 mla_module = pytest.importorskip(
     "megatron.core.transformer.multi_latent_attention",
-    reason="Megatron MLA not importable in this environment",
+    reason="MLA base module not importable in this environment",
 )
 
 from primus.backends.megatron.core.models.deepseek_v4.deepseek_v4_transformer_config import (  # noqa: E402

--- a/tests/unit_tests/megatron/transformer/deepseek_v4/test_v4_indexer_distill_loss.py
+++ b/tests/unit_tests/megatron/transformer/deepseek_v4/test_v4_indexer_distill_loss.py
@@ -1,0 +1,284 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Tests for the CSA indexer distillation loss.
+
+Covers the two halves separately:
+
+* the loss itself -- KL against a known target, the all-masked-row guard, and
+  the fact that it actually produces indexer gradients;
+* the wiring -- ``v4_indexer_distill_loss_coeff`` gates both the loss and
+  whether the indexer parameters are trainable at all.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+mla_module = pytest.importorskip(
+    "megatron.core.transformer.multi_latent_attention",
+    reason="Megatron MLA not importable in this environment",
+)
+
+from primus.backends.megatron.core.models.deepseek_v4.deepseek_v4_transformer_config import (  # noqa: E402
+    DeepSeekV4TransformerConfig,
+)
+from primus.backends.megatron.core.transformer.deepseek_v4_attention import (  # noqa: E402
+    DeepseekV4Attention,
+)
+from primus.backends.megatron.core.transformer.dual_rope import DualRoPE  # noqa: E402
+from primus.backends.megatron.core.transformer.indexer_distill_loss import (  # noqa: E402
+    V4IndexerLossAutoScaler,
+    compute_indexer_distill_loss,
+)
+
+_DTYPE = torch.float32
+
+
+# ---------------------------------------------------------------------------
+# The loss itself
+# ---------------------------------------------------------------------------
+
+
+def test_kl_is_zero_when_indexer_matches_attention():
+    """A perfectly-predicting indexer incurs no loss.
+
+    Build the indexer scores so their softmax equals the (single-head)
+    attention distribution over the selected entries; KL must vanish.
+    """
+    torch.manual_seed(0)
+    B, H, S, K, Dh, P = 1, 1, 3, 4, 8, 6
+    query = torch.randn(B, H, S, Dh, dtype=_DTYPE)
+    pool = torch.randn(B, P, Dh, dtype=_DTYPE)
+    topk_idxs = torch.arange(K, dtype=torch.long).view(1, 1, K).expand(B, S, K).contiguous()
+    scale = 1.0 / math.sqrt(Dh)
+
+    gathered = pool[torch.arange(B).view(B, 1, 1), topk_idxs]  # [B,S,K,Dh]
+    attn_logits = torch.einsum("bhsd,bskd->bhsk", query, gathered) * scale
+    # One head, so the target distribution is exactly this row's softmax; give
+    # the indexer the same logits.
+    index_scores = attn_logits[:, 0]
+
+    loss = compute_indexer_distill_loss(
+        index_topk_scores=index_scores,
+        topk_idxs=topk_idxs,
+        query=query,
+        pool=pool,
+        softmax_scale=scale,
+        loss_coeff=1.0,
+    )
+    assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_kl_is_positive_and_scales_with_coeff():
+    """A mismatched indexer is penalised, linearly in the coefficient."""
+    torch.manual_seed(0)
+    B, H, S, K, Dh, P = 2, 4, 5, 3, 8, 7
+    query = torch.randn(B, H, S, Dh, dtype=_DTYPE)
+    pool = torch.randn(B, P, Dh, dtype=_DTYPE)
+    topk_idxs = torch.randint(0, P, (B, S, K), dtype=torch.long)
+    index_scores = torch.randn(B, S, K, dtype=_DTYPE)
+    scale = 1.0 / math.sqrt(Dh)
+
+    kwargs = dict(
+        index_topk_scores=index_scores,
+        topk_idxs=topk_idxs,
+        query=query,
+        pool=pool,
+        softmax_scale=scale,
+    )
+    loss_1 = compute_indexer_distill_loss(loss_coeff=1.0, **kwargs)
+    loss_2 = compute_indexer_distill_loss(loss_coeff=2.0, **kwargs)
+
+    assert loss_1.item() > 0.0
+    assert loss_2.item() == pytest.approx(2.0 * loss_1.item(), rel=1e-5)
+
+
+def test_fully_masked_rows_do_not_produce_nan():
+    """Early queries can have zero legal compressed entries.
+
+    Those rows softmax over all -inf; the loss must neutralise them rather
+    than emit NaN (which would poison the whole step).
+    """
+    B, H, S, K, Dh, P = 1, 2, 4, 3, 8, 5
+    query = torch.randn(B, H, S, Dh, dtype=_DTYPE)
+    pool = torch.randn(B, P, Dh, dtype=_DTYPE)
+
+    topk_idxs = torch.randint(0, P, (B, S, K), dtype=torch.long)
+    index_scores = torch.randn(B, S, K, dtype=_DTYPE)
+    # Row 0 has no legal entry at all; row 1 has a single one.
+    topk_idxs[0, 0, :] = -1
+    index_scores[0, 0, :] = float("-inf")
+    topk_idxs[0, 1, 1:] = -1
+    index_scores[0, 1, 1:] = float("-inf")
+
+    loss = compute_indexer_distill_loss(
+        index_topk_scores=index_scores,
+        topk_idxs=topk_idxs,
+        query=query,
+        pool=pool,
+        softmax_scale=1.0 / math.sqrt(Dh),
+        loss_coeff=1e-2,
+    )
+    assert torch.isfinite(loss), f"loss must stay finite, got {loss}"
+
+
+def test_loss_produces_indexer_gradients():
+    """The KL flows back into whatever produced the index scores."""
+    torch.manual_seed(0)
+    B, H, S, K, Dh, P = 1, 2, 4, 3, 8, 6
+    query = torch.randn(B, H, S, Dh, dtype=_DTYPE)
+    pool = torch.randn(B, P, Dh, dtype=_DTYPE)
+    topk_idxs = torch.randint(0, P, (B, S, K), dtype=torch.long)
+
+    index_scores = torch.randn(B, S, K, dtype=_DTYPE, requires_grad=True)
+    loss = compute_indexer_distill_loss(
+        index_topk_scores=index_scores,
+        topk_idxs=topk_idxs,
+        query=query,
+        pool=pool,
+        softmax_scale=1.0 / math.sqrt(Dh),
+        loss_coeff=1e-2,
+    )
+    loss.backward()
+
+    assert index_scores.grad is not None
+    assert torch.isfinite(index_scores.grad).all()
+    assert index_scores.grad.abs().sum() > 0.0
+
+
+def test_auto_scaler_is_transparent_forward_and_seeds_aux_backward():
+    """The scaler passes the tensor through and differentiates the aux loss."""
+    x = torch.randn(3, 4, requires_grad=True)
+    aux_src = torch.randn(2, requires_grad=True)
+    aux_loss = aux_src.sum()
+
+    out = V4IndexerLossAutoScaler.apply(x, aux_loss)
+    torch.testing.assert_close(out, x, rtol=0, atol=0)
+
+    out.sum().backward()
+    # x keeps its own gradient, and the aux subgraph got seeded with ones.
+    assert x.grad is not None and torch.allclose(x.grad, torch.ones_like(x))
+    assert aux_src.grad is not None and torch.allclose(aux_src.grad, torch.ones_like(aux_src))
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the coefficient gates training of the indexer
+# ---------------------------------------------------------------------------
+
+
+def _make_csa_attention(coeff: float) -> DeepseekV4Attention:
+    config = DeepSeekV4TransformerConfig(
+        num_layers=1,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_query_groups=1,
+        kv_channels=16,
+        qk_pos_emb_head_dim=8,
+        qk_head_dim=8,
+        v_head_dim=16,
+        kv_lora_rank=16,
+        rope_type="rope",
+        rotary_base=10000.0,
+        rotary_scaling_factor=1.0,
+        rotary_percent=1.0,
+        original_max_position_embeddings=2048,
+        q_lora_rank=32,
+        o_groups=2,
+        o_lora_rank=8,
+        attn_sliding_window=0,
+        attn_sink=True,
+        compress_ratios=None,
+        compress_rope_theta=40000.0,
+        use_v4_attention_backend="eager",
+        use_v4_csa_attention_backend="eager",
+        layernorm_epsilon=1e-6,
+        norm_epsilon=1e-6,
+        attention_dropout=0.0,
+        hidden_dropout=0.0,
+        v4_indexer_distill_loss_coeff=coeff,
+    )
+    config.index_topk = 2
+    config.index_head_dim = 16
+    config.index_n_heads = 2
+
+    rope = DualRoPE(
+        rotary_dim=config.qk_pos_emb_head_dim,
+        rope_theta=config.rotary_base,
+        compress_rope_theta=config.compress_rope_theta,
+        yarn_factor=1.0,
+        original_max_position_embeddings=config.original_max_position_embeddings,
+    )
+    return DeepseekV4Attention(config, rope=rope, compress_ratio=4, submodules=None)
+
+
+def test_indexer_frozen_when_coeff_is_zero(monkeypatch):
+    """Default (0.0): no loss, and the indexer stays out of the grad buckets."""
+    monkeypatch.delenv("PRIMUS_V4_INDEXER_TRAINABLE", raising=False)
+    attn = _make_csa_attention(coeff=0.0)
+
+    assert attn.indexer_distill_enabled is False
+    assert attn.indexer is not None
+    assert not any(p.requires_grad for p in attn.indexer.parameters())
+
+
+def test_indexer_trainable_when_coeff_positive(monkeypatch):
+    """A positive coefficient unfreezes the indexer."""
+    monkeypatch.delenv("PRIMUS_V4_INDEXER_TRAINABLE", raising=False)
+    attn = _make_csa_attention(coeff=1e-2)
+
+    assert attn.indexer_distill_enabled is True
+    assert attn.indexer is not None
+    assert all(p.requires_grad for p in attn.indexer.parameters())
+
+
+def test_forward_backward_reaches_indexer_weights(monkeypatch):
+    """End to end: a CSA step with the loss on gives the indexer gradients.
+
+    Without the distillation loss the indexer is unreachable from the output
+    (only argTopK indices are consumed), so a non-zero gradient here is proof
+    the aux objective is wired into the main backward.
+    """
+    monkeypatch.delenv("PRIMUS_V4_INDEXER_TRAINABLE", raising=False)
+    torch.manual_seed(0)
+    attn = _make_csa_attention(coeff=1e-2).to(_DTYPE)
+    attn.train()
+
+    B, S = 1, 8  # P = S // 4 = 2 pool entries
+    hidden = torch.randn(B, S, attn.config.hidden_size, dtype=_DTYPE)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, S)
+
+    out = attn(hidden, position_ids)
+    out.sum().backward()
+
+    assert attn.last_indexer_distill_loss is not None
+    assert torch.isfinite(attn.last_indexer_distill_loss)
+
+    grads = [p.grad for p in attn.indexer.parameters() if p.grad is not None]
+    assert grads, "indexer received no gradient at all"
+    total = sum(g.abs().sum().item() for g in grads)
+    assert math.isfinite(total) and total > 0.0, f"indexer gradient is degenerate: {total}"
+
+
+def test_no_indexer_loss_in_eval(monkeypatch):
+    """Eval must not build the aux graph."""
+    monkeypatch.delenv("PRIMUS_V4_INDEXER_TRAINABLE", raising=False)
+    torch.manual_seed(0)
+    attn = _make_csa_attention(coeff=1e-2).to(_DTYPE)
+    attn.eval()
+    attn.last_indexer_distill_loss = None
+
+    B, S = 1, 8
+    hidden = torch.randn(B, S, attn.config.hidden_size, dtype=_DTYPE)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, S)
+    with torch.no_grad():
+        attn(hidden, position_ids)
+
+    assert attn.last_indexer_distill_loss is None


### PR DESCRIPTION
## Summary

Four correctness fixes to the DeepSeek-V4-Flash attention path, plus one opt-in
feature that is a no-op by default. Every fix is backed by the released
reference implementation (`deepseek-ai/DeepSeek-V4-Flash`, `inference/model.py`)
and the DeepSeek-V4 paper.

Three of these change model math on almost every layer, so **loss curves will
shift and checkpoints trained with the old code are no longer equivalent**.
That is the intended effect: the old behaviour did not match the reference.

| # | Change | Severity | Layers affected | Throughput |
|---|--------|----------|-----------------|------------|
| 1 | Drop YaRN `m_scale` from the attention softmax scale | High | 41 compressed | 0% |
| 2 | Rotate compressed KV at original-sequence positions; fix Flash `compress_rope_theta` | High | 41 compressed | ~0% |
| 3 | De-rotate the attention output before the O projection | **Blocking** | all 43 | only real cost here |
| 4 | Keep the indexer QK in high precision by default | High | 21 CSA | slightly faster |
| 5 | Add opt-in indexer distillation loss | **Blocking** (gap) | 21 CSA | 0% (default off) |

> Layer counts: V4-Flash's `compress_ratios` has 44 entries; the trailing `0` is
> the MTP slot and is truncated by `_normalize_compress_ratios`. The 43 decoder
> layers are **2 SWA + 21 CSA + 20 HCA**, so 41 layers are compressed and the
> last decoder layer is CSA, not SWA.

---

## 1. Drop YaRN `m_scale` from the attention softmax scale

`_attention_scale()` multiplied the plain `1/sqrt(head_dim)` temperature by the
YaRN magnitude factor of the layer's RoPE:

```python
base = 1.0 / math.sqrt(self.head_dim)
rope_scale = self.rope.attn_scale(compress_ratio=self.compress_ratio)
return base * rope_scale
```

With Flash's `rotary_scaling_factor = 16`, `0.1*ln(16)+1 ≈ 1.2773`, so every
logit on the 41 compressed layers was inflated by ~1.277x — effectively a
lower softmax temperature and a sharper attention distribution than designed.

The reference sets

```python
self.softmax_scale = self.head_dim ** -0.5
```

for both the core attention and the indexer, with no magnitude factor anywhere
in the file. Paper §2.4 gives the reason: V4 applies RMSNorm directly to the
attention queries and KV entries, which "effectively prevents attention logits
from exploding" — so no temperature compensation is needed (and, for the same
reason, QK-Clip is not used).

The YaRN **frequency** interpolation on `inv_freq` is untouched; only the
softmax temperature changes. `RoPECache.attn_scale` is kept for diagnostics with
a comment so it does not get wired back in.

## 2. Rotate compressed KV at original-sequence positions (and fix the Flash base)

Two independent defects in the compressed (CSA/HCA) RoPE branch.

**Position basis.** `_build_compressed_pool` rotated compressed entry `s` at
position `s`, while queries are rotated at their original token positions `t`.
Entry `s` actually represents the window `[s*ratio, (s+1)*ratio)`, so its
representative position is `s*ratio`. The two sides lived in different
coordinate systems and the relative phase was off by a factor of
`compress_ratio` (4x for CSA, 128x for HCA).

The reference rotates the compressed pool at original-sequence positions,
sampled with a stride of `ratio`:

```python
if start_pos == 0:
    freqs_cis = self.freqs_cis[:cutoff:ratio]          # 0, ratio, 2*ratio, ...
else:
    freqs_cis = self.freqs_cis[start_pos + 1 - self.compress_ratio].unsqueeze(0)
```

Both the prefill slice and the decode index land on the window's **start**
token, i.e. `s * ratio`.

`RoPECache.forward_arange` grows a `stride` argument (folded into the memo key)
so the compressed table stays cached across steps and layers — positions are
still deterministic, so there is no per-step cost.

**Base value.** Flash inherited `compress_rope_theta = 160000` from
`deepseek_v4_base.yaml`, but that is the **V4-Pro** value. The released Flash
reference ships

```python
compress_rope_theta: float = 40000.0
```

in its `ModelArgs`. `deepseek_v4_flash.yaml` now pins 40000;
`deepseek_v4_base.yaml` keeps 160000 for Pro with a comment.

> Heads-up for anyone cross-checking against HuggingFace `transformers`: its
> `DeepseekV4Config` still defaults `compress_rope_theta` to 160000, which
> conflicts with the released `inference/model.py`. See
> huggingface/transformers#45910. This PR follows the reference implementation.

## 3. De-rotate the attention output before the O projection (blocking)

V4 shares a single latent between K and V, so the values entering the softmax
are already RoPE-rotated and the core attention output

```
o_t = sum_s P[t,s] * R(s) * v_s
```

carries **absolute** position information. The model expects relative
positions, so the output tail must be rotated by `position = -t`.

Paper §2.3: *"Since the KV entries serve as both attention keys and values, the
naive core attention outputs will carry absolute position embeddings … As a
countermeasure, we also apply RoPE with position −i on the last 64 dimensions of
each output."*

The reference does exactly this, immediately before `wo_a`:

```python
o = sparse_attn(q, kv, self.attn_sink, topk_idxs, self.softmax_scale)
apply_rotary_emb(o[..., -rd:], freqs_cis, True)   # inverse=True == conj()
o = o.view(bsz, seqlen, self.n_local_groups, -1)  # -> wo_a
```

Primus went straight from the attention output into the grouped-O projection,
so all 43 layers fed `wo_a` a tensor carrying absolute positions. This is not
absorbable by training: `wo_a` is a learned linear, and what is missing is a
**per-token** rotation.

Implementation notes:

- **One insertion point covers every backend.** All ten attention backends
  (eager / triton_v1,v2 / gluon v1,v2,v3 / flydsl / turbo / core_attention)
  converge to `[B,S,H,head_dim]` before the O projection, so no kernel changes
  were needed.
- **No Triton changes.** The inverse rotation is `R(-θ) = R(θ)ᵀ`, i.e. the same
  kernel with a negated sine (`rot_even = e·cos − o·sin`, `rot_odd = e·sin + o·cos`
  with `sin → −sin`). The Triton forward uses the identical formula and its
  backward is derived from the same cos/sin, so autograd stays correct.
- **Uses the layer's own RoPE** (compress base on compressed layers, main base
  on dense), matching the reference's single `freqs_cis`.
- **Out-of-place**, because the attention backward retains the core output.
- Both exits (the dense `core_attention` fast path and the generic
  dense/HCA/CSA path) now go through a single `_project_output()` helper, so no
  branch can reach `wo_a` without de-rotating.

## 4. Keep the indexer QK in high precision by default

`run_deepseek_v4_flash.sh` defaulted `USE_V4_FP8_INDEXER` to `True`, overriding
both `run_deepseek_v4.sh` (`False`) and `deepseek_v4_base.yaml` (`false`). The
production Flash recipe was therefore training with a fake-quantized indexer
while every other surface in the repo said otherwise — and the divergence is
exactly why nobody noticed.

Two reasons this should not be a silent default:

1. **It changes model numerics, not just precision.** The indexer decides which
   `index_topk` compressed entries each query attends to, so quantization error
   there does not merely perturb a value, it changes the selection.
2. **It buys nothing today.** `use_fp8_qk` only fake-quantizes the QK operands
   (quantize/dequantize) and the GEMM still runs in BF16, so outside QAT
   experiments it is pure overhead.

Low-precision indexer QK is a legitimate direction — the paper describes FP4 for
the lightning indexer — but it should be opt-in and measured rather than enabled
by default in one launcher only. The knob remains available via the environment
variable.

## 5. Add opt-in indexer distillation loss

`topk` is not differentiable and the forward discarded the indexer scores, so
the indexer had no gradient path at all and was frozen. That is correct when
loading an already-trained indexer, but a from-scratch pretrain selects
essentially at random across all 21 CSA layers.

(The freeze was deliberate: leaving permanently-dead params in the distributed
optimizer's grad buckets wastes grad/optimizer state and cross-node sync
bandwidth, and breaks the grad-bucket invariant that every bucket parameter must
fire its grad-ready backward hook. So unfreezing and adding the loss must
happen together.)

Adds `primus/backends/megatron/core/transformer/indexer_distill_loss.py`:

- `compute_indexer_distill_loss(...)` — `KL(attention || indexer)` over the
  selected entries, following the DeepSeek-V3.2 formulation (§2.1): the
  indexer's score distribution is pulled towards the distribution the real
  attention places over the same entries. Uses the **sparse (top-k)** variant,
  i.e. the loss is evaluated only on the entries the indexer actually selected,
  which is both cheaper and consistent with what the forward pass uses. Since
  those entries are already gathered per query, the computation stays in
  `[B, S, K]` and never materialises the dense `[B, H, S, P]` score tensor.
- `V4IndexerLossAutoScaler` — passes a tensor through untouched in forward and
  seeds the aux loss with a gradient in backward. This is the same aux-loss
  autoscaler pattern already used in this training stack for the MoE auxiliary
  loss and the MTP loss.

Wiring:

- `v4_indexer_distill_loss_coeff` (default `0.0`) gates the loss **and** whether
  the indexer is trainable, so the two can never disagree. `1e-2` is a
  reasonable starting value.
- The loss is attached to `pool`, which every CSA backend consumes, so the aux
  gradient is seeded whichever kernel the layer dispatches to instead of
  threading a second return value through all ten of them.
- Rows with no legal compressed entry (early queries) are neutralised before the
  softmax, so an all-masked row yields 0 rather than NaN.
- Plumbed through `--v4_indexer_distill_loss_coeff`. No argparse registration is
  needed: `train pretrain` uses `parse_known_args` and unknown `--key value`
  pairs become config overrides via `parse_cli_overrides` + deep-merge, with
  `0.0` coerced to float.

**Default `0.0` makes this commit a complete no-op for existing runs**: no loss,
indexer still frozen, params still excluded from the grad buckets.

---

## Test plan

Unit tests on MI355X (8x, ROCm):

- `tests/unit_tests/megatron/transformer/deepseek_v4/` — **484 passed, 81 skipped, 0 failed**
- Targeted files: 69 passed
  - `test_deepseek_v4_attention.py` — inverse-RoPE round trip, wiring on all
    three branches (asserting the result differs from the un-derotated
    projection), out-of-place contract, compressed-pool positions, softmax scale
  - `test_v4_indexer_distill_loss.py` — 9 tests: zero KL for a perfect indexer,
    positive and linear in the coefficient, finite on fully-masked rows,
    produces gradients, auto-scaler contract, frozen at coeff 0, trainable and
    receiving non-zero gradients through a real CSA forward/backward at coeff>0,
    inactive in eval
  - `test_rope_arange_cache.py` — `stride` parity and cache-key coverage
  - `test_deepseek_v4_yaml.py` — per-variant `compress_rope_theta`
  - `test_deepseek_v4_run_script_defaults.py` — torch-free run-script defaults

Two existing inline references encoded the bugs being fixed (they multiplied by
`attn.rope.attn_scale(...)` and used `comp_pos = torch.arange(P)`) and are
corrected as part of the fix, not to accommodate it. The compressed-position
test deliberately uses `P > 1`: the two conventions coincide at `P == 1`, which
is why the previous HCA test (`S == compress_ratio`) could never have caught it.

End-to-end, 1 node x 8 MI355X, seq=4096, GBS=8, turbo backends, 2 runs each:

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| iter_time | 312.05 ms | 314.75 ms | +0.87% |
| TFLOP/s/GPU | 858.85 | 851.45 | −0.86% |
| tok/s/GPU | 13126.5 | 13013.3 | −0.86% |
| peak memory | 211.39 GB | 209.50 GB | −0.90% |

Run-to-run spread was 0.03–0.12%, so the ~0.86% cost is real. It comes from #3
(the extra per-layer elementwise rotation and kernel launch); #1 is a constant,
#2 stays cached, and #4/#5 are no-ops on this path. Fusing the RoPE into the
main attention kernel would recover it.

---

## Notes for reviewers

**Pre-existing long-run instability, unrelated to this PR.** While soaking the
node I hit a crash a few minutes into training: a single rank exits with code 1,
no Python traceback, no ROCm/HSA fault, and the launcher tears the job down
exactly ~45 s after the last iteration log. I reproduced it on **baseline code**
with these commits reverted, where it died even earlier:

| Run | Code | Crash iter | Failing rank |
|-----|------|------------|--------------|
| baseline (20 iters) | baseline | — | completed |
| fixed | fixed | 339 | rank 3 |
| fixed | fixed | 1208 | rank 1 |
| **baseline** | **baseline** | **43** | rank 4 |
| fixed | fixed | 25 / 272 / 804 | varies |

Crash iteration and failing rank are random; host memory (48 GB of 3023 GB used)
and GPU memory (72.9%) are both fine; loss, grad norm and NaN counts are clean
right up to the crash. This looks like an environment/framework issue and needs
its own investigation — a good first step is enabling per-rank torchrun logs
(`--redirects=3 --tee=3`), since the failing rank's stderr is currently not
captured at all.

The short E2E runs above never hit it because 20 iterations is only ~6 s of
training, well short of the trigger window.

**Follow-ups not in this PR:**

- Numerical parity against the reference `inference/model.py` (single layer,
  small shapes, eager backend) — the strongest possible validation of #1–#3.
- Re-measure #3's cost at steady state (300+ iters each). The A/B above uses the
  trainer's cumulative average over 20 iterations, which still carries warm-up;
  a longer run of the fixed code shows ~305 ms / ~878 TFLOP/s.
- YaRN frequency interpolation is still unresolved and deliberately untouched:
  the reference `ModelArgs` uses `original_seq_len = 0` (so
  `precompute_freqs_cis` skips interpolation entirely) with `rope_factor = 40`,
  while Primus uses `original_max_position_embeddings = 65536` with
  `rotary_scaling_factor = 16`. These disagree; settling it needs the official
  `config.json`.
- `ape` and `attn_sink` are plain parameters here, but the reference checkpoint
  stores them in FP32 — relevant to checkpoint parity.
