### PR TITLE
fix(runner): pass the runner dir to the slurm entry so sbatch works on spur

### DIFF
--- a/examples/deepseek-v4/run_deepseek_v4_flash.sh
+++ b/examples/deepseek-v4/run_deepseek_v4_flash.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # the DeepSeek-V4 Flash multi-node runs. Detected via the `spur` command.
 if command -v spur >/dev/null 2>&1; then
     export PRIMUS_LAUNCHER=slurm
-    export SLURM_LAUNCH_CMD=sbatch
+    export SLURM_LAUNCH_CMD="${SLURM_LAUNCH_CMD:-srun}"
     export SLURM_PARTITION=amd-spur
     export SLURM_QOS=amd-burst-qos
     export SLURM_ACCOUNT=amd-primus

--- a/runner/primus-cli-slurm-entry.sh
+++ b/runner/primus-cli-slurm-entry.sh
@@ -7,8 +7,17 @@
 
 set -euo pipefail
 
-# Resolve runner directory robustly (handles symlinks)
-RUNNER_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+# Resolve runner directory. Prefer PRIMUS_RUNNER_DIR when the launcher exported
+# it: schedulers relocate a batch script into their spool dir (spur copies it to
+# /var/spool/spur/job<id>/spur_job.sh, standard Slurm to
+# /var/spool/slurmd/job<id>/slurm_script), so on the sbatch path $0 points at a
+# copy with no sibling lib/. Fall back to self-location (handles symlinks) for
+# srun and direct invocation.
+if [[ -n "${PRIMUS_RUNNER_DIR:-}" && -f "${PRIMUS_RUNNER_DIR}/lib/common.sh" ]]; then
+    RUNNER_DIR="$PRIMUS_RUNNER_DIR"
+else
+    RUNNER_DIR="$(cd "$(dirname "$(realpath "$0")")" && pwd)"
+fi
 
 # Load common library (required)
 # shellcheck disable=SC1091

--- a/runner/primus-cli-slurm.sh
+++ b/runner/primus-cli-slurm.sh
@@ -294,54 +294,38 @@ fi
 ENTRY="$RUNNER_DIR/primus-cli-slurm-entry.sh"
 require_file "$ENTRY" "[slurm] Entry script not found: $ENTRY"
 
-# Build full command.
-#
-# Scheduler-flavor handling for the sbatch path:
-#   - Standard Slurm `sbatch` accepts `script [args...]` (and runs the script on
-#     node 0 only), so we can pass the entry + args directly, as before.
-#   - Spur's `sbatch` reimplementation accepts ONLY one positional (the script):
-#     it rejects args passed to the batch script, has no --wrap, and runs the
-#     script on EVERY allocated node. So we can't use `sbatch ENTRY <args>` there
-#     (it fails with "unexpected argument '--image'"). Instead we emit a
-#     self-contained script that bakes in the entry + all args and runs the
-#     per-node entry directly (no inner srun -- that would nest job steps); QOS /
-#     partition / account are passed as sbatch options (which spur does accept).
-# Spur is detected by the presence of the `spur` command. srun is unchanged on
-# both flavors (its COMMAND accepts args and fans out per task).
+# On the sbatch path the scheduler copies the batch script into its spool dir, so
+# the entry cannot locate its own lib/ from $0. Hand it the real runner directory
+# (propagated by sbatch --export=ALL, which is the default on both flavors).
+export PRIMUS_RUNNER_DIR="$RUNNER_DIR"
+
+# Build full command. Spur is detected by the presence of the `spur` command; its
+# srun needs an explicit task count -- see below.
 IS_SPUR=false
 command -v spur >/dev/null 2>&1 && IS_SPUR=true
 
-# Emit a self-contained batch-script body: `bash ENTRY <entry-args> -- <primus-args>`
-# with every token safely quoted so it re-runs verbatim inside the batch job.
-_emit_spur_batch_script() {
-    # "$@" here are the Primus args (everything after the first '--').
-    printf '#!/bin/bash\n'
-    printf 'set -euo pipefail\n'
-    printf 'exec bash %q' "$ENTRY"
-    local _a
-    for _a in "${ENTRY_ARGS[@]}"; do printf ' %q' "$_a"; done
-    printf ' --'
-    for _a in "$@"; do printf ' %q' "$_a"; done
-    printf '\n'
-}
-
-JOB_SCRIPT=""
-if [[ "$LAUNCH_CMD" == "sbatch" && "$IS_SPUR" == "true" ]]; then
-    if [[ "$DRY_RUN_MODE" == "true" ]]; then
-        LOG_INFO "[slurm] Spur detected: sbatch would submit this self-contained per-node script:"
-        _emit_spur_batch_script "$@" | sed 's/^/[slurm]   | /' >&2
-        LOG_INFO "[slurm] [DRY RUN] Would execute: $LAUNCH_CMD ${SLURM_FLAGS[*]} <generated-script>"
-        LOG_INFO "[slurm] Dry-run mode: command not executed"
-        exit 0
+# Standard Slurm's srun derives one task per node from -N, while spur's srun
+# defaults to --ntasks=1: `srun -N 4 ENTRY` dispatches a single task, so only one
+# node runs the entry and the other ranks never start. Request one task per node
+# unless the caller already chose a task count. sbatch is unaffected (spur runs
+# the batch script on every allocated node regardless of --ntasks).
+if [[ "$IS_SPUR" == "true" && "$LAUNCH_CMD" == "srun" ]]; then
+    spur_nodes=""
+    spur_has_ntasks=false
+    for ((i = 0; i < ${#SLURM_FLAGS[@]}; i++)); do
+        case "${SLURM_FLAGS[i]}" in
+            -N|--nodes) spur_nodes="${SLURM_FLAGS[i + 1]:-}" ;;
+            --nodes=*) spur_nodes="${SLURM_FLAGS[i]#--nodes=}" ;;
+            -n|--ntasks|--ntasks=*) spur_has_ntasks=true ;;
+        esac
+    done
+    if [[ "$spur_has_ntasks" == "false" && "$spur_nodes" =~ ^[0-9]+$ ]]; then
+        SLURM_FLAGS+=(-n "$spur_nodes")
+        LOG_INFO "[slurm] Spur srun: requesting one task per node (-n $spur_nodes)"
     fi
-    JOB_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/primus-sbatch.XXXXXX.sh")"
-    _emit_spur_batch_script "$@" > "$JOB_SCRIPT"
-    chmod +x "$JOB_SCRIPT"
-    LOG_INFO "[slurm] Spur sbatch: submitting self-contained per-node script: $JOB_SCRIPT"
-    CMD=("$LAUNCH_CMD" "${SLURM_FLAGS[@]}" "$JOB_SCRIPT")
-else
-    CMD=("$LAUNCH_CMD" "${SLURM_FLAGS[@]}" "$ENTRY" "${ENTRY_ARGS[@]}" -- "$@")
 fi
+
+CMD=("$LAUNCH_CMD" "${SLURM_FLAGS[@]}" "$ENTRY" "${ENTRY_ARGS[@]}" -- "$@")
 
 # Display command
 if [[ "$DRY_RUN_MODE" == "true" ]]; then
@@ -351,16 +335,4 @@ if [[ "$DRY_RUN_MODE" == "true" ]]; then
 fi
 
 LOG_INFO "[slurm] Executing: ${CMD[*]}"
-if [[ -n "$JOB_SCRIPT" ]]; then
-    # Don't exec here: run sbatch, then remove the temp script. Spur copies the
-    # script into its spool dir at submit time, so it is safe to delete once
-    # sbatch returns.
-    set +e
-    "${CMD[@]}"
-    _rc=$?
-    set -e
-    rm -f "$JOB_SCRIPT"
-    exit "$_rc"
-else
-    exec "${CMD[@]}"
-fi
+exec "${CMD[@]}"


### PR DESCRIPTION
## Summary

Replaces the spur-specific `sbatch` workaround added in #887 with a fix for the underlying problem, and fixes per-node fan-out on spur's `srun`. Net −19 lines; both launchers now share a single code path.

## Background / problem

The workaround generated a throwaway per-node batch script that re-invoked `primus-cli-slurm-entry.sh` by absolute path. Two separate spur limitations motivated it, and only one still exists:

- **Script arguments** — spur's `sbatch` used to take a single positional and reject arguments passed to the batch script, so `sbatch ENTRY -- --image ...` failed with `unexpected argument '--image'`. spur 0.6.0 accepts them (`Usage: sbatch [OPTIONS] [SCRIPT] [SCRIPT_ARGS]...`), including `-`-prefixed args, so the workaround is no longer needed for this.
- **Script relocation** — the scheduler copies the batch script into its spool dir, so the entry's `realpath $0` self-location resolves to that copy and `source "$RUNNER_DIR/lib/common.sh"` fails:

  ```
  /var/spool/spur/job7145/spur_job.sh: line 16: /var/spool/spur/job7145/lib/common.sh: No such file or directory
  [ERROR] Failed to load common library: /var/spool/spur/job7145/lib/common.sh
  ```

  This is what actually broke `sbatch ENTRY <args>`, and it is **not spur-specific**: standard Slurm relocates to `/var/spool/slurmd/job<id>/slurm_script` the same way, so the `sbatch` path was likely never functional on either flavor. Confirmed directly with a probe reporting its own resolved path: under `sbatch` it saw `/var/spool/spur/job8120/spur_job.sh`, under `srun` it saw the real path.

Separately, spur's `srun` defaults to `--ntasks=1` where standard Slurm derives one task per node from `-N`. `srun -N 4 ENTRY` therefore dispatched a single task and only one node ever started the entry, leaving the remaining ranks absent.

## Changes

- **`runner/primus-cli-slurm.sh`** — export `PRIMUS_RUNNER_DIR="$RUNNER_DIR"` so the entry no longer has to self-locate. Removes `_emit_spur_batch_script`, the temp-file lifecycle, and the duplicated dry-run / exec branches, restoring a single `CMD=(...)` + `exec` for both launchers. Adds a spur-gated task-count injection for `srun`: appends `-n <nodes>` unless the caller already passed `-n` / `--ntasks`.
- **`runner/primus-cli-slurm-entry.sh`** — prefer `PRIMUS_RUNNER_DIR` when it is set and actually contains `lib/common.sh`; otherwise fall back to `realpath $0` as before, so `srun` and direct invocation are unchanged.
- **`examples/deepseek-v4/run_deepseek_v4_flash.sh`** — make the launcher overridable (`SLURM_LAUNCH_CMD="${SLURM_LAUNCH_CMD:-srun}"`) instead of hardcoding it.

## Validation

4-node DeepSeek-V4 Flash on `amd-spur`, 32 ranks, mock data, `TRAIN_ITERS=10`, spur `0.6.0 (1be3693a)`:

- **sbatch** (job 8246): `COMPLETED`, `ExitCode=0:0`, `world_size=32`, `pretrain() completed successfully`, 5m03s. Aggregated log written to the experiment dir via `SBATCH_OUTPUT`.
- **srun** (job 8350): `COMPLETED`, `ExitCode=0:0`, `NumTasks=4`, `world_size=32`, 4m56s, wrapper exit 0.
- **`--dry-run`**: `sbatch` passes the entry directly with no generated script; `srun -N 4` appends `-n 4`; explicit `-n 2` / `--ntasks=3` are left untouched; `--nodes=4` (equals form) is recognized.
- `shellcheck` and all pre-commit hooks pass.

## Compatibility / notes

- The task-count injection is gated on `command -v spur`, so standard-Slurm `srun` behavior is unchanged.
- `export PRIMUS_RUNNER_DIR` is unconditional, which is what also repairs the standard-Slurm `sbatch` path. Not verified — no standard-Slurm cluster available for this change.
- The entry's fallback preserves the previous behavior whenever `PRIMUS_RUNNER_DIR` is unset, so invoking the entry directly still works.
- `primus-cli-container.sh` auto-forwards `PRIMUS_*` env vars into the container, so `PRIMUS_RUNNER_DIR` will appear in the container environment. It is inert there (only the entry reads it, and the repo is bind-mounted at the same absolute path).

## Open question for reviewers

The flash launcher default is `srun` in this PR. That choice was made while the `sbatch` path was still broken, and with `sbatch` working again it is arguably the wrong default: `sbatch` returns immediately so the job survives a disconnected shell, its aggregated log lands in the experiment dir, and `--exclusive` is applied (`run_deepseek_v4.sh` only adds it in `sbatch` mode). Flipping the default back to `sbatch` while keeping the override is a one-line change — happy to do it if reviewers agree.