### PR TITLE
fix(megatron): honor MXFP4 gradient SR setting

### DIFF
--- a/primus/backends/megatron/core/fp4_utils.py
+++ b/primus/backends/megatron/core/fp4_utils.py
@@ -50,6 +50,29 @@ def _primus_turbo_enabled() -> bool:
         return False
 
 
+_UNSET = object()
+
+
+def _mxfp4_gradient_sr_enabled(config: TransformerConfig) -> bool:
+    """Resolve gradient stochastic rounding from model config or global args.
+
+    Megatron's ``TransformerConfig`` only receives declared dataclass fields,
+    while this Primus option lives on the global args namespace. Diffusion
+    configs declare the field directly, so an explicit config value takes
+    precedence over the args fallback.
+    """
+    value = getattr(config, "mxfp4_gradient_stochastic_rounding", _UNSET)
+    if value is not _UNSET:
+        return bool(value)
+
+    try:
+        from megatron.training.global_vars import get_args
+
+        return bool(getattr(get_args(), "mxfp4_gradient_stochastic_rounding", False))
+    except Exception:
+        return False
+
+
 MXFP4_SCALING_BLOCK_SIZE = 32
 
 WARN_ONCE = True
@@ -120,7 +143,7 @@ if HAVE_TE and HAVE_TURBO:
             format=Format.E2M1_X2,
             block_size=MXFP4_SCALING_BLOCK_SIZE,
             scale_dtype=ScaleDtype.E8M0,
-            use_gradient_sr=getattr(config, "mxfp4_gradient_stochastic_rounding", False),
+            use_gradient_sr=_mxfp4_gradient_sr_enabled(config),
         )
         return fp4_quant_config, ""
 

--- a/primus/configs/modules/megatron/primus_turbo.yaml
+++ b/primus/configs/modules/megatron/primus_turbo.yaml
@@ -6,6 +6,12 @@ enable_primus_turbo: false
 # enable turbo auto-tuning
 use_turbo_autotune: false
 
+# ===== MXFP4 =====
+# Use stochastic rounding when quantizing MXFP4 gradients. This is disabled by
+# default and requires a Primus-Turbo grouped GEMM implementation with matching
+# activation and gradient layouts.
+mxfp4_gradient_stochastic_rounding: false
+
 # ===== Attention =====
 # operator switch
 use_turbo_attention: false

--- a/tests/unit_tests/backends/megatron/test_fp4_utils_mxfp4.py
+++ b/tests/unit_tests/backends/megatron/test_fp4_utils_mxfp4.py
@@ -4,7 +4,7 @@
 """
 Unit tests for fp4_utils.py MXFP4 recipe and context manager changes.
 
-Tests get_fp4_recipe error handling for an unsupported recipe.
+Tests recipe error handling and gradient stochastic-rounding configuration.
 """
 
 from types import SimpleNamespace
@@ -12,6 +12,45 @@ from types import SimpleNamespace
 import pytest
 
 from tests.utils import PrimusUT
+
+
+class TestMXFP4GradientStochasticRounding:
+    """Verify Megatron and diffusion configs resolve the SR option correctly."""
+
+    def test_explicit_config_value_takes_precedence(self, monkeypatch):
+        import megatron.training.global_vars as global_vars
+
+        from primus.backends.megatron.core.fp4_utils import _mxfp4_gradient_sr_enabled
+
+        def unexpected_get_args():
+            raise AssertionError("global args should not be read for an explicit config value")
+
+        monkeypatch.setattr(global_vars, "get_args", unexpected_get_args)
+
+        assert _mxfp4_gradient_sr_enabled(SimpleNamespace(mxfp4_gradient_stochastic_rounding=True))
+        assert not _mxfp4_gradient_sr_enabled(SimpleNamespace(mxfp4_gradient_stochastic_rounding=False))
+
+    def test_megatron_config_falls_back_to_global_args(self, monkeypatch):
+        import megatron.training.global_vars as global_vars
+
+        from primus.backends.megatron.core.fp4_utils import _mxfp4_gradient_sr_enabled
+
+        args = SimpleNamespace(mxfp4_gradient_stochastic_rounding=True)
+        monkeypatch.setattr(global_vars, "get_args", lambda: args)
+
+        assert _mxfp4_gradient_sr_enabled(SimpleNamespace())
+
+    def test_unavailable_global_args_default_to_disabled(self, monkeypatch):
+        import megatron.training.global_vars as global_vars
+
+        from primus.backends.megatron.core.fp4_utils import _mxfp4_gradient_sr_enabled
+
+        def unavailable_get_args():
+            raise RuntimeError("global args are not initialized")
+
+        monkeypatch.setattr(global_vars, "get_args", unavailable_get_args)
+
+        assert not _mxfp4_gradient_sr_enabled(SimpleNamespace())
 
 
 class TestGetFp4RecipeMXFP4(PrimusUT):


### PR DESCRIPTION
## Summary

- Add `mxfp4_gradient_stochastic_rounding` as an opt-in Primus configuration.
- Resolve the setting from `TransformerConfig` when explicitly provided, otherwise fall back to Megatron global arguments.
- Forward the resolved value to `Float4QuantConfig(use_gradient_sr=...)`.
- Add unit tests for config precedence, Megatron argument fallback, and the disabled fallback behavior.

## Motivation

Megatron only copies declared dataclass fields into `TransformerConfig`. Since this is a Primus-specific option, reading it directly from `TransformerConfig` silently defaulted to `False` in the Megatron training path.

## Compatibility

- Disabled by default, preserving existing behavior.
- Scoped to MXFP4 only.
- Enabling gradient SR with FlyDSL grouped GEMM requires a Primus-Turbo version containing the corresponding gradient-SR/layout support.

## Testing

- Added targeted MXFP4 configuration-resolution unit tests.
- `git diff --check`
- Python syntax validation