### PR TITLE
fix(megatron): patch upstream GatedDeltaNet gate for ROCm NaN

### DIFF
--- a/primus/backends/megatron/patches/gdn_rocm_gate_patches.py
+++ b/primus/backends/megatron/patches/gdn_rocm_gate_patches.py
@@ -1,0 +1,135 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron upstream GatedDeltaNet ROCm gate patch
+==============================================
+
+Qwen3.5 and other models with ``experimental_attention_variant: gated_delta_net``
+use Megatron-LM's ``megatron.core.ssm.gated_delta_net.GatedDeltaNet`` (not the
+Primus HybridStack copy).  On ROCm, FLA's Triton ``chunk_gated_delta_rule`` can
+produce NaN gradients when the gate is fused inside the kernel
+(``use_gate_in_kernel=True``, the default).  Pre-computing ``g`` in fp32 and
+passing ``use_gate_in_kernel=False`` matches the Primus hybrid GDN path and
+avoids NaN gradients during backward on ROCm.
+"""
+
+import torch
+
+from primus.backends.megatron.patches._patch_guard import is_patched, mark_patched
+from primus.backends.megatron.patches._source_patch_utils import patch_method_source
+from primus.core.patches import PatchContext, get_args, register_patch
+from primus.core.utils.module_utils import log_rank_0
+
+_PATCH_KEY = "megatron.ssm.gdn_rocm_gate"
+
+# Unique anchor in GatedDeltaNet.forward (megatron/core/ssm/gated_delta_net.py).
+_GATE_ORI = (
+    "        g = -self.A_log.exp() * F.softplus(alpha.float() + self.dt_bias)  # In fp32\n"
+    "        beta = beta.sigmoid()\n"
+    '        nvtx_range_pop(suffix="g_and_beta")\n'
+    "\n"
+    '        nvtx_range_push(suffix="gated_delta_rule")\n'
+    "        if self.config.deterministic_mode:\n"
+    "            core_attn_out, last_recurrent_state = torch_chunk_gated_delta_rule(\n"
+    "                query,\n"
+    "                key,\n"
+    "                value,\n"
+    "                g=g,\n"
+    "                beta=beta,\n"
+    "                initial_state=None,\n"
+    "                output_final_state=False,\n"
+    "                use_qk_l2norm_in_kernel=False,\n"
+    "            )\n"
+    "        else:\n"
+    "            core_attn_out, last_recurrent_state = chunk_gated_delta_rule(\n"
+    "                query,\n"
+    "                key,\n"
+    "                value,\n"
+    "                g=g,\n"
+    "                beta=beta,\n"
+    "                initial_state=None,\n"
+    "                output_final_state=False,\n"
+    "                use_qk_l2norm_in_kernel=False,\n"
+    "            )"
+)
+
+_GATE_NEW = (
+    "        # Pre-compute gate in fp32; use_gate_in_kernel=False avoids FLA Triton NaN on ROCm.\n"
+    "        g = -self.A_log.float().exp() * F.softplus(alpha.float() + self.dt_bias)\n"
+    "        beta = beta.sigmoid()\n"
+    '        nvtx_range_pop(suffix="g_and_beta")\n'
+    "\n"
+    '        nvtx_range_push(suffix="gated_delta_rule")\n'
+    "        if self.config.deterministic_mode:\n"
+    "            core_attn_out, last_recurrent_state = torch_chunk_gated_delta_rule(\n"
+    "                query,\n"
+    "                key,\n"
+    "                value,\n"
+    "                g=g,\n"
+    "                beta=beta,\n"
+    "                initial_state=None,\n"
+    "                output_final_state=False,\n"
+    "                use_qk_l2norm_in_kernel=False,\n"
+    "            )\n"
+    "        else:\n"
+    "            core_attn_out, last_recurrent_state = chunk_gated_delta_rule(\n"
+    "                query,\n"
+    "                key,\n"
+    "                value,\n"
+    "                g=g.to(query.dtype),\n"
+    "                beta=beta,\n"
+    "                initial_state=None,\n"
+    "                output_final_state=False,\n"
+    "                use_qk_l2norm_in_kernel=False,\n"
+    "                use_gate_in_kernel=False,\n"
+    "            )"
+)
+
+
+def _is_rocm(ctx: PatchContext) -> bool:
+    """Return True when running on an AMD ROCm platform."""
+    return getattr(torch.version, "hip", None) is not None
+
+
+def _uses_gated_delta_net(args) -> bool:
+    return getattr(args, "experimental_attention_variant", None) == "gated_delta_net"
+
+
+def _should_patch_gdn_rocm_gate(ctx: PatchContext) -> bool:
+    return _is_rocm(ctx) and _uses_gated_delta_net(get_args(ctx))
+
+
+def _install_gdn_rocm_gate_patch() -> None:
+    from megatron.core.ssm.gated_delta_net import GatedDeltaNet
+
+    if is_patched(GatedDeltaNet, _PATCH_KEY):
+        log_rank_0(f"[Patch:{_PATCH_KEY}] GatedDeltaNet already patched; skipping.")
+        return
+
+    patch_method_source(GatedDeltaNet, "forward", _GATE_ORI, _GATE_NEW)
+
+    mark_patched(GatedDeltaNet, _PATCH_KEY)
+    log_rank_0(
+        f"[Patch:{_PATCH_KEY}] Patched GatedDeltaNet.forward: fp32 gate precompute + "
+        "use_gate_in_kernel=False for FLA chunk_gated_delta_rule on ROCm."
+    )
+
+
+@register_patch(
+    _PATCH_KEY,
+    backend="megatron",
+    phase="before_train",
+    description=(
+        "Pre-compute GDN gate in fp32 and disable FLA in-kernel gate fusion on "
+        "Megatron upstream GatedDeltaNet to avoid NaN gradients on ROCm."
+    ),
+    condition=_should_patch_gdn_rocm_gate,
+    priority=51,
+    tags=["rocm", "gdn"],
+)
+def patch_gdn_rocm_gate(ctx: PatchContext) -> None:
+    _install_gdn_rocm_gate_patch()

--- a/runner/helpers/hooks/train/pretrain/megatron/requirements-megatron.txt
+++ b/runner/helpers/hooks/train/pretrain/megatron/requirements-megatron.txt
@@ -1,4 +1,5 @@
 # Add Megatron pretrain hook private Python deps here when needed.
 # Qwen3.5 / gated-delta-net attention (Megatron core GatedDeltaNet) needs FLA.
-flash-linear-attention==0.5.1
+# 0.5.2 fixes TileLang being enabled by default on ROCm (0.5.0/0.5.1 regressed qwen3_5).
+flash-linear-attention==0.5.2
 causal-conv1d~=1.5

--- a/tests/unit_tests/backends/megatron/test_gdn_rocm_gate_patches.py
+++ b/tests/unit_tests/backends/megatron/test_gdn_rocm_gate_patches.py
@@ -1,0 +1,115 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the Megatron upstream GatedDeltaNet ROCm gate patch.
+
+Verifies:
+  1. The source anchor still matches upstream ``GatedDeltaNet.forward``.
+  2. The patch rewrites the forward body and is idempotent.
+  3. Registration condition requires both ROCm and ``gated_delta_net``.
+"""
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("megatron")
+
+from megatron.core.ssm.gated_delta_net import GatedDeltaNet
+
+import primus.backends.megatron.patches.gdn_rocm_gate_patches as patch_mod
+from primus.backends.megatron.patches._patch_guard import is_patched
+from primus.core.patches.context import PatchContext
+
+
+def _clear_patch_state(cls):
+    if hasattr(cls, "_primus_applied_patch_keys"):
+        cls._primus_applied_patch_keys.discard(patch_mod._PATCH_KEY)
+
+
+@pytest.fixture
+def pristine_gdn_forward():
+    """Restore ``GatedDeltaNet.forward`` and patch-guard state after each test."""
+    original = GatedDeltaNet.forward
+    yield
+    GatedDeltaNet.forward = original
+    _clear_patch_state(GatedDeltaNet)
+
+
+def test_gate_anchor_matches_upstream_forward():
+    source = inspect.getsource(GatedDeltaNet.forward)
+    assert (
+        patch_mod._GATE_ORI in source
+    ), "Upstream GatedDeltaNet.forward changed; update gdn_rocm_gate_patches anchor."
+
+
+def test_gate_new_differs_from_anchor():
+    assert patch_mod._GATE_NEW != patch_mod._GATE_ORI
+    assert "use_gate_in_kernel=False" in patch_mod._GATE_NEW
+    assert "A_log.float().exp()" in patch_mod._GATE_NEW
+
+
+def test_install_patch_rewrites_forward(pristine_gdn_forward, monkeypatch):
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
+    original = GatedDeltaNet.forward
+    original_source = inspect.getsource(original)
+
+    patch_mod._install_gdn_rocm_gate_patch()
+
+    assert is_patched(GatedDeltaNet, patch_mod._PATCH_KEY)
+    assert GatedDeltaNet.forward is not original
+
+    # exec()-patched methods are not inspectable; verify the expected rewrite.
+    rewritten = original_source.replace(patch_mod._GATE_ORI, patch_mod._GATE_NEW)
+    assert "use_gate_in_kernel=False" in rewritten
+    assert "A_log.float().exp()" in rewritten
+
+
+def test_install_patch_is_idempotent(pristine_gdn_forward, monkeypatch):
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
+
+    patch_mod._install_gdn_rocm_gate_patch()
+    first = GatedDeltaNet.forward
+    patch_mod._install_gdn_rocm_gate_patch()
+
+    assert GatedDeltaNet.forward is first
+
+
+@pytest.mark.parametrize(
+    "variant, expected",
+    [
+        ("gated_delta_net", True),
+        ("dsa", False),
+        (None, False),
+    ],
+)
+def test_uses_gated_delta_net(variant, expected):
+    args = SimpleNamespace(experimental_attention_variant=variant)
+    assert patch_mod._uses_gated_delta_net(args) is expected
+
+
+@pytest.mark.parametrize(
+    "hip, variant, expected",
+    [
+        ("6.2.41133-65d174c3", "gated_delta_net", True),
+        ("6.2.41133-65d174c3", "dsa", False),
+        (None, "gated_delta_net", False),
+    ],
+)
+def test_should_patch_gdn_rocm_gate(hip, variant, expected, monkeypatch):
+    monkeypatch.setattr(patch_mod.torch.version, "hip", hip, raising=False)
+    args = SimpleNamespace(experimental_attention_variant=variant)
+    ctx = PatchContext(
+        backend="megatron",
+        phase="before_train",
+        extra={"module_config": SimpleNamespace(params=args)},
+    )
+    assert patch_mod._should_patch_gdn_rocm_gate(ctx) is expected
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Add `gdn_rocm_gate_patches.py` to patch Megatron upstream `GatedDeltaNet.forward` on ROCm when `experimental_attention_variant=gated_delta_net`.
- Pre-compute the gate in fp32 and pass `use_gate_in_kernel=False` to FLA `chunk_gated_delta_rule`, matching the existing Primus hybrid GDN fix from #676.
- Fixes CI failure in `test_qwen3_5_35B_A3B`, where Qwen3.5 uses the upstream GDN path (`is_hybrid_model=False`) and hit NaN gradients on rank 6 during iteration 1 backward.