### PR TITLE
fix(megatron): make device_id init_process_group patch opt-in (AIMA-227)

### DIFF
--- a/primus/backends/megatron/patches/distributed_init_patches.py
+++ b/primus/backends/megatron/patches/distributed_init_patches.py
@@ -5,17 +5,30 @@
 ###############################################################################
 
 """
-Distributed initialization patches (FSDP2 only).
+Distributed initialization patches (opt-in, FSDP2 only).
 
 Patches Megatron's _initialize_distributed to pass device_id to
 torch.distributed.init_process_group. Without device_id, RCCL guesses
-the GPU-to-rank mapping, which causes deadlocks on MI355X after the
-first FSDP2 iteration.
+the GPU-to-rank mapping, which was reported to cause deadlocks on MI355X
+after the first FSDP2 iteration.
 
-This patch is gated on use_torch_fsdp2 because device_id triggers eager
-RCCL communicator creation for the world PG and all ~26 Megatron sub-groups,
-consuming ~768 MiB of additional GPU memory. Under DDP this extra allocation
-pushes large models over the GPU memory limit.
+device_id triggers eager RCCL communicator creation for the world PG and all
+~26 Megatron sub-groups. That is expensive, so the patch is opt-in via
+enable_init_process_group_device_id (default false):
+
+- +16.0 GiB/GPU peak VRAM and +9.9 s startup, measured on llama3-70B BF16
+  FSDP2, 1 node x 8 MI355X, TP/PP/EP=1, ROCm 26.5. The memory is invisible to
+  the torch caching allocator (max reserved is byte-identical across arms), so
+  it is communicator-side, not activations or parameters.
+- No throughput effect there (-0.07 %, within run-to-run noise over two
+  interleaved repeats per arm).
+- Under ODC the eager communicators also serialize XGMI copy streams; see the
+  condition below.
+
+The deadlock this guards against did not reproduce on that recipe with the
+patch disabled, on either ROCm 26.5 or 26.3, so it must not be assumed
+necessary everywhere. It has not been tested multi-node or with TP/PP/EP > 1,
+which is why the patch is kept rather than removed. See AIMA-227.
 """
 
 import os
@@ -32,9 +45,14 @@ from primus.core.utils.module_utils import log_rank_0
     phase="before_train",
     description=(
         "Inject device_id into torch.distributed.init_process_group to "
-        "prevent RCCL device mapping deadlocks on MI355X (FSDP2 only)."
+        "prevent RCCL device mapping deadlocks on MI355X "
+        "(opt-in, FSDP2 only)."
     ),
     priority=10,
+    # Opt-in: the eager communicator creation costs +16.0 GiB/GPU and +9.9 s of
+    # startup for no throughput gain on llama3-70B FSDP2 (see module docstring),
+    # so callers must ask for it on the configurations where it buys liveness.
+    #
     # ODC (enable_odc=true) drives gradient exchange over rocSHMEM P2P, not RCCL, and
     # relies on those P2P copy streams overlapping with compute in the backward pass.
     # The device_id injection here eagerly creates the world + ~26 sub-group RCCL
@@ -45,7 +63,9 @@ from primus.core.utils.module_utils import log_rank_0
     # under ODC. Safe on MI300X (the MI355X deadlock this guards does not trigger
     # here; commits before this patch existed ran ODC correctly).
     condition=lambda ctx: (
-        getattr(get_args(ctx), "use_torch_fsdp2", False) and not getattr(get_args(ctx), "enable_odc", False)
+        getattr(get_args(ctx), "enable_init_process_group_device_id", False)
+        and getattr(get_args(ctx), "use_torch_fsdp2", False)
+        and not getattr(get_args(ctx), "enable_odc", False)
     ),
 )
 def patch_init_process_group_device_id(ctx: PatchContext):

--- a/primus/configs/modules/megatron/primus_megatron_module.yaml
+++ b/primus/configs/modules/megatron/primus_megatron_module.yaml
@@ -82,6 +82,14 @@ no_fp8_weight_transpose_cache: false
 # parallelism
 decoder_pipeline_manual_split_list: null # int list
 
+# distributed init
+# Pass an explicit device_id to torch.distributed.init_process_group (FSDP2 only).
+# Opt-in: it forces eager RCCL communicator creation for the world PG and every
+# Megatron sub-group, which costs ~16 GiB/GPU of peak VRAM and ~10s of startup
+# with no throughput gain on llama3-70B FSDP2 (1 node x 8 MI355X, ROCm 26.5).
+# Enable it only where the RCCL device-mapping deadlock actually reproduces.
+enable_init_process_group_device_id: false
+
 # MoE comm & comp Overlap
 patch_moe_overlap: false
 

--- a/tests/unit_tests/backends/megatron/patches/test_distributed_init_patches.py
+++ b/tests/unit_tests/backends/megatron/patches/test_distributed_init_patches.py
@@ -1,0 +1,97 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the device_id init_process_group patch gating.
+
+The patch forces eager RCCL communicator creation, which costs ~16 GiB/GPU of
+peak VRAM and ~10s of startup with no throughput gain on llama3-70B FSDP2, so
+it must stay off unless a config explicitly asks for it. These tests pin the
+full truth table of its ``condition`` so the default cannot silently flip back.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from primus.core.patches import PatchContext, PatchRegistry
+
+PATCH_NAME = "megatron.distributed.init_process_group_device_id"
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
+
+def _ctx(**params):
+    """Build a PatchContext whose module_config.params carries ``params``."""
+    return PatchContext(
+        backend="megatron",
+        phase="before_train",
+        extra={"module_config": SimpleNamespace(params=SimpleNamespace(**params))},
+    )
+
+
+@pytest.fixture
+def condition():
+    """The patch's real ``condition``, so these tests pin production behaviour.
+
+    Sibling suites clear the process-wide ``PatchRegistry``, so the patch may be
+    absent by the time this runs. Reloading its module re-runs ``@register_patch``
+    (``register`` overrides a duplicate id), which makes the fixture independent
+    of test ordering.
+    """
+    import importlib
+
+    import primus.backends.megatron.patches.distributed_init_patches as mod
+
+    patch = PatchRegistry.get(PATCH_NAME)
+    if patch is None:
+        importlib.reload(mod)
+        patch = PatchRegistry.get(PATCH_NAME)
+
+    assert patch is not None, f"{PATCH_NAME} is not registered"
+    assert patch.condition is not None, "patch must stay conditionally gated"
+    return patch.condition
+
+
+@pytest.mark.parametrize(
+    "params, expected, reason",
+    [
+        ({}, False, "absent flag must not enable the patch"),
+        (
+            {"use_torch_fsdp2": True},
+            False,
+            "FSDP2 alone must not enable it -- this is the opt-in change",
+        ),
+        (
+            {"enable_init_process_group_device_id": True, "use_torch_fsdp2": True},
+            True,
+            "explicit opt-in under FSDP2 applies",
+        ),
+        (
+            {"enable_init_process_group_device_id": True, "use_torch_fsdp2": False},
+            False,
+            "device_id is FSDP2-only; DDP would pay the memory for nothing",
+        ),
+        (
+            {
+                "enable_init_process_group_device_id": True,
+                "use_torch_fsdp2": True,
+                "enable_odc": True,
+            },
+            False,
+            "ODC carve-out: eager RCCL comms serialize its XGMI copy streams",
+        ),
+    ],
+)
+def test_condition_truth_table(condition, params, expected, reason):
+    assert bool(condition(_ctx(**params))) is expected, reason
+
+
+def test_default_config_leaves_patch_disabled():
+    """The shipped default must be off, so no recipe pays 16 GiB unknowingly."""
+    cfg = REPO_ROOT / "primus/configs/modules/megatron/primus_megatron_module.yaml"
+    values = yaml.safe_load(cfg.read_text())
+    assert values["enable_init_process_group_device_id"] is False


### PR DESCRIPTION
## Summary

Makes the `device_id` injection into `torch.distributed.init_process_group`
opt-in via `enable_init_process_group_device_id` (default `false`), instead of
applying to every FSDP2 run.

Tracking: AIMA-227. The patch was introduced by
[PR #856](https://github.com/AMD-AGI/Primus/pull/856) and was suspected of
costing llama3-70B throughput. It does not cost throughput — it costs memory.

### Measured cost of the patch

`llama3_70B-BF16-pretrain.yaml`, mock data, FSDP2, TP/PP/EP=1, mbs 3 / gbs 24,
seq 8192, 1 node x 8 MI355X, ROCm 26.5. Arms interleaved ON/OFF/ON/OFF on one
node so node/thermal drift cannot masquerade as a patch effect; 50 iterations
each, 2 repeats per arm.

| Metric | patch ON vs OFF |
|---|---|
| Steady-state iteration time | **−0.07 %** (ON marginally faster; within run-to-run noise) |
| Throughput (TFLOP/s/GPU) | within noise, same direction |
| Megatron init | **+9.9 s** |
| Peak VRAM (`rocm-smi`) | **+16.03 GiB/GPU** |
| Torch max reserved (torch allocator) | **0 MB** (byte-identical) |

Both arms: 50/50 iterations, 0 NaN, 0 skipped, loss converging identically.

The extra 16 GiB is **invisible to the torch caching allocator** (max reserved
is byte-identical across arms), so it is not activations or parameters — it is
communicator-side memory from eagerly building the world PG plus every Megatron
sub-group. The old docstring estimated ~768 MiB; the measured cost is ~21x that,
so the docstring is corrected here too.

### Why opt-in rather than removed

With the patch disabled, the deadlock it guards against did not reproduce:

- ROCm 26.5, patch off: 50/50 iterations, twice, no hang.
- Stock `rocm/primus:v26.3` (bundled Primus `45955d45`, which has no
  `distributed_init_patches.py` at all): 20/20 iterations, `rc=0`, no hang,
  loss converging normally. First-iteration loss agrees with the 26.5 arms to
  five significant figures, so both are running the same model and data.

Without the patch PyTorch simply emits the warning the patch exists to silence
(`barrier(): using the device under current context. You can specify device_id
in init_process_group ...`) and proceeds.

Since version was **not** the discriminating variable, a ROCm-version gate
would be wrong. But the evidence is single-node with TP/PP/EP=1, so the patch is
kept and gated rather than deleted.

### Scope not covered by this evidence

- **1 node x 8 GPUs only** — the classic RCCL device-mapping deadlock is a
  multi-node phenomenon; the allocation QoS capped at one node.
- **TP = PP = EP = 1** — this recipe is pure FSDP2 data parallelism, so most
  Megatron sub-groups are degenerate. A TP/PP/EP-heavy recipe builds real
  sub-group communicators and would likely pay a larger eager-init cost.
- **One recipe** (`llama3_70B-BF16`).

### Behaviour change

60 recipe YAMLs set `use_torch_fsdp2: true` and therefore stop applying the
patch by default. MI300X/MI325X recipes were paying the 16 GiB for nothing —
the existing ODC comment in this file already states the MI355X deadlock "does
not trigger" on MI300X. The MI355X FSDP2 recipes are the ones whose behaviour
genuinely changes.

**Open question blocking merge (hence draft):** should any shipped MI355X recipe
set `enable_init_process_group_device_id: true`? That needs the original repro
conditions — node count, recipe, parallelism — from the patch author
(@luiza-amd). If the deadlock was multi-node, the multi-node recipes should set
it true and this PR should carry that change.

## Test plan

- [x] 6 new unit tests in
      `tests/unit_tests/backends/megatron/patches/test_distributed_init_patches.py`:
      full `condition` truth table (absent flag, FSDP2-only, explicit opt-in,
      DDP rejection, ODC carve-out) plus an assertion that the shipped default is
      `false`, so the default cannot silently flip back.
- [x] Test is ordering-independent: sibling suites clear the process-wide
      `PatchRegistry`, so the fixture reloads the patch module when needed.
      Verified passing both alone and after `tests/unit_tests/core/patches`.
- [x] `pytest tests/unit_tests/core/patches tests/unit_tests/backends/megatron/patches`
      → 4 failed, 68 passed. The 4 failures are **pre-existing** in
      `tests/unit_tests/core/patches/test_patch.py`, reproduced on a pristine
      `origin/main` worktree at `a89d28b5` (4 failed, 62 passed) before this change.
- [x] `black==24.8.0` (line-length 110), `isort==5.13.2 --profile black`,
      `autoflake==2.3.1` all clean on the changed files.
- [x] End-to-end: patch-off arms confirmed via the patch's own banner being
      absent from the training log, and patch-on arms via it being present.
- [ ] Confirm with the patch author whether a multi-node MI355X recipe needs the
      flag set true.
