### PR TITLE
feat(maxdiffusion): add Primus JAX MaxDiffusion backend (WAN/FLUX)

### DIFF
--- a/examples/maxdiffusion/configs/MI300X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/flux_dev-pretrain.yaml
@@ -1,0 +1,51 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:flux_dev-pretrain}
+workspace: ./output
+
+# Per-config environment (arch-agnostic; see the MI355X flux config). The
+# gfx950-only RCCL_WARP_SPEED_AUTO=0 workaround is applied by run.sh and is a
+# no-op on MI300X (gfx942). NOTE: as on MI355X, Shardy is left at the image
+# default (the default maxdiffusion image forces it on for cudnn_flash_te); set
+# JAX_USE_SHARDY_PARTITIONER here only if you switch to an older image.
+env:
+  KERAS_BACKEND: "jax"
+  JAX_SPMD_MODE: "allow_all"
+  JAX_TRACEBACK_FILTERING: "off"
+  JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  TOKENIZERS_PARALLELISM: "1"
+  SKIP_GCS: "1"
+  XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
+  TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
+  XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  NVTE_FUSED_ATTN: "1"
+  NVTE_FUSED_ATTN_CK: "1"
+  NVTE_FUSED_ATTN_AOTRITON: "0"
+  NVTE_CK_USES_BWD_V3: "1"
+  NVTE_CK_USES_FWD_V3: "1"
+  NVTE_CK_IS_V3_ATOMIC_FP32: "0"
+  NVTE_CK_HOW_V3_BF16_CVT: "2"
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: "1"
+
+modules:
+  pre_trainer:
+    framework: maxdiffusion
+    config: pre_trainer.yaml
+
+    model: flux_dev.yaml
+    maxdiffusion_entrypoint: flux
+
+    overrides:
+      run_name: "flux_dev_pretrain"
+      output_dir: "./output/flux_dev-pretrain"
+      base_output_directory: "./output/flux_dev-pretrain"
+      max_train_steps: ${MAX_STEPS:20}
+      dataset_type: "synthetic"
+      hardware: "gpu"
+      checkpoint_every: -1
+      enable_profiler: false
+      # MI300X has 192 GB HBM (vs 288 GB on MI355X); the MI355X config uses
+      # per_device_batch_size 14. Lower here if FLUX.1-dev OOMs on MI300X.
+      per_device_batch_size: 8
+      ici_data_parallelism: 1
+      ici_tensor_parallelism: 1

--- a/examples/maxdiffusion/configs/MI300X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/wan2.1_1.3b-pretrain.yaml
@@ -1,0 +1,52 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:wan2.1_1.3b-pretrain}
+workspace: ./output
+
+# Per-config environment (ported from the retired MAD jax-maxdiffusion env
+# scripts). TrainRuntime applies this top-level `env:` before JAX/XLA init.
+# These flags are arch-agnostic; the gfx950-only RCCL_WARP_SPEED_AUTO=0
+# workaround is applied by run.sh and is a no-op on MI300X (gfx942).
+env:
+  KERAS_BACKEND: "jax"
+  JAX_SPMD_MODE: "allow_all"
+  JAX_TRACEBACK_FILTERING: "off"
+  JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  TOKENIZERS_PARALLELISM: "1"
+  SKIP_GCS: "1"
+  XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
+  TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
+  XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  NVTE_FUSED_ATTN: "1"
+  NVTE_FUSED_ATTN_CK: "1"
+  NVTE_FUSED_ATTN_AOTRITON: "0"
+  NVTE_CK_USES_BWD_V3: "1"
+  NVTE_CK_USES_FWD_V3: "1"
+  NVTE_CK_IS_V3_ATOMIC_FP32: "0"
+  NVTE_CK_HOW_V3_BF16_CVT: "2"
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: "1"
+
+modules:
+  pre_trainer:
+    framework: maxdiffusion
+    config: pre_trainer.yaml
+
+    model: wan2.1_1.3b.yaml
+    maxdiffusion_entrypoint: wan
+
+    overrides:
+      run_name: "wan2.1_1.3b_pretrain"
+      output_dir: "./output/wan2.1_1.3b-pretrain"
+      base_output_directory: "./output/wan2.1_1.3b-pretrain"
+      max_train_steps: ${MAX_STEPS:20}
+      dataset_type: "synthetic"
+      hardware: "gpu"
+      checkpoint_every: -1
+      enable_profiler: false
+      # MI300X has 192 GB HBM (vs 288 GB on MI355X); reduce per_device_batch_size
+      # here if a model OOMs relative to the MI355X config.
+      per_device_batch_size: 1
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_context_parallelism: 1
+      ici_tensor_parallelism: 1

--- a/examples/maxdiffusion/configs/MI300X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/wan2.1_14b-pretrain.yaml
@@ -1,0 +1,51 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:wan2.1_14b-pretrain}
+workspace: ./output
+
+# Per-config environment (arch-agnostic; see the 1.3B MI300X config). The
+# gfx950-only RCCL_WARP_SPEED_AUTO=0 workaround is applied by run.sh and is a
+# no-op on MI300X (gfx942).
+env:
+  KERAS_BACKEND: "jax"
+  JAX_SPMD_MODE: "allow_all"
+  JAX_TRACEBACK_FILTERING: "off"
+  JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  TOKENIZERS_PARALLELISM: "1"
+  SKIP_GCS: "1"
+  XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
+  TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
+  XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  NVTE_FUSED_ATTN: "1"
+  NVTE_FUSED_ATTN_CK: "1"
+  NVTE_FUSED_ATTN_AOTRITON: "0"
+  NVTE_CK_USES_BWD_V3: "1"
+  NVTE_CK_USES_FWD_V3: "1"
+  NVTE_CK_IS_V3_ATOMIC_FP32: "0"
+  NVTE_CK_HOW_V3_BF16_CVT: "2"
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: "1"
+
+modules:
+  pre_trainer:
+    framework: maxdiffusion
+    config: pre_trainer.yaml
+
+    model: wan2.1_14b.yaml
+    maxdiffusion_entrypoint: wan
+
+    overrides:
+      run_name: "wan2.1_14b_pretrain"
+      output_dir: "./output/wan2.1_14b-pretrain"
+      base_output_directory: "./output/wan2.1_14b-pretrain"
+      max_train_steps: ${MAX_STEPS:20}
+      dataset_type: "synthetic"
+      hardware: "gpu"
+      checkpoint_every: -1
+      enable_profiler: false
+      # MI300X has 192 GB HBM (vs 288 GB on MI355X); reduce per_device_batch_size
+      # here if wan2.1_14b OOMs relative to the MI355X config.
+      per_device_batch_size: 1
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_context_parallelism: 1
+      ici_tensor_parallelism: 1

--- a/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
@@ -1,0 +1,50 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:flux_dev-pretrain}
+workspace: ./output
+
+# Per-config environment (ported from base_flux_dev_env.sh). NOTE: the retired
+# shell env also set JAX_USE_SHARDY_PARTITIONER=0, but the default maxdiffusion
+# image (docker/jax_maxdiffusion.jax_the_rock_ci_45156b7_20260701) patches
+# attention_flax.py to FORCE Shardy on for cudnn_flash_te (GSPMD aborts there on
+# JAX 0.10 + TE 2.14). We therefore leave Shardy at the image default; set
+# JAX_USE_SHARDY_PARTITIONER here only if you switch to an older image.
+env:
+  KERAS_BACKEND: "jax"
+  JAX_SPMD_MODE: "allow_all"
+  JAX_TRACEBACK_FILTERING: "off"
+  JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  TOKENIZERS_PARALLELISM: "1"
+  SKIP_GCS: "1"
+  XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
+  TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
+  XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  NVTE_FUSED_ATTN: "1"
+  NVTE_FUSED_ATTN_CK: "1"
+  NVTE_FUSED_ATTN_AOTRITON: "0"
+  NVTE_CK_USES_BWD_V3: "1"
+  NVTE_CK_USES_FWD_V3: "1"
+  NVTE_CK_IS_V3_ATOMIC_FP32: "0"
+  NVTE_CK_HOW_V3_BF16_CVT: "2"
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: "1"
+
+modules:
+  pre_trainer:
+    framework: maxdiffusion
+    config: pre_trainer.yaml
+
+    model: flux_dev.yaml
+    maxdiffusion_entrypoint: flux
+
+    overrides:
+      run_name: "flux_dev_pretrain"
+      output_dir: "./output/flux_dev-pretrain"
+      base_output_directory: "./output/flux_dev-pretrain"
+      max_train_steps: ${MAX_STEPS:20}
+      dataset_type: "synthetic"
+      hardware: "gpu"
+      checkpoint_every: -1
+      enable_profiler: false
+      per_device_batch_size: 14
+      ici_data_parallelism: 1
+      ici_tensor_parallelism: 1

--- a/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
@@ -14,11 +14,28 @@ env:
   JAX_SPMD_MODE: "allow_all"
   JAX_TRACEBACK_FILTERING: "off"
   JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  JAX_COMPILATION_CACHE_DIR: "/app/.cache/jax/"
+  MIOPEN_CUSTOM_CACHE_DIR: "/app/.cache/miopen/"
   TOKENIZERS_PARALLELISM: "1"
   SKIP_GCS: "1"
   XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
   TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
   XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  # ROCm/HIP + RCCL/NCCL knobs. These MUST match the verified-good
+  # base_flux_dev_env.sh: dropping NCCL_PROTO=Simple / HSA_NO_SCRATCH_RECLAIM=1 /
+  # GPU_MAX_HW_QUEUES / HIP_FORCE_DEV_KERNARG / RCCL_MSCCL_ENABLE caused an RCCL
+  # init hang (GPUs 0%, CPU busy-wait) during model construction.
+  HSA_FORCE_FINE_GRAIN_PCIE: "1"
+  HSA_NO_SCRATCH_RECLAIM: "1"
+  GPU_MAX_HW_QUEUES: "2"
+  HIP_FORCE_DEV_KERNARG: "1"
+  RCCL_MSCCL_ENABLE: "0"
+  NCCL_MAX_NCHANNELS: "112"
+  NCCL_IB_TC: "41"
+  NCCL_IB_SL: "0"
+  NCCL_DEBUG: "WARN"
+  NCCL_PROTO: "Simple"
+  LIBTPU_INIT_ARGS: ""
   NVTE_FUSED_ATTN: "1"
   NVTE_FUSED_ATTN_CK: "1"
   NVTE_FUSED_ATTN_AOTRITON: "0"
@@ -41,6 +58,11 @@ modules:
       output_dir: "./output/flux_dev-pretrain"
       base_output_directory: "./output/flux_dev-pretrain"
       max_train_steps: ${MAX_STEPS:20}
+      # Log throughput every step: the perf extractor parses the per-step
+      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
+      # default log_period=100 emits nothing at 20 steps, so perf came back empty
+      # and madengine silently reused a stale CSV.
+      log_period: 1
       dataset_type: "synthetic"
       hardware: "gpu"
       checkpoint_every: -1

--- a/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
@@ -63,6 +63,11 @@ modules:
       # default log_period=100 emits nothing at 20 steps, so perf came back empty
       # and madengine silently reused a stale CSV.
       log_period: 1
+      # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
+      # metrics here (max_utils.write_metrics_locally). This is the reliable perf
+      # source; the per-step stdout "completed step:" line is dropped under the
+      # Primus launcher. Empty when unset -> no-op (upstream default).
+      metrics_file: "${PERF_METRICS_FILE:}"
       dataset_type: "synthetic"
       hardware: "gpu"
       checkpoint_every: -1

--- a/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
@@ -14,8 +14,13 @@ env:
   JAX_SPMD_MODE: "allow_all"
   JAX_TRACEBACK_FILTERING: "off"
   JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
-  JAX_COMPILATION_CACHE_DIR: "/app/.cache/jax/"
-  MIOPEN_CUSTOM_CACHE_DIR: "/app/.cache/miopen/"
+  # Persist the XLA compilation cache on the bind-mounted workspace (NFS) instead
+  # of the ephemeral in-container /app/.cache/jax, so a cold compile (which can be
+  # tens of minutes with autotune_level=5) is paid once and reused across runs
+  # rather than every run recompiling and risking a launcher timeout. /myworkspace
+  # is the container bind-mount of the repo root.
+  JAX_COMPILATION_CACHE_DIR: "/myworkspace/.jax_cache/flux_dev"
+  MIOPEN_CUSTOM_CACHE_DIR: "/myworkspace/.jax_cache/flux_dev/miopen"
   TOKENIZERS_PARALLELISM: "1"
   SKIP_GCS: "1"
   XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
@@ -1,0 +1,54 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:wan2.1_1.3b-pretrain}
+workspace: ./output
+
+# Per-config environment (single source of truth in Primus). TrainRuntime applies
+# this top-level `env:` before JAX/XLA init. Ported from the retired MAD
+# scripts/jax-maxdiffusion/env_scripts/base_wan_1.3B_env.sh so the JAX
+# MaxDiffusion tuning travels with the config instead of a sourced shell script.
+env:
+  KERAS_BACKEND: "jax"
+  JAX_SPMD_MODE: "allow_all"
+  JAX_TRACEBACK_FILTERING: "off"
+  JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  TOKENIZERS_PARALLELISM: "1"
+  SKIP_GCS: "1"
+  XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
+  TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
+  XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  NVTE_FUSED_ATTN: "1"
+  NVTE_FUSED_ATTN_CK: "1"
+  NVTE_FUSED_ATTN_AOTRITON: "0"
+  NVTE_CK_USES_BWD_V3: "1"
+  NVTE_CK_USES_FWD_V3: "1"
+  NVTE_CK_IS_V3_ATOMIC_FP32: "0"
+  NVTE_CK_HOW_V3_BF16_CVT: "2"
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: "1"
+
+modules:
+  pre_trainer:
+    framework: maxdiffusion
+    config: pre_trainer.yaml
+
+    # MaxDiffusion model preset (the native pyconfig file, hosted in Primus).
+    model: wan2.1_1.3b.yaml
+
+    # Primus-only selector (stripped before the config reaches MaxDiffusion's
+    # pyconfig): picks the src.maxdiffusion.train_wan entrypoint + WanTrainer.
+    maxdiffusion_entrypoint: wan
+
+    overrides:
+      run_name: "wan2.1_1.3b_pretrain"
+      output_dir: "./output/wan2.1_1.3b-pretrain"
+      base_output_directory: "./output/wan2.1_1.3b-pretrain"
+      max_train_steps: ${MAX_STEPS:20}
+      dataset_type: "synthetic"
+      hardware: "gpu"
+      checkpoint_every: -1
+      enable_profiler: false
+      per_device_batch_size: 1
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_context_parallelism: 1
+      ici_tensor_parallelism: 1

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
@@ -12,8 +12,14 @@ env:
   JAX_SPMD_MODE: "allow_all"
   JAX_TRACEBACK_FILTERING: "off"
   JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
-  JAX_COMPILATION_CACHE_DIR: "/app/.cache/jax/"
-  MIOPEN_CUSTOM_CACHE_DIR: "/app/.cache/miopen/"
+  # Persist the XLA compilation cache on the bind-mounted workspace (NFS) instead
+  # of the ephemeral in-container /app/.cache/jax. The WAN fused-attention graph
+  # (long video sequence + autotune_level=5) can take 30-45 min to compile on a
+  # cold cache; without persistence every run recompiles from scratch and can
+  # exceed the launcher timeout before a single step runs. /myworkspace is the
+  # container bind-mount of the repo root.
+  JAX_COMPILATION_CACHE_DIR: "/myworkspace/.jax_cache/wan2.1_1.3b"
+  MIOPEN_CUSTOM_CACHE_DIR: "/myworkspace/.jax_cache/wan2.1_1.3b/miopen"
   TOKENIZERS_PARALLELISM: "1"
   SKIP_GCS: "1"
   XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
@@ -65,6 +65,11 @@ modules:
       # default log_period=100 emits nothing at 20 steps, so perf came back empty
       # and madengine silently reused a stale CSV.
       log_period: 1
+      # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
+      # metrics here (max_utils.write_metrics_locally). This is the reliable perf
+      # source; the per-step stdout "completed step:" line is dropped under the
+      # Primus launcher. Empty when unset -> no-op (upstream default).
+      metrics_file: "${PERF_METRICS_FILE:}"
       dataset_type: "synthetic"
       hardware: "gpu"
       checkpoint_every: -1

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
@@ -12,11 +12,28 @@ env:
   JAX_SPMD_MODE: "allow_all"
   JAX_TRACEBACK_FILTERING: "off"
   JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  JAX_COMPILATION_CACHE_DIR: "/app/.cache/jax/"
+  MIOPEN_CUSTOM_CACHE_DIR: "/app/.cache/miopen/"
   TOKENIZERS_PARALLELISM: "1"
   SKIP_GCS: "1"
   XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
   TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
   XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  # ROCm/HIP + RCCL/NCCL knobs. These MUST match the verified-good
+  # base_wan_1.3B_env.sh: dropping NCCL_PROTO=Simple / HSA_NO_SCRATCH_RECLAIM=1 /
+  # GPU_MAX_HW_QUEUES / HIP_FORCE_DEV_KERNARG / RCCL_MSCCL_ENABLE caused an RCCL
+  # init hang (GPUs 0%, CPU busy-wait) during model construction.
+  HSA_FORCE_FINE_GRAIN_PCIE: "1"
+  HSA_NO_SCRATCH_RECLAIM: "1"
+  GPU_MAX_HW_QUEUES: "2"
+  HIP_FORCE_DEV_KERNARG: "1"
+  RCCL_MSCCL_ENABLE: "0"
+  NCCL_MAX_NCHANNELS: "112"
+  NCCL_IB_TC: "41"
+  NCCL_IB_SL: "0"
+  NCCL_DEBUG: "WARN"
+  NCCL_PROTO: "Simple"
+  LIBTPU_INIT_ARGS: ""
   NVTE_FUSED_ATTN: "1"
   NVTE_FUSED_ATTN_CK: "1"
   NVTE_FUSED_ATTN_AOTRITON: "0"
@@ -43,6 +60,11 @@ modules:
       output_dir: "./output/wan2.1_1.3b-pretrain"
       base_output_directory: "./output/wan2.1_1.3b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
+      # Log throughput every step: the perf extractor parses the per-step
+      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
+      # default log_period=100 emits nothing at 20 steps, so perf came back empty
+      # and madengine silently reused a stale CSV.
+      log_period: 1
       dataset_type: "synthetic"
       hardware: "gpu"
       checkpoint_every: -1

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
@@ -10,8 +10,14 @@ env:
   JAX_SPMD_MODE: "allow_all"
   JAX_TRACEBACK_FILTERING: "off"
   JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
-  JAX_COMPILATION_CACHE_DIR: "/app/.cache/jax/"
-  MIOPEN_CUSTOM_CACHE_DIR: "/app/.cache/miopen/"
+  # Persist the XLA compilation cache on the bind-mounted workspace (NFS) instead
+  # of the ephemeral in-container /app/.cache/jax. The WAN fused-attention graph
+  # (long video sequence + autotune_level=5) can take 30-50 min to compile on a
+  # cold cache; without persistence every run recompiles from scratch and can
+  # exceed the launcher timeout before a single step runs. /myworkspace is the
+  # container bind-mount of the repo root.
+  JAX_COMPILATION_CACHE_DIR: "/myworkspace/.jax_cache/wan2.1_14b"
+  MIOPEN_CUSTOM_CACHE_DIR: "/myworkspace/.jax_cache/wan2.1_14b/miopen"
   TOKENIZERS_PARALLELISM: "1"
   SKIP_GCS: "1"
   XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
@@ -1,0 +1,48 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:wan2.1_14b-pretrain}
+workspace: ./output
+
+# Per-config environment (ported from base_wan_14B_env.sh). See the 1.3B config
+# for the rationale; TrainRuntime applies this before JAX/XLA init.
+env:
+  KERAS_BACKEND: "jax"
+  JAX_SPMD_MODE: "allow_all"
+  JAX_TRACEBACK_FILTERING: "off"
+  JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  TOKENIZERS_PARALLELISM: "1"
+  SKIP_GCS: "1"
+  XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
+  TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
+  XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  NVTE_FUSED_ATTN: "1"
+  NVTE_FUSED_ATTN_CK: "1"
+  NVTE_FUSED_ATTN_AOTRITON: "0"
+  NVTE_CK_USES_BWD_V3: "1"
+  NVTE_CK_USES_FWD_V3: "1"
+  NVTE_CK_IS_V3_ATOMIC_FP32: "0"
+  NVTE_CK_HOW_V3_BF16_CVT: "2"
+  NVTE_ALLOW_NONDETERMINISTIC_ALGO: "1"
+
+modules:
+  pre_trainer:
+    framework: maxdiffusion
+    config: pre_trainer.yaml
+
+    model: wan2.1_14b.yaml
+    maxdiffusion_entrypoint: wan
+
+    overrides:
+      run_name: "wan2.1_14b_pretrain"
+      output_dir: "./output/wan2.1_14b-pretrain"
+      base_output_directory: "./output/wan2.1_14b-pretrain"
+      max_train_steps: ${MAX_STEPS:20}
+      dataset_type: "synthetic"
+      hardware: "gpu"
+      checkpoint_every: -1
+      enable_profiler: false
+      per_device_batch_size: 1
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_context_parallelism: 1
+      ici_tensor_parallelism: 1

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
@@ -10,11 +10,28 @@ env:
   JAX_SPMD_MODE: "allow_all"
   JAX_TRACEBACK_FILTERING: "off"
   JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES: "all"
+  JAX_COMPILATION_CACHE_DIR: "/app/.cache/jax/"
+  MIOPEN_CUSTOM_CACHE_DIR: "/app/.cache/miopen/"
   TOKENIZERS_PARALLELISM: "1"
   SKIP_GCS: "1"
   XLA_PYTHON_CLIENT_MEM_FRACTION: "0.95"
   TF_CUDNN_WORKSPACE_LIMIT_IN_MB: "71296"
   XLA_FLAGS: "--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=5 --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_all_gather_combine_threshold_bytes=134217728 --xla_gpu_reduce_scatter_combine_threshold_bytes=134217728 --xla_gpu_enable_command_buffer=''"
+  # ROCm/HIP + RCCL/NCCL knobs. These MUST match the verified-good
+  # base_wan_14B_env.sh: dropping NCCL_PROTO=Simple / HSA_NO_SCRATCH_RECLAIM=1 /
+  # GPU_MAX_HW_QUEUES / HIP_FORCE_DEV_KERNARG / RCCL_MSCCL_ENABLE caused an RCCL
+  # init hang (GPUs 0%, CPU busy-wait) during model construction.
+  HSA_FORCE_FINE_GRAIN_PCIE: "1"
+  HSA_NO_SCRATCH_RECLAIM: "1"
+  GPU_MAX_HW_QUEUES: "2"
+  HIP_FORCE_DEV_KERNARG: "1"
+  RCCL_MSCCL_ENABLE: "0"
+  NCCL_MAX_NCHANNELS: "112"
+  NCCL_IB_TC: "41"
+  NCCL_IB_SL: "0"
+  NCCL_DEBUG: "WARN"
+  NCCL_PROTO: "Simple"
+  LIBTPU_INIT_ARGS: ""
   NVTE_FUSED_ATTN: "1"
   NVTE_FUSED_ATTN_CK: "1"
   NVTE_FUSED_ATTN_AOTRITON: "0"
@@ -37,6 +54,11 @@ modules:
       output_dir: "./output/wan2.1_14b-pretrain"
       base_output_directory: "./output/wan2.1_14b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
+      # Log throughput every step: the perf extractor parses the per-step
+      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
+      # default log_period=100 emits nothing at 20 steps, so perf came back empty
+      # and madengine silently reused a stale CSV.
+      log_period: 1
       dataset_type: "synthetic"
       hardware: "gpu"
       checkpoint_every: -1

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
@@ -59,6 +59,11 @@ modules:
       # default log_period=100 emits nothing at 20 steps, so perf came back empty
       # and madengine silently reused a stale CSV.
       log_period: 1
+      # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
+      # metrics here (max_utils.write_metrics_locally). This is the reliable perf
+      # source; the per-step stdout "completed step:" line is dropped under the
+      # Primus launcher. Empty when unset -> no-op (upstream default).
+      metrics_file: "${PERF_METRICS_FILE:}"
       dataset_type: "synthetic"
       hardware: "gpu"
       checkpoint_every: -1

--- a/examples/maxdiffusion/prepare.py
+++ b/examples/maxdiffusion/prepare.py
@@ -1,0 +1,131 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Prepare hook for the Primus MaxDiffusion (JAX) backend.
+
+Invoked by ``examples/scripts/prepare_experiment.py`` (resolved as
+``examples/<framework>/prepare.py`` where framework == ``maxdiffusion``).
+
+Unlike MaxText (a git submodule under ``third_party/maxtext``), MaxDiffusion is
+``pip install -e .`` from a clone at ``/workspace/maxdiffusion`` (see
+docker/jax_maxdiffusion.*). We resolve that path (MAXDIFFUSION_PATH override,
+else the default clone dir) and, when present, forward it as ``--backend_path``
+so the adapter can put it on ``sys.path``. Datasets are synthetic for the
+benchmark configs, so no dataset prep is needed.
+"""
+
+import argparse
+from pathlib import Path
+from typing import Optional
+
+from examples.scripts.utils import (
+    get_env_case_insensitive,
+    log_error_and_exit,
+    log_info,
+    write_patch_args,
+)
+from primus.core.launcher.config import PrimusConfig
+from primus.core.launcher.parser import load_primus_config
+
+_DEFAULT_MAXDIFFUSION_PATH = "/workspace/maxdiffusion"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Prepare Primus MaxDiffusion environment")
+    parser.add_argument("--primus_path", type=str, required=True, help="Root path to the Primus project")
+    parser.add_argument("--data_path", type=str, required=True, help="Path to data directory")
+    parser.add_argument("--config", type=str, required=True, help="Path to experiment YAML config")
+    parser.add_argument(
+        "--patch_args",
+        type=str,
+        default="/tmp/primus_patch_args.txt",
+        help="Path to write additional args (used during training phase)",
+    )
+    parser.add_argument(
+        "--backend_path",
+        type=str,
+        default=None,
+        help="Optional override for the MaxDiffusion checkout path.",
+    )
+    return parser.parse_known_args()
+
+
+def resolve_maxdiffusion_path(cli_path: Optional[str]) -> Path:
+    if cli_path:
+        path = Path(cli_path)
+        log_info(f"Using MaxDiffusion path from CLI: {path}")
+        return path
+    env_value = get_env_case_insensitive("MAXDIFFUSION_PATH")
+    if env_value:
+        path = Path(env_value)
+        log_info(f"MAXDIFFUSION_PATH found in environment: {path}")
+        return path
+    path = Path(_DEFAULT_MAXDIFFUSION_PATH)
+    log_info(f"MAXDIFFUSION_PATH not set, falling back to: {path}")
+    return path
+
+
+def prepare_dataset_if_needed(
+    primus_config: PrimusConfig, primus_path: Path, data_path: Path, patch_args: Path, env=None
+):
+    # No-op: benchmark configs use synthetic data; real datasets are prepared
+    # outside Primus (see examples/diffusion/README.md for HF dataset notes).
+    return
+
+
+def main():
+    args, unknown = parse_args()
+
+    primus_path = Path(args.primus_path).resolve()
+    data_path = Path(args.data_path).resolve()
+    exp_path = Path(args.config).resolve()
+    patch_args_file = Path(args.patch_args).resolve()
+
+    log_info(f"PRIMUS_PATH: {primus_path}")
+    log_info(f"DATA_PATH: {data_path}")
+    log_info(f"EXP: {exp_path}")
+    log_info(f"BACKEND_PATH: {args.backend_path}")
+    log_info(f"PATCH-ARGS: {patch_args_file}")
+
+    if not exp_path.is_file():
+        log_error_and_exit(f"EXP file not found: {exp_path}")
+
+    primus_config, _ = load_primus_config(args, unknown)
+
+    maxdiffusion_path = resolve_maxdiffusion_path(args.backend_path)
+
+    try:
+        pre_trainer_cfg = primus_config.get_module_config("pre_trainer")
+    except Exception:
+        log_error_and_exit("Missing required module config: pre_trainer")
+
+    if not hasattr(pre_trainer_cfg, "dataset_type") or pre_trainer_cfg.dataset_type is None:
+        log_error_and_exit("Missing required field: pre_trainer.dataset_type")
+
+    dataset_type = pre_trainer_cfg.dataset_type
+    if dataset_type == "synthetic":
+        log_info("'dataset_type: synthetic', Skipping dataset preparation.")
+    else:
+        prepare_dataset_if_needed(
+            primus_config=primus_config,
+            primus_path=primus_path,
+            data_path=data_path,
+            patch_args=patch_args_file,
+            env=None,
+        )
+
+    # Forward the checkout as --backend_path only if it exists; MaxDiffusion is
+    # usually importable as an installed package, and the adapter tolerates a
+    # missing path.
+    if maxdiffusion_path.exists():
+        write_patch_args(patch_args_file, "train_args", {"backend_path": str(maxdiffusion_path.resolve())})
+    else:
+        log_info(f"MaxDiffusion checkout not found at {maxdiffusion_path}; relying on installed package.")
+
+
+if __name__ == "__main__":
+    log_info("========== Prepare MaxDiffusion Env ==========")
+    main()

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -38,6 +38,16 @@ LOG_INFO_RANK0() {
 }
 LOG_ERROR() { echo "[NODE-$NODE_RANK($HOSTNAME)] [ERROR] $*"; }
 
+# JAX backends (MaxText, MaxDiffusion) are launched WITHOUT torchrun, install
+# requirements-jax.txt, and skip the torch/NCCL-only env. Returns 0 (true) for
+# any JAX backend, matched case-insensitively against $BACKEND.
+_is_jax_backend() {
+    case "$(printf '%s' "${BACKEND:-}" | tr '[:upper:]' '[:lower:]')" in
+        maxtext|maxdiffusion) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 EXAMPLE_FAULT_TOLERANCE() {
     for arg in "$@"; do
         case "$arg" in
@@ -99,7 +109,7 @@ if [ "${PRIMUS_SKIP_PIP:-0}" == "1" ]; then
     LOG_INFO_RANK0 "PRIMUS_SKIP_PIP=1: skipping pip install (deps from image)"
 else
     LOG_INFO_RANK0 "Pip installing required packages ..."
-    if [ "${BACKEND:-}" != "MaxText" ]; then
+    if ! _is_jax_backend; then
         pip install -r "$PRIMUS_PATH/requirements.txt"  --quiet
     else
         pip install -r "$PRIMUS_PATH/requirements-jax.txt"  --quiet
@@ -226,7 +236,7 @@ export RCCL_MSCCLPP_ENABLE=0
 export RCCL_MSCCLPP_FORCE_ENABLE=0
 export RCCL_MSCCLPP_THRESHOLD=$((1*1024*1024*1024))
 export MSCCLPP_DISABLE_CHANNEL_CACHE=FALSE
-if [ "${BACKEND:-}" != "MaxText" ]; then
+if ! _is_jax_backend; then
     export TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK=0
 fi
 
@@ -240,7 +250,7 @@ LOG_INFO_RANK0 ""
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export ENABLE_NUMA_BINDING=${ENABLE_NUMA_BINDING:-0}
 export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
-if [ "${BACKEND:-}" != "MaxText" ]; then
+if ! _is_jax_backend; then
     export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 fi
 
@@ -363,7 +373,9 @@ fi
 
 
 # -------------------- Launch Training --------------------
-if [ "${BACKEND:-}" == "MaxText" ]; then
+if _is_jax_backend; then
+    # JAX backends (MaxText, MaxDiffusion) manage devices themselves; launch a
+    # single plain-python process (no torchrun).
     CMD="python primus/cli/main.py train pretrain --config $EXP $TRAIN_EXTRA_ARGS $*"
 else
     DISTRIBUTED_ARGS=(

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -38,6 +38,16 @@ LOG_INFO_RANK0() {
 }
 LOG_ERROR() { echo "[NODE-$NODE_RANK($HOSTNAME)] [ERROR] $*"; }
 
+# JAX backends (MaxText, MaxDiffusion) are launched WITHOUT torchrun, install
+# requirements-jax.txt, and skip the torch/NCCL-only env. Returns 0 (true) for
+# any JAX backend, matched case-insensitively against $BACKEND.
+_is_jax_backend() {
+    case "$(printf '%s' "${BACKEND:-}" | tr '[:upper:]' '[:lower:]')" in
+        maxtext|maxdiffusion) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 EXAMPLE_FAULT_TOLERANCE() {
     for arg in "$@"; do
         case "$arg" in
@@ -99,7 +109,7 @@ if [ "${PRIMUS_SKIP_PIP:-0}" == "1" ]; then
     LOG_INFO_RANK0 "PRIMUS_SKIP_PIP=1: skipping pip install (deps from image)"
 else
     LOG_INFO_RANK0 "Pip installing required packages ..."
-    if [ "${BACKEND:-}" != "MaxText" ]; then
+    if ! _is_jax_backend; then
         pip install -r "$PRIMUS_PATH/requirements.txt"  --quiet
     else
         pip install -r "$PRIMUS_PATH/requirements-jax.txt"  --quiet
@@ -230,7 +240,7 @@ export RCCL_MSCCLPP_ENABLE=0
 export RCCL_MSCCLPP_FORCE_ENABLE=0
 export RCCL_MSCCLPP_THRESHOLD=$((1*1024*1024*1024))
 export MSCCLPP_DISABLE_CHANNEL_CACHE=FALSE
-if [ "${BACKEND:-}" != "MaxText" ]; then
+if ! _is_jax_backend; then
     export TORCH_NCCL_USE_TENSOR_REGISTER_ALLOCATOR_HOOK=0
 fi
 
@@ -244,7 +254,7 @@ LOG_INFO_RANK0 ""
 export GPU_MAX_HW_QUEUES=${GPU_MAX_HW_QUEUES:-2}
 export ENABLE_NUMA_BINDING=${ENABLE_NUMA_BINDING:-0}
 export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
-if [ "${BACKEND:-}" != "MaxText" ]; then
+if ! _is_jax_backend; then
     export TORCH_NCCL_HIGH_PRIORITY=${TORCH_NCCL_HIGH_PRIORITY:-1}
 fi
 
@@ -374,7 +384,9 @@ fi
 
 
 # -------------------- Launch Training --------------------
-if [ "${BACKEND:-}" == "MaxText" ]; then
+if _is_jax_backend; then
+    # JAX backends (MaxText, MaxDiffusion) manage devices themselves; launch a
+    # single plain-python process (no torchrun).
     CMD="python primus/cli/main.py train pretrain --config $EXP $TRAIN_EXTRA_ARGS $*"
 else
     DISTRIBUTED_ARGS=(

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -219,8 +219,12 @@ export HSA_ENABLE_SDMA=${HSA_ENABLE_SDMA:-1}
 
 # Prevent scratch memory from being reclaimed to stabilize large memory usage patterns (e.g., KV cache, MoE experts)
 # NOTE: Must disable scratch reclaim to avoid MoE training crash on AMD GPUs
-# Setting this to 0 prevents core dumps when using Mixture-of-Experts (MoE) models
-export HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-0}
+# Setting this to 0 prevents core dumps when using Mixture-of-Experts (MoE) models.
+# MaxText intentionally skipped here: its adapter owns HSA_NO_SCRATCH_RECLAIM
+# (gfx942 => 1; unset on gfx950) via env_spec.py, so we must not pre-set it.
+if [ "${BACKEND:-}" != "MaxText" ]; then
+    export HSA_NO_SCRATCH_RECLAIM=${HSA_NO_SCRATCH_RECLAIM:-0}
+fi
 export RCCL_MSCCL_ENABLE=0
 export RCCL_MSCCLPP_ENABLE=0
 export RCCL_MSCCLPP_FORCE_ENABLE=0
@@ -251,9 +255,16 @@ export NCCL_PXN_DISABLE=${NCCL_PXN_DISABLE:-0}
 export NCCL_P2P_NET_CHUNKSIZE=${NCCL_P2P_NET_CHUNKSIZE:-524288}
 export NVTE_USE_CAST_TRANSPOSE_TRITON=${NVTE_USE_CAST_TRANSPOSE_TRITON:-1}
 export NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE=${NVTE_USE_OPTIMIZED_HIPIFIED_CAST_TRANSPOSE:-0}
-export NVTE_ROCM_ENABLE_MXFP8=1
+export NVTE_ROCM_ENABLE_MXFP8=${NVTE_ROCM_ENABLE_MXFP8:-1}
 export NVTE_CK_USES_BWD_V3=${NVTE_CK_USES_BWD_V3:-1}
 export PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32=${PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32:-0}
+
+# NOTE (MaxText): all MaxText/JAX perf + arch env (XLA_FLAGS incl. the fp8 MoE
+# --xla_gpu_autotune_level fix, NVTE/HIP/HSA tunables, and the arch-gated
+# RCCL_WARP_SPEED_AUTO/HSA_NO_SCRATCH_RECLAIM) is owned by the Primus MaxText
+# backend adapter (primus/backends/maxtext/env_spec.py), applied in-process before
+# JAX init. This launcher intentionally sets NO MaxText perf/arch env so there is a
+# single source of truth. See primus/core/backend/env_registry.py.
 
 if [ "${PRIMUS_DETERMINISTIC:-}" == "1" ]; then
     export NCCL_ALGO="Ring"

--- a/primus/backends/maxdiffusion/__init__.py
+++ b/primus/backends/maxdiffusion/__init__.py
@@ -1,0 +1,24 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion Backend Registration.
+
+Registers the MaxDiffusion (JAX) backend adapter, mirroring the MaxText
+backend. MaxDiffusion is Google's JAX diffusion library
+(https://github.com/AI-Hypercomputer/maxdiffusion); this backend runs its
+WAN video and FLUX text-to-image trainers through Primus so that JAX
+diffusion models follow the same launch/discovery pattern as MaxText.
+
+Note: this is distinct from the in-tree PyTorch ``diffusion`` backend
+(``primus/backends/diffusion``); ``maxdiffusion`` is JAX and is launched
+without torchrun (like ``maxtext``).
+"""
+
+from primus.backends.maxdiffusion.maxdiffusion_adapter import MaxDiffusionAdapter
+from primus.core.backend.backend_registry import BackendRegistry
+
+BackendRegistry.register_adapter("maxdiffusion", MaxDiffusionAdapter)

--- a/primus/backends/maxdiffusion/argument_builder.py
+++ b/primus/backends/maxdiffusion/argument_builder.py
@@ -1,0 +1,79 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion Configuration Builder.
+
+Mirrors ``primus/backends/maxtext/argument_builder.py``:
+
+- ``MaxDiffusionConfigBuilder``
+  Light-weight builder used by ``MaxDiffusionAdapter.convert_config()`` to
+  normalise Primus ``module_config.params`` (a ``SimpleNamespace``) into the
+  form expected by downstream code. No heavy dependencies (JAX, MaxDiffusion)
+  are imported here.
+
+- ``export_params_to_yaml()``
+  Writes a flat config dict to a temporary YAML file so that MaxDiffusion's
+  ``pyconfig.initialize(argv)`` can load it as its config file (argv[1]).
+
+- ``namespace_to_dict()``
+  Recursively converts ``SimpleNamespace`` to plain dicts.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from types import SimpleNamespace
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class MaxDiffusionConfigBuilder:
+    """Builder for MaxDiffusion configuration.
+
+    Takes Primus module config parameters and returns the canonical set of
+    MaxDiffusion parameters as a ``SimpleNamespace``.
+    """
+
+    def __init__(self):
+        self.config = SimpleNamespace()
+
+    def update(self, params: SimpleNamespace):
+        """Absorb Primus params (already merged with CLI overrides)."""
+        self.config = params
+
+    def finalize(self) -> SimpleNamespace:
+        """Return the config namespace for downstream use."""
+        return self.config
+
+
+def namespace_to_dict(obj: Any) -> Any:
+    """Recursively convert ``SimpleNamespace`` (and nested containers) to dict."""
+    if isinstance(obj, SimpleNamespace):
+        return {k: namespace_to_dict(v) for k, v in vars(obj).items()}
+    if isinstance(obj, dict):
+        return {k: namespace_to_dict(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [namespace_to_dict(v) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(namespace_to_dict(v) for v in obj)
+    return obj
+
+
+def export_params_to_yaml(params_dict: Dict[str, Any]) -> str:
+    """Write a config dict to a temporary YAML file for ``pyconfig.initialize``.
+
+    The caller is responsible for deleting the returned file.
+    """
+    import yaml
+
+    fd, yaml_path = tempfile.mkstemp(suffix=".yml", prefix="primus_maxdiffusion_")
+    with os.fdopen(fd, "w") as f:
+        yaml.dump(params_dict, f, default_flow_style=False, allow_unicode=True)
+    return yaml_path

--- a/primus/backends/maxdiffusion/env_spec.py
+++ b/primus/backends/maxdiffusion/env_spec.py
@@ -13,33 +13,30 @@ before JAX/XLA is imported, consumed by :class:`MaxDiffusionAdapter` via
 ``env_defaults()`` and applied by the base adapter through the shared
 ``primus.core.backend.env_registry`` mechanism.
 
-Unlike MaxText, MaxDiffusion keeps all of its JAX/XLA/NVTE performance tuning in
+Unlike MaxText, MaxDiffusion keeps *all* of its JAX/XLA/NVTE/RCCL/HIP tuning in
 the per-config top-level ``env:`` block of each wrapper config
 (``examples/maxdiffusion/configs/**``), which TrainRuntime applies before JAX
-init. The adapter therefore only needs to own the single arch-gated knob that is
-not (and should not be) hard-coded per config:
+init. Those blocks are a faithful, complete copy of the verified-good
+``scripts/jax-maxdiffusion/env_scripts/base_*_env.sh`` from the
+``clairlee/feat/maxdiffusion_support`` baseline.
 
-  * gfx950 (MI350X/MI355X): ``RCCL_WARP_SPEED_AUTO=0`` — WarpSpeed is default-on in
-    gfx950 RCCL builds and can cause NaN losses / hangs; harmless on gfx942.
+The adapter therefore contributes *no* environment of its own. In particular it
+must NOT inject ``RCCL_WARP_SPEED_AUTO`` — the known-good MaxDiffusion baseline
+never sets it, and forcing it here diverged from that baseline (contributing to
+an RCCL init hang on gfx950). Any arch-specific diffusion knob belongs in the
+per-config ``env:`` block alongside the rest of the tuning.
 
-Precedence (see env_registry): per-config ``env:`` > outer/shell env > this
-default > image-baked.
+Precedence (see env_registry): per-config ``env:`` > outer/shell env > image-baked.
 """
 
 from __future__ import annotations
 
 from typing import List
 
-from primus.core.backend.env_registry import ARCH_GFX950, EnvVar
+from primus.core.backend.env_registry import EnvVar
 
 
 def maxdiffusion_env_defaults() -> List[EnvVar]:
-    """Return the declarative MaxDiffusion arch env defaults for the current run."""
-    return [
-        EnvVar(
-            "RCCL_WARP_SPEED_AUTO",
-            "0",
-            arch=ARCH_GFX950,
-            note="gfx950 WarpSpeed default-on can cause NaN losses / hangs",
-        ),
-    ]
+    """MaxDiffusion owns no adapter-level env; the per-config ``env:`` block is the
+    single source of truth (see module docstring)."""
+    return []

--- a/primus/backends/maxdiffusion/env_spec.py
+++ b/primus/backends/maxdiffusion/env_spec.py
@@ -1,0 +1,45 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion backend environment specification (single source of truth).
+
+This is the MaxDiffusion counterpart of ``primus/backends/maxtext/env_spec.py``.
+It declares the architecture environment that Primus is responsible for applying
+before JAX/XLA is imported, consumed by :class:`MaxDiffusionAdapter` via
+``env_defaults()`` and applied by the base adapter through the shared
+``primus.core.backend.env_registry`` mechanism.
+
+Unlike MaxText, MaxDiffusion keeps all of its JAX/XLA/NVTE performance tuning in
+the per-config top-level ``env:`` block of each wrapper config
+(``examples/maxdiffusion/configs/**``), which TrainRuntime applies before JAX
+init. The adapter therefore only needs to own the single arch-gated knob that is
+not (and should not be) hard-coded per config:
+
+  * gfx950 (MI350X/MI355X): ``RCCL_WARP_SPEED_AUTO=0`` — WarpSpeed is default-on in
+    gfx950 RCCL builds and can cause NaN losses / hangs; harmless on gfx942.
+
+Precedence (see env_registry): per-config ``env:`` > outer/shell env > this
+default > image-baked.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from primus.core.backend.env_registry import ARCH_GFX950, EnvVar
+
+
+def maxdiffusion_env_defaults() -> List[EnvVar]:
+    """Return the declarative MaxDiffusion arch env defaults for the current run."""
+    return [
+        EnvVar(
+            "RCCL_WARP_SPEED_AUTO",
+            "0",
+            arch=ARCH_GFX950,
+            note="gfx950 WarpSpeed default-on can cause NaN losses / hangs",
+        ),
+    ]

--- a/primus/backends/maxdiffusion/maxdiffusion_adapter.py
+++ b/primus/backends/maxdiffusion/maxdiffusion_adapter.py
@@ -11,7 +11,8 @@ This is the MaxDiffusion counterpart of ``MaxTextAdapter``. MaxDiffusion is a
 JAX training stack, so (like MaxText) it is launched without torchrun and its
 config is a MaxDiffusion ``pyconfig`` file. The adapter is responsible for:
 
-    - Preparing the MaxDiffusion/JAX backend environment (arch env defaults)
+    - Declaring the MaxDiffusion/JAX arch env defaults (applied by the base
+      adapter before JAX/XLA import, via the shared env_registry mechanism)
     - Making the ``maxdiffusion`` package importable
     - Converting Primus module config -> MaxDiffusion config namespace
     - Providing the MaxDiffusion trainer class to Primus
@@ -22,10 +23,12 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from primus.backends.maxdiffusion.argument_builder import MaxDiffusionConfigBuilder
+from primus.backends.maxdiffusion.env_spec import maxdiffusion_env_defaults
 from primus.core.backend.backend_adapter import BackendAdapter
+from primus.core.backend.env_registry import EnvVar
 from primus.core.utils.module_utils import log_rank_0, warning_rank_0
 
 # Where the Dockerfile clones/installs MaxDiffusion (`git clone ... /workspace/maxdiffusion`).
@@ -39,40 +42,18 @@ class MaxDiffusionAdapter(BackendAdapter):
         super().__init__(framework)
         self.third_party_dir_name = "maxdiffusion"
 
-    def prepare_backend(self, config: Any):
-        """Prepare the MaxDiffusion/JAX backend environment before trainer construction.
+    def env_defaults(self) -> List[EnvVar]:
+        """Declare MaxDiffusion arch env defaults (single source of truth).
 
-        Applies MaxDiffusion/ROCm arch defaults via ``os.environ.setdefault`` so
-        they never override values already set by the environment or a per-config
-        top-level ``env:`` block (applied earlier in
-        ``TrainRuntime._apply_config_env``).
+        Returns the declarative env spec from ``env_spec.py``. The base adapter
+        applies it via the shared ``env_registry`` mechanism in
+        ``prepare_backend`` -> ``apply_env_defaults`` (before JAX/XLA import), so
+        this adapter no longer overrides ``prepare_backend`` itself.
 
         Effective precedence (highest wins):
-            per-config ``env:``  >  these arch defaults  >  image-baked defaults
+            per-config ``env:``  >  outer/shell env  >  these defaults  >  image-baked
         """
-        self._apply_arch_env_defaults()
-        super().prepare_backend(config)
-
-    @staticmethod
-    def _apply_arch_env_defaults() -> None:
-        """Set backend/arch env defaults (only when unset) before JAX/XLA init."""
-        # gfx950 (MI350X/MI355X) NaN/hang workaround; harmless / no-op on gfx942.
-        if MaxDiffusionAdapter._is_gfx950():
-            if os.environ.setdefault("RCCL_WARP_SPEED_AUTO", "0") == "0":
-                log_rank_0("[Primus:maxdiffusion] gfx950 detected: RCCL_WARP_SPEED_AUTO=0 (default)")
-
-    @staticmethod
-    def _is_gfx950() -> bool:
-        """Best-effort detection of a gfx950 (MI350X/MI355X) device via rocminfo."""
-        import shutil
-        import subprocess
-
-        rocminfo = shutil.which("rocminfo") or "/opt/rocm/bin/rocminfo"
-        try:
-            out = subprocess.run([rocminfo], capture_output=True, text=True, timeout=15).stdout
-        except Exception:  # noqa: BLE001 - detection must never abort a run
-            return False
-        return "gfx950" in out
+        return maxdiffusion_env_defaults()
 
     def setup_backend_path(self, backend_path=None) -> str:
         """Make the ``maxdiffusion`` package importable.

--- a/primus/backends/maxdiffusion/maxdiffusion_adapter.py
+++ b/primus/backends/maxdiffusion/maxdiffusion_adapter.py
@@ -1,0 +1,145 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion BackendAdapter implementation.
+
+This is the MaxDiffusion counterpart of ``MaxTextAdapter``. MaxDiffusion is a
+JAX training stack, so (like MaxText) it is launched without torchrun and its
+config is a MaxDiffusion ``pyconfig`` file. The adapter is responsible for:
+
+    - Preparing the MaxDiffusion/JAX backend environment (arch env defaults)
+    - Making the ``maxdiffusion`` package importable
+    - Converting Primus module config -> MaxDiffusion config namespace
+    - Providing the MaxDiffusion trainer class to Primus
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+from primus.backends.maxdiffusion.argument_builder import MaxDiffusionConfigBuilder
+from primus.core.backend.backend_adapter import BackendAdapter
+from primus.core.utils.module_utils import log_rank_0, warning_rank_0
+
+# Where the Dockerfile clones/installs MaxDiffusion (`git clone ... /workspace/maxdiffusion`).
+_DEFAULT_MAXDIFFUSION_PATH = "/workspace/maxdiffusion"
+
+
+class MaxDiffusionAdapter(BackendAdapter):
+    """BackendAdapter implementation for MaxDiffusion (JAX)."""
+
+    def __init__(self, framework: str = "maxdiffusion"):
+        super().__init__(framework)
+        self.third_party_dir_name = "maxdiffusion"
+
+    def prepare_backend(self, config: Any):
+        """Prepare the MaxDiffusion/JAX backend environment before trainer construction.
+
+        Applies MaxDiffusion/ROCm arch defaults via ``os.environ.setdefault`` so
+        they never override values already set by the environment or a per-config
+        top-level ``env:`` block (applied earlier in
+        ``TrainRuntime._apply_config_env``).
+
+        Effective precedence (highest wins):
+            per-config ``env:``  >  these arch defaults  >  image-baked defaults
+        """
+        self._apply_arch_env_defaults()
+        super().prepare_backend(config)
+
+    @staticmethod
+    def _apply_arch_env_defaults() -> None:
+        """Set backend/arch env defaults (only when unset) before JAX/XLA init."""
+        # gfx950 (MI350X/MI355X) NaN/hang workaround; harmless / no-op on gfx942.
+        if MaxDiffusionAdapter._is_gfx950():
+            if os.environ.setdefault("RCCL_WARP_SPEED_AUTO", "0") == "0":
+                log_rank_0("[Primus:maxdiffusion] gfx950 detected: RCCL_WARP_SPEED_AUTO=0 (default)")
+
+    @staticmethod
+    def _is_gfx950() -> bool:
+        """Best-effort detection of a gfx950 (MI350X/MI355X) device via rocminfo."""
+        import shutil
+        import subprocess
+
+        rocminfo = shutil.which("rocminfo") or "/opt/rocm/bin/rocminfo"
+        try:
+            out = subprocess.run([rocminfo], capture_output=True, text=True, timeout=15).stdout
+        except Exception:  # noqa: BLE001 - detection must never abort a run
+            return False
+        return "gfx950" in out
+
+    def setup_backend_path(self, backend_path=None) -> str:
+        """Make the ``maxdiffusion`` package importable.
+
+        Unlike MaxText (a git submodule under ``third_party/``), MaxDiffusion is
+        installed with ``pip install -e .`` from a clone at
+        ``/workspace/maxdiffusion`` (see docker/jax_maxdiffusion.*), so it is
+        usually already importable and no sys.path edit is required. This override
+        is therefore tolerant: it adds the checkout (and its ``src``) to
+        ``sys.path`` when present, but never hard-fails when the package is an
+        installed wheel.
+
+        Resolution order: --backend_path > BACKEND_PATH > MAXDIFFUSION_PATH >
+        /workspace/maxdiffusion.
+        """
+        candidate = (
+            backend_path
+            or os.getenv("BACKEND_PATH")
+            or os.getenv("MAXDIFFUSION_PATH")
+            or _DEFAULT_MAXDIFFUSION_PATH
+        )
+        resolved = ""
+        root = Path(candidate)
+        if root.exists():
+            resolved = str(root.resolve())
+            for p in (root, root / "src"):
+                ap = os.path.abspath(str(p))
+                if os.path.exists(ap) and ap not in sys.path:
+                    sys.path.insert(0, ap)
+                    log_rank_0(f"[Primus:maxdiffusion] sys.path.insert -> {ap}")
+
+        # Verify importability without importing heavy deps eagerly.
+        import importlib.util
+
+        if importlib.util.find_spec("maxdiffusion") is None:
+            warning_rank_0(
+                "[Primus:maxdiffusion] `maxdiffusion` package not importable and "
+                f"no checkout found at '{candidate}'. Set MAXDIFFUSION_PATH or install "
+                "maxdiffusion (pip install -e .) in the image."
+            )
+        return resolved
+
+    def convert_config(self, params: Any):
+        """Convert Primus params -> MaxDiffusion configuration namespace."""
+        builder = MaxDiffusionConfigBuilder()
+        builder.update(params)
+        maxdiffusion_config = builder.finalize()
+        log_rank_0("[Primus:MaxDiffusionAdapter] Converted Primus module params -> MaxDiffusion config")
+        return maxdiffusion_config
+
+    def load_trainer_class(self, stage: str = "pretrain", trainer_class: Optional[str] = None):
+        """Return the MaxDiffusion trainer class for the given stage."""
+        if stage == "pretrain":
+            from primus.backends.maxdiffusion.maxdiffusion_pretrain_trainer import (
+                MaxDiffusionPretrainTrainer,
+            )
+
+            return MaxDiffusionPretrainTrainer
+        raise ValueError(f"Invalid stage: {stage}")
+
+    def detect_backend_version(self) -> str:
+        """Detect MaxDiffusion version for logging/patching (best-effort)."""
+        try:
+            import maxdiffusion
+
+            if hasattr(maxdiffusion, "__version__"):
+                return maxdiffusion.__version__
+        except Exception as exc:  # noqa: BLE001
+            warning_rank_0(f"MaxDiffusionAdapter: Failed to detect MaxDiffusion version: {exc}")
+        return "unknown"

--- a/primus/backends/maxdiffusion/maxdiffusion_pretrain_trainer.py
+++ b/primus/backends/maxdiffusion/maxdiffusion_pretrain_trainer.py
@@ -202,7 +202,6 @@ class MaxDiffusionPretrainTrainer(BaseTrainer):
             raise RuntimeError("MaxDiffusionPretrainTrainer.init() must be called before train().")
 
         module_name, trainer_path, init_kwargs = _FAMILY_SPECS[self._family]
-        trainer_cls = self._import_trainer_class(trainer_path)
 
         from maxdiffusion import pyconfig
         from maxdiffusion.train_utils import transformer_engine_context, validate_train_config
@@ -219,6 +218,15 @@ class MaxDiffusionPretrainTrainer(BaseTrainer):
 
                 self._update_logger_rank()
 
+                # Import the trainer class (which pulls in the TransformerEngine
+                # attention layers) INSIDE the TE mesh-guard, exactly as upstream
+                # train_wan.main()/train() does: it imports WanTrainer within the
+                # `with transformer_engine_context()` block. Importing it outside
+                # the guard leaves TE's fused/sharded attention unconfigured (the
+                # global_shard_guard MeshResource is not active), so attention
+                # falls back to a full, unsharded S^2 matmul -> ~221 GiB OOM on
+                # long WAN video sequences. See train_wan.py / train_flux.py.
+                trainer_cls = self._import_trainer_class(trainer_path)
                 trainer = trainer_cls(config)
                 trainer.start_training()
         finally:

--- a/primus/backends/maxdiffusion/maxdiffusion_pretrain_trainer.py
+++ b/primus/backends/maxdiffusion/maxdiffusion_pretrain_trainer.py
@@ -1,0 +1,253 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusionPretrainTrainer: Primus wrapper for MaxDiffusion (JAX) training.
+
+This trainer bridges Primus's configuration system with MaxDiffusion's
+trainers, following the same pattern ``MaxTextPretrainTrainer`` uses for
+MaxText.
+
+MaxDiffusion (github.com/AI-Hypercomputer/maxdiffusion) does not expose a
+MaxText-style ``initialize()``/``run()`` pair. Its entrypoints
+(``src/maxdiffusion/train_wan.py`` and ``train_flux.py``) look like::
+
+    def main(argv):
+        pyconfig.initialize(argv, validate_training=True)   # train_wan
+        config = pyconfig.config                            # module-level global
+        validate_train_config(config)
+        WanTrainer(config).start_training()                 # or FluxTrainer
+
+    if __name__ == "__main__":
+        with transformer_engine_context():
+            app.run(main)
+
+So this trainer mirrors that shape:
+    backend_args -> flat dict -> temp YAML  (== the maxdiffusion pyconfig file)
+    with transformer_engine_context():
+        pyconfig.initialize([module, yaml_path, k=v ...])
+        <WanTrainer|FluxTrainer>(pyconfig.config).start_training()
+
+The MaxDiffusion-touching (JAX) work happens inside ``train()`` and within the
+``transformer_engine_context()``, matching upstream's import/entry ordering
+(jax -> tensorflow -> transformer_engine) that the image patches rely on.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+from primus.core.trainer.base_trainer import BaseTrainer
+from primus.core.utils.module_utils import (
+    error_rank_0,
+    log_rank_0,
+    set_logging_rank,
+    warning_rank_0,
+)
+
+# Primus-internal params that are not part of MaxDiffusion's pyconfig schema and
+# must be stripped before the config YAML is handed to ``pyconfig.initialize``.
+_PRIMUS_ONLY_PARAMS = (
+    "file_sink_level",
+    "stderr_sink_level",
+    "sink_level",
+    "trainable",
+    "stage",
+    "model",
+    "maxdiffusion_entrypoint",
+    "override_model",
+)
+
+# model family -> (train module for argv[0], trainer import path, pyconfig kwargs)
+_FAMILY_SPECS = {
+    "wan": (
+        "src.maxdiffusion.train_wan",
+        "maxdiffusion.trainers.wan_trainer:WanTrainer",
+        {"validate_training": True},
+    ),
+    "flux": (
+        "src.maxdiffusion.train_flux",
+        "maxdiffusion.trainers.flux_trainer:FluxTrainer",
+        {},
+    ),
+}
+
+
+class MaxDiffusionPretrainTrainer(BaseTrainer):
+    """Trainer class for MaxDiffusion pre-training."""
+
+    def __init__(self, backend_args: Any = None, **kwargs):
+        super().__init__(backend_args=backend_args, **kwargs)
+        self._family: Optional[str] = None
+        self._yaml_path: Optional[str] = None
+        self._argv: list = []
+        log_rank_0("Initialized MaxDiffusionPretrainTrainer")
+
+    # --------------------------------------------------------------------- #
+    # Lifecycle hooks
+    # --------------------------------------------------------------------- #
+    def setup(self):
+        log_rank_0("MaxDiffusionPretrainTrainer.setup()")
+
+    def init(self):
+        """Prepare the MaxDiffusion pyconfig file and launch argv.
+
+        JAX/MaxDiffusion are intentionally NOT imported here; all backend work
+        happens in ``train()`` inside ``transformer_engine_context()`` to match
+        MaxDiffusion's upstream import ordering.
+        """
+        from primus.backends.maxdiffusion.argument_builder import (
+            export_params_to_yaml,
+            namespace_to_dict,
+        )
+
+        self._family = self._resolve_family()
+        module_name, _, _ = _FAMILY_SPECS[self._family]
+
+        params_dict = namespace_to_dict(self.backend_args)
+        override_argv = self._prepare_overrides(params_dict.get("override_model"))
+        for key in _PRIMUS_ONLY_PARAMS:
+            params_dict.pop(key, None)
+
+        self._yaml_path = export_params_to_yaml(params_dict)
+        # pyconfig.initialize(argv): argv[0]=program, argv[1]=config file,
+        # argv[2:]=key=value overrides.
+        self._argv = [module_name, self._yaml_path, *override_argv]
+        log_rank_0(
+            f"MaxDiffusionPretrainTrainer.init() family={self._family} "
+            f"config={self._yaml_path} overrides={override_argv}"
+        )
+
+    def _resolve_family(self) -> str:
+        """Determine the MaxDiffusion model family (wan|flux).
+
+        Prefers an explicit ``maxdiffusion_entrypoint`` param, else infers from
+        ``model_name`` / ``pretrained_model_name_or_path``.
+        """
+        explicit = getattr(self.backend_args, "maxdiffusion_entrypoint", None)
+        if explicit:
+            fam = str(explicit).strip().lower()
+            if fam in _FAMILY_SPECS:
+                return fam
+            raise ValueError(
+                f"MaxDiffusion: unknown maxdiffusion_entrypoint '{explicit}' "
+                f"(expected one of {sorted(_FAMILY_SPECS)})"
+            )
+        name = str(getattr(self.backend_args, "model_name", "")).lower()
+        pretrained = str(getattr(self.backend_args, "pretrained_model_name_or_path", "")).lower()
+        blob = f"{name} {pretrained}"
+        if "wan" in blob:
+            return "wan"
+        if "flux" in blob:
+            return "flux"
+        raise ValueError(
+            "MaxDiffusion: could not infer model family (wan|flux) from config; "
+            "set `maxdiffusion_entrypoint: wan|flux` in the config."
+        )
+
+    def _prepare_overrides(self, override_model: Any) -> list:
+        """Flatten ``override_model`` into MaxDiffusion ``key=value`` argv entries.
+
+        In the core runtime flow, CLI args like ``--override_model.attention flash``
+        are parsed into ``backend_args.override_model.attention = "flash"``.
+        MaxDiffusion's ``pyconfig.initialize`` consumes overrides as extra argv
+        ``key=value`` strings (append after the config file path).
+        """
+        if not override_model:
+            return []
+        if isinstance(override_model, dict):
+            override_dict = override_model
+        elif hasattr(override_model, "__dict__"):
+            override_dict = vars(override_model)
+        else:
+            return []
+        argv = []
+        for k, v in override_dict.items():
+            if isinstance(v, dict) or (hasattr(v, "__dict__") and not isinstance(v, type)):
+                raise ValueError(f"MaxDiffusion: nested override not supported: override_model.{k}={v}")
+            argv.append(f"{k}={v}")
+        if argv:
+            warning_rank_0(f"MaxDiffusion: applying override_model argv: {argv}")
+        return argv
+
+    def _update_logger_rank(self):
+        """Refresh Primus logger rank/world_size from JAX distributed state."""
+        import jax
+
+        rank = jax.process_index()
+        world_size = jax.process_count()
+
+        from primus.core.utils.logger import update_rank_info
+
+        update_rank_info(rank, world_size)
+        set_logging_rank(rank, world_size)
+        log_rank_0(
+            f"JAX distributed ready: rank={rank}, world_size={world_size}, "
+            f"devices={jax.device_count()}, local_devices={jax.local_device_count()}"
+        )
+
+    # --------------------------------------------------------------------- #
+    # Training entrypoint
+    # --------------------------------------------------------------------- #
+    def train(self):
+        """Execute MaxDiffusion training.
+
+        Initializes MaxDiffusion's ``pyconfig`` and runs the family-specific
+        trainer inside ``transformer_engine_context()``, mirroring the upstream
+        ``train_wan`` / ``train_flux`` ``main()`` entrypoints.
+        """
+        if not self._argv:
+            raise RuntimeError("MaxDiffusionPretrainTrainer.init() must be called before train().")
+
+        module_name, trainer_path, init_kwargs = _FAMILY_SPECS[self._family]
+        trainer_cls = self._import_trainer_class(trainer_path)
+
+        from maxdiffusion import pyconfig
+        from maxdiffusion.train_utils import transformer_engine_context, validate_train_config
+
+        log_rank_0(f"Executing MaxDiffusion {self._family} pretrain...")
+        try:
+            with transformer_engine_context():
+                pyconfig.initialize(self._argv, **init_kwargs)
+                config = pyconfig.config
+                validate_train_config(config)
+
+                if self._family == "wan":
+                    self._apply_flax_shard_flag()
+
+                self._update_logger_rank()
+
+                trainer = trainer_cls(config)
+                trainer.start_training()
+        finally:
+            self._cleanup_yaml()
+
+        log_rank_0("MaxDiffusion pretrain execution completed.")
+
+    @staticmethod
+    def _import_trainer_class(trainer_path: str):
+        """Import ``module:ClassName`` and return the class."""
+        import importlib
+
+        module_path, _, class_name = trainer_path.partition(":")
+        module = importlib.import_module(module_path)
+        return getattr(module, class_name)
+
+    @staticmethod
+    def _apply_flax_shard_flag() -> None:
+        """Mirror train_wan.main(): flax.config.update(flax_always_shard_variable=False)."""
+        try:
+            import flax
+
+            flax.config.update("flax_always_shard_variable", False)
+        except Exception:  # noqa: BLE001 - optional parity flag; never abort a run
+            pass
+
+    def _cleanup_yaml(self) -> None:
+        if self._yaml_path and os.path.exists(self._yaml_path):
+            try:
+                os.unlink(self._yaml_path)
+            except OSError as e:
+                error_rank_0(f"MaxDiffusionPretrainTrainer: failed to delete temp YAML {self._yaml_path}: {e}")

--- a/primus/backends/maxtext/env_spec.py
+++ b/primus/backends/maxtext/env_spec.py
@@ -1,0 +1,128 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxText backend environment specification (single source of truth).
+
+This module declares *all* MaxText/JAX performance and architecture environment
+that Primus is responsible for. It is consumed by :class:`MaxTextAdapter` via
+``env_defaults()`` and applied by the base adapter before JAX/XLA is imported.
+
+Previously this env was duplicated across three places (``examples/run_pretrain.sh``,
+``runner/helpers/hooks/train/pretrain/maxtext/prepare.py``, and the adapter's old
+``_apply_arch_env_defaults``). It now lives here only.
+
+Provenance: these values mirror the known-good MaxText launch env scripts at
+https://github.com/ROCm/MAD/tree/develop/scripts/jax-maxtext/env_scripts . Those
+scripts are identical across GPU archs *except* for two single-variable
+exceptions, which are the only arch-gated entries below:
+
+  * gfx950 (MI350X/MI355X): ``RCCL_WARP_SPEED_AUTO=0``  (WarpSpeed default-on can NaN)
+  * gfx942 (MI300X):        ``HSA_NO_SCRATCH_RECLAIM=1``
+
+Everything else — including all ``XLA_FLAGS`` knobs and the NVTE/HIP/HSA tunables —
+is architecture-agnostic (``arch="all"``).
+
+Precedence (see env_registry): per-config ``env:`` > outer/shell env > these
+defaults > image-baked. ``XLA_FLAGS`` is merged per-flag so the managed knobs win
+over an image-baked ``XLA_FLAGS`` (which may carry ``--xla_gpu_autotune_level=0``)
+while preserving any unrelated baked flags.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+from primus.core.backend.env_registry import (
+    ARCH_ALL,
+    ARCH_GFX942,
+    ARCH_GFX950,
+    MODE_XLA_MERGE,
+    EnvVar,
+)
+
+
+def _build_xla_flags() -> str:
+    """Assemble the managed ``XLA_FLAGS`` string.
+
+    The autotune level is parameterized via ``XLA_GPU_AUTOTUNE_LEVEL`` (default 4).
+    MUST be >= 1: with autotuning off (=0, as baked into some rock/TheRock images)
+    XLA/hipBLASLt always picks the default fp8 GEMM kernel, which overflows on the
+    fine-grained MoE expert einsums (qwen3-30B-A3B, deepseek-v2-lite) -> NaN loss on
+    ~every fp8 run. autotune_level>=4 lets XLA pick a numerically stable fp8 kernel.
+    """
+    autotune_level = os.getenv("XLA_GPU_AUTOTUNE_LEVEL", "4")
+    flags = (
+        "--xla_gpu_memory_limit_slop_factor=95 "
+        "--xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 "
+        "--xla_gpu_enable_command_buffer='' "
+        "--xla_gpu_enable_latency_hiding_scheduler=true "
+        "--xla_gpu_all_gather_combine_threshold_bytes=8589934592 "
+        "--xla_gpu_enable_triton_gemm=false "
+        "--xla_gpu_enable_cublaslt=true "
+        f"--xla_gpu_autotune_level={autotune_level} "
+        "--xla_gpu_enable_all_gather_combine_by_dim=false"
+    )
+    if os.getenv("DUMP_HLO", "0") == "1":
+        dump_dir = os.getenv("DUMP_HLO_DIR", "output/xla_dump_hlo")
+        flags += f" --xla_dump_to={dump_dir}"
+    return flags
+
+
+def maxtext_env_defaults() -> List[EnvVar]:
+    """Return the declarative MaxText env defaults for the current run.
+
+    Built fresh on each call so it reflects the live values of the few
+    parameterizing inputs (``XLA_GPU_AUTOTUNE_LEVEL``, ``DUMP_HLO``, ``NNODES``,
+    ``MASTER_ADDR``/``MASTER_PORT``).
+    """
+    entries: List[EnvVar] = [
+        # ---- XLA / JAX ----
+        EnvVar("XLA_FLAGS", _build_xla_flags(), mode=MODE_XLA_MERGE,
+               note="managed XLA knobs incl. autotune (fp8 MoE NaN fix)"),
+        EnvVar("XLA_PYTHON_CLIENT_MEM_FRACTION", ".97",
+               note="avoid HSA OOM during multi-node"),
+        EnvVar("TF_CPP_MIN_LOG_LEVEL", "2",
+               note="suppress benign JAX/MaxText shutdown errors"),
+        # ---- Transformer Engine (NVTE) ----
+        EnvVar("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "1"),
+        EnvVar("NVTE_USE_HIPBLASLT", "1"),
+        EnvVar("NVTE_FUSED_ATTN", "1"),
+        EnvVar("NVTE_FUSED_ATTN_CK", "1"),
+        EnvVar("NVTE_FUSED_ATTN_AOTRITON", "0"),
+        EnvVar("NVTE_CK_USES_BWD_V3", "1"),
+        EnvVar("NVTE_CK_USES_FWD_V3", "1"),
+        EnvVar("NVTE_CK_IS_V3_ATOMIC_FP32", "0"),
+        EnvVar("NVTE_CK_HOW_V3_BF16_CVT", "2"),
+        # ---- AMD GPU / HIP / HSA ----
+        EnvVar("GPU_MAX_HW_QUEUES", "2"),
+        EnvVar("HIP_FORCE_DEV_KERNARG", "1"),
+        EnvVar("HSA_FORCE_FINE_GRAIN_PCIE", "1"),
+        # NOTE: NCCL_DEBUG is deliberately NOT managed here. It is purely
+        # diagnostic (logs the RCCL version once) and every launcher already sets
+        # a shared empty default (base_env.sh / run_pretrain.sh), so owning it in
+        # the adapter would only create a cosmetic empty-vs-VERSION cross-path diff.
+        # ---- Architecture-gated (the ONLY two arch differences) ----
+        EnvVar("RCCL_WARP_SPEED_AUTO", "0", arch=ARCH_GFX950,
+               note="gfx950 WarpSpeed default-on can cause NaN losses"),
+        EnvVar("HSA_NO_SCRATCH_RECLAIM", "1", arch=ARCH_GFX942,
+               note="gfx942 scratch-reclaim stability"),
+    ]
+
+    # Multi-node JAX coordinator: derive from MASTER_ADDR/PORT so both the
+    # run_pretrain.sh path and the primus-cli path get a coordinator without any
+    # shell plumbing. Single-node runs deliberately leave these unset so MaxText
+    # uses the local single-controller path (no jax.distributed.initialize).
+    try:
+        nnodes = int(os.getenv("NNODES", "1"))
+    except ValueError:
+        nnodes = 1
+    if nnodes > 1:
+        entries.append(EnvVar("JAX_COORDINATOR_IP", os.getenv("MASTER_ADDR", "localhost")))
+        entries.append(EnvVar("JAX_COORDINATOR_PORT", os.getenv("MASTER_PORT", "1234")))
+
+    return entries

--- a/primus/backends/maxtext/maxtext_adapter.py
+++ b/primus/backends/maxtext/maxtext_adapter.py
@@ -17,7 +17,6 @@ This is the MaxText counterpart of ``TorchTitanAdapter``. It is responsible for:
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -42,43 +41,24 @@ class MaxTextAdapter(BackendAdapter):
         super().__init__(framework)
         self.third_party_dir_name = "maxtext"
 
-    def prepare_backend(self, config: Any):
+    def env_defaults(self) -> list:
         """
-        Prepare the MaxText/JAX backend environment before trainer construction.
+        Declarative MaxText/JAX performance + architecture environment.
 
-        In addition to the base setup, apply MaxText/ROCm architecture defaults
-        via ``os.environ.setdefault`` so they NEVER override values already set by
-        the environment or by a per-config top-level ``env:`` block (which the
-        runtime applies earlier in :meth:`TrainRuntime._apply_config_env`).
+        This is the single source of truth for all MaxText env that Primus owns
+        (XLA_FLAGS incl. the fp8 MoE autotune fix, NVTE/HIP/HSA tunables, and the
+        two arch-gated exceptions RCCL_WARP_SPEED_AUTO/HSA_NO_SCRATCH_RECLAIM).
+
+        The base adapter applies these via ``os.environ`` (arch-gated,
+        ``setdefault`` semantics; ``XLA_FLAGS`` merged per-flag) in
+        :meth:`prepare_backend`, i.e. before JAX/XLA is imported by the trainer.
 
         Effective precedence (highest wins):
-            per-config ``env:``  >  these arch defaults  >  image-baked defaults
+            per-config ``env:``  >  outer/shell env  >  these defaults  >  image-baked
         """
-        self._apply_arch_env_defaults()
-        super().prepare_backend(config)
+        from primus.backends.maxtext.env_spec import maxtext_env_defaults
 
-    @staticmethod
-    def _apply_arch_env_defaults() -> None:
-        """Set backend/arch env defaults (only when unset) before JAX/XLA init."""
-        # gfx950 (MI350X/MI355X) NaN/hang workaround; harmless / no-op on gfx942.
-        if MaxTextAdapter._is_gfx950():
-            if os.environ.setdefault("RCCL_WARP_SPEED_AUTO", "0") == "0":
-                log_rank_0("[Primus:maxtext] gfx950 detected: RCCL_WARP_SPEED_AUTO=0 (default)")
-
-    @staticmethod
-    def _is_gfx950() -> bool:
-        """Best-effort detection of a gfx950 (MI350X/MI355X) device via rocminfo."""
-        import shutil
-        import subprocess
-
-        rocminfo = shutil.which("rocminfo") or "/opt/rocm/bin/rocminfo"
-        try:
-            out = subprocess.run(
-                [rocminfo], capture_output=True, text=True, timeout=15
-            ).stdout
-        except Exception:  # noqa: BLE001 - detection must never abort a run
-            return False
-        return "gfx950" in out
+        return maxtext_env_defaults()
 
     def setup_backend_path(self, backend_path=None) -> str:
         """

--- a/primus/configs/models/maxdiffusion/flux_dev.yaml
+++ b/primus/configs/models/maxdiffusion/flux_dev.yaml
@@ -1,0 +1,304 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This sentinel is a reminder to choose a real run name.
+run_name: ''
+
+metrics_file: "" # for testing, local file that stores scalar metrics. If empty, no metrics are written.
+# If true save metrics such as loss and TFLOPS to GCS in {base_output_directory}/{run_name}/metrics/
+write_metrics: True
+
+timing_metrics_file: "" # for testing, local file that stores function timing metrics such as state creation, compilation. If empty, no metrics are written.
+write_timing_metrics: True 
+
+gcs_metrics: False
+# If true save config to GCS in {base_output_directory}/{run_name}/
+save_config_to_gcs: False
+log_period: 100
+
+pretrained_model_name_or_path: 'black-forest-labs/FLUX.1-dev'
+clip_model_name_or_path: 'ariG23498/clip-vit-large-patch14-text-flax'
+t5xxl_model_name_or_path: 'ariG23498/t5-v1-1-xxl-flax'
+
+# Flux params
+flux_name: "flux-dev"
+max_sequence_length: 512
+time_shift: True
+base_shift: 0.5
+max_shift: 1.15
+# offloads t5 encoder after text encoding to save memory.
+offload_encoders: True
+
+
+unet_checkpoint: ''
+revision: 'refs/pr/95'
+# This will convert the weights to this dtype.
+# When running inference on TPUv5e, use weights_dtype: 'bfloat16'
+weights_dtype: 'bfloat16'
+# This sets the layer's dtype in the model. Ex: nn.Dense(dtype=activations_dtype)
+activations_dtype: 'bfloat16'
+
+# matmul and conv precision from https://jax.readthedocs.io/en/latest/jax.lax.html#jax.lax.Precision
+# Options are "DEFAULT", "HIGH", "HIGHEST"
+# fp32 activations and fp32 weights with HIGHEST will provide the best precision
+# at the cost of time.
+precision: "DEFAULT"
+
+# if False state is not jitted and instead replicate is called. This is good for debugging on single host
+# It must be True for multi-host.
+jit_initializers: True
+
+# Set true to load weights from pytorch
+from_pt: True
+split_head_dim: True
+attention: 'cudnn_flash_te' # Supported attention: dot_product, flash, cudnn_flash_te
+# If mask_padding_tokens is True, we pass in segment ids to splash attention to avoid attending to padding tokens.
+# Else we do not pass in segment ids and on vpu bound hardware like trillium this is faster.
+# However, when padding tokens are significant, this will lead to worse quality and should be set to True.
+mask_padding_tokens: True 
+# Maxdiffusion has 2 types of attention sharding strategies:
+# 1. attention_sharding_uniform = True : same sequence sharding rules applied for q in both (self and cross attention)
+# 2. attention_sharding_uniform = False : Heads are sharded uniformly across devices for self attention while sequence is sharded
+#    in cross attention q.
+attention_sharding_uniform: True 
+
+flash_block_sizes: {}
+# Use the following flash_block_sizes on v6e (Trillium) due to larger vmem.
+# flash_block_sizes: {
+#   "block_q" : 1536,
+#   "block_kv_compute" : 1536,
+#   "block_kv" : 1536,
+#   "block_q_dkv" : 1536,
+#   "block_kv_dkv" : 1536,
+#   "block_kv_dkv_compute" : 1536,
+#   "block_q_dq" : 1536,
+#   "block_kv_dq" : 1536
+# }
+# GroupNorm groups
+norm_num_groups: 32
+
+# If train_new_flux, flux weights will be randomly initialized to train flux from scratch
+# else they will be loaded from pretrained_model_name_or_path
+train_new_flux: False
+
+# train text_encoder - Currently not supported for SDXL
+train_text_encoder: False
+text_encoder_learning_rate: 4.25e-6
+
+# https://arxiv.org/pdf/2305.08891.pdf
+snr_gamma: -1.0
+
+timestep_bias: {
+  # a value of later will increase the frequence of the model's final training steps.
+  # none, earlier, later, range
+  strategy: "none",
+  # multiplier for bias, a value of 2.0 will double the weight of the bias, 0.5 will halve it.
+  multiplier: 1.0,
+  # when using strategy=range, the beginning (inclusive) timestep to bias.
+  begin: 0,
+  # when using strategy=range, the final step (inclusive) to bias.
+  end: 1000,
+  # portion of timesteps to bias.
+  # 0.5 will bias one half of the timesteps. Value of strategy determines
+  # whether the biased portions are in the earlier or later timesteps.
+  portion: 0.25
+}
+
+# Override parameters from checkpoints's scheduler.
+diffusion_scheduler_config: {
+  _class_name: 'FlaxEulerDiscreteScheduler',
+  prediction_type: 'epsilon',
+  rescale_zero_terminal_snr: False,
+  timestep_spacing: 'trailing'
+}
+
+# Output directory
+# Create a GCS bucket, e.g. my-maxtext-outputs and set this to "gs://my-maxtext-outputs/"
+base_output_directory: ""
+
+# Hardware
+hardware: 'gpu' # Supported hardware types are 'tpu', 'gpu'
+skip_jax_distributed_system: False
+
+# Parallelism
+mesh_axes: ['data', 'fsdp', 'context', 'tensor']
+
+# batch : batch dimension of data and activations
+# hidden :
+# embed : attention qkv dense layer hidden dim named as embed
+# heads : attention head dim = num_heads * head_dim
+# length : attention sequence length
+# temb_in : dense.shape[0] of resnet dense before conv
+# out_c : dense.shape[1] of resnet dense before conv
+# out_channels : conv.shape[-1] activation
+# keep_1 : conv.shape[0] weight
+# keep_2 : conv.shape[1] weight
+# conv_in : conv.shape[2] weight
+# conv_out : conv.shape[-1] weight
+logical_axis_rules: [
+                      ['batch', 'data'],
+                      ['activation_batch', ['data','fsdp']],
+                      ['activation_heads', 'tensor'],
+                      ['activation_kv', 'tensor'],
+                      ['mlp','tensor'],
+                      ['embed','fsdp'],
+                      ['heads', 'tensor'],
+                      ['conv_batch', ['data','fsdp']],
+                      ['out_channels', 'tensor'],
+                      ['conv_out', 'fsdp'],
+                    ]
+data_sharding: [['data', 'fsdp', 'context', 'tensor']]
+
+# One axis for each parallelism type may hold a placeholder (-1)
+# value to auto-shard based on available slices and devices.
+# By default, product of the DCN axes should equal number of slices
+# and product of the ICI axes should equal number of devices per slice.
+dcn_data_parallelism: -1  # recommended DCN axis to be auto-sharded
+dcn_fsdp_parallelism: 1
+dcn_context_parallelism: 1
+dcn_tensor_parallelism: 1
+ici_data_parallelism: 1
+ici_fsdp_parallelism: 8  # recommended ICI axis to be auto-sharded
+ici_context_parallelism: 1
+ici_tensor_parallelism: 1
+
+allow_split_physical_axes: False
+
+# Dataset
+# Replace with dataset path or train_data_dir. One has to be set.
+dataset_name: 'diffusers/pokemon-gpt4-captions'
+train_split: 'train'
+dataset_type: 'synthetic'
+# ==============================================================================
+# Synthetic Data Configuration (only used when dataset_type='synthetic')
+# ==============================================================================
+# To use synthetic data for testing/debugging without real datasets:
+# 1. Set dataset_type: 'synthetic' above
+# 2. Optionally set synthetic_num_samples (null=infinite, or a number like 10000)
+# 3. Optionally override dimensions
+#
+synthetic_num_samples: null  # null for infinite, or set a number
+#
+# Optional dimension overrides:
+resolution: 512
+# ==============================================================================
+cache_latents_text_encoder_outputs: False
+# cache_latents_text_encoder_outputs only apply to dataset_type="tf",
+# only apply to small dataset that fits in memory
+# prepare image latents and text encoder outputs
+# Reduce memory consumption and reduce step time during training
+# transformed dataset is saved at dataset_save_location
+dataset_save_location: ''
+train_data_dir: ''
+dataset_config_name: ''
+jax_cache_dir: ''
+hf_data_dir: ''
+hf_train_files: ''
+hf_access_token: ''
+image_column: 'image'
+caption_column: 'text'
+center_crop: False
+random_flip: False
+# If cache_latents_text_encoder_outputs is True
+# the num_proc is set to 1
+tokenize_captions_num_proc: 4
+transform_images_num_proc: 4
+reuse_example_batch: False
+enable_data_shuffling: True
+
+# checkpoint every number of samples, -1 means don't checkpoint.
+checkpoint_every: -1
+# enables one replica to read the ckpt then broadcast to the rest
+enable_single_replica_ckpt_restoring: False
+
+# Training loop
+learning_rate: 1.e-5
+scale_lr: False
+max_train_samples: -1
+# max_train_steps takes priority over num_train_epochs.
+max_train_steps: 20
+num_train_epochs: 1
+seed: 0
+output_dir: 'sdxl-model-finetuned'
+per_device_batch_size: 14
+
+warmup_steps_fraction: 0.1
+learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
+
+# However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before
+# dropping fully down. Or you may choose a shorter schedule, where the unspecified steps will have a learning rate of 0.
+
+# AdamW optimizer parameters
+adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradients.
+adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
+adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
+adam_weight_decay: 0 # AdamW Weight decay
+max_grad_norm: 1.0
+
+enable_profiler: False
+# Skip first n steps for profiling, to omit things like compilation and to give
+# the iteration time a chance to stabilize.
+skip_first_n_steps_for_profiler: 5
+profiler_steps: 2
+profiler: ""
+
+# Generation parameters
+prompt: "A magical castle in the middle of a forest, artistic drawing"
+prompt_2: "A magical castle in the middle of a forest, artistic drawing"
+negative_prompt: "purple, red"
+do_classifier_free_guidance: True
+guidance_scale: 3.5
+# Based on 3.4. in https://arxiv.org/pdf/2305.08891.pdf
+guidance_rescale: 0.0
+num_inference_steps: 50
+save_final_checkpoint: False
+
+# SDXL Lightning parameters
+lightning_from_pt: True
+# Empty or "ByteDance/SDXL-Lightning" to enable lightning.
+lightning_repo: ""
+# Empty or "sdxl_lightning_4step_unet.safetensors" to enable lightning.
+lightning_ckpt: ""
+
+# LoRA parameters
+# Values are lists to support multiple LoRA loading during inference in the future.
+lora_config: {
+  lora_model_name_or_path: [],
+  weight_name: [],
+  adapter_name: [],
+  scale: [],
+  from_pt: []
+}
+# Ex with values:
+# lora_config : {
+#   lora_model_name_or_path: ["ByteDance/Hyper-SD"],
+#   weight_name: ["Hyper-SDXL-2steps-lora.safetensors"],
+#   adapter_name: ["hyper-sdxl"],
+#   scale: [0.7],
+#   from_pt: [True]
+# }
+
+enable_mllog: False
+
+#controlnet
+controlnet_model_name_or_path: 'diffusers/controlnet-canny-sdxl-1.0'
+controlnet_from_pt: True
+controlnet_conditioning_scale: 0.5
+controlnet_image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Google_%22G%22_logo.svg/1024px-Google_%22G%22_logo.svg.png'
+quantization: ''
+# Shard the range finding operation for quantization. By default this is set to number of slices.
+quantization_local_shard_count: -1
+use_qwix_quantization: False 
+compile_topology_num_slices: -1 # Number of target slices, set to a positive integer.
+

--- a/primus/configs/models/maxdiffusion/wan2.1_1.3b.yaml
+++ b/primus/configs/models/maxdiffusion/wan2.1_1.3b.yaml
@@ -1,0 +1,382 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This sentinel is a reminder to choose a real run name.
+run_name: ''
+
+metrics_file: "" # for testing, local file that stores scalar metrics. If empty, no metrics are written.
+# If true save metrics such as loss and TFLOPS to GCS in {base_output_directory}/{run_name}/metrics/
+write_metrics: True
+
+timing_metrics_file: "" # for testing, local file that stores function timing metrics such as state creation, compilation. If empty, no metrics are written.
+write_timing_metrics: True 
+
+gcs_metrics: False
+# If true save config to GCS in {base_output_directory}/{run_name}/
+save_config_to_gcs: False
+log_period: 100
+
+pretrained_model_name_or_path: 'Wan-AI/Wan2.1-T2V-1.3B-Diffusers'
+model_name: wan2.1
+model_type: 'T2V'
+
+# Overrides the transformer from pretrained_model_name_or_path
+wan_transformer_pretrained_model_name_or_path: ''
+
+unet_checkpoint: ''
+revision: ''
+# This will convert the weights to this dtype.
+# When running inference on TPUv5e, use weights_dtype: 'bfloat16'
+weights_dtype: 'bfloat16'
+# This sets the layer's dtype in the model. Ex: nn.Dense(dtype=activations_dtype)
+activations_dtype: 'bfloat16'
+
+# Replicates vae across devices instead of using the model's sharding annotations for sharding.
+replicate_vae: False
+
+# matmul and conv precision from https://jax.readthedocs.io/en/latest/jax.lax.html#jax.lax.Precision
+# Options are "DEFAULT", "HIGH", "HIGHEST"
+# fp32 activations and fp32 weights with HIGHEST will provide the best precision
+# at the cost of time.
+precision: "DEFAULT"
+# Use jax.lax.scan for transformer layers
+scan_layers: False
+
+# if False state is not jitted and instead replicate is called. This is good for debugging on single host
+# It must be True for multi-host.
+jit_initializers: True
+
+# Set true to load weights from pytorch
+from_pt: True
+split_head_dim: True
+attention: 'cudnn_flash_te' # Supported attention: dot_product, flash, cudnn_flash_te, ring
+flash_min_seq_length: 0
+
+# If mask_padding_tokens is True, we pass in segment ids to splash attention to avoid attending to padding tokens.
+# Else we do not pass in segment ids and on vpu bound hardware like trillium this is faster.
+# However, when padding tokens are significant, this will lead to worse quality and should be set to True.
+mask_padding_tokens: True 
+# Maxdiffusion has 2 types of attention sharding strategies:
+# 1. attention_sharding_uniform = True : same sequence sharding rules applied for q in both (self and cross attention)
+# 2. attention_sharding_uniform = False : Heads are sharded uniformly across devices for self attention while sequence is sharded
+#    in cross attention q.
+attention_sharding_uniform: True 
+dropout: 0.1
+
+flash_block_sizes: {
+  "block_q" : 512,
+  "block_kv_compute" : 512,
+  "block_kv" : 512,
+  "block_q_dkv" : 512,
+  "block_kv_dkv" : 512,
+  "block_kv_dkv_compute" : 512,
+  "block_q_dq" : 512,
+  "block_kv_dq" : 512,
+  "use_fused_bwd_kernel": False,
+}
+# Use on v6e
+# flash_block_sizes: {
+#   "block_q" : 3024,
+#   "block_kv_compute" : 1024,
+#   "block_kv" : 2048,
+#   "block_q_dkv" : 3024,
+#   "block_kv_dkv" : 2048,
+#   "block_kv_dkv_compute" : 1024,
+#   "block_q_dq" : 3024,
+#   "block_kv_dq" : 2048,
+#   "use_fused_bwd_kernel": False,
+# }
+# Use on v5p
+# flash_block_sizes: {
+#   "block_q" : 3024,
+#   "block_kv_compute" : 1024,
+#   "block_kv" : 2048,
+#   "block_q_dkv" : 1024,
+#   "block_kv_dkv" : 3072,
+#   "block_kv_dkv_compute" : 256,
+#   "block_q_dq" : 1024,
+#   "block_kv_dq" : 3072
+# }
+# GroupNorm groups
+norm_num_groups: 32
+
+# train text_encoder - Currently not supported for SDXL
+train_text_encoder: False
+text_encoder_learning_rate: 4.25e-6
+
+# https://arxiv.org/pdf/2305.08891.pdf
+snr_gamma: -1.0
+
+timestep_bias: {
+  # a value of later will increase the frequence of the model's final training steps.
+  # none, earlier, later, range
+  strategy: "none",
+  # multiplier for bias, a value of 2.0 will double the weight of the bias, 0.5 will halve it.
+  multiplier: 1.0,
+  # when using strategy=range, the beginning (inclusive) timestep to bias.
+  begin: 0,
+  # when using strategy=range, the final step (inclusive) to bias.
+  end: 1000,
+  # portion of timesteps to bias.
+  # 0.5 will bias one half of the timesteps. Value of strategy determines
+  # whether the biased portions are in the earlier or later timesteps.
+  portion: 0.25
+}
+
+# Override parameters from checkpoints's scheduler.
+diffusion_scheduler_config: {
+  _class_name: 'FlaxEulerDiscreteScheduler',
+  prediction_type: 'epsilon',
+  rescale_zero_terminal_snr: False,
+  timestep_spacing: 'trailing'
+}
+
+# Output directory
+# Create a GCS bucket, e.g. my-maxtext-outputs and set this to "gs://my-maxtext-outputs/"
+base_output_directory: ""
+
+# Hardware
+hardware: 'gpu' # Supported hardware types are 'tpu', 'gpu'
+skip_jax_distributed_system: False
+
+# Parallelism
+mesh_axes: ['data', 'fsdp', 'context', 'tensor']
+
+# batch : batch dimension of data and activations
+# hidden :
+# embed : attention qkv dense layer hidden dim named as embed
+# heads : attention head dim = num_heads * head_dim
+# length : attention sequence length
+# temb_in : dense.shape[0] of resnet dense before conv
+# out_c : dense.shape[1] of resnet dense before conv
+# out_channels : conv.shape[-1] activation
+# keep_1 : conv.shape[0] weight
+# keep_2 : conv.shape[1] weight
+# conv_in : conv.shape[2] weight
+# conv_out : conv.shape[-1] weight
+logical_axis_rules: [
+                      ['batch', ['data', 'fsdp']],
+                      ['activation_batch', ['data', 'fsdp']],
+                      ['activation_self_attn_heads', ['context', 'tensor']],
+                      ['activation_cross_attn_q_length', ['context', 'tensor']],
+                      ['activation_length', 'context'],
+                      ['activation_heads', 'tensor'],
+                      ['mlp','tensor'],
+                      ['embed', ['context', 'fsdp']],
+                      ['heads', 'tensor'],
+                      ['norm', 'tensor'],
+                      ['conv_batch', ['data', 'context', 'fsdp']],
+                      ['out_channels', 'tensor'],
+                      ['conv_out', 'context'],
+                    ]
+data_sharding: [['data', 'fsdp', 'context', 'tensor']]
+
+# One axis for each parallelism type may hold a placeholder (-1)
+# value to auto-shard based on available slices and devices.
+# By default, product of the DCN axes should equal number of slices
+# and product of the ICI axes should equal number of devices per slice.
+dcn_data_parallelism: -1  # recommended DCN axis to be auto-sharded
+dcn_fsdp_parallelism: 1
+dcn_context_parallelism: 1
+dcn_tensor_parallelism: 1
+ici_data_parallelism: 1
+ici_fsdp_parallelism: 8
+ici_context_parallelism: 1  # recommended ICI axis to be auto-sharded
+ici_tensor_parallelism: 1
+
+allow_split_physical_axes: False
+
+# Dataset
+# Replace with dataset path or train_data_dir. One has to be set.
+dataset_name: 'diffusers/pokemon-gpt4-captions'
+train_split: 'train'
+dataset_type: 'synthetic'  # Options: 'tfrecord', 'hf', 'tf', 'grain', 'synthetic'
+synthetic_num_samples: null  # or null for infinite
+# Optional dimension overrides (comment out to use pipeline/config values):
+synthetic_override_height: 720
+synthetic_override_width: 1280
+synthetic_override_num_frames: 85
+# ==============================================================================
+# Synthetic Data Configuration (only used when dataset_type='synthetic')
+# ==============================================================================
+# To use synthetic data for testing/debugging without real datasets:
+# 1. Set dataset_type: 'synthetic' above
+# 2. Optionally set synthetic_num_samples (null=infinite, or a number like 10000)
+# 3. Optionally override dimensions with synthetic_override_* flags below
+#
+# synthetic_num_samples: null  # null for infinite, or set a number
+#
+# Optional dimension overrides (comment out to use pipeline/config values):
+# synthetic_override_height: 720
+# synthetic_override_width: 1280
+# synthetic_override_num_frames: 121
+# synthetic_override_max_sequence_length: 512
+# synthetic_override_text_embed_dim: 4096
+# synthetic_override_num_channels_latents: 16
+# synthetic_override_vae_scale_factor_spatial: 8
+# synthetic_override_vae_scale_factor_temporal: 4
+# ==============================================================================
+
+cache_latents_text_encoder_outputs: True
+# cache_latents_text_encoder_outputs only apply to dataset_type="tf",
+# only apply to small dataset that fits in memory
+# prepare image latents and text encoder outputs
+# Reduce memory consumption and reduce step time during training
+# transformed dataset is saved at dataset_save_location
+dataset_save_location: ''
+load_tfrecord_cached: True
+train_data_dir: ''
+dataset_config_name: ''
+jax_cache_dir: ''
+hf_data_dir: ''
+hf_train_files: ''
+hf_access_token: ''
+image_column: 'image'
+caption_column: 'text'
+resolution: 1024
+center_crop: False
+random_flip: False
+# If cache_latents_text_encoder_outputs is True
+# the num_proc is set to 1
+tokenize_captions_num_proc: 4
+transform_images_num_proc: 4
+reuse_example_batch: False
+enable_data_shuffling: True
+
+# Defines the type of gradient checkpoint to enable.
+# NONE - means no gradient checkpoint
+# FULL - means full gradient checkpoint, whenever possible (minimum memory usage)
+# MATMUL_WITHOUT_BATCH - means gradient checkpoint for every linear/matmul operation,
+# except for ones that involve batch dimension - that means that all attention and projection
+# layers will have gradient checkpoint, but not the backward with respect to the parameters.
+# OFFLOAD_MATMUL_WITHOUT_BATCH - same as MATMUL_WITHOUT_BATCH but offload instead of recomputing.
+# CUSTOM - set names to offload and save.
+remat_policy: "NONE"
+# For CUSTOM policy set below, current annotations are for: attn_output, query_proj, key_proj, value_proj
+# xq_out, xk_out, ffn_activation
+names_which_can_be_saved: []
+names_which_can_be_offloaded: []
+
+# checkpoint every number of samples, -1 means don't checkpoint.
+checkpoint_every: -1
+checkpoint_dir: ""
+# enables one replica to read the ckpt then broadcast to the rest
+enable_single_replica_ckpt_restoring: False
+
+# Training loop
+learning_rate: 1.e-5
+scale_lr: False
+max_train_samples: -1
+# max_train_steps takes priority over num_train_epochs.
+max_train_steps: 20
+num_train_epochs: 1
+seed: 0
+output_dir: 'sdxl-model-finetuned'
+per_device_batch_size: 1.0
+# If global_batch_size % jax.device_count is not 0, use FSDP sharding.
+global_batch_size: 0
+
+# For creating tfrecords from dataset
+tfrecords_dir: ''
+no_records_per_shard: 0
+enable_eval_timesteps: False
+timesteps_list: [125, 250, 375, 500, 625, 750, 875]
+num_eval_samples: 420
+
+warmup_steps_fraction: 0.1
+learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
+save_optimizer: False
+
+# However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before
+# dropping fully down. Or you may choose a shorter schedule, where the unspecified steps will have a learning rate of 0.
+
+# AdamW optimizer parameters
+adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradients.
+adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
+adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
+adam_weight_decay: 0 # AdamW Weight decay
+max_grad_norm: 1.0
+
+enable_profiler: False
+# Skip first n steps for profiling, to omit things like compilation and to give
+# the iteration time a chance to stabilize.
+skip_first_n_steps_for_profiler: 5
+profiler_steps: 2
+profiler: "xplane"
+
+# Enable JAX named scopes for detailed profiling and debugging
+# When enabled, adds named scopes around key operations in transformer and attention layers
+enable_jax_named_scopes: True
+
+# Generation parameters
+prompt: "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window."
+prompt_2: "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window."
+negative_prompt: "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
+do_classifier_free_guidance: True
+height: 720
+width: 1280
+num_frames: 85
+guidance_scale: 5.0
+flow_shift: 3.0
+
+# Based on 3.4. in https://arxiv.org/pdf/2305.08891.pdf
+guidance_rescale: 0.0
+num_inference_steps: 30
+fps: 16
+save_final_checkpoint: False
+
+# SDXL Lightning parameters
+lightning_from_pt: True
+# Empty or "ByteDance/SDXL-Lightning" to enable lightning.
+lightning_repo: ""
+# Empty or "sdxl_lightning_4step_unet.safetensors" to enable lightning.
+lightning_ckpt: ""
+
+# LoRA parameters
+enable_lora: False
+# Values are lists to support multiple LoRA loading during inference in the future.
+lora_config: {
+  rank: [64],
+  lora_model_name_or_path: ["lightx2v/Wan2.1-Distill-Loras"],
+  weight_name: ["wan2.1_t2v_14b_lora_rank64_lightx2v_4step.safetensors"],
+  adapter_name: ["wan21-distill-lora"],
+  scale: [1.0],
+  from_pt: []
+}
+
+enable_mllog: False
+
+#controlnet
+controlnet_model_name_or_path: 'diffusers/controlnet-canny-sdxl-1.0'
+controlnet_from_pt: True
+controlnet_conditioning_scale: 0.5
+controlnet_image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Google_%22G%22_logo.svg/1024px-Google_%22G%22_logo.svg.png'
+quantization: ''
+# Shard the range finding operation for quantization. By default this is set to number of slices.
+quantization_local_shard_count: -1
+compile_topology_num_slices: -1 # Number of target slices, set to a positive integer.
+use_qwix_quantization: False # Whether to use qwix for quantization. If set to True, the transformer of WAN will be quantized using qwix.
+# Quantization calibration method used for weights, activations and bwd. Supported methods can be found in https://github.com/google/qwix/blob/dc2a0770351c740e5ab3cce7c0efe9f7beacce9e/qwix/qconfig.py#L70-L80
+weight_quantization_calibration_method: "absmax"
+act_quantization_calibration_method: "absmax"
+bwd_quantization_calibration_method: "absmax"
+qwix_module_path: ".*"
+
+# Eval model on per eval_every steps. -1 means don't eval.
+eval_every: -1
+eval_data_dir: ""
+enable_generate_video_for_eval: False # This will increase the used TPU memory.
+eval_max_number_of_samples_in_bucket: 60 # The number of samples per bucket for evaluation. This is calculated by num_eval_samples / len(timesteps_list).
+
+enable_ssim: False

--- a/primus/configs/models/maxdiffusion/wan2.1_14b.yaml
+++ b/primus/configs/models/maxdiffusion/wan2.1_14b.yaml
@@ -1,0 +1,382 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This sentinel is a reminder to choose a real run name.
+run_name: ''
+
+metrics_file: "" # for testing, local file that stores scalar metrics. If empty, no metrics are written.
+# If true save metrics such as loss and TFLOPS to GCS in {base_output_directory}/{run_name}/metrics/
+write_metrics: True
+
+timing_metrics_file: "" # for testing, local file that stores function timing metrics such as state creation, compilation. If empty, no metrics are written.
+write_timing_metrics: True 
+
+gcs_metrics: False
+# If true save config to GCS in {base_output_directory}/{run_name}/
+save_config_to_gcs: False
+log_period: 100
+
+pretrained_model_name_or_path: 'Wan-AI/Wan2.1-T2V-14B-Diffusers'
+model_name: wan2.1
+model_type: 'T2V'
+
+# Overrides the transformer from pretrained_model_name_or_path
+wan_transformer_pretrained_model_name_or_path: ''
+
+unet_checkpoint: ''
+revision: ''
+# This will convert the weights to this dtype.
+# When running inference on TPUv5e, use weights_dtype: 'bfloat16'
+weights_dtype: 'bfloat16'
+# This sets the layer's dtype in the model. Ex: nn.Dense(dtype=activations_dtype)
+activations_dtype: 'bfloat16'
+
+# Replicates vae across devices instead of using the model's sharding annotations for sharding.
+replicate_vae: False
+
+# matmul and conv precision from https://jax.readthedocs.io/en/latest/jax.lax.html#jax.lax.Precision
+# Options are "DEFAULT", "HIGH", "HIGHEST"
+# fp32 activations and fp32 weights with HIGHEST will provide the best precision
+# at the cost of time.
+precision: "DEFAULT"
+# Use jax.lax.scan for transformer layers
+scan_layers: True
+
+# if False state is not jitted and instead replicate is called. This is good for debugging on single host
+# It must be True for multi-host.
+jit_initializers: True
+
+# Set true to load weights from pytorch
+from_pt: True
+split_head_dim: True
+attention: 'cudnn_flash_te' # Supported attention: dot_product, flash, cudnn_flash_te, ring
+flash_min_seq_length: 0
+
+# If mask_padding_tokens is True, we pass in segment ids to splash attention to avoid attending to padding tokens.
+# Else we do not pass in segment ids and on vpu bound hardware like trillium this is faster.
+# However, when padding tokens are significant, this will lead to worse quality and should be set to True.
+mask_padding_tokens: True 
+# Maxdiffusion has 2 types of attention sharding strategies:
+# 1. attention_sharding_uniform = True : same sequence sharding rules applied for q in both (self and cross attention)
+# 2. attention_sharding_uniform = False : Heads are sharded uniformly across devices for self attention while sequence is sharded
+#    in cross attention q.
+attention_sharding_uniform: True 
+dropout: 0.1
+
+flash_block_sizes: {
+  "block_q" : 512,
+  "block_kv_compute" : 512,
+  "block_kv" : 512,
+  "block_q_dkv" : 512,
+  "block_kv_dkv" : 512,
+  "block_kv_dkv_compute" : 512,
+  "block_q_dq" : 512,
+  "block_kv_dq" : 512,
+  "use_fused_bwd_kernel": False,
+}
+# Use on v6e
+# flash_block_sizes: {
+#   "block_q" : 3024,
+#   "block_kv_compute" : 1024,
+#   "block_kv" : 2048,
+#   "block_q_dkv" : 3024,
+#   "block_kv_dkv" : 2048,
+#   "block_kv_dkv_compute" : 1024,
+#   "block_q_dq" : 3024,
+#   "block_kv_dq" : 2048,
+#   "use_fused_bwd_kernel": False,
+# }
+# Use on v5p
+# flash_block_sizes: {
+#   "block_q" : 3024,
+#   "block_kv_compute" : 1024,
+#   "block_kv" : 2048,
+#   "block_q_dkv" : 1024,
+#   "block_kv_dkv" : 3072,
+#   "block_kv_dkv_compute" : 256,
+#   "block_q_dq" : 1024,
+#   "block_kv_dq" : 3072
+# }
+# GroupNorm groups
+norm_num_groups: 32
+
+# train text_encoder - Currently not supported for SDXL
+train_text_encoder: False
+text_encoder_learning_rate: 4.25e-6
+
+# https://arxiv.org/pdf/2305.08891.pdf
+snr_gamma: -1.0
+
+timestep_bias: {
+  # a value of later will increase the frequence of the model's final training steps.
+  # none, earlier, later, range
+  strategy: "none",
+  # multiplier for bias, a value of 2.0 will double the weight of the bias, 0.5 will halve it.
+  multiplier: 1.0,
+  # when using strategy=range, the beginning (inclusive) timestep to bias.
+  begin: 0,
+  # when using strategy=range, the final step (inclusive) to bias.
+  end: 1000,
+  # portion of timesteps to bias.
+  # 0.5 will bias one half of the timesteps. Value of strategy determines
+  # whether the biased portions are in the earlier or later timesteps.
+  portion: 0.25
+}
+
+# Override parameters from checkpoints's scheduler.
+diffusion_scheduler_config: {
+  _class_name: 'FlaxEulerDiscreteScheduler',
+  prediction_type: 'epsilon',
+  rescale_zero_terminal_snr: False,
+  timestep_spacing: 'trailing'
+}
+
+# Output directory
+# Create a GCS bucket, e.g. my-maxtext-outputs and set this to "gs://my-maxtext-outputs/"
+base_output_directory: ""
+
+# Hardware
+hardware: 'gpu' # Supported hardware types are 'tpu', 'gpu'
+skip_jax_distributed_system: False
+
+# Parallelism
+mesh_axes: ['data', 'fsdp', 'context', 'tensor']
+
+# batch : batch dimension of data and activations
+# hidden :
+# embed : attention qkv dense layer hidden dim named as embed
+# heads : attention head dim = num_heads * head_dim
+# length : attention sequence length
+# temb_in : dense.shape[0] of resnet dense before conv
+# out_c : dense.shape[1] of resnet dense before conv
+# out_channels : conv.shape[-1] activation
+# keep_1 : conv.shape[0] weight
+# keep_2 : conv.shape[1] weight
+# conv_in : conv.shape[2] weight
+# conv_out : conv.shape[-1] weight
+logical_axis_rules: [
+                      ['batch', ['data', 'fsdp']],
+                      ['activation_batch', ['data', 'fsdp']],
+                      ['activation_self_attn_heads', ['context', 'tensor']],
+                      ['activation_cross_attn_q_length', ['context', 'tensor']],
+                      ['activation_length', 'context'],
+                      ['activation_heads', 'tensor'],
+                      ['mlp','tensor'],
+                      ['embed', ['context', 'fsdp']],
+                      ['heads', 'tensor'],
+                      ['norm', 'tensor'],
+                      ['conv_batch', ['data', 'context', 'fsdp']],
+                      ['out_channels', 'tensor'],
+                      ['conv_out', 'context'],
+                    ]
+data_sharding: [['data', 'fsdp', 'context', 'tensor']]
+
+# One axis for each parallelism type may hold a placeholder (-1)
+# value to auto-shard based on available slices and devices.
+# By default, product of the DCN axes should equal number of slices
+# and product of the ICI axes should equal number of devices per slice.
+dcn_data_parallelism: -1  # recommended DCN axis to be auto-sharded
+dcn_fsdp_parallelism: 1
+dcn_context_parallelism: 1
+dcn_tensor_parallelism: 1
+ici_data_parallelism: 1
+ici_fsdp_parallelism: 8
+ici_context_parallelism: 1  # recommended ICI axis to be auto-sharded
+ici_tensor_parallelism: 1
+
+allow_split_physical_axes: False
+
+# Dataset
+# Replace with dataset path or train_data_dir. One has to be set.
+dataset_name: 'diffusers/pokemon-gpt4-captions'
+train_split: 'train'
+dataset_type: 'synthetic'  # Options: 'tfrecord', 'hf', 'tf', 'grain', 'synthetic'
+synthetic_num_samples: null  # or null for infinite
+# Optional dimension overrides (comment out to use pipeline/config values):
+synthetic_override_height: 720
+synthetic_override_width: 1280
+synthetic_override_num_frames: 85
+# ==============================================================================
+# Synthetic Data Configuration (only used when dataset_type='synthetic')
+# ==============================================================================
+# To use synthetic data for testing/debugging without real datasets:
+# 1. Set dataset_type: 'synthetic' above
+# 2. Optionally set synthetic_num_samples (null=infinite, or a number like 10000)
+# 3. Optionally override dimensions with synthetic_override_* flags below
+#
+# synthetic_num_samples: null  # null for infinite, or set a number
+#
+# Optional dimension overrides (comment out to use pipeline/config values):
+# synthetic_override_height: 720
+# synthetic_override_width: 1280
+# synthetic_override_num_frames: 121
+# synthetic_override_max_sequence_length: 512
+# synthetic_override_text_embed_dim: 4096
+# synthetic_override_num_channels_latents: 16
+# synthetic_override_vae_scale_factor_spatial: 8
+# synthetic_override_vae_scale_factor_temporal: 4
+# ==============================================================================
+
+cache_latents_text_encoder_outputs: True
+# cache_latents_text_encoder_outputs only apply to dataset_type="tf",
+# only apply to small dataset that fits in memory
+# prepare image latents and text encoder outputs
+# Reduce memory consumption and reduce step time during training
+# transformed dataset is saved at dataset_save_location
+dataset_save_location: ''
+load_tfrecord_cached: True
+train_data_dir: ''
+dataset_config_name: ''
+jax_cache_dir: ''
+hf_data_dir: ''
+hf_train_files: ''
+hf_access_token: ''
+image_column: 'image'
+caption_column: 'text'
+resolution: 1024
+center_crop: False
+random_flip: False
+# If cache_latents_text_encoder_outputs is True
+# the num_proc is set to 1
+tokenize_captions_num_proc: 4
+transform_images_num_proc: 4
+reuse_example_batch: False
+enable_data_shuffling: True
+
+# Defines the type of gradient checkpoint to enable.
+# NONE - means no gradient checkpoint
+# FULL - means full gradient checkpoint, whenever possible (minimum memory usage)
+# MATMUL_WITHOUT_BATCH - means gradient checkpoint for every linear/matmul operation,
+# except for ones that involve batch dimension - that means that all attention and projection
+# layers will have gradient checkpoint, but not the backward with respect to the parameters.
+# OFFLOAD_MATMUL_WITHOUT_BATCH - same as MATMUL_WITHOUT_BATCH but offload instead of recomputing.
+# CUSTOM - set names to offload and save.
+remat_policy: "FULL"
+# For CUSTOM policy set below, current annotations are for: attn_output, query_proj, key_proj, value_proj
+# xq_out, xk_out, ffn_activation
+names_which_can_be_saved: []
+names_which_can_be_offloaded: []
+
+# checkpoint every number of samples, -1 means don't checkpoint.
+checkpoint_every: -1
+checkpoint_dir: ""
+# enables one replica to read the ckpt then broadcast to the rest
+enable_single_replica_ckpt_restoring: False
+
+# Training loop
+learning_rate: 1.e-5
+scale_lr: False
+max_train_samples: -1
+# max_train_steps takes priority over num_train_epochs.
+max_train_steps: 20
+num_train_epochs: 1
+seed: 0
+output_dir: 'sdxl-model-finetuned'
+per_device_batch_size: 1.0
+# If global_batch_size % jax.device_count is not 0, use FSDP sharding.
+global_batch_size: 0
+
+# For creating tfrecords from dataset
+tfrecords_dir: ''
+no_records_per_shard: 0
+enable_eval_timesteps: False
+timesteps_list: [125, 250, 375, 500, 625, 750, 875]
+num_eval_samples: 420
+
+warmup_steps_fraction: 0.1
+learning_rate_schedule_steps: -1 # By default the length of the schedule is set to the number of steps.
+save_optimizer: False
+
+# However you may choose a longer schedule (learning_rate_schedule_steps > steps), in which case the training will end before
+# dropping fully down. Or you may choose a shorter schedule, where the unspecified steps will have a learning rate of 0.
+
+# AdamW optimizer parameters
+adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradients.
+adam_b2: 0.999 # Exponential decay rate to track the second moment of past gradients.
+adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
+adam_weight_decay: 0 # AdamW Weight decay
+max_grad_norm: 1.0
+
+enable_profiler: False
+# Skip first n steps for profiling, to omit things like compilation and to give
+# the iteration time a chance to stabilize.
+skip_first_n_steps_for_profiler: 5
+profiler_steps: 2
+profiler: "xplane"
+
+# Enable JAX named scopes for detailed profiling and debugging
+# When enabled, adds named scopes around key operations in transformer and attention layers
+enable_jax_named_scopes: True
+
+# Generation parameters
+prompt: "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window."
+prompt_2: "A cat and a dog baking a cake together in a kitchen. The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. The kitchen is cozy, with sunlight streaming through the window."
+negative_prompt: "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
+do_classifier_free_guidance: True
+height: 720
+width: 1280
+num_frames: 85
+guidance_scale: 5.0
+flow_shift: 3.0
+
+# Based on 3.4. in https://arxiv.org/pdf/2305.08891.pdf
+guidance_rescale: 0.0
+num_inference_steps: 30
+fps: 16
+save_final_checkpoint: False
+
+# SDXL Lightning parameters
+lightning_from_pt: True
+# Empty or "ByteDance/SDXL-Lightning" to enable lightning.
+lightning_repo: ""
+# Empty or "sdxl_lightning_4step_unet.safetensors" to enable lightning.
+lightning_ckpt: ""
+
+# LoRA parameters
+enable_lora: False
+# Values are lists to support multiple LoRA loading during inference in the future.
+lora_config: {
+  rank: [64],
+  lora_model_name_or_path: ["lightx2v/Wan2.1-Distill-Loras"],
+  weight_name: ["wan2.1_t2v_14b_lora_rank64_lightx2v_4step.safetensors"],
+  adapter_name: ["wan21-distill-lora"],
+  scale: [1.0],
+  from_pt: []
+}
+
+enable_mllog: False
+
+#controlnet
+controlnet_model_name_or_path: 'diffusers/controlnet-canny-sdxl-1.0'
+controlnet_from_pt: True
+controlnet_conditioning_scale: 0.5
+controlnet_image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Google_%22G%22_logo.svg/1024px-Google_%22G%22_logo.svg.png'
+quantization: ''
+# Shard the range finding operation for quantization. By default this is set to number of slices.
+quantization_local_shard_count: -1
+compile_topology_num_slices: -1 # Number of target slices, set to a positive integer.
+use_qwix_quantization: False # Whether to use qwix for quantization. If set to True, the transformer of WAN will be quantized using qwix.
+# Quantization calibration method used for weights, activations and bwd. Supported methods can be found in https://github.com/google/qwix/blob/dc2a0770351c740e5ab3cce7c0efe9f7beacce9e/qwix/qconfig.py#L70-L80
+weight_quantization_calibration_method: "absmax"
+act_quantization_calibration_method: "absmax"
+bwd_quantization_calibration_method: "absmax"
+qwix_module_path: ".*"
+
+# Eval model on per eval_every steps. -1 means don't eval.
+eval_every: -1
+eval_data_dir: ""
+enable_generate_video_for_eval: False # This will increase the used TPU memory.
+eval_max_number_of_samples_in_bucket: 60 # The number of samples per bucket for evaluation. This is calculated by num_eval_samples / len(timesteps_list).
+
+enable_ssim: False

--- a/primus/configs/modules/maxdiffusion/pre_trainer.yaml
+++ b/primus/configs/modules/maxdiffusion/pre_trainer.yaml
@@ -1,0 +1,4 @@
+extends:
+  - ../module_base.yaml
+
+stage: pretrain

--- a/primus/core/backend/backend_adapter.py
+++ b/primus/core/backend/backend_adapter.py
@@ -29,19 +29,58 @@ class BackendAdapter(ABC):
     # Default Methods (May be overridden by subclasses)
     # ============================================================================
 
+    def env_defaults(self) -> list:
+        """
+        Declarative backend environment defaults (opt-in).
+
+        Return a list of :class:`primus.core.backend.env_registry.EnvVar`
+        entries describing the performance/architecture environment this backend
+        needs. The base :meth:`prepare_backend` applies them (arch-gated,
+        ``setdefault`` semantics) before the backend imports its GPU libraries, so
+        a backend never has to touch ``os.environ`` directly.
+
+        Default is an empty list: backends whose env is fully handled by the shell
+        launcher / torchrun (e.g. Megatron, TorchTitan) opt out simply by not
+        overriding this method, and :meth:`apply_env_defaults` becomes a no-op for
+        them (no arch detection, no env mutation).
+
+        Precedence (highest wins): per-config ``env:`` > outer/shell env >
+        these defaults > image-baked.
+        """
+        return []
+
+    def apply_env_defaults(self) -> None:
+        """Apply :meth:`env_defaults` into ``os.environ`` (see ``env_registry``)."""
+        from primus.core.backend.env_registry import apply_env_defaults
+
+        def _safe_log(msg: str) -> None:
+            # Env application must never abort a run on a logging issue (e.g. the
+            # Primus logger not yet initialized in a bare/standalone invocation).
+            try:
+                from primus.core.utils.module_utils import log_rank_0
+
+                log_rank_0(msg)
+            except Exception:  # noqa: BLE001
+                pass
+
+        apply_env_defaults(self.env_defaults(), self.framework, _safe_log)
+
     def prepare_backend(self, config: Any):
         """
         Prepare backend environment before building args / constructing trainer.
 
         Default behavior:
+          - Apply this backend's declarative env defaults (:meth:`env_defaults`).
           - Run backend-specific setup hooks registered in `BackendRegistry`.
 
         Backends can override this method if they need extra environment setup
-        beyond `BackendRegistry.run_setup(self.framework)`.
+        beyond the above. Most backends should instead just override
+        :meth:`env_defaults` and keep this default implementation.
         """
         from primus.core.backend.backend_registry import BackendRegistry
         from primus.core.utils.module_utils import log_rank_0
 
+        self.apply_env_defaults()
         BackendRegistry.run_setup(self.framework)
         log_rank_0(f"[Primus:{self.framework}] Backend prepared")
 

--- a/primus/core/backend/env_registry.py
+++ b/primus/core/backend/env_registry.py
@@ -1,0 +1,177 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Declarative backend environment registry.
+
+This module is the *mechanism* behind ``BackendAdapter.env_defaults()`` /
+``BackendAdapter.apply_env_defaults()``. Each backend adapter declares the
+performance/architecture environment it needs as a list of :class:`EnvVar`
+entries; the base adapter applies them (once, before the backend imports its
+GPU libraries) via :func:`apply_env_defaults`.
+
+Design goals:
+  - **Single source of truth.** A backend's env contract lives in one Python
+    list, not scattered across shell launchers and prepare hooks.
+  - **Layered precedence** (highest wins)::
+
+        per-config ``env:``  >  outer/shell env  >  these backend defaults  >  image-baked
+
+    Achieved with ``os.environ.setdefault`` for ordinary vars so we NEVER clobber
+    something the user/shell/YAML already set.
+  - **Architecture awareness.** An entry may be gated to a specific GPU arch
+    (e.g. ``gfx950`` only, ``gfx942`` only). Non-matching entries are skipped.
+  - **XLA_FLAGS merge.** ``XLA_FLAGS`` is special: Docker images bake it (often
+    with a value we must override, e.g. ``--xla_gpu_autotune_level=0``), so plain
+    ``setdefault`` would be a no-op. Entries with ``mode="xla_merge"`` are merged
+    into any existing ``XLA_FLAGS`` at the individual ``--flag`` granularity, with
+    the managed knobs winning while unrelated baked flags are preserved.
+
+Backends with no special env (Megatron, TorchTitan, ...) simply return ``[]``
+from ``env_defaults()`` and this module is a no-op for them.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional
+
+# Supported arch gates. "all" applies everywhere; the others are matched against
+# the detected GPU architecture string from rocminfo.
+ARCH_ALL = "all"
+ARCH_GFX950 = "gfx950"  # MI350X / MI355X
+ARCH_GFX942 = "gfx942"  # MI300X / MI325X
+
+# Application modes.
+MODE_SETDEFAULT = "setdefault"  # os.environ.setdefault (respect anything already set)
+MODE_XLA_MERGE = "xla_merge"  # per-flag merge into XLA_FLAGS, managed knobs win
+
+
+@dataclass(frozen=True)
+class EnvVar:
+    """A single declarative environment default.
+
+    Args:
+        name: Environment variable name.
+        value: Desired value (string).
+        arch: Arch gate — ``"all"`` (default), ``"gfx950"``, or ``"gfx942"``.
+        mode: ``"setdefault"`` (default) or ``"xla_merge"`` (for ``XLA_FLAGS``).
+        note: Optional human-readable rationale (for logs / maintainers).
+    """
+
+    name: str
+    value: str
+    arch: str = ARCH_ALL
+    mode: str = MODE_SETDEFAULT
+    note: str = ""
+
+
+_ARCH_CACHE: Optional[str] = None
+
+
+def detect_gpu_arch() -> str:
+    """Best-effort GPU arch detection via ``rocminfo``.
+
+    Returns ``"gfx950"``, ``"gfx942"``, or ``"unknown"``. Result is cached for the
+    process. Never raises — detection must never abort a training run.
+    """
+    global _ARCH_CACHE
+    if _ARCH_CACHE is not None:
+        return _ARCH_CACHE
+
+    arch = "unknown"
+    rocminfo = shutil.which("rocminfo") or "/opt/rocm/bin/rocminfo"
+    try:
+        out = subprocess.run(
+            [rocminfo], capture_output=True, text=True, timeout=15
+        ).stdout
+        for cand in (ARCH_GFX950, ARCH_GFX942):
+            if cand in out:
+                arch = cand
+                break
+    except Exception:  # noqa: BLE001 - detection must never abort a run
+        pass
+
+    _ARCH_CACHE = arch
+    return arch
+
+
+def _parse_xla_flags(flags: str) -> "OrderedDict[str, str]":
+    """Parse an ``XLA_FLAGS`` string into an ordered ``flag-key -> full-token`` map.
+
+    Tokens look like ``--name=value``, ``--name=''`` or bare ``--name``; none of
+    the values contain spaces, so a whitespace split is sufficient. The key is the
+    portion before ``=`` so we can override on a per-flag basis.
+    """
+    parsed: "OrderedDict[str, str]" = OrderedDict()
+    for tok in flags.split():
+        key = tok.split("=", 1)[0] if "=" in tok else tok
+        parsed[key] = tok
+    return parsed
+
+
+def merge_xla_flags(existing: str, managed: str) -> str:
+    """Merge ``managed`` XLA flags over ``existing`` at ``--flag`` granularity.
+
+    Managed knobs win; flags present only in ``existing`` (e.g. image-baked flags
+    we don't manage) are preserved in their original position.
+    """
+    merged = _parse_xla_flags(existing)
+    for key, tok in _parse_xla_flags(managed).items():
+        merged[key] = tok
+    return " ".join(merged.values())
+
+
+def apply_env_defaults(
+    entries: Iterable[EnvVar],
+    framework: str,
+    logger: Optional[Callable[[str], None]] = None,
+) -> List[str]:
+    """Apply a backend's declarative env defaults into ``os.environ``.
+
+    - Arch-gated entries are skipped unless the detected arch matches (rocminfo is
+      only queried if at least one arch-gated entry is present).
+    - ``setdefault`` entries never override an already-set value.
+    - ``xla_merge`` entries merge into ``XLA_FLAGS`` (managed knobs win).
+
+    Returns the list of variable names that were actually applied (useful for
+    diagnostics / parity checks).
+    """
+    entries = list(entries)
+    if not entries:
+        return []
+
+    log = logger or (lambda _msg: None)
+
+    needs_arch = any(e.arch != ARCH_ALL for e in entries)
+    arch = detect_gpu_arch() if needs_arch else ARCH_ALL
+
+    applied: List[str] = []
+    for e in entries:
+        if e.arch != ARCH_ALL and e.arch != arch:
+            continue
+
+        if e.mode == MODE_XLA_MERGE:
+            before = os.environ.get(e.name, "")
+            after = merge_xla_flags(before, e.value)
+            os.environ[e.name] = after
+            if after != before:
+                applied.append(e.name)
+                log(f"[Primus:{framework}] {e.name} merged (managed XLA knobs win)")
+        else:
+            # setdefault semantics: only set (and count) when currently unset, so
+            # outer/shell/YAML `env:` values always take precedence.
+            if e.name not in os.environ:
+                os.environ[e.name] = e.value
+                applied.append(e.name)
+                suffix = f" ({e.note})" if e.note else ""
+                log(f"[Primus:{framework}] {e.name}={e.value} (default){suffix}")
+
+    return applied

--- a/runner/helpers/hooks/train/pretrain/maxtext/prepare.py
+++ b/runner/helpers/hooks/train/pretrain/maxtext/prepare.py
@@ -277,58 +277,16 @@ def main():
     log_info(f"Exposing resolved backend path via extra.backend_path={maxtext_path}")
     print(f"extra.backend_path={maxtext_path}")
 
-    # Expose JAX coordinator environment variables for distributed training
-    # These will be exported by execute_hooks.sh
-    import os
+    # All MaxText/JAX perf + arch env (XLA_FLAGS incl. the fp8 MoE autotune fix,
+    # NVTE/HIP/HSA tunables, RCCL_WARP_SPEED_AUTO/HSA_NO_SCRATCH_RECLAIM, and the
+    # JAX coordinator for multi-node) is now owned by the Primus MaxText backend
+    # adapter (primus/backends/maxtext/env_spec.py), applied in-process before JAX
+    # init. This hook therefore no longer emits any of it -- a single source of
+    # truth shared by every launch path (primus-cli, run_pretrain.sh, MAD).
 
-    master_addr = os.getenv("MASTER_ADDR", "localhost")
-    master_port = os.getenv("MASTER_PORT", "1234")
-
-    log_info(
-        f"Exposing JAX coordinator: JAX_COORDINATOR_IP={master_addr}, JAX_COORDINATOR_PORT={master_port}"
-    )
-    print(f"env.JAX_COORDINATOR_IP={master_addr}")
-    print(f"env.JAX_COORDINATOR_PORT={master_port}")
-
-    # Expose MaxText/JAX performance tuning environment variables
-    # These mirror the settings from examples/run_pretrain.sh
-    log_info("Exposing MaxText performance tuning environment variables")
-
-    # XLA/JAX settings
-    dump_hlo_dir = os.getenv("DUMP_HLO_DIR", f"{primus_path}/output/xla_dump_hlo")
-    dump_hlo = os.getenv("DUMP_HLO", "0")
-    print(f"env.DUMP_HLO_DIR={dump_hlo_dir}")
-    print(f"env.DUMP_HLO={dump_hlo}")
-    print("env.NVTE_ALLOW_NONDETERMINISTIC_ALGO=1")
-    # set XLA_PYTHON_CLIENT_MEM_FRACTION to 0.93
-    # to avoid HSA_STATUS_ERROR_OUT_OF_RESOURCES error during multi-node training
-    xla_python_client_mem_fraction = os.getenv("XLA_PYTHON_CLIENT_MEM_FRACTION", ".97")
-    print(f"env.XLA_PYTHON_CLIENT_MEM_FRACTION={xla_python_client_mem_fraction}")
-    print("env.NVTE_USE_HIPBLASLT=1")
-
-    xla_flags = "--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_command_buffer='' --xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=false --xla_gpu_enable_cublaslt=true --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=false"
-    if dump_hlo == "1":
-        xla_flags += f" --xla_dump_to={dump_hlo_dir}"
-        log_info(f"XLA HLO dumping enabled, output directory: {dump_hlo_dir}")
-    print(f"env.XLA_FLAGS={xla_flags}")
-    # set TF_CPP_MIN_LOG_LEVEL=2 to suppress the error messages at the end of JAX/MaxText training
-    print(f"env.TF_CPP_MIN_LOG_LEVEL=2")
-
-    # AMD GPU optimizations
-    print("env.HIP_FORCE_DEV_KERNARG=1")
-    print("env.HSA_FORCE_FINE_GRAIN_PCIE=1")
-
-    # Transformer Engine settings for MaxText
-    print("env.NVTE_FUSED_ATTN=1")
-    print("env.NVTE_CK_USES_BWD_V3=1")
-    print("env.NVTE_CK_USES_FWD_V3=1")
-    print("env.NVTE_CK_IS_V3_ATOMIC_FP32=0")
-    print("env.NVTE_CK_HOW_V3_BF16_CVT=2")
-    print("env.NVTE_FUSED_ATTN_CK=1")
-    print("env.NVTE_FUSED_ATTN_AOTRITON=0")
-
-    # Expose run mode: MaxText uses single mode (plain python instead of torchrun)
-    # This will be exported as RUN_MODE env var by execute_hooks.sh
+    # RUN_MODE is the one exception: it is a *launcher* decision (plain python vs
+    # torchrun) that must be known before Python starts, so it cannot live in the
+    # in-process adapter. execute_hooks.sh exports it from this line.
     log_info("Exposing run mode via env.RUN_MODE=single")
     print("env.RUN_MODE=single")
 


### PR DESCRIPTION
Run Google's MaxDiffusion WAN/FLUX trainers through primus/cli, mirroring the MaxText backend so JAX diffusion follows the same launch pattern (distinct from the in-tree PyTorch `diffusion` backend).

- primus/backends/maxdiffusion: adapter, argument_builder, pretrain trainer (pyconfig.initialize -> WanTrainer/FluxTrainer inside transformer_engine_context)
- primus/configs/models|modules/maxdiffusion: native maxdiffusion configs as model presets + module preset
- examples/maxdiffusion: MI300X + MI355X wrapper configs (top-level env:) and prepare.py hook
- examples/run_pretrain.sh: generalize the JAX-launch checks (MaxText ->
  MaxText | MaxDiffusion) so JAX backends launch without torchrun