### PR TITLE
fix(torchtitan): migrate configs to the v0.2.2 debug section, and catch the next rename

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,24 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure
       - name: Check version/commit pin consistency
         run: python tools/ci/check_version_consistency.py
+      # The three submodules the drift check reads a schema from; `submodules:
+      # recursive` on the checkout would also clone Megatron-Bridge & friends
+      # for nothing. A fetch failure is deliberately left to the check step,
+      # which names the backend it could not check instead of dropping a bare
+      # git error; drift stays warn-only, but a backend it could not check
+      # fails the job, since a check that did not run must not read as a pass.
+      - name: Fetch backend schema sources
+        continue-on-error: true
+        run: >-
+          git submodule update --init --depth 1
+          third_party/torchtitan third_party/maxtext third_party/Megatron-LM
+      - name: Check backend config schema drift
+        # `pipefail` is not on by default, and without it `tee` would report
+        # success for a check that failed -- the same silent pass this step
+        # exists to stop.
+        run: |
+          set -o pipefail
+          python tools/ci/check_config_schema.py --warn-only | tee -a "$GITHUB_STEP_SUMMARY"
 
   # Flag PRs that introduce known-vulnerable dependencies. Warn-only during
   # burn-in; drop warn-only to turn it into a hard gate once the team is ready.

--- a/docs/03-configuration-reference/torchtitan-parameters.md
+++ b/docs/03-configuration-reference/torchtitan-parameters.md
@@ -64,10 +64,8 @@ modules:
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `training.mock_data` | `true` | Primus preset extension: use synthetic data instead of reading `dataset_path`. |
-| `training.debug_moe_force_load_balance` | `false` | Primus preset extension/debug helper to force MoE load balancing behavior. |
 | `training.dataset` | `c4` | Dataset name key for TorchTitan dataset loaders. |
 | `training.dataset_path` | `null` | Filesystem or remote path to dataset assets. |
-| `training.deterministic` | `false` | Prefer deterministic algorithms (often slower). |
 | `training.enable_cpu_offload` | `false` | Offload optimizer or activations to CPU when supported. |
 | `training.gc_debug` | `false` | Extra garbage-collection diagnostics. |
 | `training.gc_freq` | `50` | Run Python GC every N steps when enabled. |
@@ -76,7 +74,6 @@ modules:
 | `training.max_norm` | `1.0` | Gradient clipping max norm (global). |
 | `training.mixed_precision_param` | `bfloat16` | Parameter dtype for mixed precision (`bfloat16`, `float16`, etc.). |
 | `training.mixed_precision_reduce` | `float32` | Dtype for reduction / gradient accumulation. |
-| `training.seed` | `null` | RNG seed; `null` lets the framework choose. |
 | `training.seq_len` | `2048` | Sequence length per sample. |
 | `training.steps` | `10000` | Total optimizer steps. |
 
@@ -123,7 +120,6 @@ modules:
 | `parallelism.pipeline_parallel_microbatch_size` | `1` | Microbatches per pipeline round. |
 | `parallelism.pipeline_parallel_schedule` | `1F1B` | Pipeline schedule name (`1F1B`, `GPipe`, …). |
 | `parallelism.pipeline_parallel_schedule_csv` | `''` | Optional CSV schedule definition. |
-| `parallelism.pipeline_parallel_split_points` | `[]` | Layer indices for manual PP splits. |
 | `parallelism.pipeline_parallel_layers_per_stage` | `null` | Layers per stage when auto-balanced. |
 | `parallelism.pipeline_parallel_first_stage_less_layers` | `1` | Fewer layers on first PP stage (for imbalance). |
 | `parallelism.pipeline_parallel_last_stage_less_layers` | `1` | Fewer layers on last PP stage. |
@@ -135,7 +131,6 @@ modules:
 | `parallelism.context_parallel_rotate_method` | `allgather` | Communication pattern for context parallel. |
 | `parallelism.disable_loss_parallel` | `false` | Disable loss parallel layout when TP is used. |
 | `parallelism.enable_async_tensor_parallel` | `false` | Overlap TP collectives with compute. |
-| `parallelism.enable_compiled_autograd` | `false` | Use `torch.compile` on autograd regions. |
 | `parallelism.fsdp_reshard_after_forward` | `default` | FSDP reshard policy (`default`, `always`, `never`). |
 | `parallelism.module_fqns_per_model_part` | `null` | Map of pipeline stage → module FQNs for multi-part models. |
 
@@ -352,6 +347,19 @@ modules:
 | `validation.seq_len` | `2048` | Validation sequence length. |
 | `validation.freq` | `10` | Run validation every N training steps. |
 | `validation.steps` | `-1` | Max validation steps (`-1` = full pass / framework default). |
+
+---
+
+## 15. Debug (`debug.*`)
+
+*Source: `pre_trainer.yaml`. Upstream added this section in TorchTitan v0.2.2; the keys previously lived under `training.*`.*
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `debug.deterministic` | `false` | Prefer deterministic algorithms (often slower). |
+| `debug.deterministic_warn_only` | `false` | Warn instead of erroring when an op has no deterministic implementation. |
+| `debug.moe_force_load_balance` | `false` | Round-robin tokens across MoE experts so every expert gets the same amount; debugging only. |
+| `debug.seed` | `null` | RNG seed; `null` lets the framework choose. |
 
 ---
 

--- a/docs/04-technical-guides/determinism-and-reproducibility.md
+++ b/docs/04-technical-guides/determinism-and-reproducibility.md
@@ -62,12 +62,13 @@ For a fully reproducible Megatron run: set a fixed `seed`, `deterministic_mode: 
 
 ## 4. Seeds and determinism (TorchTitan)
 
-Under `training:` in `primus/configs/modules/torchtitan/pre_trainer.yaml`:
+Under `debug:` in `primus/configs/modules/torchtitan/pre_trainer.yaml` (TorchTitan v0.2.2 moved these keys out of `training:`):
 
 | Parameter | Default | Purpose |
 |-----------|---------|---------|
 | `seed` | `null` | RNG seed; set an integer for reproducible runs. |
 | `deterministic` | `false` | Enable deterministic algorithms (disables some optimized kernels; slower). |
+| `deterministic_warn_only` | `false` | With `deterministic: true`, warn instead of erroring when an op has no deterministic implementation. |
 
 Related: `checkpoint.create_seed_checkpoint` (`false`) creates a deterministic seed checkpoint that all ranks load, ensuring identical initialization across a distributed run.
 
@@ -102,7 +103,7 @@ Determinism is not free:
 ## 7. Reproducibility checklist
 
 1. **Pin the environment**—same container image, ROCm version, and backend (Megatron/TorchTitan) commit.
-2. **Fix seeds**—Megatron `seed`; TorchTitan `training.seed`.
+2. **Fix seeds**—Megatron `seed`; TorchTitan `debug.seed`.
 3. **Hold the layout constant**—same world size and TP/PP/DP/EP/CP degrees.
 4. **Enable determinism**—`PRIMUS_DETERMINISTIC=1` plus backend `deterministic_mode`/`deterministic`.
 5. **Disable autotuning**—automatic in deterministic mode (HipBLASLt tuning off).

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 6
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_16b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_16b-FP8-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_236b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_236b-BF16-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_236b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_236b-FP8-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_671b-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_671b-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 16
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 20
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_16b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_16b-FP8-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_236b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_236b-BF16-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_236b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_236b-FP8-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_671b-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_671b-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 16
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 9
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 50
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_16b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_16b-FP8-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 14
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_236b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_236b-BF16-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_236b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_236b-FP8-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 8
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_671b-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_671b-pretrain.yaml
@@ -38,12 +38,14 @@ modules:
         min_lr_factor: 0.1
 
       training:
-        debug_moe_force_load_balance: true
         local_batch_size: 16
         seq_len: 4096
         max_norm: 1.0            # grad norm clipping
         steps: 15
         dataset: "c4_test"            # supported datasets: c4_test (2K), c4 (177M)
+
+      debug:
+        moe_force_load_balance: true
 
       parallelism:
         data_parallel_replicate_degree: 1

--- a/primus/configs/modules/torchtitan/pre_trainer.yaml
+++ b/primus/configs/modules/torchtitan/pre_trainer.yaml
@@ -35,10 +35,8 @@ profiling:
 
 training:
   mock_data: true
-  debug_moe_force_load_balance: false
   dataset: c4
   dataset_path: null
-  deterministic: false
   enable_cpu_offload: false
   gc_debug: false
   gc_freq: 50
@@ -47,10 +45,14 @@ training:
   max_norm: 1.0
   mixed_precision_param: bfloat16
   mixed_precision_reduce: float32
-  seed: null
   seq_len: 2048
   steps: 10000
 
+debug:
+  deterministic: false
+  deterministic_warn_only: false
+  moe_force_load_balance: false
+  seed: null
 
 parallelism:
   context_parallel_degree: 1
@@ -59,7 +61,6 @@ parallelism:
   data_parallel_shard_degree: -1
   disable_loss_parallel: false
   enable_async_tensor_parallel: false
-  enable_compiled_autograd: false
   expert_parallel_degree: 1
   expert_tensor_parallel_degree: 1
   fsdp_reshard_after_forward: default
@@ -71,7 +72,6 @@ parallelism:
   pipeline_parallel_microbatch_size: 1
   pipeline_parallel_schedule: 1F1B
   pipeline_parallel_schedule_csv: ''
-  pipeline_parallel_split_points: []
   tensor_parallel_degree: 1
 
 checkpoint:

--- a/primus/core/config/schema_check.py
+++ b/primus/core/config/schema_check.py
@@ -1,0 +1,1199 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Detect Primus YAML keys that no longer exist in the upstream backend schema.
+
+Every adapter takes unknown keys silently -- TorchTitan attaches them as dynamic attributes,
+MaxText lets pydantic drop them, Megatron gets them merged onto ``args`` by ``train_runtime`` --
+so a renamed field keeps parsing while doing nothing: ``training.debug_moe_force_load_balance``
+moved to ``debug.moe_force_load_balance``, and every DeepSeek config went on training with MoE
+load balancing off. Schemas are read statically (AST, ``yaml.safe_load``), so the check imports
+neither torch nor jax and runs on a plain CI runner.
+
+Legal keys are upstream's plus the Primus extensions, and the extensions are derived rather than
+listed: ``get_param(ctx, "<path>", ...)`` calls in the patch packages, reads off Megatron's
+``args`` namespace, Primus dataclasses extending a backend config class, and a hand-written
+allowlist. ``MegatronArgBuilder`` stripping a key is not drift: ``train_runtime`` merges the
+original params back over the result, which is how roughly 130 Primus-only keys reach ``args``.
+
+A legal key can still be dead where it is written: ``core_transformer_config_from_args`` copies a
+Primus config class's fields off ``args`` only on the model naming that class. ``norm_epsilon``
+is DeepSeek-V4's and not an upstream dest -- upstream's ``layernorm_epsilon`` merely spells its
+flag ``--norm-epsilon`` -- so it is live there and inert on a Llama config. Those are reported as
+misplaced rather than unknown, and a config whose model cannot be resolved is left alone.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping, Sequence
+
+import yaml
+
+from primus.core.config.yaml_loader import parse_yaml
+
+BACKENDS = ("torchtitan", "maxtext", "megatron")
+
+TORCHTITAN_JOB_CONFIG = Path("third_party/torchtitan/torchtitan/config/job_config.py")
+MAXTEXT_BASE_YML = Path("third_party/maxtext/src/maxtext/configs/base.yml")
+MEGATRON_ROOT = Path("third_party/Megatron-LM")
+MEGATRON_ARGUMENTS = Path("megatron/training/arguments.py")
+
+# `core_transformer_config_from_args` copies every field of these classes off
+# `args`, so their fields stay legal even where ArgumentGroupFactory excludes
+# them from argparse (`moe_token_dropping`, `fp8_multi_head_attention`, ...).
+MEGATRON_CONFIG_CLASSES = ("TransformerConfig", "MLATransformerConfig")
+
+# Module preset whose `experimental.custom_args_module` points at the dataclass
+# that extends TorchTitan's JobConfig.
+TORCHTITAN_MODULE_PRESET = Path("primus/configs/modules/torchtitan/pre_trainer.yaml")
+
+PATCH_DIRS = {
+    "torchtitan": Path("primus/backends/torchtitan/patches"),
+    "maxtext": Path("primus/backends/maxtext/patches"),
+}
+
+# Packages whose reads off the backend's argument namespace define the
+# Primus-only half of its key set, and which hold the Primus subclasses of the
+# backend's config dataclass.
+BACKEND_PACKAGES = {"megatron": Path("primus/backends/megatron")}
+
+# `get_model_provider(model_type=...)` is where a Megatron run decides which
+# model it builds, and the branches that name a Primus module are the ones that
+# lead to a Primus config class. See `extract_model_scopes`.
+MODEL_PROVIDERS = {
+    "megatron": (Path("primus/core/utils/import_utils.py"), "get_model_provider", "model_type"),
+}
+
+# `module.model` names a preset here, and that preset is where a model declares
+# its `model_type`; the experiment YAML that sets a model-scoped key usually
+# does not repeat it.
+MODEL_PRESETS = Path("primus/configs/models")
+
+# Every Python file Primus owns. A name read off an argument namespace anywhere
+# in here is model-agnostic evidence, which is what keeps a shared key such as
+# `moe_use_legacy_grouped_gemm` out of the model-scoped key sets.
+PRIMUS_PACKAGE = Path("primus")
+
+SCAN_ROOTS = {
+    "torchtitan": (
+        Path("examples/torchtitan/configs"),
+        Path("primus/configs/modules/torchtitan"),
+        Path("primus/configs/models/torchtitan"),
+    ),
+    "maxtext": (
+        Path("examples/maxtext/configs"),
+        Path("primus/configs/modules/maxtext"),
+        Path("primus/configs/models/maxtext"),
+    ),
+    "megatron": (
+        Path("examples/megatron/configs"),
+        Path("primus/configs/modules/megatron"),
+        Path("primus/configs/models/megatron"),
+    ),
+}
+
+DEFAULT_ALLOWLIST = Path("tools/ci/config_schema_allowlist.yaml")
+
+# Keys PrimusParser.parse_trainer_module consumes on the module node itself;
+# they never reach the backend.
+MODULE_RESERVED_KEYS = frozenset({"name", "framework", "config", "model", "overrides", "params"})
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BackendSchema:
+    """Upstream key universe for one backend."""
+
+    backend: str
+    keys: frozenset[str]
+    sections: frozenset[str]
+    source: str
+
+    def extended(self, keys: Iterable[str], sections: Iterable[str], source: str) -> "BackendSchema":
+        return BackendSchema(
+            backend=self.backend,
+            keys=self.keys | frozenset(keys),
+            sections=self.sections | frozenset(sections),
+            source=f"{self.source} + {source}",
+        )
+
+    def suggest(self, path: str) -> str | None:
+        """Best guess for where a dropped key moved to: the leaf name, the leaf minus a leading
+        ``<section>_`` (moved into a new section), or the leaf plus a prefix or suffix (renamed
+        in place). Ambiguity yields ``None``."""
+        leaf = path.rsplit(".", 1)[-1]
+        candidates = {leaf}
+        head = leaf.split("_", 1)
+        if len(head) == 2 and head[0] in {s.split(".")[0] for s in self.sections | self.keys}:
+            candidates.add(head[1])
+        matches = sorted(k for k in self.keys if k != path and k.rsplit(".", 1)[-1] in candidates)
+        if not matches:
+            matches = sorted(
+                k
+                for k in self.keys
+                if (tail := k.rsplit(".", 1)[-1]) != leaf
+                and (tail.startswith(f"{leaf}_") or tail.endswith(f"_{leaf}"))
+            )
+        return matches[0] if len(matches) == 1 else None
+
+
+def _dataclass_defs(tree: ast.Module) -> dict[str, list[tuple[str, str]]]:
+    """Map ``@dataclass`` class name -> ``[(field name, annotation source)]``."""
+    defs: dict[str, list[tuple[str, str]]] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        decorated = any("dataclass" in ast.unparse(d) for d in node.decorator_list)
+        if not decorated:
+            continue
+        fields = [
+            (stmt.target.id, ast.unparse(stmt.annotation).strip("\"'"))
+            for stmt in node.body
+            if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+        ]
+        defs[node.name] = fields
+    return defs
+
+
+def _expand_dataclass(
+    defs: dict[str, list[tuple[str, str]]],
+    cls: str,
+    prefix: str,
+    keys: set[str],
+    sections: set[str],
+    seen: frozenset[str] = frozenset(),
+) -> None:
+    for name, annotation in defs.get(cls, ()):
+        path = f"{prefix}.{name}" if prefix else name
+        if annotation in defs and annotation not in seen:
+            sections.add(path)
+            _expand_dataclass(defs, annotation, path, keys, sections, seen | {annotation})
+        else:
+            keys.add(path)
+
+
+def load_torchtitan_schema(repo_root: Path) -> BackendSchema | None:
+    """Extract ``JobConfig`` from TorchTitan's ``job_config.py`` via AST; the module imports
+    torch, so it cannot simply be imported here."""
+    src = repo_root / TORCHTITAN_JOB_CONFIG
+    if not src.is_file():
+        return None
+    defs = _dataclass_defs(ast.parse(src.read_text()))
+    if "JobConfig" not in defs:
+        raise ValueError(f"no JobConfig dataclass found in {TORCHTITAN_JOB_CONFIG}")
+    keys: set[str] = set()
+    sections: set[str] = set()
+    _expand_dataclass(defs, "JobConfig", "", keys, sections)
+    return BackendSchema(
+        backend="torchtitan",
+        keys=frozenset(keys),
+        sections=frozenset(sections),
+        source=str(TORCHTITAN_JOB_CONFIG),
+    )
+
+
+def load_maxtext_schema(repo_root: Path) -> BackendSchema | None:
+    """MaxText's ``base.yml`` is a flat mapping and is itself the schema."""
+    src = repo_root / MAXTEXT_BASE_YML
+    if not src.is_file():
+        return None
+    data = yaml.safe_load(src.read_text()) or {}
+    return BackendSchema(
+        backend="maxtext",
+        keys=frozenset(data),
+        sections=frozenset(),
+        source=str(MAXTEXT_BASE_YML),
+    )
+
+
+def _calls_named(tree: ast.AST, name: str) -> Iterator[ast.Call]:
+    """Every call whose callee is spelled ``name`` or ``<something>.name``."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if called == name:
+            yield node
+
+
+def _string_elements(node: ast.expr | None) -> set[str] | None:
+    """String constants of a literal list/tuple/set; ``None`` if not one."""
+    if not isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return None
+    return {e.value for e in node.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+
+
+def _argparse_dest(call: ast.Call) -> str | None:
+    """The attribute name argparse derives from one ``add_argument`` call: ``dest=`` if given, else
+    the first long option, so ``--no-persist-layer-norm`` gives ``no_persist_layer_norm``."""
+    for keyword in call.keywords:
+        if keyword.arg == "dest" and isinstance(keyword.value, ast.Constant):
+            return str(keyword.value.value)
+    options = [a.value for a in call.args if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+    chosen = next((o for o in options if o.startswith("--")), None) or next(iter(options), None)
+    return chosen.lstrip("-").replace("-", "_") if chosen else None
+
+
+class _MegatronSource:
+    """Just enough of an import resolver to walk the checked-out Megatron tree: config dataclasses
+    arrive through re-exports and inherit across packages, so a flat class index is not faithful."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self._trees: dict[Path, ast.Module] = {}
+
+    def tree(self, path: Path) -> ast.Module:
+        if path not in self._trees:
+            self._trees[path] = ast.parse(path.read_text())
+        return self._trees[path]
+
+    def module_file(self, module: str) -> Path | None:
+        rel = module.replace(".", "/")
+        for candidate in (self.root / f"{rel}.py", self.root / rel / "__init__.py"):
+            if candidate.is_file():
+                return candidate
+        return None
+
+    def imports(self, path: Path) -> dict[str, str]:
+        """``local name -> absolute module`` for every ``from X import name``."""
+        package = ".".join(path.relative_to(self.root).parts[:-1])
+        found: dict[str, str] = {}
+        for node in ast.walk(self.tree(path)):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            module = node.module or ""
+            if node.level:  # `from ..model_parallel_config import ModelParallelConfig`
+                parts = package.split(".")
+                parts = parts[: len(parts) - node.level + 1]
+                module = ".".join([*parts, module]) if module else ".".join(parts)
+            for alias in node.names:
+                found[alias.asname or alias.name] = module
+        return found
+
+    def resolve(
+        self, path: Path, name: str, seen: frozenset[str] = frozenset()
+    ) -> tuple[Path, ast.ClassDef] | None:
+        """Find class ``name`` as visible from ``path``, with its defining file: base classes must
+        be resolved in the scope that declares them, not the one that referenced them."""
+        for node in self.tree(path).body:
+            if isinstance(node, ast.ClassDef) and node.name == name:
+                return path, node
+        module = self.imports(path).get(name)
+        if module is None or module in seen:
+            return None
+        target = self.module_file(module)
+        return self.resolve(target, name, seen | {module}) if target else None
+
+    def config_fields(self, path: Path, cls: ast.ClassDef, exclude: Iterable[str] = ()) -> list[str]:
+        """Names ``ArgumentGroupFactory`` would turn into arguments, in field order, mirroring
+        ``build_group``: base-class fields first, ``init=False`` and ``ClassVar`` skipped, an
+        ``argparse_meta`` ``dest`` override honoured (``use_nsys_profiler`` -> ``profile``)."""
+        skip = set(exclude)
+        names: list[str] = []
+        for base in cls.bases:
+            if not isinstance(base, ast.Name):
+                continue
+            found = self.resolve(path, base.id)
+            if found:
+                names.extend(self.config_fields(*found, exclude=skip))
+        for stmt in cls.body:
+            if not isinstance(stmt, ast.AnnAssign) or not isinstance(stmt.target, ast.Name):
+                continue
+            if ast.unparse(stmt.annotation).lstrip("\"'").startswith(("ClassVar", "InitVar")):
+                continue
+            if _has_field_kwarg(stmt.value, "init", False):
+                continue
+            dest = _argparse_meta_dest(stmt.value) or stmt.target.id
+            if dest not in skip and dest not in names:
+                names.append(dest)
+        return names
+
+
+def _field_call(value: ast.expr | None) -> ast.Call | None:
+    """The ``dataclasses.field(...)`` call of a field default, if any."""
+    if not isinstance(value, ast.Call):
+        return None
+    func = value.func
+    called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return value if called == "field" else None
+
+
+def _has_field_kwarg(value: ast.expr | None, name: str, expected: Any) -> bool:
+    call = _field_call(value)
+    if call is None:
+        return False
+    return any(
+        kw.arg == name and isinstance(kw.value, ast.Constant) and kw.value.value is expected
+        for kw in call.keywords
+    )
+
+
+def _argparse_meta_dest(value: ast.expr | None) -> str | None:
+    """``metadata={"argparse_meta": {"dest": "profile"}}`` -> ``"profile"``."""
+    call = _field_call(value)
+    if call is None:
+        return None
+    for keyword in call.keywords:
+        if keyword.arg != "metadata" or not isinstance(keyword.value, ast.Dict):
+            continue
+        for outer_key, outer in zip(keyword.value.keys, keyword.value.values):
+            if not (isinstance(outer_key, ast.Constant) and outer_key.value == "argparse_meta"):
+                continue
+            if not isinstance(outer, ast.Dict):
+                continue
+            for inner_key, inner in zip(outer.keys, outer.values):
+                if isinstance(inner_key, ast.Constant) and inner_key.value == "dest":
+                    if isinstance(inner, ast.Constant):
+                        return str(inner.value)
+    return None
+
+
+def _resolve_exclude(tree: ast.Module, call: ast.Call) -> set[str]:
+    """The ``exclude=`` list of one ``ArgumentGroupFactory`` call, following a literal assignment
+    when the argument is a variable, as ``TransformerConfig``'s call passes. An expression that
+    cannot be read statically yields no exclusions, erring towards a missed report."""
+    argument = next((kw.value for kw in call.keywords if kw.arg == "exclude"), None)
+    literal = _string_elements(argument)
+    if literal is not None:
+        return literal
+    if not isinstance(argument, ast.Name):
+        return set()
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        targets = node.targets if isinstance(node, ast.Assign) else []
+        if any(isinstance(t, ast.Name) and t.id == argument.id for t in targets):
+            names |= _string_elements(node.value) or set()
+    return names
+
+
+def load_megatron_schema(repo_root: Path) -> BackendSchema | None:
+    """Rebuild Megatron's flat argument namespace from ``arguments.py``: roughly 355 literal
+    ``add_argument`` calls, plus eleven ``ArgumentGroupFactory(<dataclass>)`` calls generating as
+    many again. The generated half holds ``train_iters``, ``global_batch_size`` and
+    ``micro_batch_size``, so the literal calls alone would report half of every config as drift."""
+    root = repo_root / MEGATRON_ROOT
+    src = root / MEGATRON_ARGUMENTS
+    if not src.is_file():
+        return None
+    source = _MegatronSource(root)
+    tree = source.tree(src)
+
+    keys = {dest for call in _calls_named(tree, "add_argument") if (dest := _argparse_dest(call))}
+    for call in _calls_named(tree, "ArgumentGroupFactory"):
+        target = call.args[0] if call.args else None
+        if not isinstance(target, ast.Name):
+            continue
+        found = source.resolve(src, target.id)
+        if found is None:
+            raise ValueError(f"{MEGATRON_ARGUMENTS}: cannot resolve ArgumentGroupFactory({target.id})")
+        keys.update(source.config_fields(*found, exclude=_resolve_exclude(tree, call)))
+    for name in MEGATRON_CONFIG_CLASSES:
+        found = source.resolve(src, name)
+        if found is not None:
+            keys.update(source.config_fields(*found))
+
+    return BackendSchema(
+        backend="megatron",
+        keys=frozenset(keys),
+        sections=frozenset(),  # Megatron's namespace is flat: every key is a leaf.
+        source=str(MEGATRON_ROOT / MEGATRON_ARGUMENTS),
+    )
+
+
+SCHEMA_LOADERS = {
+    "torchtitan": load_torchtitan_schema,
+    "maxtext": load_maxtext_schema,
+    "megatron": load_megatron_schema,
+}
+
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AllowRule:
+    pattern: str
+    reason: str
+    consumer: str
+    origin: str
+
+    def matches(self, path: str) -> bool:
+        return path == self.pattern or fnmatch.fnmatchcase(path, self.pattern)
+
+
+@dataclass(frozen=True)
+class Allowlist:
+    """Rules that widen a backend's legal key set, indexed for lookup: Megatron derives thousands,
+    so exact patterns are hashed and only real fnmatch patterns scanned, and exact wins over glob."""
+
+    rules: tuple[AllowRule, ...]
+
+    def __post_init__(self) -> None:
+        exact: dict[str, AllowRule] = {}
+        globs: list[AllowRule] = []
+        prefixes: set[str] = set()
+        for rule in self.rules:
+            if any(ch in rule.pattern for ch in "*?["):
+                globs.append(rule)
+            else:
+                exact.setdefault(rule.pattern, rule)
+            parts = rule.pattern.split(".")
+            prefixes.update(".".join(parts[:i]) for i in range(1, len(parts)))
+        object.__setattr__(self, "_exact", exact)
+        object.__setattr__(self, "_globs", tuple(globs))
+        object.__setattr__(self, "_prefixes", frozenset(prefixes))
+
+    def match(self, path: str) -> AllowRule | None:
+        rule = self._exact.get(path)
+        return rule or next((r for r in self._globs if r.matches(path)), None)
+
+    def is_prefix(self, path: str) -> bool:
+        """True when some rule targets a child of ``path`` (so ``path`` is a section)."""
+        return path in self._prefixes
+
+    def patterns(self) -> list[str]:
+        return sorted({r.pattern for r in self.rules})
+
+
+def extract_get_param_rules(repo_root: Path, backend: str) -> list[AllowRule]:
+    """Collect config paths read by ``get_param(ctx, "<path>", ...)`` in patches."""
+    patch_dir = repo_root / PATCH_DIRS.get(backend, Path("does/not/exist"))
+    if not patch_dir.is_dir():
+        return []
+    rules: list[AllowRule] = []
+    for py in sorted(patch_dir.rglob("*.py")):
+        tree = ast.parse(py.read_text())
+        rel = py.relative_to(repo_root)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or len(node.args) < 2:
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "get_param":
+                continue
+            arg = node.args[1]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                rules.append(
+                    AllowRule(
+                        pattern=arg.value,
+                        reason="read by the Primus patch system",
+                        consumer=f"{rel}:{node.lineno}",
+                        origin="patch:get_param",
+                    )
+                )
+    return rules
+
+
+_ARGS_OBJECT_HINTS = ("arg", "cfg", "config")
+
+
+def _is_args_object(node: ast.expr) -> bool:
+    """True when ``node`` looks like Megatron's argument or config namespace (``args.x``,
+    ``self.args.x``, ``get_args().x``), but not every attribute read: ``tensor.shape`` is not one."""
+    while isinstance(node, ast.Call):
+        node = node.func
+    name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", None)
+    return bool(name) and any(hint in name.lower() for hint in _ARGS_OBJECT_HINTS)
+
+
+def extract_args_read_rules(repo_root: Path, backend: str) -> list[AllowRule]:
+    """Collect the names a backend package reads off the argument namespace. Two forms count as a
+    reader: attribute access on an args-shaped object, and the bare name as a string literal
+    anywhere in the package -- reads reach ``args`` through too many indirections (module
+    constants, local getters, config-to-env bridges, generated source) for a narrower rule."""
+    package = repo_root / BACKEND_PACKAGES.get(backend, Path("does/not/exist"))
+    if not package.is_dir():
+        return []
+    rules: list[AllowRule] = []
+    seen: set[str] = set()
+
+    def record(name: str, path: Path, lineno: int, origin: str) -> None:
+        # An ALL_CAPS literal is a constant, an enum member or an environment variable, never an
+        # argument name -- and a config setting one as if it were (`HSA_NO_SCRATCH_RECLAIM: 1`)
+        # is exactly the mistake this check should keep reporting.
+        if name in seen or not name.isidentifier() or name == name.upper():
+            return
+        seen.add(name)
+        rules.append(
+            AllowRule(
+                pattern=name,
+                reason=f"read off the {backend} args namespace by the backend package",
+                consumer=f"{path.relative_to(repo_root)}:{lineno}",
+                origin=origin,
+            )
+        )
+
+    for py in sorted(package.rglob("*.py")):
+        for node in ast.walk(ast.parse(py.read_text())):
+            if isinstance(node, ast.Attribute) and _is_args_object(node.value):
+                record(node.attr, py, node.lineno, "backend:args_attribute")
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                record(node.value, py, node.lineno, "backend:args_name")
+    return rules
+
+
+def _class_bases(node: ast.ClassDef) -> set[str]:
+    return {ast.unparse(base).rsplit(".", 1)[-1] for base in node.bases}
+
+
+def _class_fields(node: ast.ClassDef) -> set[str]:
+    return {
+        stmt.target.id
+        for stmt in node.body
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+    }
+
+
+def _primus_config_classes(repo_root: Path, backend: str) -> tuple[dict[str, ast.ClassDef], frozenset[str]]:
+    """``(every class in the backend package, those extending its config class)``, grown to a
+    fixpoint because the chain can be several classes long: ``FluxConfig`` ->
+    ``BaseDiffusionConfig`` -> ``TransformerConfig``."""
+    package = repo_root / BACKEND_PACKAGES.get(backend, Path("does/not/exist"))
+    if not package.is_dir():
+        return {}, frozenset()
+    classes: dict[str, ast.ClassDef] = {}
+    for py in sorted(package.rglob("*.py")):
+        for node in ast.walk(ast.parse(py.read_text())):
+            if isinstance(node, ast.ClassDef):
+                classes[node.name] = node
+
+    derived: set[str] = set()
+    frontier = set(MEGATRON_CONFIG_CLASSES)
+    while frontier:
+        frontier = {
+            n for n, c in classes.items() if n not in derived and _class_bases(c) & (frontier | derived)
+        }
+        derived |= frontier
+    return classes, frozenset(derived)
+
+
+def extract_backend_config_extensions(repo_root: Path, backend: str) -> tuple[frozenset[str], str]:
+    """Fields of the Primus dataclasses that extend the backend's config class, which
+    ``core_transformer_config_from_args`` copies off ``args`` and thereby makes legal keys."""
+    classes, derived = _primus_config_classes(repo_root, backend)
+    if not derived:
+        return frozenset(), ""
+    keys = frozenset().union(*(_class_fields(classes[name]) for name in derived))
+    return keys, str(BACKEND_PACKAGES[backend])
+
+
+# ---------------------------------------------------------------------------
+# Model scopes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ModelScope:
+    """Keys that only reach the model one YAML discriminator selects: live on that model's path,
+    a silent no-op on every other."""
+
+    key: str
+    """YAML key that decides which model gets built, e.g. ``model_type``."""
+
+    value: str
+    """The value of ``key`` that selects this model, e.g. ``deepseek_v4``."""
+
+    default: str | None
+    """What ``key`` means when a config omits it; ``None`` when there is no default."""
+
+    config_class: str
+    keys: frozenset[str]
+    source: str
+
+    def describe(self) -> str:
+        return f"{self.key}: {self.value}"
+
+
+def _is_args_namespace(node: ast.expr) -> bool:
+    """True for ``args``, ``self.args``, ``get_args()``, ``backend_args``, ..."""
+    while isinstance(node, ast.Call):
+        node = node.func
+    name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", None)
+    return bool(name) and "arg" in name.lower()
+
+
+def _args_namespace_reads(repo_root: Path) -> frozenset[str]:
+    """Names read off an *argument* namespace anywhere in ``primus/``, deliberately narrower than
+    ``_is_args_object``: ``config.norm_epsilon`` only says the key is a field of whichever config
+    class got built, while ``args.moe_use_legacy_grouped_gemm`` says it reaches its reader on
+    every model. Only the latter disqualifies a key from being model-scoped."""
+    package = repo_root / PRIMUS_PACKAGE
+    if not package.is_dir():
+        return frozenset()
+    names: set[str] = set()
+    for py in sorted(package.rglob("*.py")):
+        try:
+            tree = ast.parse(py.read_text())
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and _is_args_namespace(node.value):
+                names.add(node.attr)
+            elif isinstance(node, ast.Call) and len(node.args) >= 2:
+                called = getattr(node.func, "id", None)
+                target = node.args[1]
+                if called in ("getattr", "setattr", "hasattr") and _is_args_namespace(node.args[0]):
+                    if isinstance(target, ast.Constant) and isinstance(target.value, str):
+                        names.add(target.value)
+    return frozenset(names)
+
+
+def _model_provider_branches(repo_root: Path, backend: str) -> tuple[str | None, dict[str, str], str]:
+    """Read the model dispatch -- ``(default, {discriminator value: module}, source)`` -- from
+    ``get_model_provider``'s branches; only one naming a Primus module reaches a Primus config."""
+    src, func_name, key = MODEL_PROVIDERS.get(backend, (None, "", ""))
+    if src is None:
+        return None, {}, ""
+    path = repo_root / src
+    if not path.is_file():
+        return None, {}, ""
+    tree = ast.parse(path.read_text())
+    func = next(
+        (n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == func_name),
+        None,
+    )
+    if func is None:
+        return None, {}, ""
+
+    default = None
+    positional = func.args.posonlyargs + func.args.args
+    for arg, value in zip(positional[len(positional) - len(func.args.defaults) :], func.args.defaults):
+        if arg.arg == key and isinstance(value, ast.Constant) and isinstance(value.value, str):
+            default = value.value
+
+    branches: dict[str, str] = {}
+    for node in ast.walk(func):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if not isinstance(test, ast.Compare) or len(test.ops) != 1:
+            continue
+        if not isinstance(test.ops[0], ast.Eq) or not isinstance(test.left, ast.Name):
+            continue
+        if test.left.id != key:
+            continue
+        right = test.comparators[0]
+        if not (isinstance(right, ast.Constant) and isinstance(right.value, str)):
+            continue
+        for stmt in node.body:
+            for call in _calls_named(stmt, "import_module"):
+                arg = call.args[0] if call.args else None
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    branches[right.value] = arg.value
+    return default, branches, str(src)
+
+
+def _config_class_of_module(repo_root: Path, module: str) -> str | None:
+    """The class a module hands to ``core_transformer_config_from_args``."""
+    path = repo_root / (module.replace(".", "/") + ".py")
+    if not path.is_file():
+        return None
+    tree = ast.parse(path.read_text())
+    for call in _calls_named(tree, "core_transformer_config_from_args"):
+        for keyword in call.keywords:
+            if keyword.arg == "config_class" and isinstance(keyword.value, ast.Name):
+                return keyword.value.id
+    return None
+
+
+def _inherited_fields(classes: dict[str, ast.ClassDef], derived: frozenset[str], cls: str) -> set[str]:
+    """Fields ``cls`` declares plus its Primus-side ancestors', stopping at the backend's own
+    config class: an upstream field is upstream's, not this model's."""
+    fields: set[str] = set()
+    frontier = {cls}
+    seen: set[str] = set()
+    while frontier:
+        name = frontier.pop()
+        if name in seen or name not in derived:
+            continue
+        seen.add(name)
+        fields |= _class_fields(classes[name])
+        frontier |= _class_bases(classes[name])
+    return fields
+
+
+def extract_model_scopes(
+    repo_root: Path, backend: str, upstream: BackendSchema, allow: Allowlist
+) -> tuple[ModelScope, ...]:
+    """Derive the model-scoped key sets by following the model dispatch. Four things disqualify a
+    field, each meaning it reaches something on other models too: upstream defines the argument;
+    another Primus config class declares it; something reads it off the argument namespace; or a
+    patch or the hand-written allowlist vouches for it globally."""
+    default, branches, source = _model_provider_branches(repo_root, backend)
+    if not branches:
+        return ()
+    key = MODEL_PROVIDERS[backend][2]
+    classes, derived = _primus_config_classes(repo_root, backend)
+
+    owners: dict[str, str] = {}  # config class -> discriminator value
+    for value, module in sorted(branches.items()):
+        config_class = _config_class_of_module(repo_root, module)
+        if config_class is not None and config_class in derived:
+            owners[config_class] = value
+    if not owners:
+        return ()
+
+    # Which models claim each field. `None` stands for a Primus config class no
+    # discriminator selects, so its fields belong to no model in particular.
+    claims: dict[str, set[str | None]] = {}
+    for name in sorted(derived):
+        value = owners.get(name)
+        for field in _class_fields(classes[name]):
+            claims.setdefault(field, set()).add(value)
+    agnostic = _args_namespace_reads(repo_root)
+
+    def is_scoped(field: str, value: str) -> bool:
+        if claims.get(field) != {value} or field in upstream.keys or field in agnostic:
+            return False
+        rule = allow.match(field)
+        # A `backend:` rule is the read that made the key legal in the first
+        # place, and it is exactly what the scope is about. A patch or a
+        # hand-written entry is a claim that the key works everywhere.
+        return rule is None or rule.origin.startswith("backend:")
+
+    scopes = []
+    for config_class, value in sorted(owners.items(), key=lambda item: item[1]):
+        keys = {k for k in _inherited_fields(classes, derived, config_class) if is_scoped(k, value)}
+        if not keys:
+            continue
+        scopes.append(
+            ModelScope(
+                key=key,
+                value=value,
+                default=default,
+                config_class=config_class,
+                keys=frozenset(keys),
+                source=source,
+            )
+        )
+    return tuple(scopes)
+
+
+def build_model_scopes(
+    repo_root: Path, backend: str, allowlist_path: Path | None = None
+) -> tuple[ModelScope, ...]:
+    """``extract_model_scopes`` from a repo root alone; empty when unavailable."""
+    upstream = SCHEMA_LOADERS[backend](repo_root)
+    if upstream is None:
+        return ()
+    allow = build_allowlist(repo_root, backend, allowlist_path)
+    return extract_model_scopes(repo_root, backend, upstream, allow)
+
+
+def extract_custom_args_schema(repo_root: Path) -> tuple[frozenset[str], frozenset[str], str]:
+    """Follow ``experimental.custom_args_module`` and expand the dataclass it names, mirroring
+    ``config_utils.build_job_config_from_namespace``. Returned as schema, not allowlist entries,
+    so unknown keys *inside* an extension section stay reportable."""
+    empty = (frozenset(), frozenset(), "")
+    preset = repo_root / TORCHTITAN_MODULE_PRESET
+    if not preset.is_file():
+        return empty
+    module_path = (parse_yaml(str(preset)).get("experimental") or {}).get("custom_args_module")
+    if not module_path:
+        return empty
+    src = repo_root / (module_path.replace(".", "/") + ".py")
+    if not src.is_file():
+        return empty
+    defs = _dataclass_defs(ast.parse(src.read_text()))
+    keys: set[str] = set()
+    sections: set[str] = set()
+    _expand_dataclass(defs, "JobConfig", "", keys, sections)
+    return frozenset(keys), frozenset(sections), module_path
+
+
+def load_manual_allowlist(path: Path, backend: str) -> list[AllowRule]:
+    """Read the hand-written allowlist; ``reason`` and ``consumer`` are mandatory."""
+    if not path.is_file():
+        return []
+    data = yaml.safe_load(path.read_text()) or {}
+    rules = []
+    for scope in ("common", backend):
+        for entry in data.get(scope) or []:
+            missing = [f for f in ("key", "reason", "consumer") if not entry.get(f)]
+            if missing:
+                raise ValueError(f"{path}: entry {entry!r} is missing required field(s) {missing}")
+            rules.append(
+                AllowRule(
+                    pattern=entry["key"],
+                    reason=entry["reason"],
+                    consumer=entry["consumer"],
+                    origin=f"allowlist:{scope}",
+                )
+            )
+    return rules
+
+
+def check_manual_allowlist_consumers(repo_root: Path, path: Path, backend: str) -> list[str]:
+    """Report allowlist entries whose ``consumer`` no longer backs up the claim: the file must
+    exist and must still mention the key. Line numbers are deliberately not checked -- they rot
+    within weeks and a wrong one says nothing about whether the key is still read."""
+    if not path.is_file():
+        return []
+    data = yaml.safe_load(path.read_text()) or {}
+    problems = []
+    for scope in ("common", backend):
+        for entry in data.get(scope) or []:
+            consumer = str(entry.get("consumer", ""))
+            # Tolerate a legacy "path:line" form by dropping the line number.
+            rel = consumer.split(":", 1)[0].strip()
+            if not rel:
+                continue
+            target = repo_root / rel
+            if not target.is_file():
+                # Submodules are not always checked out; absence proves nothing.
+                if rel.startswith("third_party/"):
+                    continue
+                problems.append(f"{entry['key']}: consumer {rel} does not exist")
+                continue
+            token = entry["key"].split(".", 1)[0].rstrip("*")
+            if token and token not in target.read_text(errors="ignore"):
+                problems.append(f"{entry['key']}: {rel} no longer mentions '{token}'")
+    return problems
+
+
+def build_allowlist(repo_root: Path, backend: str, allowlist_path: Path | None = None) -> Allowlist:
+    path = allowlist_path or (repo_root / DEFAULT_ALLOWLIST)
+    rules = extract_get_param_rules(repo_root, backend)
+    rules += extract_args_read_rules(repo_root, backend)
+    rules += load_manual_allowlist(path, backend)
+    return Allowlist(tuple(rules))
+
+
+def extend_schema(repo_root: Path, backend: str, schema: BackendSchema) -> BackendSchema:
+    """Add the Primus extension sections declared in-tree to an upstream schema."""
+    if backend == "torchtitan":
+        keys, sections, module_path = extract_custom_args_schema(repo_root)
+        return schema.extended(keys, sections, module_path) if module_path else schema
+    keys, source = extract_backend_config_extensions(repo_root, backend)
+    return schema.extended(keys, (), source) if keys else schema
+
+
+def build_schema(repo_root: Path, backend: str) -> BackendSchema | None:
+    """Upstream schema plus the Primus extension sections declared in-tree."""
+    schema = SCHEMA_LOADERS[backend](repo_root)
+    return extend_schema(repo_root, backend, schema) if schema is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    backend: str
+    key: str
+    file: str
+
+
+@dataclass(frozen=True)
+class ScopedFinding:
+    """A key that exists, but not for the model this config selects."""
+
+    backend: str
+    key: str
+    file: str
+    scope: ModelScope
+    actual: str
+
+
+@dataclass(frozen=True)
+class KeyFinding:
+    """All occurrences of one unknown key, collapsed into a single row."""
+
+    backend: str
+    key: str
+    count: int
+    files: tuple[str, ...]
+    suggestion: str | None
+
+
+@dataclass(frozen=True)
+class ScopedKeyFinding:
+    """All occurrences of one misplaced model-scoped key, collapsed into a row."""
+
+    backend: str
+    key: str
+    scope: ModelScope
+    count: int
+    files: tuple[str, ...]
+    models: tuple[str, ...]
+
+    def sample(self, limit: int = 3) -> str:
+        shown = ", ".join(f"`{f}`" for f in self.files[:limit])
+        extra = len(self.files) - limit
+        return f"{shown} (+{extra} more)" if extra > 0 else shown
+
+
+def _walk(
+    node: Any,
+    prefix: str,
+    schema: BackendSchema,
+    allow: Allowlist,
+    out: list[str],
+    leaves: set[str] | None = None,
+) -> None:
+    """Report the shallowest unknown path; never recurse below a bad or known leaf. ``leaves``
+    collects every path the walk settled on, known or not: a scoped key is a *known* one."""
+    if not isinstance(node, dict):
+        return
+    for name, value in node.items():
+        path = f"{prefix}.{name}" if prefix else str(name)
+        if path in schema.sections or (path not in schema.keys and allow.is_prefix(path)):
+            _walk(value, path, schema, allow, out, leaves)
+            continue
+        if leaves is not None:
+            leaves.add(path)
+        if path in schema.keys or allow.match(path):
+            continue
+        out.append(path)
+
+
+def _module_key_sources(doc: dict) -> Iterator[tuple[str, dict, dict]]:
+    """Yield ``(framework, keys, module)`` triples for each module of an experiment YAML."""
+    for module in (doc.get("modules") or {}).values():
+        if not isinstance(module, dict):
+            continue
+        framework = module.get("framework")
+        keys = {k: v for k, v in module.items() if k not in MODULE_RESERVED_KEYS}
+        keys.update(module.get("overrides") or {})
+        yield framework, keys, module
+
+
+def _preset_filename(name: Any) -> str | None:
+    if not isinstance(name, str) or not name:
+        return None
+    return name if name.endswith((".yaml", ".yml")) else f"{name}.yaml"
+
+
+def build_model_preset_index(repo_root: Path, backend: str, key: str) -> dict[str, str | None]:
+    """``<preset file name> -> <its value for key>`` for every model preset. A preset missing from
+    the index is one the scan could not read, not one that leaves ``key`` unset."""
+    index: dict[str, str | None] = {}
+    base = repo_root / MODEL_PRESETS / backend
+    if not base.is_dir():
+        return index
+    for path in sorted(p for p in base.rglob("*.y*ml") if p.is_file()):
+        try:
+            preset = parse_yaml(str(path))
+        except (OSError, ValueError, yaml.YAMLError):
+            continue
+        if not isinstance(preset, dict):
+            continue
+        value = preset.get(key)
+        index[str(path.relative_to(base))] = None if value is None else str(value)
+    return index
+
+
+def _selected_model(
+    keys: dict, module: dict | None, scope: ModelScope, presets: Mapping[str, str | None]
+) -> str | None:
+    """What ``scope.key`` will be at runtime here, or ``None`` when unknowable. An experiment names
+    its model by preset and does not repeat the ``model_type`` the preset declares, so the preset
+    has to be consulted; an unreadable one leaves the answer unknown and nothing is reported."""
+    if scope.key in keys:
+        return str(keys[scope.key])
+    if module is not None:
+        filename = _preset_filename(module.get("model"))
+        if filename is None or filename not in presets:
+            return None
+        declared = presets[filename]
+        if declared is not None:
+            return declared
+    return scope.default
+
+
+def scan_file(
+    path: Path,
+    backend: str,
+    schema: BackendSchema,
+    allow: Allowlist,
+    rel: str,
+    scopes: Sequence[ModelScope] = (),
+    presets: Mapping[str, str | None] | None = None,
+) -> tuple[list[Finding], list[ScopedFinding]]:
+    doc = parse_yaml(str(path))
+    if not isinstance(doc, dict):
+        return [], []
+    unknown: list[str] = []
+    scoped: list[ScopedFinding] = []
+    known_presets = presets if presets is not None else {}
+
+    def check_scopes(keys: dict, module: dict | None, leaves: set[str]) -> None:
+        for scope in scopes:
+            misplaced = sorted(leaves & scope.keys)
+            if not misplaced:
+                continue
+            actual = _selected_model(keys, module, scope, known_presets)
+            if actual is None or actual == scope.value:
+                continue
+            scoped.extend(ScopedFinding(backend, key, rel, scope, actual) for key in misplaced)
+
+    if "modules" in doc:
+        envelope = {k: v for k, v in doc.items() if k != "modules"}
+        for framework, keys, module in _module_key_sources(doc):
+            if framework != backend:
+                continue
+            leaves: set[str] = set()
+            _walk({**envelope, **keys}, "", schema, allow, unknown, leaves)
+            check_scopes({**envelope, **keys}, module, leaves)
+    else:
+        leaves = set()
+        _walk(doc, "", schema, allow, unknown, leaves)
+        check_scopes(doc, None, leaves)
+    # dict.fromkeys: a file with two modules of the same backend must not count twice.
+    return (
+        [Finding(backend, key, rel) for key in dict.fromkeys(unknown)],
+        list(dict.fromkeys(scoped)),
+    )
+
+
+def iter_config_files(repo_root: Path, roots: Iterable[Path]) -> Iterator[Path]:
+    for root in roots:
+        base = root if root.is_absolute() else repo_root / root
+        if base.is_file():
+            yield base
+        elif base.is_dir():
+            yield from sorted(p for p in base.rglob("*.y*ml") if p.is_file())
+
+
+@dataclass(frozen=True)
+class LoadError:
+    """A config the scanner could not read, and therefore did **not** check."""
+
+    file: str
+    message: str
+
+
+def _describe_load_error(path: Path, exc: Exception, repo_root: Path) -> str:
+    """Name the file that is actually missing, not just the one being scanned: a broken
+    ``extends:`` target is the usual cause and the raw error names an un-normalised path."""
+    missing = getattr(exc, "filename", None)
+    if not missing or Path(missing).resolve() == path.resolve():
+        return f"{type(exc).__name__}: {exc}"
+    target = Path(missing).resolve()
+    try:
+        target = target.relative_to(repo_root.resolve())
+    except ValueError:
+        pass  # outside repo_root (e.g. a submodule checkout); report the absolute path instead
+    return f"cannot resolve `{target}` (check the `extends:` paths)"
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    backend: str
+    schema: BackendSchema | None
+    findings: tuple[Finding, ...] = ()
+    scanned: int = 0
+    errors: tuple[LoadError, ...] = ()
+    scoped: tuple[ScopedFinding, ...] = ()
+    scopes: tuple[ModelScope, ...] = ()
+
+    @property
+    def available(self) -> bool:
+        return self.schema is not None
+
+    @property
+    def checked(self) -> int:
+        """Configs actually inspected. Anything that failed to load is not one."""
+        return self.scanned - len(self.errors)
+
+
+def scan_backend(
+    repo_root: Path,
+    backend: str,
+    roots: Iterable[Path] | None = None,
+    allowlist_path: Path | None = None,
+) -> ScanResult:
+    """Scan one backend; ``ScanResult.available`` is False when the submodule is absent."""
+    upstream = SCHEMA_LOADERS[backend](repo_root)
+    if upstream is None:
+        return ScanResult(backend=backend, schema=None)
+    schema = extend_schema(repo_root, backend, upstream)
+    allow = build_allowlist(repo_root, backend, allowlist_path)
+    scopes = extract_model_scopes(repo_root, backend, upstream, allow)
+    # One discriminator per backend, so every scope shares `key`.
+    presets = build_model_preset_index(repo_root, backend, scopes[0].key) if scopes else {}
+    findings: list[Finding] = []
+    scoped: list[ScopedFinding] = []
+    errors: list[LoadError] = []
+    scanned = 0
+    for path in iter_config_files(repo_root, roots if roots is not None else SCAN_ROOTS[backend]):
+        scanned += 1
+        try:
+            rel = str(path.relative_to(repo_root))
+        except ValueError:
+            rel = str(path)
+        # An unreadable config is an unchecked config: record it instead of
+        # raising (no traceback in CI) and instead of ignoring it (no silent pass).
+        try:
+            unknown, misplaced = scan_file(path, backend, schema, allow, rel, scopes, presets)
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            errors.append(LoadError(rel, _describe_load_error(path, exc, repo_root)))
+            continue
+        findings.extend(unknown)
+        scoped.extend(misplaced)
+    return ScanResult(
+        backend=backend,
+        schema=schema,
+        findings=tuple(findings),
+        scanned=scanned,
+        errors=tuple(errors),
+        scoped=tuple(scoped),
+        scopes=scopes,
+    )
+
+
+def dedupe(findings: Sequence[Finding], schema: BackendSchema | None = None) -> list[KeyFinding]:
+    """Collapse per-file findings into one row per key: a single upstream rename shows up in
+    dozens of configs, and the per-key view is the actionable one. Widest blast radius first, and
+    ``(backend, key)`` is unique per row, so the order is total and does not depend on the order
+    the findings arrived in."""
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for finding in findings:
+        grouped.setdefault((finding.backend, finding.key), []).append(finding.file)
+    rows = [
+        KeyFinding(
+            backend=backend,
+            key=key,
+            count=len(files),
+            files=tuple(sorted(set(files))),
+            suggestion=schema.suggest(key) if schema is not None else None,
+        )
+        for (backend, key), files in grouped.items()
+    ]
+    return sorted(rows, key=lambda r: (r.backend, -r.count, r.key))
+
+
+def dedupe_scoped(findings: Sequence[ScopedFinding]) -> list[ScopedKeyFinding]:
+    """Collapse per-file scoped findings into one row per key, carrying the models it was wrongly
+    set on: deleting the key and moving it are different fixes."""
+    grouped: dict[tuple[str, str, ModelScope], list[ScopedFinding]] = {}
+    for finding in findings:
+        grouped.setdefault((finding.backend, finding.key, finding.scope), []).append(finding)
+    rows = [
+        ScopedKeyFinding(
+            backend=backend,
+            key=key,
+            scope=scope,
+            count=len(found),
+            files=tuple(sorted({f.file for f in found})),
+            models=tuple(sorted({f.actual for f in found})),
+        )
+        for (backend, key, scope), found in grouped.items()
+    ]
+    return sorted(rows, key=lambda r: (r.backend, -r.count, r.key))

--- a/primus/core/config/yaml_loader.py
+++ b/primus/core/config/yaml_loader.py
@@ -139,6 +139,8 @@ def _apply_extends(path: str, cfg: dict):
           - preset1.yaml
           - preset2.yaml
 
+    A lone preset may also be given as a scalar: ``extends: preset1.yaml``.
+
     merge order:
         result = deep_merge(preset1, preset2)
         result = deep_merge(result, current_cfg)
@@ -148,7 +150,14 @@ def _apply_extends(path: str, cfg: dict):
 
     merged = {}
 
-    for ext in cfg["extends"]:
+    extends = cfg["extends"]
+    # A single preset may be written as a scalar. Without this, iterating the
+    # string walks it character by character and reports a missing file named
+    # after its first letter.
+    if isinstance(extends, str):
+        extends = [extends]
+
+    for ext in extends:
         ext_path = os.path.join(os.path.dirname(path), ext)
         ext_cfg = parse_yaml(ext_path)
         merged = deep_merge(merged, ext_cfg)  # later preset overrides earlier

--- a/tests/unit_tests/configs/test_config_schema_check.py
+++ b/tests/unit_tests/configs/test_config_schema_check.py
@@ -1,0 +1,1305 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the backend config schema drift scanner.
+
+Most tests run against a synthetic repo built in ``tmp_path`` so they neither
+need the ``third_party/`` submodules nor break when upstream moves a field.
+A few tests do touch the real tree, because they guard the failure modes that
+motivated the scanner:
+
+* ``training.mock_data`` must be derived automatically from the patch system
+  (it is a Primus-only field; a previous audit wrongly called it dead code);
+* ``primus_turbo`` must be derived from ``experimental.custom_args_module``;
+* ``train_iters`` and friends must come out of Megatron's generated arguments,
+  because reading its literal ``add_argument`` calls alone would report roughly
+  half of every valid Megatron config as drift;
+* ``norm_epsilon`` must come out as scoped to DeepSeek-V4, and no DeepSeek-V4
+  config may be reported for setting it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from primus.core.config.schema_check import (
+    Allowlist,
+    AllowRule,
+    Finding,
+    KeyFinding,
+    ScopedFinding,
+    build_allowlist,
+    build_model_scopes,
+    build_schema,
+    check_manual_allowlist_consumers,
+    dedupe,
+    dedupe_scoped,
+    extract_args_read_rules,
+    extract_backend_config_extensions,
+    extract_custom_args_schema,
+    extract_get_param_rules,
+    load_manual_allowlist,
+    load_maxtext_schema,
+    load_megatron_schema,
+    load_torchtitan_schema,
+    scan_backend,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_JOB_CONFIG_SRC = """
+# Upstream imports torch at module scope, which is why the scanner must use AST.
+import torch
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Training:
+    seq_len: int = 2048
+    steps: int = 10000
+
+
+@dataclass
+class Debug:
+    seed: int | None = None
+    moe_force_load_balance: bool = False
+
+
+@dataclass
+class Float8Linear:
+    filter_fqns: list[str] = field(default_factory=list)
+
+
+@dataclass
+class QuantizedLinear:
+    float8: Float8Linear = field(default_factory=Float8Linear)
+
+
+@dataclass
+class Quantize:
+    linear: QuantizedLinear = field(default_factory=QuantizedLinear)
+
+
+class NotADataclass:
+    ignored: int = 0
+
+
+@dataclass
+class Experimental:
+    custom_args_module: str = ""
+
+
+@dataclass
+class JobConfig:
+    training: Training = field(default_factory=Training)
+    debug: Debug = field(default_factory=Debug)
+    quantize: Quantize = field(default_factory=Quantize)
+    experimental: Experimental = field(default_factory=Experimental)
+"""
+
+_CONFIG_EXTENSION_SRC = """
+from dataclasses import dataclass, field
+
+from torchtitan.config.job_config import JobConfig as TTJobConfig
+
+
+@dataclass
+class PrimusTurboConfig:
+    enable_primus_turbo: bool = False
+    use_turbo_attention: bool = False
+
+
+@dataclass
+class JobConfig(TTJobConfig):
+    primus_turbo: PrimusTurboConfig = field(default_factory=PrimusTurboConfig)
+"""
+
+_PATCH_SRC = """
+from primus.core.patches import get_param, register_patch
+
+
+@register_patch(patch_id="fake", backend="torchtitan", phase="setup")
+def fake_patch(ctx):
+    if get_param(ctx, "training.mock_data", False):
+        return get_param(ctx, "primus_turbo.enable_primus_turbo", False)
+    return None
+"""
+
+_ALLOWLIST_SRC = """
+common:
+  - key: work_group
+    reason: Primus envelope.
+    consumer: primus/core/launcher/parser.py:211
+  - key: user_name
+    reason: Primus envelope.
+    consumer: primus/core/launcher/parser.py:212
+  - key: exp_name
+    reason: Primus envelope.
+    consumer: primus/core/launcher/parser.py:213
+torchtitan:
+  - key: model.*
+    reason: Model-arg override, validated at runtime.
+    consumer: primus/backends/torchtitan/patches/model_override_patches.py:273
+"""
+
+
+_MEGATRON_ARGUMENTS_SRC = """
+# Upstream imports torch at module scope, which is why the scanner must use AST.
+import torch
+
+from megatron.core.transformer import MLATransformerConfig, TransformerConfig
+from megatron.training.argument_utils import ArgumentGroupFactory
+
+
+def add_megatron_arguments(parser):
+    group = parser.add_argument_group(title="core")
+    group.add_argument("--seq-length", type=int, default=None)
+    group.add_argument("--num-experts", type=int, default=None)
+    # An explicit dest is the only thing that keeps this off `no_persist_layer_norm`.
+    group.add_argument("--no-persist-layer-norm", action="store_false", dest="persist_layer_norm")
+
+    # Upstream builds this list in code rather than inline.
+    exclude = [
+        "moe_token_dropping",
+        "gradient_accumulation_fusion",
+    ]
+    ArgumentGroupFactory(TransformerConfig, exclude=exclude).build_group(parser, "transformer")
+
+    from megatron.training.config import LoggerConfig, TrainingConfig
+
+    ArgumentGroupFactory(TrainingConfig).build_group(parser, "training")
+    ArgumentGroupFactory(LoggerConfig, exclude=["memory_keys"]).build_group(parser, "logging")
+    return parser
+
+
+def core_transformer_config_from_args(args, config_class=None):
+    config_class = config_class or TransformerConfig
+    if args.multi_latent_attention:
+        config_class = MLATransformerConfig
+    return config_class(**{f.name: getattr(args, f.name) for f in dataclasses.fields(config_class)})
+"""
+
+_MEGATRON_TRAINING_CONFIG_SRC = """
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TrainingConfig:
+    train_iters: int | None = None
+    global_batch_size: int | None = None
+    micro_batch_size: int = 1
+    # Derived after parsing, so ArgumentGroupFactory skips it.
+    computed_batches: int | None = field(init=False, default=None)
+
+
+@dataclass
+class LoggerConfig:
+    log_interval: int = 100
+    memory_keys: dict | None = None
+    use_nsys_profiler: bool = field(
+        default=False, metadata={"argparse_meta": {"arg_names": ["--profile"], "dest": "profile"}}
+    )
+"""
+
+_MEGATRON_TRANSFORMER_CONFIG_SRC = """
+from dataclasses import dataclass
+
+from ..model_parallel_config import ModelParallelConfig
+
+
+@dataclass
+class TransformerConfig(ModelParallelConfig):
+    num_layers: int = 0
+    moe_token_dropping: bool = False
+    gradient_accumulation_fusion: bool = True
+
+
+@dataclass
+class MLATransformerConfig(TransformerConfig):
+    q_lora_rank: int | None = None
+"""
+
+_MEGATRON_PATCH_SRC = """
+import os
+
+from primus.core.patches import get_args, register_patch
+
+_PARAM_NAME = "dataloader_mp_context"
+
+
+@register_patch(patch_id="fake", backend="megatron", phase="setup")
+def fake_patch(ctx, tensor):
+    # An attribute of something that is not an args object must stay out.
+    _ = tensor.shape
+    os.environ["HSA_NO_SCRATCH_RECLAIM"] = "1"
+    if getattr(get_args(ctx), "use_turbo_attention", False):
+        return get_args(ctx).log_avg_skip_iterations
+    return getattr(get_args(ctx), _PARAM_NAME, None)
+"""
+
+_MEGATRON_CONFIG_EXTENSION_SRC = """
+from dataclasses import dataclass
+
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+
+
+@dataclass
+class PrimusBaseConfig(MLATransformerConfig):
+    norm_epsilon: float | None = None
+
+
+@dataclass
+class PrimusChildConfig(PrimusBaseConfig):
+    conv_bias: bool = False
+"""
+
+# The config class of one model, holding one field of each kind the scope
+# derivation has to tell apart.
+_MEGATRON_SCOPED_CONFIG_SRC = """
+from dataclasses import dataclass
+
+from megatron.core.transformer.transformer_config import MLATransformerConfig
+
+
+@dataclass
+class FakeV4TransformerConfig(MLATransformerConfig):
+    hash_routing_seed: int = 0
+    attn_sink: bool = False
+    # Upstream defines this one, so every model gets it from `args`.
+    num_layers: int = 0
+    # A config class no model selects declares this one too.
+    conv_bias: bool = False
+    # A patch reads this one off `args`, which every model has.
+    index_topk: int = 0
+    # The hand-written allowlist vouches for this one everywhere.
+    swiglu_limit: float = 0.0
+"""
+
+_MEGATRON_SCOPED_BUILDER_SRC = """
+from megatron.training.arguments import core_transformer_config_from_args
+
+from .fake_v4_config import FakeV4TransformerConfig
+
+
+def fake_v4_builder(args, pre_process, post_process, config=None):
+    if config is None:
+        config = core_transformer_config_from_args(args, config_class=FakeV4TransformerConfig)
+    return config
+"""
+
+# Mirrors the real dispatch: the branch that names a Primus module outright is
+# the one that leads to a Primus config class; the others reach upstream.
+_MODEL_PROVIDER_SRC = """
+import importlib
+from functools import partial
+
+
+def get_model_provider(model_type="gpt"):
+    if model_type == "fake_v4":
+        module = importlib.import_module(
+            "primus.backends.megatron.core.models.fake_v4.fake_v4_builders"
+        )
+        return partial(module.model_provider, module.fake_v4_builder)
+    if model_type == "mamba":
+        return lazy_import(["model_provider", "pretrain_mamba"], "model_provider")
+    return lazy_import(["model_provider", "pretrain_gpt"], "model_provider")
+"""
+
+_MEGATRON_SCOPE_PATCH_SRC = """
+from primus.core.patches import get_args, register_patch
+
+
+@register_patch(patch_id="fake_flops", backend="megatron", phase="setup")
+def fake_flops_patch(ctx):
+    if get_args(ctx).model_type == "fake_v4":
+        # A read off the args namespace, which every model has: not model-scoped.
+        return get_args(ctx).index_topk
+    return None
+"""
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip())
+    return path
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """A minimal repo with both submodules, a patch, and an extension dataclass."""
+    _write(tmp_path / "third_party/torchtitan/torchtitan/config/job_config.py", _JOB_CONFIG_SRC)
+    _write(
+        tmp_path / "third_party/maxtext/src/maxtext/configs/base.yml",
+        "run_name: ''\nsteps: 10\nper_device_batch_size: 1\n",
+    )
+    _write(
+        tmp_path / "primus/backends/torchtitan/primus_turbo_extensions/config_extension.py",
+        _CONFIG_EXTENSION_SRC,
+    )
+    _write(tmp_path / "primus/backends/torchtitan/patches/fake_patches.py", _PATCH_SRC)
+    _write(
+        tmp_path / "primus/configs/modules/torchtitan/pre_trainer.yaml",
+        """
+        experimental:
+          custom_args_module: "primus.backends.torchtitan.primus_turbo_extensions.config_extension"
+        training:
+          mock_data: true
+        """,
+    )
+    _write(tmp_path / "tools/ci/config_schema_allowlist.yaml", _ALLOWLIST_SRC)
+    return tmp_path
+
+
+@pytest.fixture
+def megatron_repo(tmp_path: Path) -> Path:
+    """A minimal repo whose Megatron mirrors the parts the scanner has to read.
+
+    Namely: config dataclasses reached through a re-export, a base class in
+    another package, an ``exclude`` list built in code, an ``init=False`` field
+    and an ``argparse_meta`` dest override.
+    """
+    megatron = tmp_path / "third_party/Megatron-LM/megatron"
+    _write(megatron / "training/arguments.py", _MEGATRON_ARGUMENTS_SRC)
+    _write(
+        megatron / "training/config/__init__.py",
+        "from megatron.training.config.training_config import LoggerConfig, TrainingConfig\n",
+    )
+    _write(megatron / "training/config/training_config.py", _MEGATRON_TRAINING_CONFIG_SRC)
+    _write(
+        megatron / "core/transformer/__init__.py",
+        "from .transformer_config import MLATransformerConfig, TransformerConfig\n",
+    )
+    _write(megatron / "core/transformer/transformer_config.py", _MEGATRON_TRANSFORMER_CONFIG_SRC)
+    _write(
+        megatron / "core/model_parallel_config.py",
+        "from dataclasses import dataclass\n\n\n"
+        "@dataclass\nclass ModelParallelConfig:\n"
+        "    tensor_model_parallel_size: int = 1\n    timers: object = None\n",
+    )
+    _write(tmp_path / "primus/backends/megatron/patches/fake_patches.py", _MEGATRON_PATCH_SRC)
+    _write(tmp_path / "primus/backends/megatron/patches/fake_flops_patches.py", _MEGATRON_SCOPE_PATCH_SRC)
+    _write(
+        tmp_path / "primus/backends/megatron/core/models/fake_config.py",
+        _MEGATRON_CONFIG_EXTENSION_SRC,
+    )
+    _write(
+        tmp_path / "primus/backends/megatron/core/models/fake_v4/fake_v4_config.py",
+        _MEGATRON_SCOPED_CONFIG_SRC,
+    )
+    _write(
+        tmp_path / "primus/backends/megatron/core/models/fake_v4/fake_v4_builders.py",
+        _MEGATRON_SCOPED_BUILDER_SRC,
+    )
+    _write(tmp_path / "primus/core/utils/import_utils.py", _MODEL_PROVIDER_SRC)
+    _write(tmp_path / "primus/configs/models/megatron/fake_v4.yaml", "model_type: fake_v4\nnum_layers: 2\n")
+    _write(tmp_path / "primus/configs/models/megatron/plain.yaml", "num_layers: 2\n")
+    _write(
+        tmp_path / "tools/ci/config_schema_allowlist.yaml",
+        "common:\n"
+        "  - key: work_group\n"
+        "    reason: Primus envelope.\n"
+        "    consumer: primus/core/launcher/parser.py\n"
+        "megatron:\n"
+        "  - key: swiglu_limit\n"
+        "    reason: Read by every MoE model, not just this one.\n"
+        "    consumer: primus/core/launcher/parser.py\n",
+    )
+    _write(tmp_path / "primus/core/launcher/parser.py", "cfg.work_group, cfg.swiglu_limit\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Schema extraction
+# ---------------------------------------------------------------------------
+
+
+def test_torchtitan_schema_extracted_from_ast(fake_repo: Path):
+    schema = load_torchtitan_schema(fake_repo)
+
+    assert schema is not None
+    assert schema.sections == {
+        "training",
+        "debug",
+        "quantize",
+        "quantize.linear",
+        "quantize.linear.float8",
+        "experimental",
+    }
+    assert schema.keys == {
+        "training.seq_len",
+        "training.steps",
+        "debug.seed",
+        "debug.moe_force_load_balance",
+        "quantize.linear.float8.filter_fqns",
+        "experimental.custom_args_module",
+    }
+    # A plain class must not leak into the schema.
+    assert not any(k.startswith("ignored") for k in schema.keys)
+
+
+def test_maxtext_schema_is_flat(fake_repo: Path):
+    schema = load_maxtext_schema(fake_repo)
+
+    assert schema is not None
+    assert schema.keys == {"run_name", "steps", "per_device_batch_size"}
+    assert schema.sections == frozenset()
+
+
+def test_schema_suggests_where_a_moved_key_went(fake_repo: Path):
+    schema = load_torchtitan_schema(fake_repo)
+
+    assert schema.suggest("training.seed") == "debug.seed"
+    # Upstream drops the section-name prefix when it moves a field into a section.
+    assert schema.suggest("training.debug_moe_force_load_balance") == "debug.moe_force_load_balance"
+    assert schema.suggest("training.no_such_thing_anywhere") is None
+
+
+def test_missing_submodule_yields_no_schema(tmp_path: Path):
+    assert load_torchtitan_schema(tmp_path) is None
+    assert load_maxtext_schema(tmp_path) is None
+    assert load_megatron_schema(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Megatron schema extraction
+# ---------------------------------------------------------------------------
+
+
+def test_megatron_schema_joins_literal_and_generated_arguments(megatron_repo: Path):
+    schema = load_megatron_schema(megatron_repo)
+
+    assert schema is not None
+    assert schema.sections == frozenset()  # Megatron's namespace is flat.
+    # The literal `add_argument` half.
+    assert {"seq_length", "num_experts"} <= schema.keys
+    # The ArgumentGroupFactory half, which is where the most-used names live.
+    assert {"train_iters", "global_batch_size", "micro_batch_size", "log_interval"} <= schema.keys
+    # A field's base class contributes too: TransformerConfig(ModelParallelConfig).
+    assert {"tensor_model_parallel_size", "timers"} <= schema.keys
+
+
+def test_megatron_factory_exclude_list_is_honoured(megatron_repo: Path):
+    """`memory_keys` is excluded from LoggerConfig, so no argument carries it."""
+    schema = load_megatron_schema(megatron_repo)
+
+    assert "log_interval" in schema.keys
+    assert "memory_keys" not in schema.keys
+
+
+def test_megatron_transformer_config_keeps_its_excluded_fields(megatron_repo: Path):
+    """`core_transformer_config_from_args` copies every field off `args`.
+
+    So a TransformerConfig field stays a legal key even where the factory
+    excludes it from argparse -- unlike LoggerConfig, which nothing builds from
+    `args`.
+    """
+    schema = load_megatron_schema(megatron_repo)
+
+    assert {"moe_token_dropping", "gradient_accumulation_fusion"} <= schema.keys
+    # MLATransformerConfig is the other class that function can pick.
+    assert "q_lora_rank" in schema.keys
+
+
+def test_megatron_derived_fields_are_not_arguments(megatron_repo: Path):
+    """`field(init=False)` is computed after parsing; `build_group` skips it."""
+    assert "computed_batches" not in load_megatron_schema(megatron_repo).keys
+
+
+def test_megatron_argparse_meta_dest_wins_over_the_field_name(megatron_repo: Path):
+    """`use_nsys_profiler` reaches `args` as `profile`, so only `profile` is legal."""
+    schema = load_megatron_schema(megatron_repo)
+
+    assert "profile" in schema.keys
+    assert "use_nsys_profiler" not in schema.keys
+
+
+def test_megatron_explicit_dest_wins_over_the_option_name(megatron_repo: Path):
+    """`--no-persist-layer-norm dest=persist_layer_norm` must not yield both."""
+    schema = load_megatron_schema(megatron_repo)
+
+    assert "persist_layer_norm" in schema.keys
+    assert "no_persist_layer_norm" not in schema.keys
+
+
+def test_megatron_suggests_a_renamed_argument(megatron_repo: Path):
+    """A flat namespace renames in place, by adding a prefix or a suffix."""
+    schema = load_megatron_schema(megatron_repo)
+
+    assert schema.suggest("layers") == "num_layers"
+    assert schema.suggest("nothing_like_this") is None
+
+
+# ---------------------------------------------------------------------------
+# Allowlist derivation
+# ---------------------------------------------------------------------------
+
+
+def test_get_param_paths_are_derived_from_patches(fake_repo: Path):
+    rules = extract_get_param_rules(fake_repo, "torchtitan")
+
+    patterns = {r.pattern for r in rules}
+    assert patterns == {"training.mock_data", "primus_turbo.enable_primus_turbo"}
+    assert all(r.consumer.startswith("primus/backends/torchtitan/patches/") for r in rules)
+
+
+def test_custom_args_module_is_followed(fake_repo: Path):
+    keys, sections, module_path = extract_custom_args_schema(fake_repo)
+
+    assert module_path.endswith("config_extension")
+    assert sections == {"primus_turbo"}
+    assert keys == {"primus_turbo.enable_primus_turbo", "primus_turbo.use_turbo_attention"}
+
+
+def test_extension_section_stays_checked(fake_repo: Path):
+    """`primus_turbo` is a section, not an opaque wildcard: bad children still fail."""
+    schema = build_schema(fake_repo, "torchtitan")
+
+    assert "primus_turbo" in schema.sections
+    assert "primus_turbo.use_turbo_attention" in schema.keys
+    assert "primus_turbo.nonexistent" not in schema.keys
+
+
+def test_megatron_args_reads_are_derived_from_the_backend_package(megatron_repo: Path):
+    rules = extract_args_read_rules(megatron_repo, "megatron")
+    patterns = {r.pattern for r in rules}
+
+    assert "use_turbo_attention" in patterns  # getattr(args, "<name>", default)
+    assert "log_avg_skip_iterations" in patterns  # get_args(ctx).<name>
+    assert "dataloader_mp_context" in patterns  # read through a module constant
+    # An attribute of something that is not an args object is not a config key.
+    assert "shape" not in patterns
+    # Neither is an environment variable, so a config that sets one still fails.
+    assert "HSA_NO_SCRATCH_RECLAIM" not in patterns
+    assert all(r.consumer.startswith("primus/backends/megatron/") for r in rules)
+
+
+def test_megatron_config_extension_fields_are_schema(megatron_repo: Path):
+    """A Primus TransformerConfig subclass widens the key set, transitively."""
+    keys, source = extract_backend_config_extensions(megatron_repo, "megatron")
+
+    assert source == "primus/backends/megatron"
+    assert {"norm_epsilon", "conv_bias"} <= keys
+    schema = build_schema(megatron_repo, "megatron")
+    assert {"norm_epsilon", "conv_bias"} <= schema.keys
+
+
+# ---------------------------------------------------------------------------
+# Model scopes
+# ---------------------------------------------------------------------------
+
+
+def test_model_scope_is_read_off_the_model_dispatch(megatron_repo: Path):
+    """`get_model_provider` is what decides the model, so it is what we follow."""
+    scopes = build_model_scopes(megatron_repo, "megatron")
+
+    assert len(scopes) == 1
+    scope = scopes[0]
+    assert (scope.key, scope.value, scope.default) == ("model_type", "fake_v4", "gpt")
+    assert scope.config_class == "FakeV4TransformerConfig"
+    assert scope.source == "primus/core/utils/import_utils.py"
+
+
+def test_only_a_field_nothing_else_explains_is_model_scoped(megatron_repo: Path):
+    """Four kinds of field share the scoped class and none of them is scoped."""
+    scope = build_model_scopes(megatron_repo, "megatron")[0]
+
+    assert scope.keys == {"hash_routing_seed", "attn_sink"}
+    assert "num_layers" not in scope.keys  # upstream defines it for every model
+    assert "conv_bias" not in scope.keys  # a config class no model selects has it too
+    assert "index_topk" not in scope.keys  # a patch reads it off `args`
+    assert "swiglu_limit" not in scope.keys  # the hand-written allowlist vouches for it
+
+
+def test_no_model_dispatch_means_no_scopes(fake_repo: Path):
+    """TorchTitan has no such dispatch; the check must simply not look for one."""
+    assert build_model_scopes(fake_repo, "torchtitan") == ()
+
+
+def test_a_scoped_key_on_another_model_is_reported(megatron_repo: Path):
+    _write(
+        megatron_repo / "examples/megatron/configs/other_model.yaml",
+        """
+        work_group: amd
+        modules:
+          pre_trainer:
+            framework: megatron
+            config: pre_trainer.yaml
+            model: plain.yaml
+            overrides:
+              train_iters: 50
+              hash_routing_seed: 7
+        """,
+    )
+
+    result = scan_backend(megatron_repo, "megatron")
+
+    assert result.findings == ()  # the key is not unknown, only misplaced
+    misplaced = [f for f in result.scoped if f.file.endswith("other_model.yaml")]
+    assert [(f.key, f.actual) for f in misplaced] == [("hash_routing_seed", "gpt")]
+    assert misplaced[0].scope.describe() == "model_type: fake_v4"
+
+
+def test_a_scoped_key_on_its_own_model_is_not_reported(megatron_repo: Path):
+    """The `model_type` lives in the model preset, not in the experiment YAML."""
+    _write(
+        megatron_repo / "examples/megatron/configs/right_model.yaml",
+        """
+        work_group: amd
+        modules:
+          pre_trainer:
+            framework: megatron
+            config: pre_trainer.yaml
+            model: fake_v4.yaml
+            overrides:
+              hash_routing_seed: 7
+        """,
+    )
+
+    result = scan_backend(megatron_repo, "megatron")
+
+    assert result.scoped == ()
+
+
+def test_an_experiment_may_override_the_model_type_itself(megatron_repo: Path):
+    _write(
+        megatron_repo / "examples/megatron/configs/override.yaml",
+        """
+        work_group: amd
+        modules:
+          pre_trainer:
+            framework: megatron
+            config: pre_trainer.yaml
+            model: plain.yaml
+            overrides:
+              model_type: fake_v4
+              hash_routing_seed: 7
+        """,
+    )
+
+    assert scan_backend(megatron_repo, "megatron").scoped == ()
+
+
+def test_an_unreadable_model_preset_reports_nothing(megatron_repo: Path):
+    """Guessing here would report the one config where the key belongs."""
+    _write(
+        megatron_repo / "examples/megatron/configs/unknown_model.yaml",
+        """
+        work_group: amd
+        modules:
+          pre_trainer:
+            framework: megatron
+            config: pre_trainer.yaml
+            model: not_a_preset.yaml
+            overrides:
+              hash_routing_seed: 7
+        """,
+    )
+
+    assert scan_backend(megatron_repo, "megatron").scoped == ()
+
+
+def test_a_model_preset_of_its_own_is_judged_on_what_it_declares(megatron_repo: Path):
+    """A preset that omits `model_type` gets the dispatch default, which is `gpt`."""
+    _write(megatron_repo / "primus/configs/models/megatron/stray.yaml", "attn_sink: true\n")
+    _write(
+        megatron_repo / "primus/configs/models/megatron/scoped.yaml", "model_type: fake_v4\nattn_sink: true\n"
+    )
+
+    result = scan_backend(megatron_repo, "megatron")
+
+    assert [(f.file, f.key, f.actual) for f in result.scoped] == [
+        ("primus/configs/models/megatron/stray.yaml", "attn_sink", "gpt")
+    ]
+
+
+def test_dedupe_scoped_collapses_one_key_across_files(megatron_repo: Path):
+    scope = build_model_scopes(megatron_repo, "megatron")[0]
+    findings = [ScopedFinding("megatron", "attn_sink", f"cfg{i}.yaml", scope, "gpt") for i in range(4)]
+    findings.append(ScopedFinding("megatron", "attn_sink", "cfg4.yaml", scope, "mamba"))
+
+    rows = dedupe_scoped(findings)
+
+    assert len(rows) == 1
+    assert (rows[0].key, rows[0].count, rows[0].models) == ("attn_sink", 5, ("gpt", "mamba"))
+    assert rows[0].sample(2) == "`cfg0.yaml`, `cfg1.yaml` (+3 more)"
+
+
+def test_manual_allowlist_requires_reason_and_consumer(tmp_path: Path):
+    path = _write(tmp_path / "allow.yaml", "common:\n  - key: foo\n    reason: because\n")
+
+    with pytest.raises(ValueError, match="consumer"):
+        load_manual_allowlist(path, "torchtitan")
+
+
+def test_manual_allowlist_scopes_are_merged(fake_repo: Path):
+    allow = build_allowlist(fake_repo, "torchtitan")
+
+    assert allow.match("work_group") is not None
+    assert allow.match("model.n_layers").pattern == "model.*"
+    assert allow.match("training.mock_data").origin == "patch:get_param"
+    assert allow.match("nope") is None
+
+
+def test_allowlist_entry_is_flagged_once_its_consumer_stops_reading_it(tmp_path: Path):
+    _write(tmp_path / "primus/core/launcher/parser.py", "cfg.work_group = x\n")
+    path = _write(
+        tmp_path / "allow.yaml",
+        "common:\n"
+        "  - key: work_group\n"
+        "    reason: still read\n"
+        "    consumer: primus/core/launcher/parser.py\n"
+        "  - key: removed_key\n"
+        "    reason: stale\n"
+        "    consumer: primus/core/launcher/parser.py\n",
+    )
+
+    problems = check_manual_allowlist_consumers(tmp_path, path, "torchtitan")
+
+    assert len(problems) == 1
+    assert "removed_key" in problems[0]
+
+
+def test_allowlist_entry_is_flagged_once_its_consumer_file_is_gone(tmp_path: Path):
+    path = _write(
+        tmp_path / "allow.yaml",
+        "common:\n  - key: foo\n    reason: r\n    consumer: primus/core/deleted.py\n",
+    )
+
+    problems = check_manual_allowlist_consumers(tmp_path, path, "torchtitan")
+
+    assert len(problems) == 1 and "does not exist" in problems[0]
+
+
+def test_a_line_number_left_on_a_consumer_does_not_break_the_check(tmp_path: Path):
+    """The path is what gets verified, so a legacy `path:line` must still pass."""
+    _write(tmp_path / "primus/core/launcher/parser.py", "cfg.work_group = x\n")
+    path = _write(
+        tmp_path / "allow.yaml",
+        "common:\n"
+        "  - key: work_group\n"
+        "    reason: r\n"
+        "    consumer: primus/core/launcher/parser.py:211\n",
+    )
+
+    assert check_manual_allowlist_consumers(tmp_path, path, "torchtitan") == []
+
+
+def test_an_unchecked_out_submodule_is_not_reported_as_a_stale_consumer(tmp_path: Path):
+    """Absence of a submodule proves nothing about the entry, so stay quiet."""
+    path = _write(
+        tmp_path / "allow.yaml",
+        "maxtext:\n  - key: base_config\n    reason: r\n    consumer: third_party/maxtext/x.py\n",
+    )
+
+    assert check_manual_allowlist_consumers(tmp_path, path, "maxtext") == []
+
+
+def test_the_shipped_allowlist_entries_are_all_still_backed():
+    for backend in ("torchtitan", "maxtext", "megatron"):
+        problems = check_manual_allowlist_consumers(
+            _REPO_ROOT, _REPO_ROOT / "tools/ci/config_schema_allowlist.yaml", backend
+        )
+        assert problems == []
+
+
+def test_real_repo_derives_primus_only_fields():
+    """Regression guard: these must never be reported as drift."""
+    allow = build_allowlist(_REPO_ROOT, "torchtitan")
+    schema = build_schema(_REPO_ROOT, "torchtitan")
+    if schema is None:
+        pytest.skip("third_party/torchtitan is not checked out")
+
+    mock_data = allow.match("training.mock_data")
+    assert mock_data is not None and mock_data.origin == "patch:get_param"
+    assert "primus_turbo" in schema.sections
+    assert "primus_turbo.enable_primus_turbo" in schema.keys
+
+
+def test_real_repo_megatron_schema_holds_the_generated_arguments():
+    """Guard the half of Megatron's namespace that no `add_argument` call names."""
+    schema = build_schema(_REPO_ROOT, "megatron")
+    if schema is None:
+        pytest.skip("third_party/Megatron-LM is not checked out")
+
+    assert {"train_iters", "global_batch_size", "micro_batch_size", "log_interval"} <= schema.keys
+    assert {"seq_length", "lr", "num_experts"} <= schema.keys  # the literal half
+    assert len(schema.keys) > 600
+
+
+def test_real_repo_derives_primus_only_megatron_fields():
+    """Regression guard: these must never be reported as drift."""
+    allow = build_allowlist(_REPO_ROOT, "megatron")
+
+    for key in ("use_turbo_attention", "log_avg_skip_iterations", "enable_zero_bubble", "odc_gda_pipe"):
+        rule = allow.match(key)
+        assert rule is not None and rule.origin.startswith("backend:"), key
+
+
+def test_real_repo_scopes_norm_epsilon_to_deepseek_v4():
+    """The case this feature exists for.
+
+    `norm_epsilon` is not a Megatron argparse dest -- `layernorm_epsilon` is, and
+    it merely declares `--norm-epsilon` as its flag. Only
+    `DeepSeekV4TransformerConfig` gives the yaml key a field to land in.
+    """
+    scopes = build_model_scopes(_REPO_ROOT, "megatron")
+    if not scopes:
+        pytest.skip("third_party/Megatron-LM is not checked out")
+
+    by_value = {scope.value: scope for scope in scopes}
+    assert "deepseek_v4" in by_value
+    scope = by_value["deepseek_v4"]
+    assert (scope.key, scope.default) == ("model_type", "gpt")
+    assert scope.config_class == "DeepSeekV4TransformerConfig"
+    assert "norm_epsilon" in scope.keys
+    # A field read off `args` by code every model runs is not this model's.
+    assert "moe_use_legacy_grouped_gemm" not in scope.keys
+
+
+def test_real_repo_never_scopes_the_hand_assembled_flux_fields():
+    """`FluxConfig` is assembled by `FluxPretrainTrainer`, not by the dispatch.
+
+    It never reaches `core_transformer_config_from_args`, and its trainer class
+    appears in no model preset, so no `model_type` value owns its fields and
+    they stay legal on the backend as a whole. Should scoping ever start
+    attributing an unowned config class to some model, every diffusion preset in
+    the tree gets reported for keys it does read.
+    """
+    result = scan_backend(_REPO_ROOT, "megatron")
+    if not result.available:
+        pytest.skip("third_party/Megatron-LM is not checked out")
+
+    assert result.scopes, "the model dispatch no longer resolves"
+    # Declared by `FluxConfig` and `BaseDiffusionConfig`, by nothing upstream.
+    diffusion_fields = {
+        "num_joint_layers",
+        "num_single_layers",
+        "context_dim",
+        "vec_in_dim",
+        "guidance_embed",
+        "single_block_bias",
+        "sensitive_layers_enabled",
+        "fp8_scaling_strategy",
+    }
+    for scope in result.scopes:
+        assert diffusion_fields.isdisjoint(scope.keys), scope.config_class
+    assert [f.key for f in result.scoped if f.key in diffusion_fields] == []
+    assert [f.file for f in result.scoped if "diffusion" in f.file] == []
+
+
+def test_real_repo_never_reports_a_scoped_key_on_the_model_it_belongs_to():
+    """The false-positive guard: DeepSeek-V4's own configs set every V4 key there is."""
+    result = scan_backend(_REPO_ROOT, "megatron")
+    if not result.available:
+        pytest.skip("third_party/Megatron-LM is not checked out")
+
+    assert result.scopes, "the model dispatch no longer resolves"
+    for finding in result.scoped:
+        assert finding.actual != finding.scope.value
+    assert [f.file for f in result.scoped if "deepseek_v4" in f.file] == []
+
+
+# ---------------------------------------------------------------------------
+# Scanning and reporting
+# ---------------------------------------------------------------------------
+
+
+def _exp_yaml(overrides: str) -> str:
+    return (
+        textwrap.dedent(
+            """
+            work_group: ${PRIMUS_TEAM:amd}
+            user_name: root
+            exp_name: probe
+            modules:
+              pre_trainer:
+                framework: torchtitan
+                config: pre_trainer.yaml
+                model: fake.yaml
+                overrides:
+            """
+        ).lstrip()
+        + textwrap.indent(textwrap.dedent(overrides).strip() + "\n", " " * 6)
+    )
+
+
+def test_scan_reports_only_unknown_keys(fake_repo: Path):
+    _write(
+        fake_repo / "examples/torchtitan/configs/probe.yaml",
+        _exp_yaml(
+            """
+            training:
+              seq_len: 4096
+              seed: 42
+            model:
+              n_layers: 4
+            primus_turbo:
+              enable_primus_turbo: true
+              bogus: 1
+            """
+        ),
+    )
+
+    result = scan_backend(fake_repo, "torchtitan")
+
+    assert result.available
+    assert {f.key for f in result.findings} == {"training.seed", "primus_turbo.bogus"}
+    assert not result.errors
+
+
+def test_scan_skips_modules_of_other_backends(fake_repo: Path):
+    _write(
+        fake_repo / "examples/torchtitan/configs/other.yaml",
+        """
+        work_group: amd
+        modules:
+          pre_trainer:
+            framework: megatron
+            config: pre_trainer.yaml
+            model: fake.yaml
+            overrides:
+              anything_goes: 1
+        """,
+    )
+
+    assert scan_backend(fake_repo, "torchtitan").findings == ()
+
+
+def test_unloadable_config_is_reported_not_raised(fake_repo: Path):
+    _write(fake_repo / "examples/torchtitan/configs/broken.yaml", "extends:\n  - missing.yaml\n")
+
+    result = scan_backend(fake_repo, "torchtitan")
+
+    assert [e.file for e in result.errors] == ["examples/torchtitan/configs/broken.yaml"]
+    # The reader wrote `missing.yaml`, so name that, not the raw exception path.
+    assert result.errors[0].message.startswith("cannot resolve `examples/torchtitan/configs/missing.yaml`")
+
+
+def test_unloadable_config_does_not_count_as_checked(fake_repo: Path):
+    """The whole point of the tool is that nothing passes unexamined."""
+    _write(fake_repo / "examples/torchtitan/configs/ok.yaml", _exp_yaml("training:\n  seq_len: 8\n"))
+    _write(fake_repo / "examples/torchtitan/configs/broken.yaml", "extends:\n  - missing.yaml\n")
+
+    result = scan_backend(fake_repo, "torchtitan")
+
+    # pre_trainer.yaml + ok.yaml + broken.yaml
+    assert result.scanned == 3
+    assert result.checked == 2
+    assert result.findings == ()
+
+
+def test_megatron_scan_reports_only_unknown_keys(megatron_repo: Path):
+    """Megatron configs are flat, so every finding is a top-level key."""
+    _write(
+        megatron_repo / "examples/megatron/configs/probe.yaml",
+        """
+        work_group: amd
+        modules:
+          pre_trainer:
+            framework: megatron
+            config: pre_trainer.yaml
+            model: fake.yaml
+            overrides:
+              train_iters: 50
+              norm_epsilon: 1.0e-6
+              use_turbo_attention: true
+              renamed_away: 1
+        """,
+    )
+
+    result = scan_backend(megatron_repo, "megatron")
+
+    assert result.available
+    assert {f.key for f in result.findings} == {"renamed_away"}
+    assert not result.errors
+
+
+def test_scan_without_submodule_is_unavailable(tmp_path: Path):
+    result = scan_backend(tmp_path, "torchtitan")
+
+    assert not result.available
+    assert result.findings == () and result.scanned == 0
+
+
+def test_dedupe_collapses_one_key_across_files(fake_repo: Path):
+    findings = [Finding("torchtitan", "training.seed", f"cfg{i}.yaml") for i in range(5)]
+    findings.append(Finding("torchtitan", "training.steps", "cfg0.yaml"))
+
+    rows = dedupe(findings, load_torchtitan_schema(fake_repo))
+
+    assert [(r.key, r.count) for r in rows] == [("training.seed", 5), ("training.steps", 1)]
+    assert rows[0].suggestion == "debug.seed"
+    assert rows[0].files == tuple(f"cfg{i}.yaml" for i in range(5))
+    assert rows[1].files == ("cfg0.yaml",)
+
+
+def test_dedupe_drops_duplicate_files_for_one_key():
+    rows = dedupe([Finding("maxtext", "gone", "a.yaml")] * 3)
+
+    assert rows[0].count == 3 and rows[0].files == ("a.yaml",)
+
+
+def test_dedupe_orders_by_blast_radius_whatever_order_it_is_handed():
+    """`(backend, key)` is unique per row, so the order is total: no tie for the input order to
+    break, and CI can diff one run's summary against the next."""
+    findings = [Finding("megatron", "wide", f"cfg{i}.yaml") for i in range(3)]
+    findings += [Finding("megatron", "narrow", "cfg0.yaml"), Finding("maxtext", "other", "cfg0.yaml")]
+
+    assert [(r.backend, r.key) for r in dedupe(findings)] == [
+        ("maxtext", "other"),
+        ("megatron", "wide"),
+        ("megatron", "narrow"),
+    ]
+    assert dedupe(findings) == dedupe(findings[::-1])
+
+
+def test_allowlist_matches_exact_before_glob():
+    allow = Allowlist((AllowRule("a.b", "r", "c", "manual"), AllowRule("a.*", "r", "c", "manual")))
+
+    assert allow.match("a.b").pattern == "a.b"
+    assert allow.match("a.c").pattern == "a.*"
+    assert allow.match("b.c") is None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_cli():
+    path = _REPO_ROOT / "tools/ci/check_config_schema.py"
+    spec = importlib.util.spec_from_file_location("primus_check_config_schema", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row(key: str, files: tuple[str, ...], suggestion: str | None = None) -> KeyFinding:
+    return KeyFinding("megatron", key, len(files), files, suggestion)
+
+
+def test_group_rows_merges_the_keys_that_share_their_configs():
+    """The whole point: one preset's worth of rot is one row, not twenty."""
+    cli = _load_cli()
+    rows = [
+        _row("zeta", ("a.yaml", "b.yaml")),
+        _row("alpha", ("a.yaml", "b.yaml")),
+        _row("solo", ("c.yaml",)),
+    ]
+
+    renamed, merged = cli.group_rows(rows)
+
+    assert renamed == []
+    assert [(g.keys, g.count) for g in merged] == [(("alpha", "zeta"), 2), (("solo",), 1)]
+    # Merging must not lose a config: the row's files are every member's files.
+    assert merged[0].files == ("a.yaml", "b.yaml")
+
+
+def test_group_rows_keeps_a_renamed_key_out_of_the_merged_table():
+    """A rename is a per-key fix; hiding it inside a list of twenty-five undoes the report."""
+    cli = _load_cli()
+    rows = [
+        _row("bulk_one", ("a.yaml", "b.yaml", "c.yaml")),
+        _row("bulk_two", ("a.yaml", "b.yaml", "c.yaml")),
+        _row("moved", ("a.yaml", "b.yaml", "c.yaml"), suggestion="moved_elsewhere"),
+    ]
+
+    renamed, merged = cli.group_rows(rows)
+
+    assert [g.keys for g in renamed] == [("moved",)]
+    assert renamed[0].suggestion == "moved_elsewhere"
+    assert [g.keys for g in merged] == [("bulk_one", "bulk_two")]
+
+
+def test_group_rows_does_not_merge_across_a_differing_config_set():
+    cli = _load_cli()
+    rows = [_row("here", ("a.yaml",)), _row("there", ("b.yaml",))]
+
+    assert [g.keys for g in cli.group_rows(rows)[1]] == [("here",), ("there",)]
+
+
+def test_group_rows_ignores_the_order_it_is_given():
+    """CI diffs the summary, so the same findings must render the same way every run."""
+    cli = _load_cli()
+    rows = [_row(k, ("a.yaml", "b.yaml")) for k in ("m", "b", "z")] + [_row("x", ("c.yaml",))]
+
+    def keys(found):
+        return [[g.keys for g in half] for half in found]
+
+    assert keys(cli.group_rows(rows)) == keys(cli.group_rows(rows[::-1]))
+
+
+def test_shorten_paths_drops_the_shared_prefix_but_keeps_what_disambiguates():
+    cli = _load_cli()
+    short = cli.shorten_paths(
+        [
+            "primus/configs/models/megatron/deepseek_v2.yaml",
+            "primus/configs/modules/megatron/pre_trainer.yaml",
+            "examples/megatron/configs/MI300X/shared.yaml",
+            "examples/megatron/configs/MI355X/shared.yaml",
+        ]
+    )
+
+    assert short["primus/configs/models/megatron/deepseek_v2.yaml"] == "deepseek_v2.yaml"
+    assert short["primus/configs/modules/megatron/pre_trainer.yaml"] == "pre_trainer.yaml"
+    # `shared.yaml` alone would name two different configs, so the tail grows.
+    assert short["examples/megatron/configs/MI300X/shared.yaml"] == "MI300X/shared.yaml"
+    assert short["examples/megatron/configs/MI355X/shared.yaml"] == "MI355X/shared.yaml"
+
+
+def test_shorten_paths_falls_back_to_the_whole_path_when_a_tail_never_disambiguates():
+    """A path that is another one's suffix runs out of segments before it runs out of rivals."""
+    cli = _load_cli()
+
+    short = cli.shorten_paths(["a/b.yaml", "x/a/b.yaml"])
+
+    assert short == {"a/b.yaml": "a/b.yaml", "x/a/b.yaml": "x/a/b.yaml"}
+
+
+_RENAMED_TABLE = "### Keys that look renamed rather than dropped"
+_MERGED_TABLE = "### Keys with no obvious replacement"
+
+
+def _drift_out(fake_repo: Path, monkeypatch, capsys, overrides: str, files: int = 1) -> str:
+    for i in range(files):
+        _write(fake_repo / f"examples/torchtitan/configs/probe{i}.yaml", _exp_yaml(overrides))
+    cli = _load_cli()
+    monkeypatch.setattr(cli, "ROOT", fake_repo)
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--backend", "torchtitan", "--warn-only"])
+    assert cli.main() == 0
+    return capsys.readouterr().out
+
+
+def test_cli_prints_every_grouped_key_as_plain_text(fake_repo: Path, monkeypatch, capsys):
+    """CI logs get grepped for a key name, so merging rows must not hide one."""
+    out = _drift_out(fake_repo, monkeypatch, capsys, "training:\n  seed: 1\n  gone_a: 1\n  gone_b: 2\n", 3)
+
+    assert _RENAMED_TABLE in out and _MERGED_TABLE in out
+    assert "`training.gone_a`, `training.gone_b`" in out  # merged onto one row, both still named
+    assert "| `training.seed` | 3 | `debug.seed` |" in out  # the rename keeps its own row and column
+    assert "2 distinct set(s) of configs" not in out  # the two share one set
+    assert "The other 2 drifted out of only 1 distinct set(s) of configs" in out
+
+
+def test_cli_omits_the_rename_table_when_nothing_looks_renamed(fake_repo: Path, monkeypatch, capsys):
+    """An empty table is a heading and a header row saying nothing; print neither."""
+    out = _drift_out(fake_repo, monkeypatch, capsys, "training:\n  gone_a: 1\n")
+
+    assert _RENAMED_TABLE not in out
+    assert "Likely moved to" not in out  # the column only ever holds a suggestion
+    assert _MERGED_TABLE in out
+    assert "All 1 drifted out of only 1 distinct set(s) of configs" in out  # not "The other 1"
+    assert "`training.gone_a`" in out
+
+
+def test_cli_omits_the_merged_table_when_everything_looks_renamed(fake_repo: Path, monkeypatch, capsys):
+    out = _drift_out(fake_repo, monkeypatch, capsys, "training:\n  seed: 1\n")
+
+    assert _MERGED_TABLE not in out
+    assert "distinct set(s) of configs" not in out
+    assert _RENAMED_TABLE in out
+    assert "| `training.seed` | 1 | `debug.seed` |" in out
+
+
+def test_cli_fails_when_no_submodule_is_checked_out(tmp_path: Path, monkeypatch, capsys):
+    cli = _load_cli()
+    monkeypatch.setattr(cli, "ROOT", tmp_path)
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py"])
+
+    assert cli.main() == 1
+    out = capsys.readouterr().out
+    assert "backend(s) not checked" in out and "git submodule update --init" in out
+
+
+def test_cli_fails_on_a_skipped_backend_even_when_warning_only(fake_repo: Path, monkeypatch, capsys):
+    """The bug this exists for: a partial checkout used to pass in silence.
+
+    ``fake_repo`` has TorchTitan and MaxText but no Megatron, which is exactly
+    what a CI job that fetches two of the three submodules produces.
+    """
+    cli = _load_cli()
+    monkeypatch.setattr(cli, "ROOT", fake_repo)
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--warn-only"])
+
+    assert cli.main() == 1
+    out = capsys.readouterr().out
+    assert "FAILED -- 1 backend(s) not checked" in out
+    assert "**megatron**" in out
+    assert "No drift" in out  # the two backends that were checked are clean
+
+    # ... while the same two backends on their own still pass.
+    monkeypatch.setattr(
+        "sys.argv",
+        ["check_config_schema.py", "--warn-only", "--backend", "torchtitan", "--backend", "maxtext"],
+    )
+    assert cli.main() == 0
+
+
+def test_cli_warn_only_suppresses_the_failure(fake_repo: Path, monkeypatch, capsys):
+    _write(
+        fake_repo / "examples/torchtitan/configs/probe.yaml",
+        _exp_yaml("training:\n  seed: 42\n"),
+    )
+    cli = _load_cli()
+    monkeypatch.setattr(cli, "ROOT", fake_repo)
+
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--backend", "torchtitan"])
+    assert cli.main() == 1
+    assert "`training.seed`" in capsys.readouterr().out
+
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--backend", "torchtitan", "--warn-only"])
+    assert cli.main() == 0
+
+
+def test_cli_reports_a_misplaced_key_apart_from_drift(megatron_repo: Path, monkeypatch, capsys):
+    """The two need different fixes, so they must not share a table."""
+    _write(
+        megatron_repo / "examples/megatron/configs/stray.yaml",
+        """
+        work_group: amd
+        modules:
+          pre_trainer:
+            framework: megatron
+            config: pre_trainer.yaml
+            model: plain.yaml
+            overrides:
+              hash_routing_seed: 7
+        """,
+    )
+    cli = _load_cli()
+    monkeypatch.setattr(cli, "ROOT", megatron_repo)
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--backend", "megatron"])
+
+    assert cli.main() == 1
+    out = capsys.readouterr().out
+    assert "No drift: every key in" in out  # the key exists; it is only misplaced
+    assert "Keys set on a model that cannot read them" in out
+    assert "`hash_routing_seed`" in out and "model_type: fake_v4" in out
+
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--backend", "megatron", "--warn-only"])
+    assert cli.main() == 0
+
+
+def test_cli_fails_when_a_config_could_not_be_loaded(fake_repo: Path, monkeypatch, capsys):
+    """An unchecked config must never be reported as a clean one."""
+    _write(fake_repo / "examples/torchtitan/configs/broken.yaml", "extends:\n  - missing.yaml\n")
+    cli = _load_cli()
+    monkeypatch.setattr(cli, "ROOT", fake_repo)
+
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--backend", "torchtitan"])
+    assert cli.main() == 1
+    out = capsys.readouterr().out
+    assert "could not be loaded and were NOT checked" in out
+    assert "broken.yaml" in out
+    assert "No drift: every key in" not in out
+    assert "Checked 1 of 2 config(s)" in out
+
+    monkeypatch.setattr("sys.argv", ["check_config_schema.py", "--backend", "torchtitan", "--warn-only"])
+    assert cli.main() == 0

--- a/tests/unit_tests/core/config/test_yaml_loader.py
+++ b/tests/unit_tests/core/config/test_yaml_loader.py
@@ -49,6 +49,24 @@ class TestYamlLoader:
         assert result["child_val"] == 3
         assert "extends" not in result  # Should be removed
 
+    def test_parse_yaml_scalar_extends(self, tmp_path):
+        """A lone preset written as a scalar must not be iterated per character."""
+        base = tmp_path / "base.yaml"
+        base.write_text("base_val: 1\noverride_val: 1")
+
+        child = tmp_path / "child.yaml"
+        child.write_text(
+            """
+        extends: base.yaml
+        override_val: 2
+        """
+        )
+
+        result = parse_yaml(str(child))
+        assert result["base_val"] == 1
+        assert result["override_val"] == 2
+        assert "extends" not in result
+
     def test_parse_yaml_multi_extends(self, tmp_path):
         """Test extending multiple files."""
         base1 = tmp_path / "base1.yaml"

--- a/tools/ci/check_config_schema.py
+++ b/tools/ci/check_config_schema.py
@@ -1,0 +1,322 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Fail CI when a Primus YAML sets a backend key upstream no longer defines.
+
+Every backend adapter accepts unknown keys silently, so a field that upstream
+renamed or moved keeps parsing while doing nothing. Prints the drift as Markdown
+for `$GITHUB_STEP_SUMMARY`:
+
+    python tools/ci/check_config_schema.py --warn-only >> "$GITHUB_STEP_SUMMARY"
+
+A key upstream looks to have merely renamed gets a table and a row of its own:
+that is a fix someone applies one key at a time. The rest share a table where a
+row is a set of configs, because dozens of dead keys are usually one preset's
+worth of rot, and repeating the same three long paths for each of them buries
+the part a reader has to act on.
+
+TorchTitan, MaxText and Megatron each have their schema read from their own
+`third_party/` submodule. A backend whose submodule is not checked out has
+nothing to compare against and is skipped, which exits non-zero even under
+`--warn-only`: a checkout that fetches only some of them drops that part of the
+check, and a check that did not run must not look like one that passed.
+
+A config that cannot be loaded (broken `extends:` path, unparseable YAML) fails
+the check just like drift does -- an unchecked config must never be counted as a
+passing one. `--warn-only` suppresses both.
+
+Misplaced model-scoped keys get their own table. Such a key is not unknown --
+some Primus config class does declare it -- but that class is built for one
+model only, so setting the key on any other model is the same silent no-op.
+"""
+
+import argparse
+import sys
+import time
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from primus.core.config.schema_check import (  # noqa: E402
+    BACKENDS,
+    DEFAULT_ALLOWLIST,
+    KeyFinding,
+    build_allowlist,
+    check_manual_allowlist_consumers,
+    dedupe,
+    dedupe_scoped,
+    scan_backend,
+)
+
+SHOWN_PATTERNS = 40
+SHOWN_FILES = 3
+
+
+def shorten_paths(paths: Iterable[str]) -> dict[str, str]:
+    """Map every path to the fewest trailing segments no other path here also ends with.
+
+    Almost every config sits under one of a handful of roots, so the shared
+    `primus/configs/models/megatron/` is pure repetition -- but only where
+    dropping it still names one file, and `MI300X/` and `MI355X/` hold configs
+    with identical names.
+    """
+    parts = {path: path.split("/") for path in set(paths)}
+    tails = Counter("/".join(s[-d:]) for s in parts.values() for d in range(1, len(s) + 1))
+    short = {}
+    for path, segments in parts.items():
+        # The whole path always names itself, so it is the fallback rather than a candidate.
+        candidates = ("/".join(segments[-d:]) for d in range(1, len(segments)))
+        short[path] = next((tail for tail in candidates if tails[tail] == 1), path)
+    return short
+
+
+@dataclass(frozen=True)
+class DriftRow:
+    """One row of the drift table: the keys that live in exactly the same configs."""
+
+    backend: str
+    keys: tuple[str, ...]
+    count: int
+    files: tuple[str, ...]
+    suggestion: str | None
+
+    def sample(self, short: dict[str, str], limit: int = SHOWN_FILES) -> str:
+        shown = ", ".join(f"`{short.get(f, f)}`" for f in self.files[:limit])
+        extra = len(self.files) - limit
+        return f"{shown} (+{extra} more)" if extra > 0 else shown
+
+
+def group_rows(rows: Sequence[KeyFinding]) -> tuple[list[DriftRow], list[DriftRow]]:
+    """Split the findings into ``(renamed, merged)``, the two tables.
+
+    A key with a suggested rename keeps its own row: that one is a direct fix
+    someone applies key by key, and burying it in a list of twenty-five is the
+    opposite of the point. The rest say the same thing many times over, so the
+    ones that drifted out of the very same configs share a row -- which loses
+    nothing, the row's configs being every member's.
+    """
+    renamed, shared = [], {}
+    for row in rows:
+        if row.suggestion:
+            renamed.append(DriftRow(row.backend, (row.key,), row.count, row.files, row.suggestion))
+        else:
+            shared.setdefault((row.backend, row.count, row.files), []).append(row.key)
+    merged = [
+        DriftRow(backend, tuple(sorted(keys)), count, files, None)
+        for (backend, count, files), keys in shared.items()
+    ]
+
+    def order(row: DriftRow) -> tuple[str, int, str]:
+        return row.backend, -row.count, row.keys[0]
+
+    return sorted(renamed, key=order), sorted(merged, key=order)
+
+
+def subsection(title: str, lead: str) -> list[str]:
+    """A `###` heading and its lead-in, spaced the way Markdown wants them."""
+    return ["", f"### {title}", "", lead, ""]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", action="append", choices=BACKENDS, help="Limit to one backend.")
+    parser.add_argument(
+        "--path",
+        action="append",
+        type=Path,
+        help="Scan these files/dirs instead of the default roots (requires a single --backend).",
+    )
+    parser.add_argument("--allowlist", type=Path, help="Override the allowlist YAML path.")
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Report findings but exit 0. A skipped backend still fails.",
+    )
+    parser.add_argument(
+        "--show-allowlist", action="store_true", help="Also print the derived allowlist patterns."
+    )
+    args = parser.parse_args()
+    if args.path and len(args.backend or BACKENDS) != 1:
+        parser.error("--path requires exactly one --backend")
+    return args
+
+
+def main():
+    args = parse_args()
+    backends = args.backend or list(BACKENDS)
+    started = time.perf_counter()
+
+    lines = ["## Backend config schema drift", ""]
+    rows, skipped, errors, checked = [], [], [], 0
+    stale, scoped, model_scopes = [], [], []
+
+    allowlist_path = args.allowlist or (ROOT / DEFAULT_ALLOWLIST)
+    for backend in backends:
+        for problem in check_manual_allowlist_consumers(ROOT, allowlist_path, backend):
+            if problem not in stale:  # the `common` scope is read once per backend
+                stale.append(problem)
+
+        result = scan_backend(ROOT, backend, args.path, args.allowlist)
+        if not result.available:
+            skipped.append(backend)
+            continue
+        checked += result.checked
+        errors.extend(result.errors)
+        rows.extend(dedupe(result.findings, result.schema))
+        scoped.extend(dedupe_scoped(result.scoped))
+        model_scopes.extend((backend, scope) for scope in result.scopes)
+
+    # Loud, and its own section: a backend nobody compared against anything is
+    # the one outcome that must not read like a pass. It is also the one that
+    # `--warn-only` does not forgive, so say so where the reader is looking.
+    if skipped:
+        lines.append(f"### FAILED -- {len(skipped)} backend(s) not checked")
+        lines.append("")
+        lines.append(
+            f"**{', '.join(skipped)}**: upstream schema not found under `third_party/`, so no "
+            "config of theirs was compared against anything. Run `git submodule update --init` "
+            "to restore the check. Drift is warn-only; a check that never ran is not."
+        )
+        lines.append("")
+    # Reported even when no schema is available: an allowlist entry whose
+    # consumer is gone widens the legal key set, which is the blindness this
+    # check exists to remove, and verifying it needs no submodule.
+    if stale:
+        lines.append(f"**{len(stale)} allowlist entr(y/ies) no longer backed by their consumer:**")
+        lines.append("")
+        for problem in stale:
+            lines.append(f"- {problem}")
+        lines.append("")
+
+    if len(skipped) == len(backends):
+        lines.append("Nothing to check." if not stale else "No schema available; allowlist checked.")
+        print("\n".join(lines))
+        return 1
+
+    if rows:
+        renamed, merged = group_rows(rows)
+        short = shorten_paths(f for row in rows for f in row.files)
+        shared = len(rows) - len(renamed)
+        lines.append(
+            f"**{len(rows)} unknown key(s)** across {sum(r.count for r in rows)} occurrence(s). "
+            "Each one parses and then does nothing: fix the config, or add the key to "
+            "`tools/ci/config_schema_allowlist.yaml` with a reason and a consumer. Example files "
+            "are shortened to the shortest trailing path that names one config here."
+        )
+        # Two tables, because the two halves are two different jobs. A rename is
+        # a key-by-key edit with a known destination; the rest is a decision per
+        # set of configs, and a `Likely moved to` column of nothing but dashes.
+        if renamed:
+            lines += subsection(
+                "Keys that look renamed rather than dropped",
+                f"{len(renamed)} of them: upstream still defines a name this close, so each is one "
+                "direct edit and gets a row to itself.",
+            )
+            lines.append("| Backend | Unknown key | Configs | Likely moved to | Example files |")
+            lines.append("| --- | --- | ---: | --- | --- |")
+            for row in renamed:
+                lines.append(
+                    f"| {row.backend} | `{row.keys[0]}` | {row.count} | "
+                    f"`{row.suggestion}` | {row.sample(short)} |"
+                )
+        if merged:
+            lines += subsection(
+                "Keys with no obvious replacement",
+                f"{'The other' if renamed else 'All'} {shared} drifted out of only {len(merged)} "
+                "distinct set(s) of configs, so a row here is one such set and every key that "
+                "drifted out of exactly it.",
+            )
+            lines.append("| Backend | Configs | Example files | Unknown key(s) |")
+            lines.append("| --- | ---: | --- | --- |")
+            for row in merged:
+                keys = ", ".join(f"`{k}`" for k in row.keys)
+                lines.append(f"| {row.backend} | {row.count} | {row.sample(short)} | {keys} |")
+    elif not errors:
+        lines.append(
+            f"No drift: every key in {checked} config(s) exists upstream " "or is a known Primus extension."
+        )
+    elif checked:
+        lines.append(f"No drift in the {checked} config(s) that loaded.")
+
+    if scoped:
+        if lines[-1]:
+            lines.append("")
+        lines.append("### Keys set on a model that cannot read them")
+        lines.append("")
+        lines.append("| Backend | Key | Only reaches | Set instead on | Configs | Example |")
+        lines.append("| --- | --- | --- | --- | ---: | --- |")
+        for row in scoped:
+            models = ", ".join(f"`{m}`" for m in row.models)
+            lines.append(
+                f"| {row.backend} | `{row.key}` | `{row.scope.describe()}` "
+                f"({row.scope.config_class}) | {models} | {row.count} | {row.sample(2)} |"
+            )
+        lines.append("")
+        lines.append(
+            f"**{len(scoped)} model-scoped key(s)** set on {sum(r.count for r in scoped)} config(s) "
+            "that build a different model. The key parses, no config class carries it, and the "
+            "value is silently replaced by the upstream default: drop it, or use the field the "
+            "model in question actually reads."
+        )
+
+    # An unreadable config was never checked, so it cannot count towards a pass.
+    if errors:
+        if lines[-1]:
+            lines.append("")
+        lines.append(f"**{len(errors)} config(s) could not be loaded and were NOT checked:**")
+        lines.append("")
+        for error in errors:
+            lines.append(f"- `{error.file}`: {error.message}")
+
+    if args.show_allowlist:
+        lines.append("")
+        lines.append("<details><summary>Derived allowlist</summary>")
+        lines.append("")
+        for backend in backends:
+            # Megatron derives one pattern per name read off `args`, thousands of
+            # them, so show a sample rather than flooding the summary.
+            patterns = build_allowlist(ROOT, backend, args.allowlist).patterns()
+            shown = ", ".join(f"`{p}`" for p in patterns[:SHOWN_PATTERNS])
+            extra = len(patterns) - SHOWN_PATTERNS
+            lines.append(
+                f"- **{backend}** ({len(patterns)}): {shown}"
+                + (f", ... (+{extra} more)" if extra > 0 else "")
+            )
+        lines.append("")
+        lines.append("</details>")
+
+        # A scope narrows the legal key set rather than widening it, so it earns
+        # the same scrutiny as an allowlist entry: show what it covers.
+        if model_scopes:
+            lines.append("")
+            lines.append("<details><summary>Derived model scopes</summary>")
+            lines.append("")
+            for backend, scope in model_scopes:
+                keys = ", ".join(f"`{k}`" for k in sorted(scope.keys))
+                lines.append(
+                    f"- **{backend}** `{scope.describe()}` -> `{scope.config_class}` "
+                    f"(from `{scope.source}`): {keys}"
+                )
+            lines.append("")
+            lines.append("</details>")
+
+    lines.append("")
+    scope = f"{checked} config(s)" if not errors else f"{checked} of {checked + len(errors)} config(s)"
+    lines.append(f"_Checked {scope} in {time.perf_counter() - started:.2f}s._")
+    print("\n".join(lines))
+    # A missing submodule is an infrastructure failure, not a config one, so it
+    # gets none of the grace period `--warn-only` buys the findings.
+    if skipped:
+        return 1
+    return 1 if (rows or scoped or errors or stale) and not args.warn_only else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/config_schema_allowlist.yaml
+++ b/tools/ci/config_schema_allowlist.yaml
@@ -1,0 +1,79 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+#
+# Hand-written escape hatch for `tools/ci/check_config_schema.py`.
+#
+# Keep this file small. Primus extension fields are derived automatically from
+# `get_param(ctx, "<path>", ...)` calls in the backend patch packages, from the
+# names the Megatron backend package reads off `args`, and from the Primus
+# dataclasses that extend a backend's config class, so a new patch consuming a
+# new field needs no edit here. Only keys that no automatic source can see
+# belong below.
+#
+# Every entry requires:
+#   key      - exact dotted path, or an fnmatch pattern (e.g. `model.*`)
+#   reason   - why the key is legal even though upstream does not define it
+#   consumer - the file that actually reads it (a reviewer must be able to
+#              confirm the key is not dead). Give a path with no line number:
+#              the check verifies the file exists and still mentions the key,
+#              which survives refactoring, whereas a line number does not.
+
+common:
+  - key: work_group
+    reason: Primus experiment envelope, never forwarded to the backend.
+    consumer: primus/core/launcher/parser.py
+  - key: user_name
+    reason: Primus experiment envelope, never forwarded to the backend.
+    consumer: primus/core/launcher/parser.py
+  - key: exp_name
+    reason: Primus experiment envelope, never forwarded to the backend.
+    consumer: primus/core/launcher/parser.py
+  - key: workspace
+    reason: Primus experiment envelope, never forwarded to the backend.
+    consumer: primus/core/launcher/parser.py
+  - key: platform
+    reason: Selects the platform preset and its overrides.
+    consumer: primus/core/launcher/parser.py
+  - key: extends
+    reason: Preset composition directive, consumed and stripped while loading.
+    consumer: primus/core/config/yaml_loader.py
+  - key: trainable
+    reason: Primus module flag declared by primus/configs/modules/module_base.yaml.
+    consumer: primus/core/base_module.py
+  - key: sink_level
+    reason: Primus logging level, declared by primus/configs/modules/module_base.yaml.
+    consumer: primus/core/base_module.py
+  - key: file_sink_level
+    reason: Primus logging level, declared by primus/configs/modules/module_base.yaml.
+    consumer: primus/core/base_module.py
+  - key: stderr_sink_level
+    reason: Primus logging level, declared by primus/configs/modules/module_base.yaml.
+    consumer: primus/core/base_module.py
+
+torchtitan:
+  - key: model.*
+    reason: >-
+      Everything under `model` that is not a JobConfig.Model field is a model-arg
+      override, validated at runtime against the flavor dataclass (an unknown
+      name raises AttributeError there, so it cannot fail silently).
+    consumer: primus/backends/torchtitan/patches/model_override_patches.py
+
+maxtext:
+  - key: base_config
+    reason: pyconfig directive naming the MaxText base config to inherit from; not a field of base.yml itself.
+    consumer: third_party/maxtext/src/maxtext/configs/pyconfig.py
+
+megatron:
+  - key: configs
+    reason: >-
+      Top-level section of a TE-precision quantization recipe, which Megatron
+      loads from a file named by `te_precision_config_file` rather than from a
+      module preset. Such a recipe is not a Primus config and has its own schema.
+    consumer: third_party/Megatron-LM/megatron/core/quantization/quant_config.py
+  - key: matchers
+    reason: >-
+      Top-level section of a TE-precision quantization recipe (see `configs`).
+    consumer: third_party/Megatron-LM/megatron/core/quantization/quant_config.py


### PR DESCRIPTION
## What this fixes

TorchTitan v0.2.2 moved `seed`, `deterministic` and `moe_force_load_balance` out of `training` into a new `debug` dataclass, and dropped two `parallelism` fields. Primus kept writing the old paths. Because `dict_to_dataclass` attaches unknown keys as dynamic attributes instead of failing, nothing complained — **every DeepSeek config went on training with MoE load balancing off**.

This migrates the 16 affected configs and adds a check so the next upstream rename shows up in CI instead of in a throughput number.

## The drift check

`tools/ci/check_config_schema.py` compares every Primus config against the backend's real key set:

| Backend | Where the key set comes from |
| --- | --- |
| TorchTitan | `job_config.py`, read as an AST |
| MaxText | its base yaml |
| Megatron | both halves of `arguments.py` |

Megatron needs both halves or neither is worth reading: roughly 355 literal `add_argument` calls, plus eleven `ArgumentGroupFactory` calls that generate as many again from config dataclasses. The generated half holds `train_iters`, `global_batch_size` and `micro_batch_size`, so reading the literal calls alone would flag half of every valid config.

Schemas are read statically, so the check imports neither torch nor jax and runs on a plain CI runner in about 10s.

Primus extensions are **derived, not listed**: from `get_param()` calls in the patch packages, reads off Megatron's `args` namespace, and Primus dataclasses extending a backend config class. The hand-written allowlist is a last resort, and each entry names a file and a reason rather than a line number — line numbers rot within weeks and say nothing about whether the key is still read, so the check verifies instead that the file exists and still mentions the key.

## Keys that are legal but dead where they are written

A Primus config subclass widens the key set for the whole backend, but `core_transformer_config_from_args` copies its fields off `args` only on the model that names it. `norm_epsilon` is the case that matters: it is not an upstream dest (upstream's field is `layernorm_epsilon`, which merely spells its flag `--norm-epsilon`), so it reaches a field only on DeepSeek-V4 and is inert everywhere else. These are reported as a separate category — the key is not unknown, it is in the wrong place. A config whose model cannot be resolved is left alone rather than guessed at.

## CI behaviour

Drift is **warn-only** during burn-in. A backend whose schema is missing **fails**, because a check that never ran must not look like a pass — which is exactly how the Megatron third of this check would have shipped dead, had the submodule fetch not been updated alongside it.

## Note for reviewers

This overlaps with #935, which fixes the same `moe_force_load_balance` symptom for one MI355X config by way of a runtime compat patch, and touches the same hunk of `examples/torchtitan/configs/MI355X/deepseek_v3_16b-BF16-pretrain.yaml`. Worth settling which one carries that fix before either lands. The other two patches in #935 (whole-block compile, bf16 MoE combine) are unrelated to this change.
