### PR TITLE
docs: refresh README feature/model/news sections for 2026 work

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,24 @@
 
 ## ✨ Key Features
 
-- **🔄 Multi-Backend Support**: Seamlessly switch between Megatron-LM, TorchTitan, and other training frameworks
+- **🔄 Multi-Backend Support**: Seamlessly switch between Megatron-LM, TorchTitan, JAX MaxText, Megatron-Bridge, and the diffusion backend under one configuration system
+- **🎯 Full Training Lifecycle**: Pretraining, SFT / LoRA post-training ([Docs](./docs/02-user-guide/posttraining.md)), and image / video diffusion training ([Docs](./docs/04-technical-guides/diffusion-models/README.md))
 - **🚀 Unified CLI**: One command interface for local development, containers, and Slurm clusters ([Docs](./docs/02-user-guide/cli-reference.md))
-- **⚡ ROCm Optimized**: Deep integration with AMD ROCm stack and optimized kernels from Primus-Turbo
-- **📦 Production Ready**: Battle-tested on large-scale training with hundreds of GPUs
-- **🔌 Extensible Architecture**: Plugin-based design for easy integration of custom models and workflows
-- **🛡️ Enterprise Features**: Built-in fault tolerance, checkpoint management, and monitoring
+- **⚡ ROCm Optimized**: Deep integration with AMD ROCm stack, Primus-Turbo kernels, DeepEP, fused [MegaMoE](./docs/04-technical-guides/mega-moe.md), and FP8 / MXFP8 / MXFP4 recipes
+- **📐 Plan Before You Train**: [Projection](./docs/02-user-guide/projection.md) estimates parallelism and memory fit before you allocate a cluster, and the [tuning agent](./docs/02-user-guide/tuning-agent.md) searches configs automatically
+- **📦 Production Ready**: Battle-tested on large-scale training with hundreds of GPUs; shipped as ROCm Docker images and a pip wheel
+- **🔌 Extensible Architecture**: Patch-based backend integration for custom models and workflows ([Docs](./docs/06-developer-guide/extending-backends.md))
+- **🛡️ Enterprise Features**: Built-in fault tolerance, checkpoint management, and monitoring with MLflow / TraceLens
 
 ---
 
 ## ✅ Supported Models (high level)
 
-- **Megatron-LM**: LLaMA2 / LLaMA3 / LLaMA4 families, DeepSeek-V2/V3, Mixtral-style MoE, and other GPT-style models
-- **TorchTitan**: LLaMA3 / LLaMA4, DeepSeek-V3, and related decoder-only architectures
-- **MaxText (JAX)**: LLaMA3.x and other MaxText-supported transformer models (subset; see MaxText docs for details)
+- **Megatron-LM**: LLaMA2 / LLaMA3.x / LLaMA4 families, DeepSeek-V2 / V3 / V4, Qwen2.5 and Qwen3 (dense and MoE), Mixtral, Grok, GPT-OSS 20B/120B, GLM, Kimi K2, MiniMax, LFM2, plus hybrid and linear-attention stacks (Mamba, Zebra-LLaMA with GDN / KDA)
+- **TorchTitan**: LLaMA3.x / LLaMA4, DeepSeek-V3 (16B to 671B), and Qwen3 0.6B to 32B
+- **MaxText (JAX)**: LLaMA2 / LLaMA3.x, DeepSeek-V2 16B, Mixtral-8x7B, Grok1, and Qwen3 14B / 30B-A3B (subset; see MaxText docs for details)
+- **Megatron-Bridge**: SFT and LoRA post-training for Qwen3 8B/32B, LLaMA3.1 70B, Zebra-LLaMA, and Mamba
+- **Diffusion**: Flux.1 (schnell / dev) text-to-image and Wan 2.1 / 2.2 text- and image-to-video
 
 For the full and up-to-date model matrix, see [Supported Models](./docs/06-developer-guide/model-support-matrix.md).
 
@@ -33,15 +37,31 @@ For the full and up-to-date model matrix, see [Supported Models](./docs/06-devel
 
 ## 🆕 What's New
 
+- **[2026/07/29]** ⚡ **MegaMoE** - FlyDSL-based fused MoE layer that folds expert all-to-all into the grouped GEMMs, plus FP4 grouped GEMM support ([MegaMoE guide](./docs/04-technical-guides/mega-moe.md))
+- **[2026/07/29]** Hybrid linear-attention models: Gated Delta Net (GDN) and Kimi Delta Attention (KDA) on Megatron-LM ([Hybrid models](./docs/04-technical-guides/hybrid-models/README.md))
+- **[2026/07/22]** Backend upgrades: TorchTitan v0.2.2 (PyTorch 2.12) with GPT-OSS, and MaxText v26.5
+- **[2026/07/17]** 🚀 **DeepSeek-V4 training support** - model definition, fused attention/MoE kernels, Muon optimizer, FP8/FP4 recipes, and a projection toolkit ([examples](./examples/deepseek-v4))
+- **[2026/07/16]** 🎨 **Diffusion backend** - Flux.1 image and Wan video training with FP8/MXFP4, FSDP2, and Energon data pipelines ([Diffusion docs](./docs/04-technical-guides/diffusion-models/README.md))
+- **[2026/07/14]** MLPerf Training 6.0 examples on MI355X: Llama2-70B LoRA, Llama3.1-8B, and GPT-OSS-20B ([examples](./examples/mlperf))
+- **[2026/06/15]** [Tuning agent](./docs/02-user-guide/tuning-agent.md) with memory-aware benchmarking for automatic config search
+- **[2026/06/08]** Primus is published as a pip wheel with a bundled `primus-cli` ([install](#install-as-a-python-package-pip))
+- **[2026/01/22]** Post-training via Megatron-Bridge - SFT and LoRA workflows ([Post-training](./docs/02-user-guide/posttraining.md))
+- **[2026/01/06]** MXFP4 low-precision training in the Megatron-LM backend, with MXFP8 recipes following in June
 - **[2025/12/17]** MoE Training Best Practices on AMD GPUs - [MoE Package Blog](https://rocm.blogs.amd.com/software-tools-optimization/primus-moe-package/README.html)
 - **[2025/11/14]** 🎉 **Primus CLI 1.0 Released** - Unified command-line interface with comprehensive documentation
 - **[2025/08/22]** Primus introduction [blog](https://rocm.blogs.amd.com/software-tools-optimization/primus/README.html)
+
+<details>
+<summary>Earlier updates</summary>
+
 - **[2025/06/18]** Added TorchTitan backend support
 - **[2025/05/16]** Added benchmark suite for performance evaluation
 - **[2025/04/18]** Added [Preflight](./primus/tools/preflight/README.md) cluster sanity checker
 - **[2025/04/14]** Integrated HipBLASLt autotuning for optimized GPU kernel performance
 - **[2025/04/09]** Extended support for LLaMA2, LLaMA3, DeepSeek-V2/V3 models
 - **[2025/03/04]** Released Megatron trainer module
+
+</details>
 
 ---
 

--- a/docs/06-developer-guide/model-support-matrix.md
+++ b/docs/06-developer-guide/model-support-matrix.md
@@ -12,10 +12,11 @@ The following aligns with the backend overview and the configs present in this t
 
 | Backend | Model families (documentation / stack scope) |
 | ------- | ---------------------------------------------- |
-| **Megatron-LM** | LLaMA2 / LLaMA3 / LLaMA3.1 / LLaMA3.3 / LLaMA4 (sizes from small to 405B+), DeepSeek-V2 (including lite) and DeepSeek-V3, Mixtral MoE and large MoE recipe YAML, Qwen2.5 and Qwen3 (dense and MoE), Grok, GPT-OSS (20B / 120B), GLM, Kimi K2, LFM2, MiniMax, Zebra LLaMA, Mamba, and generic `language_model.yaml` bases. |
+| **Megatron-LM** | LLaMA2 / LLaMA3 / LLaMA3.1 / LLaMA3.3 / LLaMA4 (sizes from small to 405B+), DeepSeek-V2 (including lite), DeepSeek-V3, and DeepSeek-V4 (flash / pro), Mixtral MoE and large MoE recipe YAML, Qwen2.5 and Qwen3 (dense and MoE), Grok, GPT-OSS (20B / 120B), GLM, Kimi K2, LFM2, MiniMax, Zebra LLaMA (including GDN and KDA linear-attention variants), Mamba, and generic `language_model.yaml` bases. |
 | **TorchTitan** | LLaMA3 family (including 3.1), LLaMA4 examples, DeepSeek-V3 examples, and Qwen3 examples including 0.6B, 1.7B, 4B, 8B, 14B, and 32B variants where present. Additional presets exist under `primus/configs/models/torchtitan/` without being exhaustively listed here. |
 | **MaxText (JAX)** | LLaMA2 / LLaMA3 / LLaMA3.3, DeepSeek-V2 16B, Mixtral-8x7B, Grok1, Qwen3 14B / 30B-A3B (per presets and examples). Broader coverage may exist in upstream MaxText; see [MaxText](https://github.com/AI-Hypercomputer/maxtext). |
 | **Megatron Bridge** | Qwen3 pretraining and post-training examples, plus post-training examples for Zebra LLaMA and Mamba where present. LLaMA 3.1 70B Bridge examples appear under MI355X. |
+| **Diffusion** | Flux.1 (`schnell` / `dev`) text-to-image and Wan 2.1 / 2.2 text- and image-to-video presets under `primus/configs/models/diffusion/`, with examples under `examples/diffusion/configs/` and `examples/megatron/configs/*/diffusion/`. See [Diffusion models](../04-technical-guides/diffusion-models/README.md). |
 | **HummingbirdXT** | Registered backend with a post-training trainer and one checked-in example; user-facing support level still needs maintainer confirmation. |
 
 **Interpretation:** “Supported” in upstream code can exceed what this repository ships as YAML. Rows below reference representative files that exist under `primus/configs/models/` and `examples/`; they should not be treated as a complete generated inventory.


### PR DESCRIPTION
## Summary

The README still described Primus roughly as of early 2025, so a reader could not tell
from the front page that the diffusion backend, DeepSeek-V4, MegaMoE, GDN/KDA hybrid
models, post-training, and the projection/tuning tooling exist.

- **Key Features**: backend list now covers MaxText / Megatron-Bridge / diffusion; added a
  training-lifecycle bullet (pretrain, SFT+LoRA, diffusion) and a projection + tuning-agent
  bullet; ROCm bullet now names Primus-Turbo, DeepEP, MegaMoE, and FP8/MXFP8/MXFP4;
  "plugin-based" corrected to the actual patch-based mechanism.
- **Supported Models**: rewritten against presets actually checked in under
  `primus/configs/models/` and `examples/` — adds DeepSeek-V4, Qwen2.5/Qwen3, Grok,
  GPT-OSS, GLM, Kimi K2, MiniMax, LFM2, Mamba/Zebra-LLaMA (GDN/KDA), plus new
  Megatron-Bridge and Diffusion rows.
- **What's New**: added the 10 most significant 2026 milestones (MegaMoE, GDN/KDA,
  TorchTitan v0.2.2 / MaxText v26.5, DeepSeek-V4, diffusion backend, MLPerf Training 6.0,
  tuning agent, pip wheel, Megatron-Bridge post-training, MXFP4) and collapsed the
  pre-2025/08 entries into a `<details>` block.
- **Model support matrix**: added DeepSeek-V4, the GDN/KDA Zebra-LLaMA variants, and a
  Diffusion row, since the README cites this doc as the authoritative inventory.

Dates are taken from the merge dates of the corresponding PRs (#927, #676, #871, #906,
#882, #832, #877, #854, #755, #750, #500, #470).

## Test plan

- [x] All 19 relative links in the README resolve to existing files/directories
- [x] Root `README.md` is not part of the Sphinx build (source dir is `docs/`, toc root is
      `docs/01-getting-started/overview.md`, no `include` of `../README.md`), so the
      `<details>` block only needs to render on GitHub
- [ ] Visually confirm the `<details>` block and the two rewritten sections render correctly
      in the GitHub PR preview