### PR TITLE
test: tier the trainer E2E suites and add an example-config smoke test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,11 @@ name: Primus-CI-TAS
 
 on:
   workflow_dispatch:
+    inputs:
+      full_tests:
+        description: "Run the full test matrix (every model E2E, including @pytest.mark.weekly siblings, slow unit tests and the MaxText models)"
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -11,9 +16,16 @@ on:
     # Re-list the implicit defaults (opened/synchronize/reopened) and add
     # ready_for_review so flipping a Draft PR to Ready triggers its first run.
     types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Saturday 18:00 UTC (Sunday 02:00 UTC+8) — the weekend full run. Kept far
+    # from Primus-Benchmark's daily 16:00 UTC cron; it also uses other runners.
+    - cron: "0 18 * * 6"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.event.merge_group.head_ref || github.ref }}
+  # Scheduled runs get their own group: they share `github.ref` (refs/heads/main)
+  # with pushes to main, and cancel-in-progress would otherwise let any merge
+  # kill a multi-hour weekend run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'weekly' || github.head_ref || github.event.merge_group.head_ref || github.ref }}
   cancel-in-progress: true
 
 # Default to read-only. No job uses GITHUB_TOKEN for writes (Docker Hub push
@@ -23,6 +35,11 @@ permissions:
   contents: read
 
 env:
+  # Test tier, the single switch every test step derives its pytest args from.
+  # "0" (PR/push) keeps one model E2E per architecture and feature path; "1"
+  # (weekend cron, or a manual run with full_tests=true) adds the
+  # @pytest.mark.weekly siblings and the slow unit tests.
+  PRIMUS_CI_FULL: ${{ (github.event_name == 'schedule' || github.event.inputs.full_tests == 'true') && '1' || '0' }}
   PRIMUS_TURBO_COMMIT: 2f622de6a29ab711925e8fe6bcc763be76ac2699 # fix: loss NaN issue (Primus-Turbo bump); fix: fixed flydsl version (#446)
   PRIMUS_TURBO_AITER_COMMIT: 0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e # AITER v0.1.14.post1 (tag commit) — required by Primus-Turbo main aiter_utils.py
   #ROCSHMEM_COMMIT: 17ff985c026f9f97f85068647e863ab541dd5645 # Update version to 3.2.0 for 7.2.0 rocm release (#351) (#355)
@@ -99,6 +116,11 @@ jobs:
             echo "IMAGE_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # Own tag so the weekend run cannot race a concurrent main push over
+            # ":latest" (both would build the same commit, but not necessarily
+            # at the same time).
+            echo "IMAGE_TAG=weekly" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_NAME="${{ github.ref }}"
             TAG="${TAG_NAME#refs/tags/}"
@@ -296,6 +318,8 @@ jobs:
             echo "IMAGE_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "IMAGE_TAG=weekly" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_NAME="${{ github.ref }}"
             TAG="${TAG_NAME#refs/tags/}"
@@ -347,6 +371,8 @@ jobs:
             echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/pr-${{ github.event.pull_request.number }}-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/main-${ts}-${commit_id}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/weekly-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_NAME="${{ github.ref }}"
             TAG="${TAG_NAME#refs/tags/}"
@@ -370,12 +396,16 @@ jobs:
           #       diffusion TE-vs-local spec attention parity check.
           # Note HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid RCCL perf hit (TAS-8N Node), rocm ver:70125424
           docker exec -i \
-            -e GITHUB_WORKSPACE="${CWS}" -e HSA_NO_SCRATCH_RECLAIM=1 \
+            -e GITHUB_WORKSPACE="${CWS}" -e HSA_NO_SCRATCH_RECLAIM=1 -e PRIMUS_CI_FULL \
             -w "${CWS}" "${UT_CONTAINER}" bash -s <<'IN'
           set -e
           echo "Running Primus Core tests..."
           mkdir -p "${GITHUB_WORKSPACE}/test-reports"
-          pytest --maxfail=1 -s ./tests/unit_tests/ \
+          # Weekend full run also takes the @pytest.mark.slow release-tier shape
+          # gates (they self-skip off MI355X).
+          TIER_ARGS=()
+          [[ "${PRIMUS_CI_FULL:-0}" == "1" ]] && TIER_ARGS=(--run-slow)
+          pytest --maxfail=1 -s ./tests/unit_tests/ "${TIER_ARGS[@]}" \
             --cov=primus --cov-report=term-missing:skip-covered \
             --junitxml="${GITHUB_WORKSPACE}/test-reports/core-unit.xml" \
             --deselect=tests/unit_tests/megatron/cco/test_tp_overlap.py::TPOverlapTestCase::test_fp8_te_linear \
@@ -442,6 +472,11 @@ jobs:
           read RM RT < "${GITHUB_WORKSPACE}/.e2e_scope"
           echo "RUN_MEGATRON_E2E=${RM:-1}" >> "$GITHUB_ENV"
           echo "RUN_TORCHTITAN_E2E=${RT:-1}" >> "$GITHUB_ENV"
+          if [[ "${PRIMUS_CI_FULL:-0}" == "1" ]]; then
+            echo "**Test tier:** full — every model E2E plus the slow unit tests." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Test tier:** slim — one model E2E per architecture (\`-m 'not weekly'\`); the siblings run in the weekend scheduled build." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Run Primus Model Tests -- Megatron-LM
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN}}
@@ -449,7 +484,7 @@ jobs:
           if [[ "${RUN_MEGATRON_E2E:-1}" != "1" ]]; then echo "Skipping Megatron-LM E2E: no relevant changes."; exit 0; fi
           docker exec -i \
             -e GITHUB_WORKSPACE="${CWS}" -e UT_LOG_PATH -e HF_TOKEN \
-            -e COVERAGE_PROCESS_START -e COVERAGE_FILE \
+            -e COVERAGE_PROCESS_START -e COVERAGE_FILE -e PRIMUS_CI_FULL \
             -e MASTER_PORT=10009 -e DATA_PATH=/mnt/apps_proxy/tas/0_public/data \
             -e HSA_NO_SCRATCH_RECLAIM=1 \
             -w "${CWS}" "${UT_CONTAINER}" bash -s <<'IN'
@@ -466,7 +501,9 @@ jobs:
           # crashes (SIGABRT) while compiling the mamba_ssm SSD backward kernel with an
           # LLVM assertion (Sequence.h: `Begin <= End`) in make_amdgcn. Re-enable once
           # the Triton/LLVM toolchain is fixed for this kernel.
-          pytest  --maxfail=1 -s ./tests/trainer/test_megatron_trainer.py \
+          TIER_ARGS=()
+          [[ "${PRIMUS_CI_FULL:-0}" == "1" ]] || TIER_ARGS=(-m "not weekly")
+          pytest  --maxfail=1 -s ./tests/trainer/test_megatron_trainer.py "${TIER_ARGS[@]}" \
             --deselect tests/trainer/test_megatron_trainer.py::TestMegatronTrainer::test_mamba_130M_bridge_pretrain \
             --deselect tests/trainer/test_megatron_trainer.py::TestMegatronTrainer::test_mamba_370M \
             --deselect tests/trainer/test_megatron_trainer.py::TestMegatronTrainer::test_zebra_llama_1B_hybrid \
@@ -479,7 +516,7 @@ jobs:
           if [[ "${RUN_TORCHTITAN_E2E:-1}" != "1" ]]; then echo "Skipping TorchTitan E2E: no relevant changes."; exit 0; fi
           docker exec -i \
             -e GITHUB_WORKSPACE="${CWS}" -e UT_LOG_PATH -e HF_TOKEN \
-            -e COVERAGE_PROCESS_START -e COVERAGE_FILE \
+            -e COVERAGE_PROCESS_START -e COVERAGE_FILE -e PRIMUS_CI_FULL \
             -e MASTER_PORT=10009 -e DATA_PATH=/mnt/apps_proxy/tas/0_public/data \
             -e HSA_NO_SCRATCH_RECLAIM=1 \
             -w "${CWS}" "${UT_CONTAINER}" bash -s <<'IN'
@@ -496,7 +533,9 @@ jobs:
           # attention v3 backward kernel raises "RuntimeError: invalid argument for
           # fmha_v3_bwd" during loss.backward() on the fp8 path (all ranks).
           # Re-enable once the primus_turbo/aiter fp8 attention backward is fixed.
-          pytest  --maxfail=1 -s ./tests/trainer/test_torchtitan_trainer.py \
+          TIER_ARGS=()
+          [[ "${PRIMUS_CI_FULL:-0}" == "1" ]] || TIER_ARGS=(-m "not weekly")
+          pytest  --maxfail=1 -s ./tests/trainer/test_torchtitan_trainer.py "${TIER_ARGS[@]}" \
             --deselect tests/trainer/test_torchtitan_trainer.py::TestTorchTitanTrainer::test_deepseek_v3_671b \
             --deselect tests/trainer/test_torchtitan_trainer.py::TestTorchTitanTrainer::test_deepseek_v3_16b_fp8 \
             --junitxml="${GITHUB_WORKSPACE}/test-reports/torchtitan-e2e.xml"
@@ -677,6 +716,8 @@ jobs:
             echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/pr-${{ github.event.pull_request.number }}-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/main-${ts}-${commit_id}" >> $GITHUB_ENV
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "UT_LOG_PATH=${PRIMUS_WORKDIR}/ut_out/weekly-${ts}-${commit_id}" >> $GITHUB_ENV
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG_NAME="${{ github.ref }}"
             TAG="${TAG_NAME#refs/tags/}"
@@ -731,6 +772,8 @@ jobs:
           # run_unit_tests.py shells out to pytest; PYTEST_ADDOPTS injects the
           # JUnit report without having to touch the wrapper script.
           export PYTEST_ADDOPTS="--junitxml=${GITHUB_WORKSPACE}/test-reports/maxtext-e2e.xml"
+          # JAX_SKIP_UT=1 in both tiers: the MaxText models it hides stay hidden
+          # even in the weekend full run, like the --deselect'ed cases.
           # MASTER_PORT=10009 DATA_PATH=/wekafs/primus-data \
           MASTER_PORT=10009 DATA_PATH=/mnt/apps_proxy/tas/0_public/data \
           JAX_SKIP_UT=1 python ./tests/run_unit_tests.py --jax

--- a/docs/06-developer-guide/testing.md
+++ b/docs/06-developer-guide/testing.md
@@ -87,6 +87,57 @@ python ./tests/run_unit_tests.py --jax
 - **Unit tests:** Cover configuration parsing, preset loading, CLI behavior, patch registration, adapters, and other library logic under `tests/unit_tests/`.
 - **Trainer tests:** End-to-end training against real backends; require AMD GPUs and appropriate data paths (and sometimes tokens). See `.github/workflows/ci.yaml` for CI values such as `DATA_PATH`, `MASTER_PORT`, and `HSA_NO_SCRATCH_RECLAIM`.
 
+### Test tiers (slim on PRs, full on weekends)
+
+Each trainer E2E case is a full training launch, so the suites hold one model per
+architecture and per feature path. A model that only scales the dims of an
+existing test is **deleted**, not kept in a slower tier — its recipe stays
+schema-checked by the example-config smoke test below. What remains is split by
+the **`@pytest.mark.weekly`** marker (registered in `tests/conftest.py`):
+
+| Tier | Trigger | Model E2E | Unit tests |
+| --- | --- | --- | --- |
+| slim | pull request, push to `main`/tags | `-m "not weekly"` | default (slow gates skipped) |
+| full | `schedule` cron (Sat 18:00 UTC), or `workflow_dispatch` with `full_tests=true` | no filter | `--run-slow` |
+
+The workflow derives every test step's arguments from a single `PRIMUS_CI_FULL`
+workflow-level env var, so there is one switch to flip.
+
+Two kinds of case belong in the weekly tier: extended coverage that is not worth
+a PR's wall clock — secondary architectures, extra precisions, variants of a
+feature whose primary path stays per-PR — and new E2E cases during burn-in,
+promoted to the per-PR tier by deleting the marker once a weekend run has shown
+them green. Each marked case carries a comment saying what still covers its path
+on PRs.
+
+Reproduce either tier locally:
+
+```bash
+pytest tests/trainer/test_megatron_trainer.py -m "not weekly" -s   # what PR CI runs
+pytest tests/trainer/test_megatron_trainer.py -s                   # full matrix
+```
+
+Two things are deliberately outside this mechanism and stay hidden in **both**
+tiers: the cases `--deselect`ed in `ci.yaml` because they are broken on the
+current toolchain, and the MaxText models hidden by `JAX_SKIP_UT=1`.
+
+Do not delete the last remaining test of an architecture or of a feature path.
+Two cases with identical `extra_args` are not necessarily isomorphic: the flag
+that makes one unique often lives in its recipe yaml, so compare those too.
+
+### Example-config smoke test
+
+`tests/unit_tests/configs/test_example_configs.py` loads **every** yaml under
+`examples/**/configs/` through the real config stack — env interpolation,
+`extends:` merge, module/model preset merge, experiment overrides — and asserts
+each resolves to a well-formed experiment whose declared `framework` matches its
+backend directory. It is CPU-only (`load_primus_config` does not import
+megatron/torchtitan/jax) and runs in seconds.
+
+This is what makes deleting an isomorphic E2E safe: the recipe stops being
+*trained*, but a renamed model preset, a broken `extends:` chain or a `${VAR}`
+without a default still fails CI, naming the exact yaml.
+
 ## 4. Writing new tests
 
 - **Pytest:** Add files named `test_*.py` under `tests/unit_tests/`, following existing patterns and reusing fixtures from `conftest.py` where present.
@@ -101,6 +152,8 @@ From `.github/workflows/ci.yaml`:
 - **`dependency-review`:** Runs `actions/dependency-review-action` on pull requests to flag dependency changes.
 - **`run-unittest-torch`:** Self-hosted GPU runner. Installs `requirements.txt`, runs `bash ./tests/runner/run_all_tests.sh`, then `pytest tests/unit_tests/` under coverage (`--cov=primus --cov-report=term-missing`) with specific tests `--deselect`ed (currently some `megatron/cco` TP-overlap and `megatron/transformer/moe` dispatcher cases—see the workflow file). Trainer steps set `MASTER_PORT`, `DATA_PATH`, `HSA_NO_SCRATCH_RECLAIM=1`, and `HF_TOKEN` for Megatron and TorchTitan trainer tests. A follow-up **coverage** step combines unit and E2E coverage.
 - **`run-unittest-jax`:** JAX runner. Installs `requirements-jax.txt`, runs the same shell test script, then `python ./tests/run_unit_tests.py --jax` with CI environment variables (for example `JAX_SKIP_UT=1` and `DATA_PATH` as defined in the workflow).
+
+The torch job picks its tier from `PRIMUS_CI_FULL` and prints the resolved tier in the job summary. See [Test tiers](#test-tiers-slim-on-prs-full-on-weekends).
 
 The **`build-docker`** job builds images after lint passes; unit test jobs depend on **`code-lint`**, not on **`build-docker`**.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,4 +46,39 @@ python ./tests/run_unit_tests.py          # Torch backends
 python ./tests/run_unit_tests.py --jax    # JAX/MaxText backend
 ```
 
+## Test Tiers
+
+Every trainer E2E case is a full training launch, so the suites hold **one model
+per architecture and per feature path**. Anything beyond that is either deleted
+or deferred to the weekend:
+
+- **Deleted.** A model that only scales the dims of an existing test earns no
+  coverage. Its recipe is still schema-checked by
+  `unit_tests/configs/test_example_configs.py`, which loads every yaml under
+  `examples/**/configs/`.
+- **`@pytest.mark.weekly`.** Extended coverage worth having but not worth a PR's
+  wall clock, and new cases during burn-in. Deselected on PRs and pushes; run by
+  the weekend scheduled build (Saturday 18:00 UTC), which you can also trigger by
+  hand via the `Primus-CI-TAS` workflow with `full_tests=true`. Promote a case to
+  the per-PR tier by deleting the marker once a weekend run has shown it green.
+- **Per-PR.** Everything else.
+
+```bash
+# What PR CI runs
+pytest tests/trainer/test_megatron_trainer.py -m "not weekly" -s
+
+# The weekend tier: full matrix, plus the slow unit-test shape gates
+pytest tests/trainer/test_megatron_trainer.py -s
+pytest tests/unit_tests/ --run-slow -s
+```
+
+Before removing a model, check it is not the last user of a feature path. The
+difference often lives in the recipe yaml rather than in the test body, so two
+cases whose `extra_args` look identical can still cover different code — diff the
+recipes before concluding they are isomorphic.
+
+Cases hidden by `--deselect` in `ci.yaml` (broken on the current toolchain) and
+by `JAX_SKIP_UT=1` (most MaxText models) stay hidden in **both** tiers; they are
+not part of this mechanism.
+
 For comprehensive testing documentation, see the [Testing Guide](../docs/06-developer-guide/testing.md).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,16 @@ def pytest_configure(config):
     if str(project_root) not in sys.path:
         sys.path.insert(0, str(project_root))
 
+    # What belongs in this tier, and what should be deleted instead of demoted
+    # into it, is documented in docs/06-developer-guide/testing.md.
+    config.addinivalue_line(
+        "markers",
+        (
+            "weekly: extended or not-yet-burned-in E2E coverage. Deselected on "
+            "PR/push CI via -m 'not weekly'; run by the weekend scheduled CI run."
+        ),
+    )
+
     megatron_path = os.environ.get("MEGATRON_PATH")
     if megatron_path is None or not os.path.exists(megatron_path):
         megatron_path = project_root / "third_party" / "Megatron-LM"

--- a/tests/trainer/test_megatron_trainer.py
+++ b/tests/trainer/test_megatron_trainer.py
@@ -12,6 +12,8 @@ import subprocess
 import sys
 import unittest
 
+import pytest
+
 from tests.utils import PrimusUT, run_training_script
 
 
@@ -128,6 +130,21 @@ def run_posttrain_script(
 
 
 class TestMegatronTrainer(PrimusUT):
+    """One model per architecture, plus one case per feature path.
+
+    Every case is a full training launch, so a model that only scales the dims
+    of a sibling earns no coverage and does not belong here: qwen3_235B_A22B
+    (same template as qwen3_30B_A3B) and mixtral_8x22B (same template as
+    mixtral_8x7B, whose recipe additionally covers DeepEP / sync-free MoE) were
+    removed for that reason. Their example yamls are still schema-checked by
+    tests/unit_tests/configs/test_example_configs.py.
+
+    Before adding a model, check it is not isomorphic to one already here, and
+    before removing one, check it is not the last user of a feature path --
+    llama3_70B for instance is the only recipe that enables use_torch_fsdp2.
+    See tests/README.md.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -142,6 +159,26 @@ class TestMegatronTrainer(PrimusUT):
             self.__class__.__name__,
             "llama3_8B",
             exp_path=f"examples/megatron/configs/{GPU_PLATFORM}/llama3_8B-BF16-pretrain.yaml",
+            env_override={},
+            extra_args=[
+                "--num_layers",
+                "4",
+                "--train_iters",
+                "3",
+                "--enable_primus_turbo",
+                "1",
+                "--use_turbo_attention",
+                "1",
+            ],
+        )
+
+    # The only dense FP8 case; every other FP8 case here is MoE.
+    @pytest.mark.weekly
+    def test_llama3_8B_fp8(self):
+        run_script(
+            self.__class__.__name__,
+            "llama3_8B_fp8",
+            exp_path=f"examples/megatron/configs/{GPU_PLATFORM}/llama3_8B-FP8-pretrain.yaml",
             env_override={},
             extra_args=[
                 "--num_layers",
@@ -227,46 +264,9 @@ class TestMegatronTrainer(PrimusUT):
             ],
         )
 
-    def test_qwen3_235B_A22B(self):
-        run_script(
-            self.__class__.__name__,
-            "qwen3_235B_A22B",
-            exp_path=f"examples/megatron/configs/{GPU_PLATFORM}/qwen3_235B_A22B-BF16-pretrain.yaml",
-            env_override={},
-            extra_args=[
-                "--num_layers",
-                "4",
-                "--moe_layer_freq",
-                "[0]*1+[1]*3",
-                "--train_iters",
-                "3",
-                "--micro_batch_size",
-                "1",
-                "--global_batch_size",
-                "8",
-                "--expert_model_parallel_size",
-                "8",
-                "--pipeline_model_parallel_size",
-                "1",
-                # Unset the config's interleaved pipeline_model_parallel_layout (it
-                # requires PP>1, but this test runs with PP=1). "None" is coerced to
-                # Python None by parse_cli_overrides, which clears the layout; an empty
-                # string instead builds an empty layout that fails validation.
-                "--pipeline_model_parallel_layout",
-                "None",
-                "--recompute_granularity",
-                "full",
-                "--recompute_method",
-                "block",
-                "--recompute_num_layers",
-                "0",
-                "--enable_primus_turbo",
-                "1",
-                "--use_turbo_attention",
-                "1",
-            ],
-        )
-
+    # Its gated_delta_net attention is an experimental variant and needs
+    # flash-linear-attention; qwen3 MoE stays covered per-PR by qwen3_30B_A3B.
+    @pytest.mark.weekly
     def test_qwen3_5_35B_A3B(self):
         run_script(
             self.__class__.__name__,
@@ -351,6 +351,9 @@ class TestMegatronTrainer(PrimusUT):
             ],
         )
 
+    # Secondary architecture; MoE with expert parallelism stays covered per-PR by
+    # deepseek_v2_lite and qwen3_30B_A3B.
+    @pytest.mark.weekly
     def test_mixtral_8x7B(self):
         run_script(
             self.__class__.__name__,
@@ -377,11 +380,14 @@ class TestMegatronTrainer(PrimusUT):
             ],
         )
 
-    def test_mixtral_8x22B(self):
+    # Its own architecture: rope scaling, qk_layernorm and shared-expert overlap
+    # on every layer.
+    @pytest.mark.weekly
+    def test_llama4_17B16E(self):
         run_script(
             self.__class__.__name__,
-            "mixtral_8x22B_v0.1",
-            exp_path=f"examples/megatron/configs/{GPU_PLATFORM}/mixtral_8x22B_v0.1-BF16-pretrain.yaml",
+            "llama4_17B16E",
+            exp_path=f"examples/megatron/configs/{GPU_PLATFORM}/llama4_17B16E-BF16-pretrain.yaml",
             env_override={},
             extra_args=[
                 "--num_layers",
@@ -392,19 +398,14 @@ class TestMegatronTrainer(PrimusUT):
                 "1",
                 "--global_batch_size",
                 "8",
-                "--moe_layer_freq",
-                "1",
                 "--expert_model_parallel_size",
                 "8",
-                "--pipeline_model_parallel_size",
-                "1",
-                "--enable_primus_turbo",
-                "1",
-                "--use_turbo_attention",
-                "1",
             ],
         )
 
+    # Secondary architecture; PP+VPP stay covered per-PR by deepseek_v3 and
+    # test_interleaved_pipeline_parallelism.
+    @pytest.mark.weekly
     def test_grok2(self):
         run_script(
             self.__class__.__name__,
@@ -619,6 +620,8 @@ class TestMegatronTrainer(PrimusUT):
             Dataloader_mp_context_patch_log in stdout
         ), "Expected dataloader_mp_context patch log not found in stdout"
 
+    # A fused-op combination on top of llama3_8B, which stays covered per-PR.
+    @pytest.mark.weekly
     def test_sdma_allgather_fused_residual_norm(self):
         # Neither patch runs in any other case here: SDMA param all-gather
         # only activates with ENABLE_SDMA_ALLGATHER=1 (env var, not a --arg) +
@@ -730,6 +733,8 @@ class TestMegatronTrainer(PrimusUT):
             extra_args=["--attention_backend", "unfused"],
         )
 
+    # UEP variant; the deepep path stays covered per-PR by test_turbo_deepep.
+    @pytest.mark.weekly
     def test_deepseekv2_lite_uep(self):
         run_script(
             self.__class__.__name__,
@@ -812,6 +817,10 @@ class TestMegatronTrainer(PrimusUT):
         self.assertIn("Training completed.", stdout)
         return stdout
 
+    # The three zbv cases below differ only in wgrad-split backend (TE / turbo /
+    # legacy grouped GEMM), and at 8 layers with PP=4 VPP=2 each costs more than
+    # the 4-layer cases above.
+    @pytest.mark.weekly
     def test_deepseek_v2_lite_te_fp8_zbv_formatted(self):
         stdout = self._run_deepseek_v2_lite_zbv_fp8_case(
             "deepseek_v2_lite_te_fp8_zbv_formatted",
@@ -823,6 +832,7 @@ class TestMegatronTrainer(PrimusUT):
         self.assertIn("[Patch:megatron.pp.te_wgrad_split]", stdout)
         self.assertNotIn("[Patch:megatron.pp.legacy_grouped_mlp_wgrad_split]", stdout)
 
+    @pytest.mark.weekly
     def test_deepseek_v2_lite_turbo_bf16_zbv_formatted(self):
         stdout = self._run_deepseek_v2_lite_zbv_fp8_case(
             "deepseek_v2_lite_turbo_fp8_zbv_formatted",
@@ -839,6 +849,7 @@ class TestMegatronTrainer(PrimusUT):
         )
         self.assertNotIn("[Patch:megatron.pp.legacy_grouped_mlp_wgrad_split]", stdout)
 
+    @pytest.mark.weekly
     def test_deepseek_v2_lite_bf16_lagacy_gg_zbv_formatted(self):
         stdout = self._run_deepseek_v2_lite_zbv_fp8_case(
             "deepseek_v2_lite_bf16_lagacy_gg_zbv_formatted",
@@ -854,7 +865,16 @@ class TestMegatronTrainer(PrimusUT):
         self.assertIn("[Patch:megatron.pp.legacy_grouped_mlp_wgrad_split]", stdout)
 
 
+@pytest.mark.weekly
 class TestMegatronTrainerDeterministic(PrimusUT):
+    """Bitwise reproducibility, weekend-only.
+
+    Every case here runs the same config twice and compares the losses as
+    strings, so each one costs two full training launches. Determinism breaks
+    from the kernel/collective stack rather than from a typical PR, so the pair
+    is not worth ~4 launches on the per-PR path.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/tests/trainer/test_torchtitan_trainer.py
+++ b/tests/trainer/test_torchtitan_trainer.py
@@ -6,6 +6,8 @@
 
 import os
 
+import pytest
+
 from tests.utils import PrimusUT, run_training_script
 
 
@@ -45,6 +47,26 @@ def run_script(
 
 
 class TestTorchTitanTrainer(PrimusUT):
+    """One config per distinct code path; isomorphic flavors are not tested here.
+
+    Every case is a full training launch, so a model whose code path a sibling
+    already covers earns no coverage. What is kept and why:
+
+    - llama3.1_8B BF16 + FP8: the dense llama path, both precisions.
+    - qwen3_0.6B: the qwen3 dense path (activation_checkpoint off).
+    - qwen3_32B: the dense config with activation_checkpoint.mode=full.
+    - deepseek_v3_16b: MLA + MoE on classic attention, no float8.
+    - deepseek_v3_16b_fp8: the only use_moe_fp8 path; also swaps classic
+      attention for the turbo one.
+    - deepseek_v3_671b: MLA + MoE under full recompute and
+      use_turbo_float8_linear.
+    - gpt_oss_20B BF16 + FP8: MoE + sink attention, selective checkpointing.
+
+    llama3.1_70B / llama3.1_405B (both precisions) and qwen3_1.7B used to be
+    here; they only scaled the dims of the above. Their recipes are still
+    schema-checked by tests/unit_tests/configs/test_example_configs.py.
+    """
+
     def test_llama3_1_8B_BF16(self):
         run_script(
             self.__class__.__name__,
@@ -75,86 +97,11 @@ class TestTorchTitanTrainer(PrimusUT):
             ],
         )
 
-    def test_llama3_1_405B_bf16(self):
-        run_script(
-            self.__class__.__name__,
-            "llama3.1_405B_bf16",
-            "examples/torchtitan/configs/MI300X/llama3.1_405B-BF16-pretrain.yaml",
-            extra_args=[
-                "--model.n_layers",
-                "4",
-                "--training.steps",
-                "3",
-                "--training.mock_data",
-                "True",
-            ],
-        )
-
-    def test_llama3_1_405B_fp8(self):
-        run_script(
-            self.__class__.__name__,
-            "llama3.1_405B_fp8",
-            "examples/torchtitan/configs/MI300X/llama3.1_405B-FP8-pretrain.yaml",
-            extra_args=[
-                "--model.n_layers",
-                "4",
-                "--training.steps",
-                "3",
-                "--training.mock_data",
-                "True",
-            ],
-        )
-
-    def test_llama3_1_70B_bf16(self):
-        run_script(
-            self.__class__.__name__,
-            "llama3.1_70B_bf16",
-            "examples/torchtitan/configs/MI300X/llama3.1_70B-BF16-pretrain.yaml",
-            extra_args=[
-                "--model.n_layers",
-                "4",
-                "--training.steps",
-                "3",
-                "--training.mock_data",
-                "True",
-            ],
-        )
-
-    def test_llama3_1_70B_fp8(self):
-        run_script(
-            self.__class__.__name__,
-            "llama3.1_70B_fp8",
-            "examples/torchtitan/configs/MI300X/llama3.1_70B-FP8-pretrain.yaml",
-            extra_args=[
-                "--model.n_layers",
-                "4",
-                "--training.steps",
-                "3",
-                "--training.mock_data",
-                "True",
-            ],
-        )
-
     def test_qwen3_0_6B(self):
         run_script(
             self.__class__.__name__,
             "qwen3_0.6B",
             "examples/torchtitan/configs/MI300X/qwen3_0.6B-pretrain.yaml",
-            extra_args=[
-                "--model.n_layers",
-                "4",
-                "--training.steps",
-                "3",
-                "--training.mock_data",
-                "True",
-            ],
-        )
-
-    def test_qwen3_1_7B(self):
-        run_script(
-            self.__class__.__name__,
-            "qwen3_1.7B",
-            "examples/torchtitan/configs/MI300X/qwen3_1.7B-pretrain.yaml",
             extra_args=[
                 "--model.n_layers",
                 "4",
@@ -252,6 +199,24 @@ class TestTorchTitanTrainer(PrimusUT):
             self.__class__.__name__,
             "gpt_oss_20B_fp8",
             "examples/torchtitan/configs/MI300X/gpt_oss_20B-FP8-pretrain.yaml",
+            extra_args=[
+                "--model.n_layers",
+                "4",
+                "--training.steps",
+                "3",
+                "--training.mock_data",
+                "True",
+            ],
+        )
+
+    # Llama 4 had no E2E in either backend. Distinct from the llama3 flavor above:
+    # MoE with a shared expert, and the recipe's use_turbo_grouped_mm path.
+    @pytest.mark.weekly
+    def test_llama4_17Bx16E(self):
+        run_script(
+            self.__class__.__name__,
+            "llama4_17Bx16E",
+            "examples/torchtitan/configs/MI300X/llama4_17Bx16E-BF16-pretrain.yaml",
             extra_args=[
                 "--model.n_layers",
                 "4",

--- a/tests/unit_tests/configs/test_example_configs.py
+++ b/tests/unit_tests/configs/test_example_configs.py
@@ -1,0 +1,93 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Schema smoke test for every shipped experiment recipe under `examples/`.
+
+The trainer E2E suites only launch one model per architecture, so most of the
+~380 example recipes are never loaded by any other test -- a rename in
+`primus/configs/models/`, a broken `extends:` chain or a `${VAR}` without a
+default would ship unnoticed. This test loads all of them through the real
+config stack (env interpolation -> extends merge -> module/model preset merge ->
+experiment overrides) and asserts the resulting experiment is well formed.
+
+It is CPU-only and needs no GPU: `load_primus_config` resolves YAML and presets
+without importing megatron / torchtitan / jax (backends are only imported later,
+by `PrimusRuntime._initialize_adapter`).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from primus.core.config.primus_config import load_primus_config
+from primus.core.utils import file_utils
+
+ROOT = Path(__file__).resolve().parents[3]
+EXAMPLES = ROOT / "examples"
+
+# Backend dir -> the `framework` every experiment under it must declare.
+BACKENDS = ("megatron", "torchtitan", "maxtext", "megatron_bridge")
+
+MODULE_NAMES = {"pre_trainer", "post_trainer"}
+
+# Not an experiment: a Transformer Engine precision-matcher fragment that lives
+# next to the recipes and has no work_group / modules of its own.
+NOT_AN_EXPERIMENT = {
+    "examples/megatron/configs/MI355X/lfm2_8B_A1B-FP8-te-precision.yaml",
+}
+
+
+def _discover():
+    found = []
+    for backend in BACKENDS:
+        for path in sorted((EXAMPLES / backend / "configs").rglob("*.yaml")):
+            rel = path.relative_to(ROOT).as_posix()
+            if rel not in NOT_AN_EXPERIMENT:
+                found.append(rel)
+    return found
+
+
+EXAMPLE_CONFIGS = _discover()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _no_workspace_side_effects():
+    """Keep loading side-effect free.
+
+    `PrimusConfig.__init__` mkdir's `<workspace>/<group>/<user>/<exp_name>`, and
+    most recipes hardcode `workspace: ./output`, so a bare load would litter the
+    repo (and fail outright when `output/` is not writable by the test user).
+    Only directory creation is stubbed; the config resolution under test is
+    untouched.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(file_utils, "create_path_if_not_exists", lambda *args, **kwargs: None)
+        yield
+
+
+def test_every_backend_contributes_configs():
+    """Guard the glob itself: a typo'd path would otherwise make the suite pass
+    with zero recipes checked."""
+    per_backend = {b: sum(1 for c in EXAMPLE_CONFIGS if c.startswith(f"examples/{b}/")) for b in BACKENDS}
+    assert all(per_backend.values()), f"no example configs discovered for some backend: {per_backend}"
+
+
+@pytest.mark.parametrize("rel_path", EXAMPLE_CONFIGS, ids=EXAMPLE_CONFIGS)
+def test_example_config_loads(rel_path):
+    cfg = load_primus_config(ROOT / rel_path, None)
+
+    modules = getattr(cfg, "modules", [])
+    assert modules, f"{rel_path}: no trainer module resolved"
+
+    backend = rel_path.split("/")[1]
+    for module in modules:
+        assert module.name in MODULE_NAMES, f"{rel_path}: unexpected module '{module.name}'"
+        # A recipe filed under examples/<backend>/ that declares another
+        # framework would be launched by the wrong adapter.
+        assert module.framework == backend, (
+            f"{rel_path}: declares framework '{module.framework}' " f"but lives under examples/{backend}/"
+        )
+        assert hasattr(module, "params"), f"{rel_path}: module '{module.name}' resolved no params"


### PR DESCRIPTION
## Why

Every trainer E2E case is a full training launch, and the suites had grown a
scale ladder: the same architecture repeated at 8B / 70B / 405B, each clamped to
2-8 layers. At that depth a 405B recipe executes the same code as an 8B one, so
the extra launches bought no coverage and every PR paid for them.

## What changed

**Deleted seven cases** that only scaled the dims of a sibling — Megatron's
`qwen3_235B_A22B` and `mixtral_8x22B`, TorchTitan's `llama3.1_405B` and
`llama3.1_70B` (both precisions) and `qwen3_1.7B`. Nothing else covered was lost:
each was compared against its siblings by diffing the recipe yamls, not just the
`extra_args`.

**Added a `@pytest.mark.weekly` tier** for coverage worth having but not worth a
PR's wall clock — the determinism pair (two launches each), secondary
architectures, and variants of a feature whose primary path stays per-PR. Every
marked case carries a comment naming what still covers it on PRs, so the decision
can be revisited without redoing the audit.

**Added an example-config smoke test** that loads every yaml under
`examples/**/configs/` through the real config stack and asserts each resolves to
a well-formed experiment. This is what makes deleting an E2E safe: the recipe
stops being *trained*, but a renamed preset, a broken `extends:` chain or a
`${VAR}` without a default still fails CI, naming the exact file. CPU-only, runs
in seconds.

**Wired CI to a single `PRIMUS_CI_FULL` switch.** PR and push runs deselect
`weekly`; a Saturday 18:00 UTC cron takes everything and adds `--run-slow`. The
tier is also reachable by hand via `workflow_dispatch` with `full_tests=true`.

## Effect

| | per-PR launches | weekend launches |
| --- | --- | --- |
| Megatron | 25 → 12 | 14 |
| TorchTitan | 15 → 9 | 1 |

## Notes for review

Two scheduling details are load-bearing rather than cosmetic. Scheduled runs get
their own concurrency group, because they otherwise share `github.ref` with
pushes to `main` and `cancel-in-progress` would let any merge kill a multi-hour
weekend run. They also get their own image tag instead of `:latest`, so the
weekend build cannot race a concurrent push over the same tag.

FP8 and the pipeline-layout paths are kept per-PR deliberately. Moving
`test_turbo_fp8_grouped_gemm` would leave the per-PR tier with no FP8 E2E at all
now that `llama3_8B_fp8` is weekly, and `deepseek_v3` is the only case exercising
`pipeline_model_parallel_layout` and `recompute_layer_ids`.