### PR TITLE
fix(tests): give each E2E test its own TorchInductor cache

### DIFF
--- a/tests/trainer/conftest.py
+++ b/tests/trainer/conftest.py
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+# Resolved once, before any test can point TMPDIR elsewhere, so each test's cache
+# root is a sibling under the real temp dir rather than nested inside the
+# previous test's (already deleted) one.
+_BASE_TMPDIR = tempfile.gettempdir()
+
+_CACHE_VARS = ("TORCHINDUCTOR_CACHE_DIR", "TRITON_CACHE_DIR")
+
+
+@pytest.fixture(autouse=True)
+def isolated_compile_caches():
+    """Give every E2E test in this directory its own TorchInductor/Triton caches.
+
+    These tests launch real training, and CI runs the whole suite inside one
+    long-lived container. With the default locations they all share
+    /tmp/torchinductor_<user> and ~/.triton, so a kernel compiled during one test
+    is reused by every later test and by every later job in that container.
+
+    TMPDIR is deliberately left alone: the training ranks hand file descriptors
+    to DataLoader workers over an AF_UNIX socket underneath it, and sun_path caps
+    that address at 107 bytes.
+
+    The caches are deleted afterwards, since the container outlives the job and
+    each test writes a few hundred MB.
+    """
+    cache_root = tempfile.mkdtemp(prefix="primus-ut-cache-", dir=_BASE_TMPDIR)
+    saved = {var: os.environ.get(var) for var in _CACHE_VARS}
+
+    os.environ["TORCHINDUCTOR_CACHE_DIR"] = os.path.join(cache_root, "torchinductor")
+    os.environ["TRITON_CACHE_DIR"] = os.path.join(cache_root, "triton")
+    try:
+        yield cache_root
+    finally:
+        for var, value in saved.items():
+            if value is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = value
+        shutil.rmtree(cache_root, ignore_errors=True)


### PR DESCRIPTION
## What this changes

Each Megatron/TorchTitan E2E test gets its own TorchInductor and Triton cache directory instead of sharing `/tmp/torchinductor_<user>` with every other test in the session. The directory is removed when the test finishes, so the long-lived CI container does not accumulate a few hundred MB per test.

## The failure it addresses

`test_qwen3_5_35B_A3B` failed in every CI job on the torch runner for about two weeks, always the same way: `found NaN in local grad norm for bucket #0 in backward pass before data-parallel communication collective`, raised at iteration 1. The failing rank varied between runs (4 and 7 observed), so it was not one bad GPU. Run in isolation the test passed consistently; only the full-suite context failed.

## How it was verified

Two full-suite runs on the CI node with the patch applied, both green: [31509240766](https://github.com/AMD-AGI/Primus/actions/runs/31509240766) and [31522850484](https://github.com/AMD-AGI/Primus/actions/runs/31522850484). Each ran 31 Megatron tests with 0 failures, and `test_qwen3_5_35B_A3B` executed and passed in both (142 s and 145 s).

Both were dispatched **before this branch merged `main`**, so they used the branch's own pre-tiering `ci.yaml`: no `-m "not weekly"`, the whole 18-model suite, `test_qwen3_5_35B_A3B` included. That matters, because `main` has since marked that test `@pytest.mark.weekly` (#961) and per-PR CI no longer runs it. **The green check on this PR after the merge does not exercise the test.** To re-verify from here, dispatch the workflow with `full_tests=true`.

## Why per-test and not a shared cache root

`examples/run_pretrain.sh` already isolates these caches under `PRIMUS_CACHE_ROOT`, and that isolation was lost when the tests moved to `primus-cli direct`, which sets no cache variables at all. Porting that scheme over as-is would not help here: its default is a cache persisted across runs, which is the same sharing pattern.

`TMPDIR` is deliberately left alone. An earlier revision pointed it at a directory named after the test, which broke `test_llama3_1_8B_tp2_distributed_dataset_regression`: its ranks hand file descriptors to DataLoader workers over an AF_UNIX socket at `$TMPDIR/pymp-XXXXXXXX/listener-XXXXXXXX`, and a 76-byte `TMPDIR` pushed that address to 108 bytes, one over the 107-byte `sun_path` limit.

## Test plan

- [x] Full suite twice on the CI node, pre-tiering config, `test_qwen3_5_35B_A3B` included — 31 passed, 0 failed, both runs
- [x] `test_llama3_1_8B_tp2_distributed_dataset_regression` — passes (the `sun_path` regression from the earlier revision is gone)
