### PR TITLE
feat(ainic): default RCCL_AINIC_ROCE=1 to enable built-in ANP

### DIFF
--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -167,6 +167,9 @@ export NCCL_CHECKS_DISABLE=1
 
 if [ "$USING_AINIC" == "1" ]; then
     LOG_INFO_RANK0 "Using AINIC"
+    # ROCm 7.2.1+ builds ANP into RCCL; RCCL_AINIC_ROCE=1 enables the built-in ANP
+    # path. An explicitly-set NCCL_NET_PLUGIN below still takes precedence.
+    export RCCL_AINIC_ROCE="${RCCL_AINIC_ROCE:-1}"
     export NCCL_IB_GID_INDEX=1
     export NCCL_IB_TC=${NCCL_IB_TC:-104}
     export NCCL_IB_FIFO_TC=${NCCL_IB_FIFO_TC:-192}

--- a/examples/run_pretrain.sh
+++ b/examples/run_pretrain.sh
@@ -189,7 +189,12 @@ if [ "$USING_AINIC" == "1" ]; then
         "${RCCL_HOME_DIR}/build/release" \
         "${ANP_HOME_DIR}/build" \
         "${MPI_HOME_DIR}/lib"
-    if [ -n "${NCCL_NET_PLUGIN:-}" ]; then
+    # With built-in ANP (RCCL_AINIC_ROCE=1) default to "none" so RCCL uses its
+    # built-in ANP transport instead of auto-loading an external plugin. An
+    # explicitly-set NCCL_NET_PLUGIN always wins.
+    if [ "${RCCL_AINIC_ROCE}" = "1" ]; then
+        export NCCL_NET_PLUGIN="${NCCL_NET_PLUGIN:-none}"
+    elif [ -n "${NCCL_NET_PLUGIN:-}" ]; then
         export NCCL_NET_PLUGIN
     elif [ -f "${ANP_HOME_DIR}/build/librccl-anp.so" ]; then
         export NCCL_NET_PLUGIN=librccl-anp.so

--- a/runner/helpers/hooks/03_enable_ainic.sh
+++ b/runner/helpers/hooks/03_enable_ainic.sh
@@ -36,14 +36,22 @@ MPI_HOME_DIR="${MPI_HOME_DIR:-/opt/ompi}"
 # precedence (force-loads the named plugin) irrespective of RCCL_AINIC_ROCE.
 RCCL_AINIC_ROCE="${RCCL_AINIC_ROCE:-1}"
 
-# NCCL_NET_PLUGIN: ANP libraray has different names in different containers: librccl-anp.so or librccl-net.so.
-if [ -z "${NCCL_NET_PLUGIN:-}" ]; then
-    if [ -f "${ANP_HOME_DIR}/build/librccl-anp.so" ]; then
-        NCCL_NET_PLUGIN="librccl-anp.so"
-    elif [ -f "${ANP_HOME_DIR}/build/librccl-net.so" ]; then
-        NCCL_NET_PLUGIN="librccl-net.so"
-    else
-        NCCL_NET_PLUGIN="librccl-anp.so"
+# NCCL_NET_PLUGIN selection.
+# With built-in ANP (RCCL_AINIC_ROCE=1) default to "none" so RCCL uses its built-in
+# ANP transport instead of auto-loading an external plugin. Otherwise auto-detect the
+# external ANP plugin (name varies by container: librccl-anp.so or librccl-net.so).
+# An explicitly-set NCCL_NET_PLUGIN always wins in both cases.
+if [ "${RCCL_AINIC_ROCE}" = "1" ]; then
+    NCCL_NET_PLUGIN="${NCCL_NET_PLUGIN:-none}"
+else
+    if [ -z "${NCCL_NET_PLUGIN:-}" ]; then
+        if [ -f "${ANP_HOME_DIR}/build/librccl-anp.so" ]; then
+            NCCL_NET_PLUGIN="librccl-anp.so"
+        elif [ -f "${ANP_HOME_DIR}/build/librccl-net.so" ]; then
+            NCCL_NET_PLUGIN="librccl-net.so"
+        else
+            NCCL_NET_PLUGIN="librccl-anp.so"
+        fi
     fi
 fi
 NCCL_IB_TC="${NCCL_IB_TC:-104}"

--- a/runner/helpers/hooks/03_enable_ainic.sh
+++ b/runner/helpers/hooks/03_enable_ainic.sh
@@ -30,6 +30,12 @@ ANP_HOME_DIR="${ANP_HOME_DIR:-/workspace/amd-anp}"
 RCCL_HOME_DIR="${RCCL_HOME_DIR:-/workspace/rccl}"
 MPI_HOME_DIR="${MPI_HOME_DIR:-/opt/ompi}"
 
+# AINIC RoCE mode. ROCm 7.2.1+ builds ANP INTO RCCL (no separate librccl-anp.so);
+# RCCL_AINIC_ROCE=1 enables that built-in ANP path. On older ROCm the external
+# plugin is selected below instead. An explicitly-set NCCL_NET_PLUGIN always takes
+# precedence (force-loads the named plugin) irrespective of RCCL_AINIC_ROCE.
+RCCL_AINIC_ROCE="${RCCL_AINIC_ROCE:-1}"
+
 # NCCL_NET_PLUGIN: ANP libraray has different names in different containers: librccl-anp.so or librccl-net.so.
 if [ -z "${NCCL_NET_PLUGIN:-}" ]; then
     if [ -f "${ANP_HOME_DIR}/build/librccl-anp.so" ]; then
@@ -71,6 +77,7 @@ echo "env.ANP_HOME_DIR=${ANP_HOME_DIR}"
 echo "env.RCCL_HOME_DIR=${RCCL_HOME_DIR}"
 echo "env.MPI_HOME_DIR=${MPI_HOME_DIR}"
 echo "env.NCCL_NET_PLUGIN=${NCCL_NET_PLUGIN}"
+echo "env.RCCL_AINIC_ROCE=${RCCL_AINIC_ROCE}"
 echo "env.NCCL_IB_TC=${NCCL_IB_TC}"
 echo "env.NCCL_IB_FIFO_TC=${NCCL_IB_FIFO_TC}"
 echo "env.NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX}"


### PR DESCRIPTION
ROCm 7.2.1+ builds ANP into RCCL itself (no separate librccl-anp.so), and RCCL_AINIC_ROCE=1 enables that built-in ANP RoCE path. Default it to 1 in both AINIC setup paths (the run_pretrain.sh inline block and the 03_enable_ainic.sh hook) so AINIC runs use the built-in ANP without users having to name librccl-anp.so explicitly.

An explicitly-set NCCL_NET_PLUGIN still takes precedence and force-loads the named external plugin irrespective of RCCL_AINIC_ROCE (per RCCL behavior), so the legacy external-plugin path (older ROCm) is preserved. Value is overridable via ${RCCL_AINIC_ROCE:-1}.