### PR TITLE
feat(projection): registry-based GEMM backend selection + projection enhancements

### DIFF
--- a/primus/cli/subcommands/projection.py
+++ b/primus/cli/subcommands/projection.py
@@ -287,15 +287,26 @@ def _add_performance_args(parser):
             "  both       - Run both benchmark and simulation, report side-by-side\n"
         ),
     )
+    try:
+        from primus.core.projection.simulation_backends.factory import (
+            list_available_gemm_backends,
+        )
+
+        _gemm_backend_choices = list(list_available_gemm_backends())
+    except Exception:
+        _gemm_backend_choices = ["origami"]
     parser.add_argument(
         "--gemm-backend",
         type=str,
         required=False,
         default=None,
-        choices=["origami"],
+        choices=_gemm_backend_choices,
         help=(
             "GEMM simulation backend (only used when --profiling-mode is 'simulate' or 'both').\n"
             "  origami  - Open-source GEMM performance model (default)\n"
+            "Choices are discovered at runtime from registered backends "
+            "(built-in + 'primus.gemm_backends' entry points + "
+            "PRIMUS_GEMM_BACKEND_PLUGINS).\n"
         ),
     )
     parser.add_argument(

--- a/primus/core/projection/module_profilers/attention.py
+++ b/primus/core/projection/module_profilers/attention.py
@@ -4,11 +4,13 @@
 # See LICENSE for license information.
 ###############################################################################
 
+import os
 from typing import Optional
 
 import torch
 
 from primus.core.projection.base_module_profiler import BaseModuleProfiler
+from primus.core.projection.training_config import gemm_dtype_from_config
 
 from .utils import benchmark_layer, v4_module_inputs
 
@@ -21,6 +23,20 @@ class AttentionProfiler(BaseModuleProfiler):
         self._cache_key = None  # Cache key (batch_size, seq_len)
         self._gemm_backend = None  # Optional: GEMM simulation backend
         self._sdpa_backend = None  # Optional: SDPA simulation backend
+        self._sim_compress_ratio = None  # Per-layer cr for V4 simulate (no module)
+
+    def set_sim_compress_ratio(self, cr):
+        """Set the DeepSeek-V4 compress ratio for the current simulated layer.
+
+        In ``simulate`` mode no torch module is built, so the cr-aware
+        attention model reads the per-layer compress ratio from here instead
+        of ``module.compress_ratio``.  The cr-aware path stays inactive until
+        this is set (or a real V4 module is bound), so non-cr-aware callers
+        see no behaviour change.
+        """
+        self._sim_compress_ratio = None if cr is None else int(cr)
+        self._cached_results = None
+        self._cache_key = None
 
     def set_module(self, module):
         """Set the actual attention module for benchmarking."""
@@ -107,6 +123,30 @@ class AttentionProfiler(BaseModuleProfiler):
             return args.num_attention_heads
 
         ln_width = 0
+
+        # --- DSv4-Pro-aware attention activation (v4 correction) --------------
+        # V4 attention is neither stock MHA nor stock MLA: (1) a single SHARED KV
+        # latent (kv_channels-wide, broadcast to all heads at compute time -> only
+        # the latent is stored, NOT heads*kv_channels); (2) it always runs a
+        # flash/FAv3 kernel (use_v4_triton_attention) that never materialises the
+        # [B,H,S,S] score matrix; (3) it carries hc_mult parallel residual streams
+        # ([B,S,K,D]) between layers.  The generic "standard" branch below
+        # over-counts KV by ~num_heads and (when use_flash_attn is unset) adds a
+        # phantom heads*seqlen softmax term; both are corrected here and the mHC
+        # K-stream residual is added back.  Validated vs the real V4 backend
+        # (deepseek_v4_attention single-latent KV + v4 flash kernels; SubA).
+        _is_v4_mem = (not args.multi_latent_attention) and (
+            getattr(args, "compress_ratios", None) is not None
+            or bool(getattr(args, "use_v4_triton_attention", False))
+        )
+        if _is_v4_mem:
+            hc = max(1, int(getattr(args, "hc_mult", 1) or 1))
+            q_proj = args.kv_channels * args.num_attention_heads  # per-head Q (stored post up-proj)
+            kv_latent = args.kv_channels  # single shared KV latent (K=V)
+            flash_softmax = q_proj  # FAv3 logsumexp stats; no [B,H,S,S]
+            mhc_residual = max(0, hc - 1) * args.hidden_size  # extra K-1 residual streams
+            activation_width = q_proj + 2 * kv_latent + args.hidden_size + flash_softmax + mhc_residual
+            return tokens_per_rank * activation_width * bytes_per_value
 
         if args.multi_latent_attention:
             # MLA uses separate latent dimensions for Q/K and V plus optional LoRA ranks.
@@ -248,8 +288,499 @@ class AttentionProfiler(BaseModuleProfiler):
 
         return fwd_time, bwd_time
 
+    def _is_v4_attention(self) -> bool:
+        """True when this profiler should use the cr-aware V4 attention model.
+
+        Active when either a real DeepSeek-V4 module is bound (benchmark-side
+        introspection) or — in pure ``simulate`` mode with no module — the
+        model config carries ``compress_ratios`` *and* a per-layer cr was
+        provided via :meth:`set_sim_compress_ratio`.  Without an explicit cr
+        the cr-aware path stays off so behaviour is unchanged.
+
+        V4 uses per-layer compression (0=dense/SWA, 128=HCA, 4=CSA) and its
+        own LoRA-factored Q/KV/O + compressor/indexer, which the generic
+        standard/MLA simulate path does not represent.
+        """
+        m = self.module
+        if m is not None and hasattr(m, "compress_ratio") and "DeepseekV4" in type(m).__name__:
+            return True
+        return (
+            self._sim_compress_ratio is not None
+            and getattr(self.config.model_config, "compress_ratios", None) is not None
+        )
+
+    def _v4_resolved_cr(self) -> int:
+        m = self.module
+        if m is not None and hasattr(m, "compress_ratio"):
+            return int(m.compress_ratio)
+        return int(self._sim_compress_ratio or 0)
+
+    def _get_v4_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, float, int]:
+        """cr-aware DeepSeek-V4 attention timing — no calibration constants.
+
+        Compute-bound terms (LoRA Q/KV/O GEMMs, compressor, indexer) come from
+        the GEMM backend; the SDPA core from the FAv3 simulator; memory-bound
+        terms (RoPE + q/k-norm + mHC elementwise, CSA gather) from explicit
+        activation byte traffic and HBM bandwidth.
+
+        The memory-bound elementwise block (norm + misc) is derived from first
+        principles by default (:meth:`_v4_memory_bound_first_principles`): a
+        byte-for-byte enumeration of every real elementwise kernel at one
+        sustained-HBM efficiency, with the selective-recompute forward replay
+        handled by the transformer-layer profiler (``bwd += attn_fwd``).  The
+        legacy trace-anchored fudge (``ELEM_EFF=0.15`` / 8 / 30 passes) is
+        available for A/B only via ``PRIMUS_ATTN_CALIBRATED=1``.
+        """
+        m = self.module
+        args = self.config.model_config
+        mp = self.config.model_parallel_config
+        tp_size = max(1, mp.tensor_model_parallel_size)
+        cp_size = max(1, mp.context_model_parallel_size)
+        tcfg = getattr(m, "config", None)
+
+        def cfg(attr, default, *aliases):
+            # Prefer the real module, then its TransformerConfig, then args.
+            for src in (m, tcfg, args):
+                for name in (attr, *aliases):
+                    if src is not None and getattr(src, name, None) is not None:
+                        return getattr(src, name)
+            return default
+
+        cr = self._v4_resolved_cr()
+        hc = max(1, int(cfg("hc_mult", 1)))
+        hidden = int(cfg("hidden_size", 0))
+        heads = int(cfg("num_heads", 0, "num_attention_heads"))
+        hd = int(cfg("head_dim", 0, "kv_channels"))
+        q_lora = int(cfg("q_lora_rank", 0) or 0)
+        o_lora = int(cfg("o_lora_rank", 0) or 0)
+        o_groups = max(1, int(cfg("o_groups", 1) or 1))
+        swa = int(cfg("attn_sliding_window", 0) or 0)
+        index_topk = int(cfg("index_topk", 0) or 0)
+        ihd = int(cfg("index_head_dim", 128) or 128)
+        inh = int(cfg("index_n_heads", heads) or heads)
+        bpe = 2  # bf16 activations
+
+        # Base (un-expanded) token count per rank.  mHC collapses the K=hc
+        # parallel residual streams into a single [B, S, D] stream BEFORE the
+        # attention sub-block runs (DeepseekV4HybridLayer._hc_apply ->
+        # HyperMixer.collapse), so every attention projection GEMM, the SDPA
+        # core, the compressor/indexer, and the in-attention elementwise ops
+        # execute at the base token count -- NOT S*hc.  The hc factor is a
+        # memory-domain cost (a hc-wide saved residual + collapse/expand
+        # bandwidth), captured separately in the memory-bound block below; it
+        # is NOT a compute multiplier on the attention block.
+        T = batch_size * seq_len // tp_size // cp_size
+        n_d = heads * hd
+        dt = gemm_dtype_from_config(self.config.model_config)
+        hbm = (getattr(self._gemm_backend, "hbm_bandwidth_gbps", None) or 5300.0) * 1e9
+
+        def g(mm, nn, kk):
+            return self._gemm_backend.simulate_gemm(mm, nn, kk, dt).forward_time_ms
+
+        # ---- attn.proj : V4 LoRA Q/KV/O GEMMs (cr-independent) ----
+        if self._gemm_backend is not None:
+            if q_lora > 0:
+                proj_fwd = g(T, q_lora, hidden) + g(T, n_d, q_lora) + g(T, hd, hidden)
+            else:
+                proj_fwd = g(T, n_d, hidden) + g(T, hd, hidden)
+            if o_lora > 0:
+                proj_fwd += g(T, o_lora, n_d) + g(T, hidden, o_groups * o_lora)
+            else:
+                proj_fwd += g(T, hidden, n_d)
+        else:
+            proj_fwd = 0.0
+        proj_bwd = 2.0 * proj_fwd
+
+        # ---- attn.core : FAv3 SDPA with cr-aware visible KV ----
+        core_fwd = core_bwd = 0.0
+        if self._sdpa_backend is not None:
+            # Split visible KV into the SWA local band (constant ~swa keys per
+            # query) and the sparse pool/top-K (triangular over the causal past).
+            #   cr 0 = dense+SWA, 128 = HCA (SWA + seq/128 pool), 4 = CSA (SWA + top-K).
+            if cr == 0:
+                swa_k, sparse_k = (swa or seq_len), 0
+            elif cr == 128:
+                swa_k, sparse_k = (swa or 0), max(1, seq_len // 128)
+            elif cr == 4:
+                # A query can never select more than the compressed pool holds,
+                # so clamp top-K to ceil(seq/cr) the same way the HCA branch does.
+                csa_pool = max(1, -(-seq_len // cr))
+                swa_k, sparse_k = (swa or 0), min(index_topk or csa_pool, csa_pool)
+            else:
+                swa_k, sparse_k = 0, seq_len
+            # #2 robustness clamp: a query can never see more than all keys.
+            swa_k = min(swa_k, seq_len)
+            sparse_k = min(sparse_k, seq_len)
+            # The SDPA sim applies a flat causal_factor=0.5 to the whole visible
+            # KV, correct only for the triangular sparse/dense part.  #9
+            # (PRIMUS_ATTN_SWA_FULLBAND=1): the SWA band is a constant-width
+            # per-query band (NOT triangular), so price it at full cost by
+            # pre-inflating the visible KV by +swa_k -> after the 0.5 factor the
+            # realised work is swa_k*1 + sparse_k*0.5.  Default off (0) keeps the
+            # audited baseline; on for the more-faithful A/B.
+            if os.getenv("PRIMUS_ATTN_SWA_FULLBAND", "0") == "1":
+                s_k = min(2 * swa_k + sparse_k, 2 * seq_len)
+            else:
+                s_k = min(swa_k + sparse_k, seq_len)
+            # The attention core runs once on the collapsed [B, S, D] stream,
+            # so the batch axis is the real microbatch -- not hc (the streams
+            # are already collapsed away before attention).
+            sd = self._sdpa_backend.simulate_sdpa(
+                batch_size=batch_size,
+                num_heads=heads,
+                seq_len=seq_len,
+                head_dim=hd,
+                causal=True,
+                dtype="bf16",
+                seq_len_kv=s_k,
+            )
+            core_fwd, core_bwd = sd.forward_time_ms, sd.backward_time_ms
+
+        # ---- compressor (cr>0) ----
+        comp_fwd = comp_bwd = 0.0
+        if cr > 0 and self._gemm_backend is not None:
+            coff = 2 if cr == 4 else 1
+            # #7: the Compressor has TWO projections (compressor.py) -- wkv
+            # (hidden->coff*hd) AND wgate (hidden->coff*hd) for the softmax-
+            # weighted window pooling.  Only wkv was counted -> compressor ~2x
+            # under.  Charge both same-shape GEMMs.
+            comp_fwd = 2.0 * g(T, coff * hd, hidden)
+            comp_bwd = 2.0 * comp_fwd
+
+        # ---- indexer (cr==4 only): projections + pool scoring ----
+        # #3: DSA TRAINS the indexer via a KL-distillation aux loss (megatron dev
+        # dsa.py/csa.py + DeepSeek-V3.2 DSA paper) -> it HAS a backward pass.
+        # Primus's shipped model freezes it for engineering reasons
+        # (deepseek_v4_attention.py requires_grad_(False) unless
+        # PRIMUS_V4_INDEXER_TRAINABLE=1), but a FAITHFUL projection of real
+        # DSv4-Pro training must count the indexer training cost, so the default
+        # here is now TRAINABLE.  Set PRIMUS_V4_INDEXER_TRAINABLE=0 to model the
+        # frozen-indexer engineering variant instead.
+        idx_trainable = os.getenv("PRIMUS_V4_INDEXER_TRAINABLE", "1") == "1"
+        idx_fwd = idx_bwd = idx_score = 0.0
+        idx_aux_fwd = idx_aux_bwd = 0.0
+        if cr == 4 and self._gemm_backend is not None:
+            pool = max(1, T // cr)
+            idx_fwd = g(T, ihd, hidden) + g(T, inh * ihd, ihd) + g(T, inh, hidden) + g(T, 2 * ihd, hidden)
+            idx_bwd = 2.0 * idx_fwd if idx_trainable else 0.0
+            # Indexer QK scoring: fp8 when the fp8 indexer is enabled, else bf16.
+            # Size it to the TARGET arch's S&F peak for that dtype (arch-specific)
+            # via the backend's peak_flops(); fall back to the MI355X anchors so
+            # behaviour is unchanged for backends/arches without an S&F table.
+            score_dt = "fp8" if bool(cfg("use_v4_fp8_indexer", False)) else "bf16"
+            peak = None
+            _pf = getattr(self._gemm_backend, "peak_flops", None)
+            if callable(_pf):
+                peak = _pf(score_dt)
+            if not peak:
+                peak = 4768.0e12 if score_dt == "fp8" else 2384.0e12  # MI355X anchors
+            idx_score = (2.0 * T * inh * pool * ihd) / peak * 1e3
+            # #3 KL-distillation aux loss (only when the indexer is trained): a
+            # softmax over the [T, pool] indexer score distribution + the target
+            # softmax + the KL reduction, memory-bound (~3 passes fwd, ~2x bwd,
+            # bf16).  The indexer proj/score GRADIENTS are idx_bwd / idx_score_bwd
+            # above; this is the extra loss-head traffic on top.
+            if idx_trainable:
+                idx_aux_fwd = 3.0 * T * pool * bpe / hbm * 1e3
+                idx_aux_bwd = 2.0 * idx_aux_fwd
+
+        # ---- CSA sparse gather/scatter memory traffic (cr==4) ----
+        # Sized on the number of (query, selected-slot) VISITS, not on
+        # ``index_topk`` alone:
+        #   * a query can never select more slots than the compressed pool holds
+        #     (``pool_len = ceil(seq/cr)``), and
+        #   * causality caps query ``t`` at ``t/cr`` slots, so the early prefix
+        #     selects fewer than ``k_cap`` -> ``avail`` is the mean fill ratio.
+        #     For the DSv4-Pro shape (S=4096, cr=4, topk=1024) the pool IS the
+        #     whole visible history, so avail=0.5 -- the top-K is degenerate and
+        #     only causality limits it.
+        # The pool itself is tiny (``pool_len * hd * bpe`` ~ 1 MiB/sample) and is
+        # re-read by every query, so the read side is served by L2 / Infinity
+        # Cache, NOT HBM: only the bytes that are actually MATERIALIZED count.
+        gather_fwd = gather_bwd = 0.0
+        if cr == 4:
+            pool_len = max(1, -(-seq_len // cr))
+            k_cap = min(index_topk or pool_len, pool_len)
+            if seq_len >= cr * k_cap:
+                avail = 1.0 - (cr * k_cap) / (2.0 * seq_len)
+            else:
+                avail = seq_len / (2.0 * cr * k_cap)
+            # CP shards the query axis; TP does NOT shard the single shared KV
+            # latent (pool + top-K indices are head-agnostic -> replicated).
+            gather_tokens = batch_size * max(1, seq_len // cp_size)
+            # Buffers are allocated over ALL k slots (masked ones are written as
+            # zeros); only the valid slots are read back downstream.
+            visit_bytes = gather_tokens * k_cap * hd * bpe
+            used_bytes = visit_bytes * avail
+            pool_bytes = batch_size * pool_len * hd * bpe
+            # Only ``use_v4_triton_csa_attention`` routes to
+            # v4_csa_attention_from_pool (the in-kernel gather).  The tilelang /
+            # flydsl flags are in-kernel sub-options of the *already-gathered*
+            # wrapper and do NOT enable the from-pool path on their own
+            # (DeepseekV4Attention._csa_forward gates on the Triton flag only),
+            # so a tilelang-only config still runs the eager materialised gather.
+            csa_fused = bool(cfg("use_v4_triton_csa_attention", False)) or os.getenv(
+                "PRIMUS_USE_V4_TRITON_CSA_ATTENTION", ""
+            ).lower() in ("1", "true", "yes")
+            if csa_fused:
+                # Forward materialises nothing: the pool tile is gathered into
+                # LDS/registers and shared across all heads (BLOCK_H spans the
+                # head axis), so the only HBM cost is one cold read of the pool.
+                gather_fwd = pool_bytes / hbm * 1e3
+                # Backward cannot avoid the dpool round trip: the sparse BWD
+                # writes a per-visit ``dpool_partial`` buffer (input dtype, every
+                # k slot) and a segmented-reduction kernel reads the valid slots
+                # back into dpool[B, pool_len, hd].  Separate kernels, so this
+                # does NOT overlap the SDPA core.  ``eta`` is the sustained HBM
+                # fraction of the strided write + permuted read.
+                eta = float(os.getenv("PRIMUS_ATTN_CSA_SCATTER_ETA", "0.6"))
+                gather_bwd = (visit_bytes + used_bytes) / (eta * hbm) * 1e3
+            else:
+                # Eager path materialises [B, S, K, hd]: the gather writes it,
+                # the ``* valid`` mask is a second read+write pass, and the
+                # attention kernel reads it back.
+                gather_fwd = 4.0 * visit_bytes / hbm * 1e3
+                # Its VJP is the expensive half: the mask backward is another
+                # read+write, and torch.gather's VJP allocates zeros over the
+                # EXPANDED pool ([B, S, pool_len, hd]), scatter-adds the valid
+                # slots into it and reduces it back over the query axis -- so the
+                # dominant term scales with pool_len (~S/cr), not with k_cap.
+                expanded_bytes = gather_tokens * pool_len * hd * bpe
+                gather_bwd = (3.0 * visit_bytes + 2.0 * used_bytes + 2.0 * expanded_bytes) / hbm * 1e3
+
+        # ---- attn.norm + attn.misc : memory-bound elementwise block ----
+        # DEFAULT is the first-principles byte-traffic model
+        # (:meth:`_v4_memory_bound_first_principles`): it enumerates every real
+        # elementwise kernel (q/kv RMS, per-head q-RMS, partial RoPE,
+        # transpose->contiguous, mHC expand/collapse, HCA cat) with explicit
+        # read+write HBM traffic at a single sustained-BW efficiency, replacing
+        # both ``norm`` and ``misc`` -- no per-term fitted pass counts.
+        #
+        # The legacy trace-anchored fudge (``norm`` = 3/4 passes over T*n_d;
+        # ``misc`` = 8/30 passes over T*hidden at ``ELEM_EFF=0.15``) is retained
+        # ONLY as an opt-out for A/B comparison via ``PRIMUS_ATTN_CALIBRATED=1``.
+        mhc_fwd = mhc_bwd = 0.0
+        if os.getenv("PRIMUS_ATTN_CALIBRATED", "0") != "1":
+            # #4: split the memory-bound block into three transparent buckets --
+            # norm (q/kv/per-head RMS), mHC (expand/collapse + compute_weights +
+            # Sinkhorn), and misc (RoPE/transpose/HCA-cat) -- instead of hiding
+            # norm (=0) and mHC inside a single over-conservative misc term.
+            (norm_fwd, norm_bwd), (mhc_fwd, mhc_bwd), (misc_fwd, misc_bwd) = (
+                self._v4_memory_bound_first_principles(
+                    T=T, n_d=n_d, hidden=hidden, hc=hc, cr=cr, q_lora=q_lora, hd=hd, bpe=bpe, hbm=hbm
+                )
+            )
+        else:
+            # ---- legacy calibrated fallback (PRIMUS_ATTN_CALIBRATED=1) ----
+            # attn.norm : RoPE + q/k norms (memory-bound).
+            norm_bytes = T * n_d * bpe
+            norm_fwd = 3.0 * norm_bytes / hbm * 1e3
+            norm_bwd = 4.0 * norm_bytes / hbm * 1e3
+            # attn.misc : generic-elementwise glue over the hc-expanded HIDDEN
+            # stream at a fitted 15% sustained-HBM efficiency.  Superseded by the
+            # first-principles model above; kept for A/B only.  All env-tunable.
+            ELEM_EFF = float(os.getenv("PRIMUS_ATTN_ELEM_EFF", "0.15"))
+            MISC_FWD_PASSES = float(os.getenv("PRIMUS_ATTN_MISC_FWD_PASSES", "8"))
+            MISC_BWD_PASSES = float(os.getenv("PRIMUS_ATTN_MISC_BWD_PASSES", "30"))
+            hidden_bytes = T * hidden * bpe
+            misc_fwd = MISC_FWD_PASSES * hidden_bytes / (ELEM_EFF * hbm) * 1e3
+            misc_bwd = MISC_BWD_PASSES * hidden_bytes / (ELEM_EFF * hbm) * 1e3
+
+        # Indexer score backward (cr==4): only when the indexer is trained
+        # (frozen by default -> no gradient path; see idx_trainable above).
+        idx_score_bwd = 2.0 * idx_score if idx_trainable else 0.0
+
+        fwd_time = (
+            proj_fwd
+            + core_fwd
+            + comp_fwd
+            + idx_fwd
+            + idx_score
+            + idx_aux_fwd
+            + gather_fwd
+            + norm_fwd
+            + mhc_fwd
+            + misc_fwd
+        )
+        bwd_time = (
+            proj_bwd
+            + core_bwd
+            + comp_bwd
+            + idx_bwd
+            + idx_score_bwd
+            + idx_aux_bwd
+            + gather_bwd
+            + norm_bwd
+            + mhc_bwd
+            + misc_bwd
+        )
+        if os.getenv("PRIMUS_PRINT_LAYER_BREAKDOWN") and int(os.getenv("RANK", "0")) == 0:
+            print(
+                "[BRKDN] attn cr=%d proj_f=%.4f proj_b=%.4f core_f=%.4f core_b=%.4f comp_f=%.4f comp_b=%.4f "
+                "idx_f=%.4f idx_b=%.4f gather_f=%.4f gather_b=%.4f norm_f=%.4f norm_b=%.4f "
+                "mhc_f=%.4f mhc_b=%.4f misc_f=%.4f misc_b=%.4f"
+                % (
+                    cr,
+                    proj_fwd,
+                    proj_bwd,
+                    core_fwd,
+                    core_bwd,
+                    comp_fwd,
+                    comp_bwd,
+                    idx_fwd + idx_score + idx_aux_fwd,
+                    idx_bwd + idx_score_bwd + idx_aux_bwd,
+                    gather_fwd,
+                    gather_bwd,
+                    norm_fwd,
+                    norm_bwd,
+                    mhc_fwd,
+                    mhc_bwd,
+                    misc_fwd,
+                    misc_bwd,
+                )
+            )
+        activation_memory = self.estimated_activation_memory(batch_size, seq_len)
+        return (fwd_time, bwd_time, activation_memory)
+
+    def _v4_memory_bound_first_principles(
+        self,
+        *,
+        T: int,
+        n_d: int,
+        hidden: int,
+        hc: int,
+        cr: int,
+        q_lora: int,
+        hd: int,
+        bpe: int,
+        hbm: float,
+    ) -> tuple[float, float, list]:
+        """First-principles byte-traffic model of the attention memory-bound block.
+
+        Replaces the calibrated ``norm`` + ``misc`` terms (the ``ELEM_EFF=0.15``
+        / 8-fwd / 30-bwd fudge) with an explicit enumeration of every real
+        elementwise kernel in :class:`DeepseekV4Attention.forward`, each costed
+        as ``bytes_read + bytes_written`` at its bf16 HBM footprint divided by a
+        single sustained-HBM efficiency.
+
+        Grounding (verified against the module + Triton kernels):
+
+        * Elementwise kernels are FUSED (per-head RMS keeps fp32 in registers;
+          the P32 fix keeps RoPE bf16 end-to-end), so each logical op moves its
+          operands through HBM once -- i.e. ``read + write`` at the bf16 size,
+          NOT a double-width fp32 materialization.
+        * A fused reduction (RMS mean-of-squares) reads its input once and
+          writes a negligible ``[..., 1]`` stat, so its RMS is ``read + write``
+          of the normalized tensor = 2 bf16 passes.
+        * Partial RoPE rewrites the whole ``head_dim`` (nope + rotated) into a
+          fresh contiguous tensor -> read + write of the full q / k tensor.
+        * This backward is the TRUE gradient computation only (each op's VJP:
+          input + upstream grad -> grad-in).  It does NOT include the selective
+          -recompute forward replay: the transformer-layer profiler already adds
+          the whole attention forward (``bwd_time += attn_fwd``) when
+          ``recompute_granularity == "selective"``, and that ``attn_fwd``
+          already contains this block's ``fwd_ms``.  Folding a replay in here
+          too would double-count it.
+
+        ``eta`` (``PRIMUS_ATTN_FP_ETA``, default ``_ACTIVATION_BW_FRACTION``
+        = 0.566) is the sustained fraction of peak HBM these medium streaming /
+        strided kernels achieve -- the SAME constant the MoE SwiGLU activation
+        and the transformer-layer residual use, so no attention-specific
+        efficiency is introduced.
+
+        Returns three ``(fwd_ms, bwd_ms)`` pairs -- ``(norm, mhc, misc)`` -- so
+        the report can attribute the norm / mHC / misc buckets separately (norm
+        was previously hidden as 0 and mHC buried inside misc).
+        """
+        # #4: near-peak efficiency for the highly-fusible norm/RoPE/transpose/mHC
+        # elementwise stream.  These small-buffer, cache-friendly kernels run
+        # close to peak HBM, so the SwiGLU-derived 0.566 (_ACTIVATION_BW_FRACTION)
+        # systematically over-priced them (~1.7x).  Default ~0.9 (near-peak);
+        # PRIMUS_ATTN_FP_ETA is still honored so the old 0.566 is one env away.
+        misc_eta = float(os.getenv("PRIMUS_ATTN_MISC_ETA", os.getenv("PRIMUS_ATTN_FP_ETA", "0.9")))
+        # T is the base (un-expanded) token count B*S: the in-attention
+        # elementwise kernels (q/kv RMS, RoPE, transpose) run on the collapsed
+        # base-S stream.  mHC operates on the [M, hc, hidden] residual, so the
+        # un-expanded token count M == T here (the hc width enters only via the
+        # per-op stream-count coefficients on the mHC expand/collapse/HCA rows).
+        M = max(1, T)
+
+        # HCA fraction: cr==128 layers pay the extra cat([local, pool]) that
+        # materializes the broadcast K and V across all heads.  When this helper
+        # is called per-layer we know the exact cr; weight = 1.0 for cr==128.
+        hca = 1.0 if cr == 128 else 0.0
+
+        tnd = T * n_d * bpe  # per-pass bf16 bytes of the n_d-wide q / attn-out tensor
+        tD = T * hidden * bpe  # per-pass bf16 bytes of the hidden-wide residual stream
+        tqr = T * q_lora * bpe  # q-LoRA-wide tensor (q_layernorm)
+        thd = T * hd * bpe  # single-latent KV-wide tensor (kv_layernorm, RoPE-k)
+
+        # Each entry: (name, fwd_bytes, bwd_bytes).  read+write => factor 2;
+        # a reduction's stat write is negligible so RMS is still ~read+write.
+        ops = [
+            # q-LoRA RMSNorm (q_layernorm on width q_lora).
+            ("q_layernorm RMS", 2 * tqr, 3 * tqr),
+            # Per-head parameter-less q-RMS on the full n_d-wide tensor.
+            ("q per-head RMS (n_d)", 2 * tnd, 3 * tnd),
+            # Partial interleaved RoPE on q: full-tensor contiguous rewrite.
+            ("RoPE q (n_d)", 2 * tnd, 2 * tnd),
+            # Single-latent KV RMSNorm + RoPE (width hd, shared across heads).
+            ("kv_layernorm RMS", 2 * thd, 3 * thd),
+            ("RoPE k (hd)", 2 * thd, 2 * thd),
+            # Attention output transpose(1,2)->contiguous copy (n_d-wide).
+            ("out transpose->contiguous (n_d)", 2 * tnd, 2 * tnd),
+            # mHC HyperConnection expand: new[M,K,D]=post*out+comb@x
+            #   fwd read x[M,K,D]+out[M,D], write new[M,K,D] => (2K+1)*M*D
+            #   bwd read g,x[M,K,D]+out[M,D], write dx[M,K,D]+dout[M,D] => (3K+2)*M*D
+            ("mHC expand", (2 * hc + 1) * M * hidden * bpe, (3 * hc + 2) * M * hidden * bpe),
+            # mHC collapse (reduce K streams -> 1): read [M,K,D] write [M,D].
+            ("mHC collapse", (hc + 1) * M * hidden * bpe, (hc + 1) * M * hidden * bpe),
+            # HCA-only cat([local, pool]) for K and V: materializes the
+            # broadcast (H-replicated) local KV + pool.  ~2x (K and V), read+write,
+            # per un-expanded token over n_d; only on cr==128 layers.
+            ("HCA cat K/V", hca * 2.0 * 2 * M * n_d * bpe, hca * 2.0 * M * n_d * bpe),
+        ]
+
+        # ---- group the ops into norm / mHC / misc, each priced at misc_eta ----
+        norm_names = {"q_layernorm RMS", "q per-head RMS (n_d)", "kv_layernorm RMS"}
+        mhc_names = {"mHC expand", "mHC collapse"}
+
+        def _grp_ms(names):
+            fb = sum(o[1] for o in ops if o[0] in names)
+            bb = sum(o[2] for o in ops if o[0] in names)
+            return fb / (misc_eta * hbm) * 1e3, bb / (misc_eta * hbm) * 1e3
+
+        norm_ms = _grp_ms(norm_names)
+        misc_ms = _grp_ms({o[0] for o in ops} - norm_names - mhc_names)
+        mhc_bw_f, mhc_bw_b = _grp_ms(mhc_names)
+
+        # mHC compute_weights (was entirely missing -> mHC under-counted, esp.
+        # backward): the mapping_proj GEMM reads the K*D-wide residual, then a
+        # per-stream RMS + a Sinkhorn(n_iters) normalization.  Sinkhorn is
+        # launch-latency-bound (tiny [M,K,K] fp32 reduces), and its backward
+        # re-runs the forward (SinkhornKnopp.backward).
+        cw_fwd = cw_bwd = 0.0
+        if hc > 1 and self._gemm_backend is not None:
+            dt = gemm_dtype_from_config(self.config.model_config)
+            cw = self._gemm_backend.simulate_gemm(M, hc * hc + 2 * hc, hc * hidden, dt).forward_time_ms
+            cw_fwd += cw
+            cw_bwd += 2.0 * cw
+            cw_mem = 2.0 * M * hc * hidden * bpe  # RMS over the K*D-wide input
+            cw_fwd += cw_mem / (misc_eta * hbm) * 1e3
+            cw_bwd += 1.5 * cw_mem / (misc_eta * hbm) * 1e3
+            n_iters = int(os.getenv("PRIMUS_HC_SINKHORN_ITERS", "20"))
+            sink_ms = (1.0 + 2.0 * max(0, n_iters - 1)) * 0.75 / 1e3  # ~0.75us/launch
+            cw_fwd += sink_ms
+            cw_bwd += sink_ms
+
+        mhc_ms = (mhc_bw_f + cw_fwd, mhc_bw_b + cw_bwd)
+        return norm_ms, mhc_ms, misc_ms
+
     def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, float, int]:
         """Get simulated results from GEMM + SDPA simulation backends."""
+        if self._is_v4_attention():
+            return self._get_v4_simulated_results(batch_size, seq_len)
+
         args = self.config.model_config
         mp = self.config.model_parallel_config
         tp_size = max(1, mp.tensor_model_parallel_size)
@@ -263,7 +794,7 @@ class AttentionProfiler(BaseModuleProfiler):
 
         # 1. Simulate linear projection GEMMs using GEMM backend
         if self._gemm_backend is not None:
-            gemm_dtype = "fp8" if getattr(args, "fp8", None) else "bf16"
+            gemm_dtype = gemm_dtype_from_config(args)
 
             if getattr(args, "multi_latent_attention", False):
                 # MLA: LoRA-factored Q and compressed KV projections

--- a/primus/core/projection/module_profilers/attention.py
+++ b/primus/core/projection/module_profilers/attention.py
@@ -711,7 +711,6 @@ class AttentionProfiler(BaseModuleProfiler):
         hca = 1.0 if cr == 128 else 0.0
 
         tnd = T * n_d * bpe  # per-pass bf16 bytes of the n_d-wide q / attn-out tensor
-        tD = T * hidden * bpe  # per-pass bf16 bytes of the hidden-wide residual stream
         tqr = T * q_lora * bpe  # q-LoRA-wide tensor (q_layernorm)
         thd = T * hd * bpe  # single-latent KV-wide tensor (kv_layernorm, RoPE-k)
 

--- a/primus/core/projection/module_profilers/dense_mlp.py
+++ b/primus/core/projection/module_profilers/dense_mlp.py
@@ -8,7 +8,10 @@ from typing import Optional, Tuple
 
 from primus.core.projection.base_module_profiler import BaseModuleProfiler
 from primus.core.projection.profiler_spec import ModuleProfilerSpec
-from primus.core.projection.training_config import TrainingConfig
+from primus.core.projection.training_config import (
+    TrainingConfig,
+    gemm_dtype_from_config,
+)
 
 from .utils import benchmark_layer
 
@@ -72,8 +75,8 @@ class DenseMLPProfiler(BaseModuleProfiler):
         cp_size = self.config.model_parallel_config.context_model_parallel_size
         batch_tokens = batch_size * seq_len // tp_size // cp_size
 
-        # FP8-hybrid: MLP projections (gate, up, down) run in FP8
-        gemm_dtype = "fp8" if getattr(self.config.model_config, "fp8", None) else "bf16"
+        # FP8-hybrid: MLP projections (gate, up, down) run in FP8 (MX8 for mxfp8)
+        gemm_dtype = gemm_dtype_from_config(self.config.model_config)
         sim_result = self._gemm_backend.simulate_mlp_gemms(
             batch_tokens=batch_tokens,
             hidden_size=self.config.model_config.hidden_size,

--- a/primus/core/projection/module_profilers/language_model.py
+++ b/primus/core/projection/module_profilers/language_model.py
@@ -22,6 +22,27 @@ from .transformer_layer import (
 )
 
 
+def _parse_compress_ratios(model_config):
+    """Return the per-layer compress-ratio list, or None.
+
+    ``compress_ratios`` may be a list (already parsed / truncated for the
+    reduced bench model) or a string like ``"[0, 0, 4, 128, ...]"`` from YAML.
+    """
+    cr = getattr(model_config, "compress_ratios", None)
+    if cr is None:
+        return None
+    if isinstance(cr, (list, tuple)):
+        return [int(x) for x in cr]
+    if isinstance(cr, str):
+        try:
+            evaluated = eval(cr.strip(), {}, {})  # noqa: S307 — trusted config literal
+            if isinstance(evaluated, (list, tuple)):
+                return [int(x) for x in evaluated]
+        except Exception:
+            return None
+    return None
+
+
 def build_profiler(spec: ModuleProfilerSpec, depth=0) -> BaseModuleProfiler:
     """
     Recursively build a profiler instance from a ModuleProfilerSpec.
@@ -442,10 +463,26 @@ class LanguageModelProfiler(BaseModuleProfiler):
         return max(1, dp_size)
 
     def get_num_bytes_per_param(self) -> float:
-        dp_size = self.get_dp_size()
+        mp = self.config.model_parallel_config
+        use_dist = bool(getattr(mp, "use_distributed_optimizer", False)) or bool(
+            getattr(mp, "use_torch_fsdp2", False)
+        )
         multiplier = 4  # param weights + gradients, bf16
-        # 2 for main params, 4 + 4 for fp32 optimizer 1st & 2nd order moments
-        optimizer_state_multiplier = 10 / dp_size  # DP sharding
+        # fp32 optimizer state: 2 for main params + 4 + 4 for 1st & 2nd moments.
+        # Muon orthogonalizes the 2D weights with momentum only (no 2nd moment),
+        # so it drops the 4 bytes of 2nd-moment state on the matrix params that
+        # dominate the parameter count (2 main + 4 momentum = 6).  Embeddings/
+        # norms nominally stay on Adam, but they are a negligible fraction of
+        # params, so approximating the whole model at the Muon rate is accurate.
+        is_muon = str(getattr(self.config.model_config, "optimizer", "") or "").lower() == "muon"
+        optimizer_state_multiplier = 6.0 if is_muon else 10.0
+        if use_dist:
+            # Distributed optimizer / dist_muon shards the fp32 optimizer state
+            # across the DP group.  get_dp_size() returns world/(EP·PP) = EDP, the
+            # group over which the expert-dominated params are replicated (requires
+            # NNODES to reflect the real cluster).  Plain (non-distributed) Muon
+            # keeps the fp32 states fully replicated on every rank -> no sharding.
+            optimizer_state_multiplier = optimizer_state_multiplier / max(1, self.get_dp_size())
         return multiplier + optimizer_state_multiplier
 
     def estimated_num_params(self, rank: Optional[int] = None) -> int:
@@ -479,6 +516,7 @@ class LanguageModelProfiler(BaseModuleProfiler):
         vpp_size = self.config.model_parallel_config.virtual_pipeline_model_parallel_size
         recompute_granularity = self.config.model_parallel_config.recompute_granularity
         recompute_num_layers = self.config.model_parallel_config.recompute_num_layers
+        recompute_method = getattr(self.config.model_parallel_config, "recompute_method", None)
 
         layer_chunks = self.get_virtual_stage_layers_for_rank(
             self,
@@ -507,12 +545,19 @@ class LanguageModelProfiler(BaseModuleProfiler):
         layer_act = 0
         for chunk_layers in layer_chunks:
             for local_idx, layer in enumerate(chunk_layers):
-                # Determine if this layer is recomputed
-                is_recomputed = (
-                    recompute_granularity == "full"
-                    and recompute_num_layers is not None
-                    and local_idx < recompute_num_layers
-                )
+                # Determine if this layer is recomputed.
+                #   full + uniform      -> EVERY layer is recomputed (true full
+                #                          recompute; recompute_num_layers is only
+                #                          the checkpoint group size in Megatron).
+                #   full + block/(none) -> only the first recompute_num_layers of
+                #                          the stage are recomputed.
+                if recompute_granularity == "full":
+                    if recompute_method == "uniform":
+                        is_recomputed = True
+                    else:
+                        is_recomputed = recompute_num_layers is not None and local_idx < recompute_num_layers
+                else:
+                    is_recomputed = False
 
                 if is_recomputed:
                     # Recomputed layer: only store input activation
@@ -544,8 +589,15 @@ class LanguageModelProfiler(BaseModuleProfiler):
         # 1F1B pipeline schedule: need to store activations for pp_size microbatches
         total_act *= pp_size
 
-        # VPP interleaved schedule memory penalty
-        interleaved_schedule_memory_penalty = 1 + ((pp_size - 1) / (pp_size * vpp_size))
+        # VPP interleaved schedule memory penalty.
+        # v4 correction: the Korthikanti interleaved penalty applies ONLY to
+        # interleaved (VPP>=2) schedules; a non-interleaved 1F1B (VPP=1) must be
+        # 1.0.  Previously it evaluated to 1+(pp-1)/pp ~= 1.94x even at VPP=1,
+        # inflating the VPP1 activation peak by ~2x.
+        if vpp_size > 1:
+            interleaved_schedule_memory_penalty = 1 + ((pp_size - 1) / (pp_size * vpp_size))
+        else:
+            interleaved_schedule_memory_penalty = 1.0
 
         # Gradient accumulation memory saving
         ga = self.config.runtime_config.global_batch_size // self.get_dp_size()
@@ -727,6 +779,22 @@ class LanguageModelProfiler(BaseModuleProfiler):
         results = {}
         profiled_types = set()
 
+        # DeepSeek-V4: attention cost depends on the per-layer compress ratio
+        # (0=dense/SWA, 4=CSA, 128=HCA), so we key representative results by
+        # ``(layer_type, cr)`` instead of ``layer_type`` alone.  In *benchmark*
+        # mode this benchmarks the real cr0/cr4/cr128 layer modules separately
+        # (instead of collapsing all layers onto one representative, which
+        # under-counts the expensive CSA/HCA layers); in *simulate* mode we
+        # additionally tell the attention sub-profiler which cr to model.
+        v4_cr_aware = getattr(self.config.model_config, "compress_ratios", None) is not None
+        v4_sim = is_simulation_mode and v4_cr_aware
+        cr_schedule = _parse_compress_ratios(self.config.model_config) if v4_cr_aware else None
+
+        def _layer_cr(idx):
+            if cr_schedule and 0 <= idx < len(cr_schedule):
+                return int(cr_schedule[idx])
+            return None
+
         for layer_idx in self.layers:
             # In benchmark mode, guard against out-of-range layer indices.
             if model is not None and layer_idx >= len(all_layers):
@@ -736,8 +804,10 @@ class LanguageModelProfiler(BaseModuleProfiler):
 
             is_moe = self.config.model_config.moe_pattern[layer_idx]
             layer_type = "moe" if is_moe else "dense"
+            cr = _layer_cr(layer_idx)
+            type_key = (layer_type, cr) if v4_cr_aware else layer_type
 
-            if layer_type in profiled_types:
+            if type_key in profiled_types:
                 continue
 
             if is_rank_0:
@@ -753,6 +823,16 @@ class LanguageModelProfiler(BaseModuleProfiler):
             if model is not None:
                 layer_module = all_layers[layer_idx]
                 layer_profiler.set_layer_module(layer_module)
+
+            # V4 simulate: tell the attention sub-profiler which compress ratio
+            # to model for this representative, and clear stale caches so the
+            # new cr is reflected.
+            if v4_sim and cr is not None:
+                attn_sub = layer_profiler.get_sub_profiler("self_attention")
+                if hasattr(attn_sub, "set_sim_compress_ratio"):
+                    attn_sub.set_sim_compress_ratio(cr)
+                layer_profiler._cached_results = None
+                layer_profiler._cache_key = None
 
             # Benchmark/simulate full layer
             forward_time = layer_profiler.measured_forward_time(batch_size, seq_len)
@@ -778,8 +858,9 @@ class LanguageModelProfiler(BaseModuleProfiler):
                 mlp_a2a_fwd = mlp_profiler.measured_a2a_forward_time(batch_size, seq_len)
                 mlp_a2a_bwd = mlp_profiler.measured_a2a_backward_time(batch_size, seq_len)
 
-            results[layer_type] = {
+            results[type_key] = {
                 "type": layer_type,
+                "compress_ratio": cr,
                 "forward_time_ms": forward_time,
                 "backward_time_ms": backward_time,
                 "activation_memory_bytes": activation_memory,
@@ -797,7 +878,7 @@ class LanguageModelProfiler(BaseModuleProfiler):
                 },
             }
 
-            profiled_types.add(layer_type)
+            profiled_types.add(type_key)
 
             is_rank_0 = int(os.getenv("RANK", "0")) == 0
             if is_rank_0:
@@ -819,7 +900,18 @@ class LanguageModelProfiler(BaseModuleProfiler):
         for layer_idx in self.layers:
             is_moe = self.config.model_config.moe_pattern[layer_idx]
             layer_type = "moe" if is_moe else "dense"
-            if layer_type in results:
+            if v4_cr_aware:
+                cr = _layer_cr(layer_idx)
+                key = (layer_type, cr)
+                if key in results:
+                    final_results[layer_idx] = results[key]
+                else:
+                    # Fall back to any profiled representative of the same type
+                    # (cr combo not present among reduced representatives).
+                    same = [v for (t, _c), v in results.items() if t == layer_type]
+                    if same:
+                        final_results[layer_idx] = same[0]
+            elif layer_type in results:
                 final_results[layer_idx] = results[layer_type]
 
         if embedding_stats is not None:

--- a/primus/core/projection/module_profilers/moe_mlp.py
+++ b/primus/core/projection/module_profilers/moe_mlp.py
@@ -9,7 +9,10 @@ from typing import Optional
 
 from primus.core.projection.base_module_profiler import BaseModuleProfiler
 from primus.core.projection.profiler_spec import ModuleProfilerSpec
-from primus.core.projection.training_config import TrainingConfig
+from primus.core.projection.training_config import (
+    TrainingConfig,
+    gemm_dtype_from_config,
+)
 
 from .utils import benchmark_layer, benchmark_moe_layer_decomposed, v4_module_inputs
 
@@ -100,7 +103,11 @@ class MoEMLPProfiler(BaseModuleProfiler):
 
         # After activation
         activation_memory = topk_tokens * moe_ffn * 2  # bf16
-        output_memory = topk_tokens * self.config.model_config.hidden_size * 2  # bf16
+        # v4 correction: the routed expert outputs are weight-summed back to a
+        # single [num_tokens, hidden] tensor (the combine step), so the stored
+        # per-layer output activation is num_tokens*hidden, NOT topk_tokens*hidden
+        # (the latter over-counted the combined output by moe_router_topk = 6x).
+        output_memory = num_tokens * self.config.model_config.hidden_size * 2  # bf16
         total = intermediate_memory + activation_memory + output_memory
         if self.config.model_config.moe_shared_expert_intermediate_size is not None:
             if self.config.model_config.swiglu:
@@ -115,6 +122,170 @@ class MoEMLPProfiler(BaseModuleProfiler):
             total += intermediate_memory + activation_memory + output_memory
 
         return total
+
+    def _permute_first_principles(
+        self,
+        *,
+        batch_tokens: int,
+        topk_tokens: int,
+        hidden_size: int,
+        bytes_per_el: int,
+        ep_size: int,
+        num_local_experts: int,
+        peak_hbm: float,
+    ) -> tuple[float, float, float, float]:
+        """First-principles byte-traffic model of the MoE token permutation.
+
+        Replaces the calibrated ``_PERMUTE_BW_FRACTION = 0.057`` fudge with an
+        explicit enumeration of the real permutation kernels of the alltoall
+        dispatcher (TE ``permutation.py``).  Each kernel is a ROW-WISE
+        contiguous copy -- ``grid = (num_tokens, cdiv(hidden, BLOCK))`` copies a
+        token's whole ``hidden``-wide row (7168 el = 7 KiB fp8 / 14 KiB bf16) to
+        its (scattered) destination -- so the byte traffic is contiguous
+        streaming, priced at ``_ACTIVATION_BW_FRACTION`` (the same sustained-BW
+        fraction the SwiGLU activation uses), NOT the 5.7%-of-peak of a
+        fine-grained random-access gather.
+
+        Real kernels per MoE layer (alltoall dispatcher, ``num_local_experts>1``):
+
+          dispatch (forward side):
+            * ``permute``        : read input tokens once, write ``topk`` copies
+                                   -> ``(batch + topk_tokens) * hidden`` (fp8 in).
+            * ``sort_chunks``    : regroup post-A2A tokens by local expert
+                                   (EP>1 only) -> ``2 * topk_tokens * hidden``.
+          combine (backward side):
+            * ``sort_chunks``    : reverse regroup -> ``2 * topk_tokens * hidden``
+                                   on the bf16 expert outputs.
+            * ``unpermute``      : weighted reduce ``topk`` copies -> 1
+                                   -> ``(topk_tokens + batch) * hidden`` (bf16).
+
+        Dispatch moves fp8 tokens (the quantized expert inputs); combine moves
+        bf16 (expert GEMM outputs, reduced in bf16) -- so the two directions use
+        different element sizes.  The A2A itself is communication and is modeled
+        separately (transformer-layer A2A term), NOT here.
+
+        A small fixed launch term covers the index / sort-map kernels
+        (``make_row_id_map`` = 3 passes, ``make_chunk_sort_map``), which are
+        latency-bound, not BW-bound.
+
+        Scatter derate ``PRIMUS_MOE_PERMUTE_SCATTER`` (default 1.0) optionally
+        knocks the streaming efficiency down for the random row-start addressing
+        (TLB / L2), i.e. eff = ``_ACTIVATION_BW_FRACTION * scatter``.
+        """
+        eta = _ACTIVATION_BW_FRACTION * float(os.getenv("PRIMUS_MOE_PERMUTE_SCATTER", "1.0"))
+        eff_bw = peak_hbm * eta  # GB/s (== 1e9 B/s units)
+        bpe_disp = bytes_per_el  # fp8 (quantized expert inputs)
+        bpe_comb = 2  # bf16 (expert outputs / grads reduced in bf16)
+        has_sort = 1.0 if (ep_size > 1 and num_local_experts > 1) else 0.0
+        launch_us = float(os.getenv("PRIMUS_MOE_PERMUTE_LAUNCH_US", "2.8"))
+
+        # #10: dispatch (permute) AND combine (unpermute) each run in BOTH the
+        # forward pass (dispatch -> experts -> combine) and the backward pass
+        # (their VJPs).  The old model booked dispatch as fwd-only and combine as
+        # bwd-only, ~2x undercounting the total permute traffic and mislabeling
+        # the fwd/bwd attribution.  Element counts (local permute + EP sort_chunks):
+        disp_elems = (batch_tokens + topk_tokens) * hidden_size + has_sort * (2 * topk_tokens) * hidden_size
+        comb_elems = (topk_tokens + batch_tokens) * hidden_size + has_sort * (2 * topk_tokens) * hidden_size
+
+        # Dispatch fwd moves fp8 tokens; every gradient pass moves bf16.
+        dispatch_fwd = disp_elems * bpe_disp / (eff_bw * 1e6) + (4.0 * launch_us) / 1e3
+        dispatch_bwd = disp_elems * bpe_comb / (eff_bw * 1e6) + (2.0 * launch_us) / 1e3
+        combine_fwd = comb_elems * bpe_comb / (eff_bw * 1e6) + (2.0 * launch_us) / 1e3
+        combine_bwd = comb_elems * bpe_comb / (eff_bw * 1e6) + (2.0 * launch_us) / 1e3
+
+        return dispatch_fwd, dispatch_bwd, combine_fwd, combine_bwd
+
+    def _expert_overhead_first_principles(
+        self,
+        *,
+        topk_tokens: int,
+        hidden_size: int,
+        moe_ffn: int,
+        num_local_experts: int,
+        swiglu: bool,
+        peak_hbm: float,
+        batched: bool = False,
+    ) -> tuple[float, float]:
+        """First-principles model of the routed-expert *non-GEMM* overhead.
+
+        Replaces the calibrated ``PRIMUS_MOE_EXPERT_OVH_FWD_MS/_BWD_MS`` fudge
+        (0.19 / 0.66 ms per local expert) with an explicit accounting of the
+        two costs the ideal GEMM sim leaves out for fp8 grouped experts:
+
+          1. **JIT activation quant/dequant traffic.**  the GEMM cost model prices the
+             expert GEMMs assuming their operands are *already* fp8; it does not
+             charge the element-wise kernels that cast bf16 activations to fp8
+             (and produce the transposed fp8 copy needed for wgrad) each step.
+             These are contiguous streaming kernels, priced at the same
+             sustained-BW fraction as the SwiGLU activation
+             (``_ACTIVATION_BW_FRACTION``).
+
+             Forward casts the GEMM *inputs* (bf16 read -> fp8 write = 3 B/el):
+               * gate/up input  X  [topk_tokens, H]
+               * down     input  h  [topk_tokens, F]
+             (Summed over local experts ``sum(M)=topk_tokens``, so the traffic
+             is independent of how many experts a rank holds.)
+
+             Backward casts the grad-outputs of each projection, and fp8 wgrad
+             needs a transposed fp8 copy too (bf16 read + fp8 write + fp8-T
+             write = 4 B/el):
+               * down grad-out [topk_tokens, H]
+               * gate grad-out [topk_tokens, F]  (swiglu only)
+               * up   grad-out [topk_tokens, F]
+
+             Weights are quantized once per step and amortized across all tokens
+             (not per-token traffic), so they are excluded here.
+
+          2. **Per-group launch latency.**  The batched-GEMM sim charges a
+             single kernel launch for all local experts, but the quant/dequant
+             kernels and the grouped-GEMM group boundaries add a handful of
+             latency-bound launches that do not scale with token count.  Priced
+             at ``PRIMUS_MOE_EXPERT_LAUNCH_US`` (default = the GEMM fixed-startup
+             0.75 us).
+
+        Tile/wave quantization of the small per-expert ``M`` is already modeled
+        by the GEMM cost model (it sweeps tiles and charges granularity), so it is NOT
+        re-added here.
+        """
+        eta = _ACTIVATION_BW_FRACTION * float(os.getenv("PRIMUS_MOE_EXPERT_QUANT_EFF", "1.0"))
+        eff_bw = peak_hbm * eta  # GB/s
+
+        H = hidden_size
+        F = moe_ffn
+
+        # Forward: only the intermediate h (down-proj input, F-wide) needs a
+        # bf16->fp8 cast (read 2 B + write 1 B = 3 B/el).  #8: the expert INPUT X
+        # (H-wide) is ALREADY fp8 -- tokens are dispatched in fp8 by the permute
+        # (bpe_disp=fp8) -- so re-quantizing ``topk_tokens*H`` was a double-count.
+        fwd_quant_elems = topk_tokens * F
+        fwd_bytes = fwd_quant_elems * 3
+
+        # Backward: cast grad-outputs bf16->fp8 with transposed copy for wgrad
+        # (read 2 B + write fp8 1 B + write fp8-T 1 B = 4 B/el).
+        if swiglu:
+            bwd_quant_elems = topk_tokens * (H + 2 * F)  # down:H, gate:F, up:F
+        else:
+            bwd_quant_elems = topk_tokens * (H + F)  # down:H, up:F
+        bwd_bytes = bwd_quant_elems * 4
+
+        fwd_ms = fwd_bytes / (eff_bw * 1e6)
+        bwd_ms = bwd_bytes / (eff_bw * 1e6)
+
+        # Per-group launch latency (BW-independent).  Forward casts ~2 buffers
+        # (X, h); backward casts ~3 (swiglu) grad-outputs, each a small launch.
+        launch_us = float(os.getenv("PRIMUS_MOE_EXPERT_LAUNCH_US", "0.75"))
+        n_fwd_launch = 2.0
+        n_bwd_launch = 3.0 if swiglu else 2.0
+        # #8: the batched grouped-GEMM quant/dequant kernels launch a CONSTANT
+        # number of times (one batched kernel spanning all local experts), NOT
+        # once per expert.  Only the legacy sequential path pays per-expert
+        # launches, so the num_local_experts (=48 at EP8) multiplier applies
+        # only when NOT batched.
+        n_groups = 1 if batched else num_local_experts
+        fwd_ms += (n_groups * n_fwd_launch * launch_us) / 1e3
+        bwd_ms += (n_groups * n_bwd_launch * launch_us) / 1e3
+
+        return fwd_ms, bwd_ms
 
     def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, float, int]:
         """Get simulated results from the GEMM simulation backend for MoE MLP.
@@ -157,9 +328,9 @@ class MoEMLPProfiler(BaseModuleProfiler):
         num_local_experts = num_experts // ep_size
         tokens_per_expert = topk_tokens // max(num_local_experts, 1)
 
-        # FP8-hybrid: MoE expert MLP projections run in FP8
-        gemm_dtype = "fp8" if getattr(self.config.model_config, "fp8", None) else "bf16"
-        bytes_per_el = 1 if gemm_dtype == "fp8" else 2
+        # FP8-hybrid: MoE expert MLP projections run in FP8 (MX8 for mxfp8 recipe)
+        gemm_dtype = gemm_dtype_from_config(self.config.model_config)
+        bytes_per_el = 1 if gemm_dtype in ("fp8", "mx8") else 2
 
         # ── 1. Routed expert GEMMs ──
         M = tokens_per_expert
@@ -171,9 +342,19 @@ class MoEMLPProfiler(BaseModuleProfiler):
         # execution → model as Origami batched GEMM (batch=num_local_experts).
         # Legacy grouped_gemm executes experts more sequentially → model as
         # individual GEMM (batch=1) × num_local_experts.
-        use_turbo = getattr(self.config.model_config, "enable_primus_turbo", False) and getattr(
-            self.config.model_config, "use_turbo_grouped_gemm", False
+        #
+        # The turbo grouped-MLP flag is surfaced under two names across the
+        # Megatron/Primus stack (``use_turbo_grouped_mlp`` in YAML,
+        # ``use_turbo_grouped_gemm`` in some configs); honor either.  The batched
+        # (near-ideal) model is used whenever turbo is on and the config has not
+        # explicitly opted into the legacy grouped_gemm kernel.
+        _mc = self.config.model_config
+        _turbo_on = getattr(_mc, "enable_primus_turbo", False)
+        _turbo_grouped = getattr(_mc, "use_turbo_grouped_gemm", False) or getattr(
+            _mc, "use_turbo_grouped_mlp", False
         )
+        _wants_legacy = getattr(_mc, "moe_use_legacy_grouped_gemm", False)
+        use_turbo = _turbo_on and _turbo_grouped and not _wants_legacy
 
         is_rank_0 = int(os.getenv("RANK", "0")) == 0
         if is_rank_0 and num_local_experts > 1:
@@ -269,6 +450,43 @@ class MoEMLPProfiler(BaseModuleProfiler):
                     "Estimates may be inaccurate."
                 )
 
+        # ── Grouped-GEMM non-GEMM overhead (fp8 quant/dequant + launch) ──
+        # The ideal-FLOP GEMM sim prices the expert GEMMs assuming fp8 operands
+        # and (in the batched path) a single launch; it misses the JIT
+        # activation quant/dequant traffic and per-group launch latency.  These
+        # are now derived from first principles (byte traffic + launch), which
+        # replaces the old calibrated per-expert constants (0.19 / 0.66 ms).
+        #
+        # Opt back into the legacy calibrated constants with
+        # ``PRIMUS_MOE_EXPERT_OVH_CALIBRATED=1``.
+        _ovh_ref_hbm = 8000.0
+        _tgt_hbm = (
+            self._gemm_backend.hbm_bandwidth_gbps
+            if self._gemm_backend is not None and self._gemm_backend.hbm_bandwidth_gbps is not None
+            else _ovh_ref_hbm
+        )
+        _brk_gemm_f, _brk_gemm_b = expert_fwd, expert_bwd  # pure grouped-GEMM (pre small-problem overhead)
+        if os.getenv("PRIMUS_MOE_EXPERT_OVH_CALIBRATED", "0") == "1":
+            # Legacy: fixed per-local-expert ms, anchored at mi355x HBM (8 TB/s)
+            # and scaled inversely with the target arch's HBM.
+            moe_ovh_fwd = float(os.getenv("PRIMUS_MOE_EXPERT_OVH_FWD_MS", "0.19"))
+            moe_ovh_bwd = float(os.getenv("PRIMUS_MOE_EXPERT_OVH_BWD_MS", "0.66"))
+            _ovh_arch_scale = _ovh_ref_hbm / _tgt_hbm
+            expert_fwd += num_local_experts * moe_ovh_fwd * _ovh_arch_scale
+            expert_bwd += num_local_experts * moe_ovh_bwd * _ovh_arch_scale
+        else:
+            ovh_fwd_ms, ovh_bwd_ms = self._expert_overhead_first_principles(
+                topk_tokens=topk_tokens,
+                hidden_size=hidden_size,
+                moe_ffn=moe_ffn,
+                num_local_experts=num_local_experts,
+                swiglu=bool(self.config.model_config.swiglu),
+                peak_hbm=_tgt_hbm,
+                batched=use_turbo,
+            )
+            expert_fwd += ovh_fwd_ms
+            expert_bwd += ovh_bwd_ms
+
         fwd_time = expert_fwd
         bwd_time = expert_bwd
 
@@ -276,10 +494,22 @@ class MoEMLPProfiler(BaseModuleProfiler):
         # Gate linear: [batch_tokens, num_experts, hidden_size]
         router_gemm = self._gemm_backend.simulate_gemm(batch_tokens, num_experts, hidden_size, gemm_dtype)
         router_fwd_ms = router_gemm.forward_time_ms
-        # Softmax + top-K selection + auxiliary loss overhead (empirical)
-        topk_overhead_ms = 0.1 + 0.002 * num_experts
+        # Softmax + top-K over the gate logits [batch_tokens, num_experts]: a
+        # memory-bound reduction (read logits, softmax, write top-K weights),
+        # priced first-principles at ~3 passes over the fp32 logits.  Replaces
+        # the empirical ``0.1 + 0.002*num_experts`` constant (~0.87 ms/layer for
+        # 384 experts) which was ~100x the real cost and layer-agnostic.
+        _peak_hbm = getattr(self._gemm_backend, "hbm_bandwidth_gbps", None) or _FALLBACK_HBM_BW_GBPS
+        _topk_eff_bw = _peak_hbm * _ACTIVATION_BW_FRACTION  # GB/s
+        topk_overhead_ms = 3.0 * batch_tokens * num_experts * 4 / (_topk_eff_bw * 1e6)
         router_fwd_ms += topk_overhead_ms
-        # Backward: dgrad + wgrad for gate linear
+        # Backward: dgrad + wgrad for gate linear (+ the same top-K traffic).
+        # NOTE: the first ``num_hash_layers`` MoE layers STILL run the learned
+        # gate GEMM (``v4_hash_router.py:214`` F.linear over all experts); only
+        # the top-K *argmax* is replaced by a static bucket lookup.  So for hash
+        # layers, zero ONLY ``topk_overhead_ms`` (keep ``router_gemm``) at the
+        # model roll-up (per-layer index is not available here).  ~0.01 ms/layer,
+        # negligible; do NOT zero the whole router term (that drops a live GEMM).
         router_bwd_ms = 2.0 * router_gemm.forward_time_ms + topk_overhead_ms
 
         fwd_time += router_fwd_ms
@@ -296,14 +526,33 @@ class MoEMLPProfiler(BaseModuleProfiler):
             if self._gemm_backend is not None and self._gemm_backend.hbm_bandwidth_gbps is not None
             else _FALLBACK_HBM_BW_GBPS
         )
-        permute_eff_bw_gbps = peak_hbm * _PERMUTE_BW_FRACTION
         activation_bw_gbps = peak_hbm * _ACTIVATION_BW_FRACTION
 
-        dispatch_bytes = (batch_tokens + topk_tokens) * hidden_size * bytes_per_el
-        combine_bytes = (topk_tokens + batch_tokens) * hidden_size * bytes_per_el
-        permute_fwd_ms = dispatch_bytes / (permute_eff_bw_gbps * 1e6)
-        permute_bwd_ms = combine_bytes / (permute_eff_bw_gbps * 1e6)
+        if os.getenv("PRIMUS_MOE_PERMUTE_FIRST_PRINCIPLES", "1") == "1":
+            # Default: first-principles byte-traffic model of the real dispatch/
+            # combine kernels (local permute + EP sort_chunks + weighted
+            # unpermute), each split into fwd + bwd (#10).
+            dispatch_fwd, dispatch_bwd, combine_fwd, combine_bwd = self._permute_first_principles(
+                batch_tokens=batch_tokens,
+                topk_tokens=topk_tokens,
+                hidden_size=hidden_size,
+                bytes_per_el=bytes_per_el,
+                ep_size=ep_size,
+                num_local_experts=num_local_experts,
+                peak_hbm=peak_hbm,
+            )
+        else:
+            # Calibrated opt-out (PRIMUS_MOE_PERMUTE_FIRST_PRINCIPLES=0): single
+            # local permute/unpermute at _PERMUTE_BW_FRACTION (5.7% of peak HBM).
+            permute_eff_bw_gbps = peak_hbm * _PERMUTE_BW_FRACTION
+            dispatch_bytes = (batch_tokens + topk_tokens) * hidden_size * bytes_per_el
+            combine_bytes = (topk_tokens + batch_tokens) * hidden_size * bytes_per_el
+            dispatch_fwd = dispatch_bytes / (permute_eff_bw_gbps * 1e6)
+            combine_bwd = combine_bytes / (permute_eff_bw_gbps * 1e6)
+            dispatch_bwd = combine_fwd = 0.0
 
+        permute_fwd_ms = dispatch_fwd + combine_fwd
+        permute_bwd_ms = dispatch_bwd + combine_bwd
         fwd_time += permute_fwd_ms
         bwd_time += permute_bwd_ms
 
@@ -318,6 +567,7 @@ class MoEMLPProfiler(BaseModuleProfiler):
         bwd_time += activation_ms
 
         # ── 5. Shared experts (if any) ──
+        _brk_shared_f = _brk_shared_b = 0.0
         shared_sz = self.config.model_config.moe_shared_expert_intermediate_size
         if shared_sz:
             shared_result = self._gemm_backend.simulate_mlp_gemms(
@@ -327,9 +577,68 @@ class MoEMLPProfiler(BaseModuleProfiler):
                 dtype=gemm_dtype,
                 swiglu=self.config.model_config.swiglu,
             )
-            fwd_time += shared_result.forward_time_ms
-            bwd_time += shared_result.backward_time_ms
+            _brk_shared_f = shared_result.forward_time_ms
+            _brk_shared_b = shared_result.backward_time_ms
+            fwd_time += _brk_shared_f
+            bwd_time += _brk_shared_b
 
+        # ── 6. ffn_hc mHC (block-level HyperMixer around the FFN sub-block) ──
+        # #4: every V4 layer wraps BOTH attention (attn_hc, counted in the
+        # attention profiler) AND the FFN (ffn_hc) in a HyperMixer.  ffn_hc was
+        # entirely uncounted here -> the whole-layer mHC was only ~half.  Mirror
+        # the attention mHC: expand/collapse bandwidth (bf16 residual) +
+        # compute_weights (mapping_proj GEMM + RMS(K*D) + Sinkhorn).
+        mhc_fwd = mhc_bwd = 0.0
+        hc = getattr(self.config.model_config, "hc_mult", 1) or 1
+        if hc > 1:
+            eta_mhc = float(os.getenv("PRIMUS_ATTN_MISC_ETA", os.getenv("PRIMUS_ATTN_FP_ETA", "0.9")))
+            M2 = batch_tokens
+            mbpe = 2  # bf16 residual stream
+            expand_f = (2 * hc + 1) * M2 * hidden_size * mbpe
+            expand_b = (3 * hc + 2) * M2 * hidden_size * mbpe
+            collapse_f = (hc + 1) * M2 * hidden_size * mbpe
+            collapse_b = (hc + 1) * M2 * hidden_size * mbpe
+            mhc_fwd = (expand_f + collapse_f) / (eta_mhc * peak_hbm * 1e6)
+            mhc_bwd = (expand_b + collapse_b) / (eta_mhc * peak_hbm * 1e6)
+            dt_mhc = gemm_dtype_from_config(self.config.model_config)
+            cw = self._gemm_backend.simulate_gemm(
+                M2, hc * hc + 2 * hc, hc * hidden_size, dt_mhc
+            ).forward_time_ms
+            cw_mem = 2.0 * M2 * hc * hidden_size * mbpe  # RMS over K*D-wide input
+            mhc_fwd += cw + cw_mem / (eta_mhc * peak_hbm * 1e6)
+            mhc_bwd += 2.0 * cw + 1.5 * cw_mem / (eta_mhc * peak_hbm * 1e6)
+            n_iters = int(os.getenv("PRIMUS_HC_SINKHORN_ITERS", "20"))
+            sink_ms = (1.0 + 2.0 * max(0, n_iters - 1)) * 0.75 / 1e3
+            mhc_fwd += sink_ms
+            mhc_bwd += sink_ms
+            fwd_time += mhc_fwd
+            bwd_time += mhc_bwd
+
+        if os.getenv("PRIMUS_PRINT_LAYER_BREAKDOWN") and int(os.getenv("RANK", "0")) == 0:
+            print(
+                "[BRKDN] moe M=%d gemm_f=%.4f gemm_b=%.4f ovh_f=%.4f ovh_b=%.4f router_f=%.4f router_b=%.4f "
+                "dispatch_f=%.4f dispatch_b=%.4f combine_f=%.4f combine_b=%.4f act_f=%.4f act_b=%.4f "
+                "shared_f=%.4f shared_b=%.4f mhc_f=%.4f mhc_b=%.4f"
+                % (
+                    M,
+                    _brk_gemm_f,
+                    _brk_gemm_b,
+                    expert_fwd - _brk_gemm_f,
+                    expert_bwd - _brk_gemm_b,
+                    router_fwd_ms,
+                    router_bwd_ms,
+                    dispatch_fwd,
+                    dispatch_bwd,
+                    combine_fwd,
+                    combine_bwd,
+                    activation_ms,
+                    activation_ms,
+                    _brk_shared_f,
+                    _brk_shared_b,
+                    mhc_fwd,
+                    mhc_bwd,
+                )
+            )
         activation_memory = self.estimated_activation_memory(batch_size, seq_len)
         return (fwd_time, bwd_time, activation_memory)
 

--- a/primus/core/projection/module_profilers/optimizer.py
+++ b/primus/core/projection/module_profilers/optimizer.py
@@ -4,6 +4,7 @@
 # See LICENSE for license information.
 ###############################################################################
 
+import os
 from typing import Optional
 
 from primus.core.projection.base_module_profiler import BaseModuleProfiler
@@ -81,7 +82,192 @@ class OptimizerProfiler(BaseModuleProfiler):
         hbm_bw_gbps = self._get_hbm_bandwidth_gbps()
         hbm_bw_bytes_per_ms = hbm_bw_gbps * 1e9 / 1e3  # bytes/ms
 
-        return total_bytes / hbm_bw_bytes_per_ms
+        # Effective HBM utilisation of the optimizer step.  The step is NOT a
+        # single streaming pass at peak: it is many small per-parameter-group
+        # elementwise kernels (fp32 master/m/v scattered across buckets), which
+        # sustain only a fraction of peak.  Anchored to the DeepSeek-V4 Pro
+        # MI355X trace (measured Adam step 93.8 ms vs a 100%-peak 19.9 ms
+        # estimate -> ~0.21).  Env-tunable.
+        opt_hbm_eff = float(os.getenv("PRIMUS_OPT_HBM_EFF", "0.21"))
+        step_ms = total_bytes / (hbm_bw_bytes_per_ms * opt_hbm_eff)
+
+        # Muon adds Newton-Schulz orthogonalization (extra bf16 matmuls on every
+        # 2D weight matrix) on top of the memory-bound state update.  This is
+        # pure GEMM compute and is modelled from first principles below: the NS
+        # iteration count and per-matrix matmul shapes are fully determined by
+        # the model geometry and the algorithm, so each matmul is priced with
+        # the GEMM backend (no fitted constant).  On the DeepSeek-V4 Pro trace
+        # this is the single largest per-iteration cost (the fused expert
+        # ``gate_up`` weight ``[2*moe_ffn, hidden]`` dominates), which is why the
+        # old ``PRIMUS_OPT_MUON_NS_MS`` default of 0 grossly under-predicted the
+        # Muon step.  Env override retained only as an escape hatch.
+        if str(getattr(self.config.model_config, "optimizer", "") or "").lower() == "muon":
+            override = os.getenv("PRIMUS_OPT_MUON_NS_MS")
+            if override is not None:
+                step_ms += float(override)
+            else:
+                ns_ms = self._muon_newton_schulz_ms()
+                # Distributed Muon (dist_muon = muon + use_distributed_optimizer):
+                # the momentum is sharded across the data-parallel group and each
+                # rank orthogonalizes only its shard, so the Newton-Schulz compute
+                # scales down by the group over which the (expert-dominated) weights
+                # are replicated.  Expert matrices are replicated across
+                # EDP = DP / EP, which dominates; use it as the sharding factor.
+                if use_distributed_optimizer or use_fsdp:
+                    ep = getattr(mp_config, "expert_model_parallel_size", 1) or 1
+                    edp = max(1, dp_size // max(1, ep))
+                    ns_ms /= edp
+                step_ms += ns_ms
+
+        return step_ms
+
+    # ------------------------------------------------------------------
+    # Muon Newton-Schulz orthogonalization compute (first-principles)
+    # ------------------------------------------------------------------
+
+    def _muon_num_ns_steps(self) -> int:
+        """Number of Newton-Schulz iterations per orthogonalization.
+
+        Read from the config when plumbed; otherwise use the algorithm default
+        (DeepSeek-V4's quintic schedule uses 10 iterations, the generic Muon
+        default is 5).  This is an algorithm hyper-parameter, not a fitted
+        calibration constant.
+        """
+        env = os.getenv("PRIMUS_OPT_MUON_NS_STEPS")
+        if env is not None:
+            return int(env)
+        cfg = self.config.model_config
+        steps = getattr(cfg, "muon_num_ns_steps", 0) or 0
+        if steps:
+            return int(steps)
+        is_v4 = getattr(cfg, "compress_ratios", None) is not None
+        return 10 if is_v4 else 5
+
+    def _muon_weight_shapes(self):
+        """Yield ``(rows, cols, count)`` for every 2D weight Muon orthogonalizes.
+
+        Muon orthogonalizes the 2D linear weight matrices (attention Q/KV/O
+        projections, dense-MLP and MoE-expert gate/up/down); 1D params, norms,
+        embeddings and the output layer are handled by Adam and excluded here.
+        Shapes follow the model geometry (sharding is ignored: with Muon the
+        distributed optimizer is not used, so each rank orthogonalizes the full
+        matrices it owns; on a single-GPU proxy that is all of them).
+        """
+        m = self.config.model_config
+        mp = self.config.model_parallel_config
+
+        hidden = m.hidden_size
+        ffn = m.ffn_hidden_size or (hidden * 4)
+        moe_ffn = m.moe_ffn_hidden_size or ffn
+        heads = m.num_attention_heads
+        hd = m.kv_channels or (hidden // max(heads, 1))
+        n_d = heads * hd
+        q_lora = getattr(m, "q_lora_rank", 0) or 0
+        kv_lora = getattr(m, "kv_lora_rank", 0) or 0
+        o_lora = getattr(m, "o_lora_rank", 0) or 0
+        o_groups = max(1, getattr(m, "o_groups", 1) or 1)
+        swiglu = bool(getattr(m, "swiglu", False))
+        gate_up_mult = 2 if swiglu else 1
+
+        num_layers = m.num_layers
+        moe_pattern = m.moe_pattern or [0] * num_layers
+        num_moe_layers = sum(1 for p in moe_pattern if p == 1)
+        num_dense_layers = num_layers - num_moe_layers
+
+        # --- Pipeline sharding (L1 fix) ---
+        # Muon's Newton-Schulz step runs independently on every PP rank over only
+        # the weights that rank owns; the per-iteration optimizer wall-clock is
+        # therefore the slowest (max-loaded) stage.  Previously these counts used
+        # the FULL model layer count, so the Muon step did not shrink with PP and
+        # dominated the projected iteration time.  Use the critical-
+        # stage layer count ceil(num_layers / pp): for balanced / near-balanced
+        # layouts (e.g. DSv4-Pro 61 layers over PP8=7,7,8,8,8,8,8,7 or
+        # PP16=3,3,4..4,3) this equals the max stage's layer count, and it stays
+        # consistent with _count_params_per_gpu's per-rank (// pp) sharding.
+        pp = getattr(mp, "pipeline_model_parallel_size", 1) or 1
+        if pp > 1 and num_layers > 0:
+            layers_per_rank = (num_layers + pp - 1) // pp  # ceil = critical stage
+            moe_frac = num_moe_layers / num_layers
+            num_moe_layers = moe_frac * layers_per_rank
+            num_dense_layers = layers_per_rank - num_moe_layers
+            num_layers = layers_per_rank  # attention projections are per-layer
+
+        ep = getattr(mp, "expert_model_parallel_size", 1) or 1
+        num_experts = m.num_experts or 0
+        experts_per_gpu = (num_experts // max(ep, 1)) if num_experts else 0
+
+        shapes = []  # (rows, cols, count)
+
+        # ---- Attention projections (per layer) ----
+        # V4 uses LoRA-factored Q/KV and a grouped LoRA O projection; fall back
+        # to dense projections when the LoRA ranks are not configured.
+        if q_lora > 0:
+            shapes.append((q_lora, hidden, num_layers))  # Q down
+            shapes.append((n_d, q_lora, num_layers))  # Q up
+        else:
+            shapes.append((n_d, hidden, num_layers))  # Q
+        if kv_lora > 0:
+            shapes.append((kv_lora, hidden, num_layers))  # KV down
+            shapes.append((n_d, kv_lora, num_layers))  # KV up
+        else:
+            shapes.append((n_d, hidden, num_layers))  # KV
+        if o_lora > 0:
+            shapes.append((o_groups * o_lora, n_d, num_layers))  # O down
+            shapes.append((hidden, o_groups * o_lora, num_layers))  # O up
+        else:
+            shapes.append((hidden, n_d, num_layers))  # O
+
+        # ---- Dense-MLP layers ----
+        if num_dense_layers > 0:
+            shapes.append((gate_up_mult * ffn, hidden, num_dense_layers))  # gate/up
+            shapes.append((hidden, ffn, num_dense_layers))  # down
+
+        # ---- MoE expert layers (routed experts + shared expert) ----
+        if num_moe_layers > 0 and experts_per_gpu > 0:
+            shapes.append((gate_up_mult * moe_ffn, hidden, num_moe_layers * experts_per_gpu))
+            shapes.append((hidden, moe_ffn, num_moe_layers * experts_per_gpu))
+        shared_sz = getattr(m, "moe_shared_expert_intermediate_size", 0) or 0
+        if num_moe_layers > 0 and shared_sz:
+            shapes.append((gate_up_mult * shared_sz, hidden, num_moe_layers))
+            shapes.append((hidden, shared_sz, num_moe_layers))
+
+        return shapes
+
+    def _muon_newton_schulz_ms(self) -> float:
+        """First-principles Muon Newton-Schulz compute time (ms) for one step.
+
+        Each 2D weight ``W`` (reduced to ``[m, n]`` with ``m = min(dim)``,
+        ``n = max(dim)``) is orthogonalized with ``num_ns_steps`` quintic
+        Newton-Schulz iterations.  Each iteration is three bf16 matmuls::
+
+            A = X @ Xᵀ      -> (m, m, k=n)
+            AA = A @ A       -> (m, m, k=m)
+            X  = ... + B @ X -> (m, n, k=m)
+
+        priced individually with the GEMM backend, so the per-matmul efficiency
+        (tile/wave quantization, small-K overheads) comes from the same model
+        used everywhere else — no calibration constant.
+        """
+        if self._gemm_backend is None:
+            return 0.0
+        steps = self._muon_num_ns_steps()
+        if steps <= 0:
+            return 0.0
+
+        total_ms = 0.0
+        for rows, cols, count in self._muon_weight_shapes():
+            if rows <= 0 or cols <= 0 or count <= 0:
+                continue
+            mm = min(rows, cols)
+            nn = max(rows, cols)
+            try:
+                t_xxt = self._gemm_backend.simulate_gemm(mm, mm, nn, "bf16").forward_time_ms
+                t_aa = self._gemm_backend.simulate_gemm(mm, mm, mm, "bf16").forward_time_ms
+                t_bx = self._gemm_backend.simulate_gemm(mm, nn, mm, "bf16").forward_time_ms
+            except Exception:
+                continue
+            total_ms += count * steps * (t_xxt + t_aa + t_bx)
+        return total_ms
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/primus/core/projection/module_profilers/transformer_layer.py
+++ b/primus/core/projection/module_profilers/transformer_layer.py
@@ -20,7 +20,12 @@ from .layer_norm import LayerNormProfiler
 from .moe_mlp import MoEMLPProfiler
 from .residual_add import ResidualAddProfiler
 from .router import RouterProfiler
-from .utils import benchmark_layer, v4_module_inputs
+from .utils import (
+    _install_balanced_routing_patches,
+    _kernel_pad_enabled,
+    benchmark_layer,
+    v4_module_inputs,
+)
 
 # ── Fallback HBM bandwidth for elementwise overhead estimation ──
 _FALLBACK_HBM_BW_GBPS = 5300.0  # MI300X default
@@ -154,10 +159,15 @@ def _estimate_moe_a2a_time_ms(config, batch_size: int, seq_len: int, gemm_backen
     hidden_size = config.model_config.hidden_size
     moe_router_topk = getattr(config.model_config, "moe_router_topk", 2)
 
-    # A2A message size: each rank sends/receives all routed tokens
-    # Shape: [batch_size * seq_len * topk, hidden_size], BF16 (2 bytes)
+    # A2A message size: each rank sends/receives all routed tokens.
+    # #11: dispatch moves FP8 tokens (quantized expert inputs) under FP8
+    # training; combine moves BF16 (reduced expert outputs).  The two directions
+    # therefore use different element sizes -- matching the permute model, which
+    # already dispatches fp8 -- so the old flat BF16 (*2) over-counted dispatch.
     tokens_per_batch = batch_size * seq_len
-    dispatch_size_bytes = tokens_per_batch * hidden_size * moe_router_topk * 2
+    disp_bpe = 1 if getattr(config.model_config, "fp8", None) else 2
+    dispatch_size_bytes = tokens_per_batch * hidden_size * moe_router_topk * disp_bpe
+    combine_size_bytes = tokens_per_batch * hidden_size * moe_router_topk * 2
 
     # Setup collective communication args
     gpus_per_node = int(os.environ.get("GPUS_PER_NODE", "8"))
@@ -174,10 +184,50 @@ def _estimate_moe_a2a_time_ms(config, batch_size: int, seq_len: int, gemm_backen
 
     # Analytical A2A communication time (base model only)
     a2a_dispatch_us = cm.alltoall(coll_args, dispatch_size_bytes, ep, groups=["ep"])
-    a2a_combine_us = cm.alltoall(coll_args, dispatch_size_bytes, ep, groups=["ep"])
+    a2a_combine_us = cm.alltoall(coll_args, combine_size_bytes, ep, groups=["ep"])
     a2a_ms = (a2a_dispatch_us + a2a_combine_us) / 1000.0
 
     return a2a_ms
+
+
+def _deepep_overlap_efficiency(config) -> float:
+    """A2A-compute overlap efficiency for DeepEP / SyncFree (simulation).
+
+    Thin wrapper over the single source of truth,
+    ``_get_deepep_overlap_efficiency`` in the performance projection (DeepEP
+    alone hides ~65% of the dispatch/combine A2A behind compute; SyncFree
+    staging pushes the async overlap to 75/80/85%).  This adds only the
+    ``use_turbo_deepep`` off-guard so the ladder itself is not duplicated.
+    """
+    from primus.core.projection.performance_projection.projection import (
+        _get_deepep_overlap_efficiency,
+    )
+
+    model_config = getattr(config, "model_config", config)
+    if not getattr(model_config, "use_turbo_deepep", False):
+        return 0.0
+    return _get_deepep_overlap_efficiency(model_config)
+
+
+def _deepep_exposed_a2a_ms(a2a_ms: float, overlap_window_ms: float, efficiency: float) -> float:
+    """Exposed (non-overlapped) A2A after DeepEP hides part behind compute.
+
+    DeepEP pipelines dispatch/combine across micro-batch chunks so the A2A of
+    one chunk overlaps with the compute of adjacent chunks.  The amount that
+    can be hidden is therefore bounded by *both*:
+
+      1. the overlap efficiency of the async transport (``efficiency``), and
+      2. the compute available to overlap against (``overlap_window_ms``).
+
+    A naive ``a2a × (1 - eff)`` model ignores (2) and would "hide" more
+    communication than there is compute to hide it behind — physically
+    impossible when the A2A dwarfs the per-layer compute (e.g. EP16 on a
+    scale-out-bound node).  We cap the hidden amount by the compute window.
+    """
+    if efficiency <= 0.0 or a2a_ms <= 0.0:
+        return a2a_ms
+    hidden = min(a2a_ms * efficiency, max(overlap_window_ms, 0.0))
+    return max(a2a_ms - hidden, 0.0)
 
 
 # Transformer Layer Data Flow
@@ -275,12 +325,17 @@ class DenseTransformerLayerProfiler(BaseModuleProfiler):
         )
 
     def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:
-        return (
+        total = (
             self.sub_profilers["layer_norm"].estimated_activation_memory(batch_size, seq_len) * 3
             + self.sub_profilers["self_attention"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["mlp"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["residual_add"].estimated_activation_memory(batch_size, seq_len) * 2
         )
+        # Selective recompute (core_attn): self-attention activations are recomputed
+        # in backward, so they are NOT retained -> subtract the attention activation.
+        if getattr(self.config.model_parallel_config, "recompute_granularity", None) == "selective":
+            total -= self.sub_profilers["self_attention"].estimated_activation_memory(batch_size, seq_len)
+        return total
 
     def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, float, int]:
         """Aggregate simulated results from sub-profilers, including TP AllReduce."""
@@ -304,6 +359,9 @@ class DenseTransformerLayerProfiler(BaseModuleProfiler):
 
         fwd_time = attn_fwd + mlp_fwd + 2 * tp_ar_ms + ln_res_fwd_ms
         bwd_time = attn_bwd + mlp_bwd + 2 * tp_ar_ms + ln_res_bwd_ms
+        # Selective recompute (core_attn): re-run attention forward during backward.
+        if getattr(self.config.model_parallel_config, "recompute_granularity", None) == "selective":
+            bwd_time += attn_fwd
         activation_memory = self.estimated_activation_memory(batch_size, seq_len)
         return (fwd_time, bwd_time, activation_memory)
 
@@ -405,13 +463,18 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
         )
 
     def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:
-        return (
+        total = (
             self.sub_profilers["layer_norm"].estimated_activation_memory(batch_size, seq_len) * 3
             + self.sub_profilers["self_attention"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["mlp"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["router"].estimated_activation_memory(batch_size, seq_len)
             + self.sub_profilers["residual_add"].estimated_activation_memory(batch_size, seq_len) * 2
         )
+        # Selective recompute (core_attn): self-attention activations are recomputed
+        # in backward, so they are NOT retained -> subtract the attention activation.
+        if getattr(self.config.model_parallel_config, "recompute_granularity", None) == "selective":
+            total -= self.sub_profilers["self_attention"].estimated_activation_memory(batch_size, seq_len)
+        return total
 
     def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, float, int]:
         """Aggregate simulated results from sub-profilers.
@@ -440,14 +503,26 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
         # so we must add it here.
         moe_a2a_ms = _estimate_moe_a2a_time_ms(self.config, batch_size, seq_len, self._gemm_backend)
 
+        # DeepEP / SyncFree: overlap the dispatch/combine A2A with the layer's
+        # compute stream.  The hidden fraction is bounded by the async overlap
+        # efficiency AND by the compute available to overlap against (attention
+        # + MoE-MLP of the same layer).  When the A2A exceeds the compute window
+        # (scale-out-bound high-EP nodes) the residual stays exposed.
+        deepep_eff = _deepep_overlap_efficiency(self.config)
+        moe_a2a_fwd_ms = _deepep_exposed_a2a_ms(moe_a2a_ms, attn_fwd + mlp_fwd, deepep_eff)
+        moe_a2a_bwd_ms = _deepep_exposed_a2a_ms(moe_a2a_ms, attn_bwd + mlp_bwd, deepep_eff)
+
         # Add LayerNorm + Residual Add overhead (simulation only).
         # These element-wise ops are missing from GEMM/SDPA simulation.
         ln_res_fwd_ms, ln_res_bwd_ms = _estimate_layernorm_residual_time_ms(
             self.config, batch_size, seq_len, self._gemm_backend
         )
 
-        fwd_time = attn_fwd + mlp_fwd + 2 * tp_ar_ms + moe_a2a_ms + ln_res_fwd_ms
-        bwd_time = attn_bwd + mlp_bwd + 2 * tp_ar_ms + moe_a2a_ms + ln_res_bwd_ms
+        fwd_time = attn_fwd + mlp_fwd + 2 * tp_ar_ms + moe_a2a_fwd_ms + ln_res_fwd_ms
+        bwd_time = attn_bwd + mlp_bwd + 2 * tp_ar_ms + moe_a2a_bwd_ms + ln_res_bwd_ms
+        # Selective recompute (core_attn): re-run attention forward during backward.
+        if getattr(self.config.model_parallel_config, "recompute_granularity", None) == "selective":
+            bwd_time += attn_fwd
         activation_memory = self.estimated_activation_memory(batch_size, seq_len)
         return (fwd_time, bwd_time, activation_memory)
 
@@ -470,6 +545,9 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
         # Decomposed MoE MLP benchmark already includes measured dispatch/combine A2A.
         fwd_time = attn_fwd + mlp_fwd + 2 * tp_ar_ms + ln_res_fwd_ms
         bwd_time = attn_bwd + mlp_bwd + 2 * tp_ar_ms + ln_res_bwd_ms
+        # Selective recompute (core_attn): re-run attention forward during backward.
+        if getattr(self.config.model_parallel_config, "recompute_granularity", None) == "selective":
+            bwd_time += attn_fwd
         activation_memory = self.estimated_activation_memory(batch_size, seq_len)
         return (fwd_time, bwd_time, activation_memory)
 
@@ -494,20 +572,33 @@ class MoETransformerLayerProfiler(BaseModuleProfiler):
                 # (mHC + V4 attention) is benchmarked. Non-V4 layers use the stock
                 # [S,B,D] input.
                 v4 = v4_module_inputs(self.layer_module, batch_size, seq_len, hidden, hc_mult, "layer")
-                if v4 is not None:
-                    ishapes, fkwargs = v4
-                    self._cached_results = benchmark_layer(
-                        self.layer_module,
-                        ishapes,
-                        transformer_config=transformer_config,
-                        forward_kwargs=fkwargs,
-                    )
-                else:
-                    self._cached_results = benchmark_layer(
-                        self.layer_module,
-                        [(seq_len, batch_size, hidden)],
-                        transformer_config=transformer_config,
-                    )
+                routing_restores = []
+                if _kernel_pad_enabled():
+                    routing_restores, _ = _install_balanced_routing_patches(self.layer_module)
+                try:
+                    if v4 is not None:
+                        ishapes, fkwargs = v4
+                        self._cached_results = benchmark_layer(
+                            self.layer_module,
+                            ishapes,
+                            transformer_config=transformer_config,
+                            forward_kwargs=fkwargs,
+                        )
+                    else:
+                        self._cached_results = benchmark_layer(
+                            self.layer_module,
+                            [(seq_len, batch_size, hidden)],
+                            transformer_config=transformer_config,
+                        )
+                finally:
+                    for restore in routing_restores:
+                        try:
+                            restore()
+                        except Exception:
+                            # Best-effort cleanup: restore failures should not fail benchmarking.
+                            _LOGGER.debug("Failed to restore routing patch during cleanup.", exc_info=True)
+            else:
+                self._cached_results = self._get_benchmark_composite_results(batch_size, seq_len)
             self._cache_key = cache_key
         return self._cached_results
 

--- a/primus/core/projection/module_profilers/utils.py
+++ b/primus/core/projection/module_profilers/utils.py
@@ -34,6 +34,30 @@ def _bench_iter_count(default_warmup: int, default_iters: int) -> Tuple[int, int
     return max(1, warmup), max(1, iters)
 
 
+def _bench_insitu_depth() -> int:
+    """In-situ measurement depth (``PRIMUS_BENCH_INSITU_DEPTH``, default 1).
+
+    The default per-layer bench times a *single* layer in isolation: warm,
+    dedicated caches and only that one layer's activations resident.  The real
+    training step keeps **all** layers' activations resident for backward and
+    runs ~10k kernels back-to-back, so HBM bandwidth and the caching allocator
+    are under pressure and the same kernels run materially slower (silicon
+    evidence: isolated attention-bwd microbench ~2x faster than in-situ EP8).
+
+    Setting depth ``K>1`` chains the representative layer ``K`` times in one
+    forward (output -> next input) and backprops once through the whole stack,
+    so ``K`` sets of activations stay resident; the reported per-layer time is
+    ``total / K``.  This captures the resident-working-set / HBM pressure *by
+    measurement* rather than by a calibration constant.  ``K=1`` is the
+    original behaviour and is the default, so nothing changes unless opted in.
+    """
+    try:
+        depth = int(os.environ.get("PRIMUS_BENCH_INSITU_DEPTH", "1"))
+    except ValueError:
+        depth = 1
+    return max(1, depth)
+
+
 def _bench_central_value(times: list[float]) -> float:
     """Compute the per-iteration central value used by the bench reporters.
 
@@ -202,6 +226,35 @@ def benchmark_layer(
     fp8_context = _get_fp8_context_for_benchmark(transformer_config)
 
     # ===========================================================================
+    # In-situ depth: optionally chain the layer K times so K activation sets are
+    # resident (captures HBM / allocator pressure by measurement; see
+    # _bench_insitu_depth).  ``_run_fwd`` feeds output[0] back as input[0] each
+    # hop and returns the final output tuple; reported time is later divided by
+    # the *effective* depth.  Depth is downgraded to 1 if the layer's first
+    # output shape does not match its first input (chaining would be invalid).
+    # ===========================================================================
+    insitu_depth = [_bench_insitu_depth()]
+
+    def _run_fwd():
+        cur = list(inputs)
+        out = None
+        for hop in range(insitu_depth[0]):
+            out = layer_module(*cur, **kwargs)
+            out_t = out if isinstance(out, (tuple, list)) else (out,)
+            if insitu_depth[0] > 1:
+                first = out_t[0]
+                if (
+                    not isinstance(first, torch.Tensor)
+                    or not isinstance(inputs[0], torch.Tensor)
+                    or first.shape != inputs[0].shape
+                ):
+                    if hop == 0:
+                        insitu_depth[0] = 1  # not chainable; fall back silently
+                    break
+                cur[0] = first  # feed hidden states forward to keep activations live
+        return out
+
+    # ===========================================================================
     # WARMUP (20 iterations) - fully warm GPU caches, JIT, and allocators
     # This matches the "warmed up" state of actual training after many iterations
     # ===========================================================================
@@ -211,7 +264,7 @@ def benchmark_layer(
 
     with fp8_context:
         for _ in range(num_warmup):
-            outputs = layer_module(*inputs, **kwargs)
+            outputs = _run_fwd()
             if not isinstance(outputs, (tuple, list)):
                 outputs = (outputs,)
 
@@ -256,12 +309,14 @@ def benchmark_layer(
 
     with fp8_context:
         for _ in range(num_iterations):
-            outputs = layer_module(*inputs, **kwargs)
+            outputs = _run_fwd()
 
     if device.type == "cuda":
         torch.cuda.synchronize(device)
     mem_after_forward = torch.cuda.max_memory_allocated(device)
-    activation_memory = (mem_after_forward - mem_before) // num_iterations
+    # ``_run_fwd`` holds ``insitu_depth`` activation sets resident; normalise
+    # back to a single layer's activation footprint.
+    activation_memory = (mem_after_forward - mem_before) // (num_iterations * insitu_depth[0])
 
     torch.cuda.empty_cache()
     torch.cuda.reset_peak_memory_stats(device)
@@ -280,7 +335,7 @@ def benchmark_layer(
             forward_end = torch.cuda.Event(enable_timing=True)
 
             forward_start.record()
-            outputs = layer_module(*inputs, **kwargs)
+            outputs = _run_fwd()
             forward_end.record()
 
             # --- Backward pass ---
@@ -306,8 +361,10 @@ def benchmark_layer(
                 if inp.requires_grad:
                     inp.grad = None
 
-    avg_forward_time = _bench_central_value(forward_times)
-    avg_backward_time = _bench_central_value(backward_times)
+    # Per-layer time = measured stacked time / effective in-situ depth.
+    depth = insitu_depth[0]
+    avg_forward_time = _bench_central_value(forward_times) / depth
+    avg_backward_time = _bench_central_value(backward_times) / depth
 
     return avg_forward_time, avg_backward_time, int(activation_memory)
 

--- a/primus/core/projection/performance_projection/projection.py
+++ b/primus/core/projection/performance_projection/projection.py
@@ -18,7 +18,10 @@ from typing import Any, Dict, List, Optional, Tuple
 import yaml
 
 from primus.core.launcher.parser import load_primus_config
-from primus.core.projection.config_validation import assert_recompute_pipeline_compat
+from primus.core.projection.config_validation import (
+    assert_recompute_pipeline_compat,
+    recompute_is_enabled,
+)
 from primus.core.projection.memory_capture import MemoryBenchmarkRecorder, format_bytes
 from primus.core.projection.module_profilers import collective_model as cm
 from primus.core.projection.module_profilers.collective_args import get_default_args
@@ -600,11 +603,32 @@ def calculate_collective_communication_time(
             # Expert gradient allreduce: across dp_replicas GPUs (1 per node)
             expert_params_per_gpu = (expert_total_params // ep) // (tp * pp)
             expert_grad_size = expert_params_per_gpu * 4  # FP32
-            # These GPUs span different nodes → use inter-node bandwidth
-            # Ring allreduce: 2 * (N-1)/N * msg / BW
+            # Single-NIC inter-node ring. Because EP fills the node (EP ==
+            # gpus_per_node), each expert lives on exactly ONE GPU per node, so a
+            # given expert's gradient is replicated only ACROSS nodes (1 GPU per
+            # node). Two consequences:
+            #   - The ring runs over inter-node links with a single NIC per rank,
+            #     so the per-NIC pod_bw (not the aggregate pod_bw*nics_per_node the
+            #     full-DP all-reduce can stripe across) is the right bandwidth.
+            #   - Hierarchical all-reduce does NOT apply: it needs intra-node
+            #     replicas of the same tensor to pre-reduce, but the node's other
+            #     GPUs hold DIFFERENT experts. The collective is already at its
+            #     inter-node-only form (the 8 experts run as 8 parallel single-NIC
+            #     rings, one per GPU/NIC).
+            #
+            # Ring all-reduce moves 2*(N-1)/N * msg per GPU (reduce-scatter +
+            # all-gather). The (N-1)/N volume fraction is capped at its 2-node
+            # value (0.5): per-GPU traffic is bounded (it only asymptotes 0.5->1.0
+            # per pass as N grows) and, in a ring, each GPU drives a single
+            # dedicated point-to-point link whose bandwidth does not degrade as
+            # nodes are added on a non-blocking rail/fat-tree fabric. So the
+            # per-GPU AR time saturates rather than growing with (N-1)/N; the cap
+            # holds it at the 2-node value. (Flat scaling is only exercised up to
+            # dp_replicas=4; beyond that it is a physically-motivated extrapolation
+            # — an oversubscribed fabric or O(N) ring latency could bend it up.)
             pod_bw = getattr(coll_args, "pod_bw", 50.0)
-            msg_scale = (dp_replicas - 1) / dp_replicas
-            expert_ar_time_ms = 2 * expert_grad_size * msg_scale / (pod_bw * 1e9) * 1e3
+            ring_factor = min((dp_replicas - 1) / dp_replicas, 0.5)
+            expert_ar_time_ms = 2 * expert_grad_size * ring_factor / (pod_bw * 1e9) * 1e3
 
             # Non-expert gradient allreduce: across full DP group
             non_expert_per_rank = non_expert_params // (tp * pp)
@@ -621,8 +645,12 @@ def calculate_collective_communication_time(
             message_info["expert_ar_dp_replicas"] = dp_replicas
             message_info["expert_ar_time_ms"] = expert_ar_time_ms
             message_info["non_expert_ar_time_ms"] = non_expert_ar_ms
-            # MoE all2all barriers prevent gradient allreduce from overlapping
-            message_info["moe_ar_no_overlap"] = True
+            # With overlap_grad_reduce, Megatron's bucketed DDP issues the
+            # expert/non-expert grad all-reduces on a dedicated stream that
+            # overlaps with subsequent backward compute. Only treat the AR as
+            # exposed (non-overlapped) when overlap_grad_reduce is disabled.
+            overlap_grad_reduce_cfg = getattr(mp_config, "overlap_grad_reduce", True)
+            message_info["moe_ar_no_overlap"] = not overlap_grad_reduce_cfg
         else:
             grad_size = num_params_per_rank * 4  # FP32 gradients
             ar_time_dp = cm.allreduce(coll_args, grad_size, dp, groups=["dp"])
@@ -1045,6 +1073,42 @@ def _has_dense_layers(moe_layer_freq):
     return True
 
 
+def _distinct_compress_ratios(module_config):
+    """Return the set of distinct per-layer compress ratios for a DeepSeek-V4
+    hybrid-attention model, or ``None`` if the model has no per-layer
+    compress_ratios schedule.  Accepts either a list/tuple or a string form
+    (e.g. ``"[0,0,4,128,4,128,4,0]"``)."""
+    crs = getattr(module_config, "compress_ratios", None)
+    if crs is None:
+        return None
+    if isinstance(crs, str):
+        crs = crs.strip("[] ")
+        if not crs:
+            return None
+        try:
+            crs = [int(x) for x in crs.split(",")]
+        except ValueError:
+            return None
+    if not isinstance(crs, (list, tuple)) or not crs:
+        return None
+    return set(int(x) for x in crs)
+
+
+def _flatten_pipeline_for_single_node(module_config):
+    """Disable PP / virtual-PP so the stack profiles on a single node."""
+    module_config.pipeline_model_parallel_size = 1
+    if hasattr(module_config, "virtual_pipeline_model_parallel_size"):
+        module_config.virtual_pipeline_model_parallel_size = 1
+    if hasattr(module_config, "pipeline_model_parallel_layout"):
+        module_config.pipeline_model_parallel_layout = None
+    for attr in (
+        "num_layers_per_virtual_pipeline_stage",
+        "num_virtual_stages_per_pipeline_rank",
+    ):
+        if hasattr(module_config, attr):
+            setattr(module_config, attr, None)
+
+
 def _limit_layers_for_projection(module_config):
     """
     Restrict the transformer stack to a small number of layers for profiling.
@@ -1056,11 +1120,38 @@ def _limit_layers_for_projection(module_config):
     original_layers = getattr(module_config, "num_layers", 1) or 1
     original_moe_layout = getattr(module_config, "moe_layer_freq", None)
     dense_layers_present = _has_dense_layers(original_moe_layout)
-    # Use 1 layer for fast profiling - results are extrapolated to full model
-    # Increase to 2-4 for better accuracy if needed. PRIMUS_PROJ_MAX_LAYERS lets
-    # the caller benchmark more representative layers (e.g. =2 to capture both the
-    # DeepSeek-V4 HCA(cr=128) and CSA(cr=4) attention kinds, which alternate).
-    max_layers = int(os.environ.get("PRIMUS_PROJ_MAX_LAYERS", "1"))
+
+    # DeepSeek-V4 hybrid attention: per-layer compress_ratio (0=dense/SWA,
+    # 4=CSA, 128=HCA) makes attention cost layer-dependent.  Collapsing the
+    # stack onto a single representative under-counts the expensive CSA/HCA
+    # layers (measured at P32 EP=8: ~178 ms with 1 rep vs ~228 ms cr-aware vs
+    # ~386 ms silicon).  When the model has >1 distinct compress_ratio, keep the
+    # full layer schedule: the cr-aware profiler (language_model.py) still only
+    # benchmarks ONE representative per distinct cr (so the wall-cost is just
+    # N_distinct layer benchmarks, not num_layers), but the composition then
+    # weights each cr by its true layer count instead of averaging.  An explicit
+    # PRIMUS_PROJ_MAX_LAYERS override still wins.
+    _distinct_crs = _distinct_compress_ratios(module_config)
+    if (
+        _distinct_crs is not None
+        and len(_distinct_crs) > 1
+        and os.environ.get("PRIMUS_PROJ_MAX_LAYERS") is None
+    ):
+        _flatten_pipeline_for_single_node(module_config)
+        return
+    # Use 1 layer for fast profiling - results are extrapolated to full model.
+    # PRIMUS_PROJ_MAX_LAYERS lets the caller benchmark more representative layers
+    # (e.g. =2 to capture both the DeepSeek-V4 HCA(cr=128) and CSA(cr=4) attention
+    # kinds, which alternate). Otherwise default to 2 when the model mixes dense
+    # and MoE layers (so extraction can classify both using the full model's
+    # moe_pattern where layer 0 is typically dense) and 1 for a uniform stack.
+    _env_max_layers = os.environ.get("PRIMUS_PROJ_MAX_LAYERS")
+    if _env_max_layers is not None:
+        max_layers = int(_env_max_layers)
+    elif has_moe and dense_layers_present:
+        max_layers = 2
+    else:
+        max_layers = 1
     target_layers = max(1, min(original_layers, max_layers))
     module_config.num_layers = target_layers
     # Set the benchmarked layers' attention kinds. PRIMUS_PROJ_COMPRESS_RATIOS
@@ -1088,19 +1179,7 @@ def _limit_layers_for_projection(module_config):
         module_config.moe_layer_freq = [0] * target_layers
 
     # disable pipeline model parallelism for single-node layer benchmarking
-    module_config.pipeline_model_parallel_size = 1
-    # PP=1 cannot use interleaved schedule (VPP>1)
-    if hasattr(module_config, "virtual_pipeline_model_parallel_size"):
-        module_config.virtual_pipeline_model_parallel_size = 1
-    # Explicit layout is only meaningful with PP>1/VPP mapping.
-    if hasattr(module_config, "pipeline_model_parallel_layout"):
-        module_config.pipeline_model_parallel_layout = None
-    for attr in (
-        "num_layers_per_virtual_pipeline_stage",
-        "num_virtual_stages_per_pipeline_rank",
-    ):
-        if hasattr(module_config, attr):
-            setattr(module_config, attr, None)
+    _flatten_pipeline_for_single_node(module_config)
 
 
 def _rescale_expert_parallelism(module_config):
@@ -1568,11 +1647,16 @@ def _estimate_a2a_per_layer_ms(training_config, ep, hardware_config_dict=None):
     moe_router_topk = getattr(model_config, "moe_router_topk", 2)
 
     tokens_per_gpu = seq_len * batch_size // max(tp, 1)
-    dispatch_size = tokens_per_gpu * hidden_size * moe_router_topk * 2  # BF16
+    # #11: dispatch = FP8 tokens (quantized expert inputs) under FP8 training;
+    # combine = BF16 (reduced expert outputs).  The old flat BF16 (*2) on
+    # dispatch over-counted it by ~2x.
+    disp_bpe = 1 if getattr(model_config, "fp8", None) else 2
+    dispatch_size = tokens_per_gpu * hidden_size * moe_router_topk * disp_bpe
+    combine_size = tokens_per_gpu * hidden_size * moe_router_topk * 2  # BF16
 
     # Analytical A2A communication time (base model only)
     a2a_dispatch = cm.alltoall(coll_args, dispatch_size, ep, groups=["ep"])
-    a2a_combine = cm.alltoall(coll_args, dispatch_size, ep, groups=["ep"])
+    a2a_combine = cm.alltoall(coll_args, combine_size, ep, groups=["ep"])
     return (a2a_dispatch + a2a_combine) / 1000  # ms
 
 
@@ -1868,6 +1952,38 @@ def _extract_layer_type_timings(layer_results: dict) -> Dict[str, dict[str, floa
     return type_timings
 
 
+def _extract_cr_timings(layer_results: dict):
+    """Map ``(layer_type, compress_ratio) -> timing`` for V4 cr-aware PP sim.
+
+    DeepSeek-V4 attention cost varies sharply by compress ratio (cr0 dense/SWA,
+    cr4 CSA, cr128 HCA — CSA is ~1.7× the cost of dense here), so the pipeline
+    simulator must time each layer by its OWN cr instead of collapsing every MoE
+    layer onto the first profiled representative. Returns ``(cr_timings,
+    type_fallback)`` where ``type_fallback`` is the first-seen timing per type
+    (used when a target cr was not among the profiled representatives).
+    """
+    cr_timings: Dict[tuple, dict] = {}
+    type_fallback: Dict[str, dict] = {}
+    for result in layer_results.values():
+        if not isinstance(result, dict):
+            continue
+        layer_type = result.get("type")
+        if layer_type not in ("dense", "moe"):
+            continue
+        entry = {
+            "forward": float(result.get("forward_time_ms", 0.0) or 0.0),
+            "backward": float(result.get("backward_time_ms", 0.0) or 0.0),
+            # wgrad is already folded into the benchmarked backward time.
+            "wgrad": 0.0,
+            "activation": float(result.get("activation_memory_bytes", 0.0) or 0.0) / _BYTES_PER_GB,
+        }
+        cr = result.get("compress_ratio")
+        if cr is not None:
+            cr_timings.setdefault((layer_type, int(cr)), entry)
+        type_fallback.setdefault(layer_type, entry)
+    return cr_timings, type_fallback
+
+
 def _add_io_layer_timings(chunk_timings: List[list[dict]], profiling_results: dict):
     if not chunk_timings:
         return
@@ -1923,18 +2039,25 @@ def _layer_needs_recompute_fwd_in_bwd(
     total_layers: int,
     pp_size: int,
     vpp_size: int,
+    recompute_method: Optional[str] = None,
 ) -> bool:
     """Whether to add one forward pass into backward for this layer in the PP simulator.
+
+    ``recompute_method == "uniform"`` is true full recompute: EVERY layer replays
+    one forward in backward (recompute_num_layers is only the Megatron checkpoint
+    group size, not a layer count).
 
     When ``recompute_layer_ids`` is set (Megatron selective block recompute), only
     those global indices are recomputed.
 
-    Otherwise Megatron ``recompute_num_layers`` is used.  Excel's column is often
-    the *model-wide* total (e.g. 48 of 61).  When YAML carries that large total,
-    use ``global_layer_idx < recompute_num_layers`` instead of per-chunk local_idx.
+    Otherwise (``block``) Megatron ``recompute_num_layers`` is used.  Excel's column
+    is often the *model-wide* total (e.g. 48 of 61).  When YAML carries that large
+    total, use ``global_layer_idx < recompute_num_layers`` instead of per-chunk local.
     """
     if total_layers <= 0:
         return False
+    if recompute_method == "uniform":
+        return True
     if recompute_layer_ids is not None:
         return global_layer_idx in recompute_layer_ids
     if recompute_num_layers <= 0:
@@ -1962,6 +2085,23 @@ def _build_chunk_time_matrix(training_config, layer_results: dict) -> Optional[L
     type_timings = _extract_layer_type_timings(layer_results)
     if not type_timings:
         return None
+    # V4 cr-aware composition: time each target layer by its OWN compress ratio
+    # (cr0/cr4/cr128) rather than collapsing all MoE layers onto the first
+    # profiled representative. Without this the heavy CSA (cr4) layers — ~47% of
+    # the 43-layer model — are mis-timed as light cr0 layers, which underestimates
+    # per-layer compute by ~1.4× and inflates projected throughput.
+    cr_timings, cr_type_fallback = _extract_cr_timings(layer_results)
+    cr_raw = getattr(model_cfg, "compress_ratios", None)
+    cr_schedule = None
+    if cr_raw is not None and cr_timings:
+        if isinstance(cr_raw, (list, tuple)):
+            cr_schedule = [int(x) for x in cr_raw]
+        elif isinstance(cr_raw, str):
+            try:
+                _ev = eval(cr_raw.strip(), {}, {})  # noqa: S307 — trusted config literal
+                cr_schedule = [int(x) for x in _ev] if isinstance(_ev, (list, tuple)) else None
+            except Exception:
+                cr_schedule = None
 
     pp_size = getattr(mp_cfg, "pipeline_model_parallel_size", 1) or 1
     vpp_size = getattr(mp_cfg, "virtual_pipeline_model_parallel_size", 1) or 1
@@ -2005,13 +2145,19 @@ def _build_chunk_time_matrix(training_config, layer_results: dict) -> Optional[L
         recompute_granularity = getattr(mp_cfg, "recompute_granularity", None)
         recompute_layer_ids = _normalized_recompute_layer_ids(mp_cfg)
         recompute_num_layers = getattr(mp_cfg, "recompute_num_layers", 0) or 0
+        recompute_method = getattr(mp_cfg, "recompute_method", None)
 
         rank_chunks = []
         for chunk_layers in stage_chunks:
             chunk_entry = {"fwd": 0.0, "bwd": 0.0, "wgrad": 0.0, "activation": 0.0}
             for local_idx, layer_idx in enumerate(chunk_layers):
                 layer_type = "moe" if layer_type_pattern[layer_idx] else "dense"
-                metrics = type_timings.get(layer_type)
+                metrics = None
+                if cr_schedule is not None and 0 <= layer_idx < len(cr_schedule):
+                    cr = int(cr_schedule[layer_idx])
+                    metrics = cr_timings.get((layer_type, cr)) or cr_type_fallback.get(layer_type)
+                if metrics is None:
+                    metrics = type_timings.get(layer_type)
                 if not metrics:
                     continue
                 fwd_time = metrics["forward"]
@@ -2030,6 +2176,7 @@ def _build_chunk_time_matrix(training_config, layer_results: dict) -> Optional[L
                     total_layers,
                     pp_size,
                     vpp_size,
+                    recompute_method,
                 ):
                     chunk_entry["bwd"] += fwd_time
             rank_chunks.append(chunk_entry)
@@ -2579,6 +2726,106 @@ def _build_runtime_primus_config(legacy_primus_config, args, module_name="pre_tr
     return runtime_cfg
 
 
+def _benchmark_optimizer_step(trainer, rank, num_warmup=2, num_iters=5):
+    """Measure a real ``optimizer.step()`` on silicon (benchmark mode).
+
+    The analytic ``OptimizerProfiler`` models the step as purely
+    HBM-bandwidth-bound (``params/DP x 30 B / BW``).  For a DeepSeek-V4-style
+    distributed AdamW step that is a large under-count: the step is dominated by
+    **launch-bound** ``multi_tensor_apply`` Adam kernels + grad-norm/clip over
+    hundreds of small per-expert param shards (measured ~63 ms vs ~3.4 ms
+    analytic at P32 EP=8, a ~19x miss and ~40% of the projection's residual gap
+    vs silicon).  Since the real model + distributed optimizer are already built
+    for the layer benchmark, time the actual ``optimizer.step()`` instead of
+    modeling it — same philosophy as the per-layer measurement.
+
+    Returns ``{"step_time_ms": float, "samples_ms": [...]}`` or ``None`` if the
+    optimizer/model are unavailable or the measurement raises (falls back to the
+    analytic estimate).
+    """
+    import torch
+
+    if os.environ.get("PRIMUS_BENCH_SKIP_OPTIMIZER", "0") == "1":
+        return None
+
+    model = getattr(trainer, "model", None)
+    optimizer = getattr(trainer, "optimizer", None)
+    if model is None or optimizer is None:
+        return None
+    if not isinstance(model, (list, tuple)):
+        model = [model]
+
+    def _fill_grads():
+        # The distributed optimizer reads grads from the contiguous grad buffers
+        # (``param.main_grad`` are views into ``buffer.grad_data``).  Fill them
+        # with random data so the step does real work (clip + Adam) over the true
+        # shapes.  Fall back to ``param.main_grad`` / ``param.grad`` if the buffer
+        # layout is not exposed.
+        filled = False
+        for chunk in model:
+            buffers = list(getattr(chunk, "buffers", []) or [])
+            buffers += list(getattr(chunk, "expert_parallel_buffers", []) or [])
+            for buf in buffers:
+                gd = getattr(buf, "grad_data", None)
+                if gd is not None:
+                    gd.normal_()
+                    filled = True
+        if not filled:
+            for chunk in model:
+                params = chunk.parameters() if hasattr(chunk, "parameters") else []
+                for p in params:
+                    if getattr(p, "main_grad", None) is not None:
+                        p.main_grad.normal_()
+                        filled = True
+                    elif p.requires_grad:
+                        p.grad = torch.randn_like(p) if p.grad is None else p.grad.normal_()
+                        filled = True
+        return filled
+
+    try:
+        if not _fill_grads():
+            if rank == 0:
+                print(
+                    "[Primus:Performance Projection] Optimizer-step benchmark skipped "
+                    "(no grad buffers found); using analytic estimate."
+                )
+            return None
+
+        for _ in range(num_warmup):
+            _fill_grads()
+            optimizer.step()
+        torch.cuda.synchronize()
+
+        start_ev = torch.cuda.Event(enable_timing=True)
+        end_ev = torch.cuda.Event(enable_timing=True)
+        samples = []
+        for _ in range(num_iters):
+            _fill_grads()
+            torch.cuda.synchronize()
+            start_ev.record()
+            optimizer.step()
+            end_ev.record()
+            torch.cuda.synchronize()
+            samples.append(start_ev.elapsed_time(end_ev))
+
+        samples.sort()
+        median_ms = samples[len(samples) // 2]
+        if rank == 0:
+            print(
+                f"[Primus:Performance Projection] Measured optimizer.step(): "
+                f"median {median_ms:.2f} ms over {num_iters} iters "
+                f"(samples: {[round(s, 2) for s in samples]})"
+            )
+        return {"step_time_ms": median_ms, "samples_ms": samples}
+    except Exception as exc:  # noqa: BLE001
+        if rank == 0:
+            print(
+                f"[Primus:Performance Projection] WARNING: optimizer-step benchmark "
+                f"failed ({exc}); falling back to analytic estimate."
+            )
+        return None
+
+
 def _run_layer_benchmark(primus_config, unknown_overrides, reduction_info=None, args=None):
     module_config = primus_config.get_module_config("pre_trainer")
     _limit_layers_for_projection(module_config)
@@ -2743,6 +2990,15 @@ def _run_layer_benchmark(primus_config, unknown_overrides, reduction_info=None, 
     # profiling results dict so downstream extraction can pick it up.
     if tp_ar_results:
         profiling_results["_tp_allreduce_benchmark"] = tp_ar_results
+
+    # Measure a real optimizer.step() on the built distributed optimizer instead
+    # of relying on the bandwidth-only analytic model (which under-counts the
+    # launch-bound multi_tensor Adam + grad-clip by ~19x for V4-scale MoE).
+    if rank == 0:
+        print("[Primus:Performance Projection] Benchmarking optimizer.step()...")
+    optimizer_bench = _benchmark_optimizer_step(trainer, rank)
+    if optimizer_bench:
+        profiling_results["_optimizer_benchmark"] = optimizer_bench
 
     # Attach the memory benchmark payload to the profiling results dict so
     # _save_profiling_results / _load_profiling_results can persist it
@@ -3425,12 +3681,47 @@ def _run_multinode_projection(
         target_grad_ar = target_breakdown.get("gradient_allreduce", 0)
 
         if overlap_grad_reduce:
-            # Overlapped: all-reduce runs concurrently with backward of the last
-            # microbatch.  Only backward (~63% of pipeline compute) can hide AR.
-            # Excel / Megatron configs enable overlap_grad_reduce even for MoE;
-            # do not force the full AR on the critical path.
-            backward_time = projected_compute_time_ms * 0.63
-            grad_ar_per_iteration_ms = max(0, target_grad_ar - backward_time)
+            # Overlapped: bucketed grad sync runs concurrently with compute.
+            # The hiding window spans the full fwd+bwd of ALL microbatches in the
+            # iteration, not just the backward of one: gradients accumulate and
+            # the distributed optimizer issues bucketed reduces throughout the
+            # backward, while the matching parameter all-gather overlaps the NEXT
+            # iteration's forward (overlap_param_gather). Using only 0.63×bwd of a
+            # single microbatch made the exposed AR explode once the reduce
+            # exceeded that tiny window
+            rt_cfg = getattr(training_config, "runtime_config", None)
+            # NOTE: time_includes_all_microbatches handling below avoids a
+            # double-count: when the compute time came from the pipeline
+            # simulation it already sums every microbatch.
+            gbs = getattr(rt_cfg, "global_batch_size", None) or 1
+            mbs = getattr(rt_cfg, "micro_batch_size", None) or 1
+            target_microbatches = max(1, gbs // (mbs * dp_target))
+            # The hiding window is the fwd+bwd compute of ALL microbatches in the
+            # iteration. When the time came from the pipeline simulation it ALREADY
+            # sums all microbatches (time_includes_all_microbatches), so multiplying
+            # again would double-count; only scale the per-microbatch path.
+            if time_includes_all_microbatches:
+                overlap_window = projected_compute_time_ms
+            else:
+                overlap_window = projected_compute_time_ms * target_microbatches
+            # With the distributed optimizer (ZeRO-1), the per-iteration grad
+            # sync is a reduce-scatter (half the all-reduce volume); the matching
+            # parameter all-gather overlaps the NEXT forward (overlap_param_gather).
+            use_dist_opt = getattr(mp_config, "use_distributed_optimizer", False)
+            effective_ar = target_grad_ar * (0.5 if use_dist_opt else 1.0)
+            # Exposed grad-AR has two parts:
+            #   1. Bandwidth-bound excess that does not fit the compute hiding
+            #      window: max(0, effective_ar - overlap_window).
+            #   2. An overlap-inefficiency residual: even when the reduce fits the
+            #      window, comm/compute overlap is never perfect (per-bucket launch
+            #      & sync overhead, reduce-scatter reduction compute, and the param
+            #      all-gather not fully tucking under the next forward).
+            GRAD_AR_OVERLAP_INEFFICIENCY = 0.20  # 80% of the reduce is hidden
+            residual = GRAD_AR_OVERLAP_INEFFICIENCY * effective_ar
+            grad_ar_per_iteration_ms = min(
+                effective_ar,
+                max(residual, effective_ar - overlap_window),
+            )
         else:
             # Not overlapped: all-reduce runs sequentially after backward
             grad_ar_per_iteration_ms = target_grad_ar
@@ -3614,6 +3905,24 @@ def _run_multinode_projection(
     )
     optimizer_profiler = OptimizerProfiler(config=training_config, gemm_backend=gemm_backend_for_optim)
     optimizer_step_ms = optimizer_profiler.estimated_step_time_ms(dp_size=dp_target)
+
+    # Prefer the on-silicon measured optimizer.step() (benchmark mode) over the
+    # bandwidth-only analytic model.  The analytic estimate assumes the step is
+    # HBM-bandwidth-bound, but for V4-scale distributed MoE it is launch-bound
+    # (hundreds of small per-expert multi_tensor Adam shards + grad clip),
+    # measured ~19x higher.  Only used when the optimizer was benchmarked at the
+    # target EP/DP config (true when benchmark GPUs == target GPUs).
+    _optimizer_bench = (
+        profiling_results.get("_optimizer_benchmark") if isinstance(profiling_results, dict) else None
+    )
+    if _optimizer_bench and _optimizer_bench.get("step_time_ms"):
+        _measured_opt_ms = float(_optimizer_bench["step_time_ms"])
+        if is_rank_0:
+            print(
+                f"[Primus:Performance Projection] Optimizer step: using MEASURED "
+                f"{_measured_opt_ms:.2f} ms (analytic estimate was {optimizer_step_ms:.2f} ms)"
+            )
+        optimizer_step_ms = _measured_opt_ms
 
     # Build full iteration time:
     #   compute (per-microbatch) × num_microbatches + gradient allreduce + optimizer step
@@ -4358,6 +4667,24 @@ def launch_projection_from_cli(args, overrides):
                 benchmark_num_experts=benchmark_num_experts,
             )
 
+            # DeepEP / SyncFree overlap: hide part of the (target-EP) A2A behind
+            # the layer compute stream.  In simulation mode the A2A is added
+            # analytically here, so the overlap must also be applied here (the
+            # benchmark-path overlap logic never runs).  The hidden amount is
+            # bounded by the overlap efficiency AND by the compute window
+            # (attention + expert-MLP) of the same layer — when the target-EP
+            # A2A dwarfs the per-layer compute (scale-out-bound high EP) most of
+            # it stays exposed.
+            deepep_active = getattr(training_config.model_config, "use_turbo_deepep", False)
+            deepep_eff = (
+                _get_deepep_overlap_efficiency(training_config.model_config) if deepep_active else 0.0
+            )
+            a2a_target_per_layer = (
+                _estimate_a2a_per_layer_ms(training_config, original_ep, hardware_config_dict)
+                if deepep_active and deepep_eff > 0
+                else 0.0
+            )
+
             if is_rank_0:
                 print(
                     "[Primus:Performance Projection] Adjusting profiling results for EP scaling (delta approach):"
@@ -4393,8 +4720,21 @@ def launch_projection_from_cli(args, overrides):
                     mlp_delta_fwd = new_mlp_fwd - mlp_fwd
                     mlp_delta_bwd = new_mlp_bwd - mlp_bwd
 
-                    new_fwd = old_fwd + mlp_delta_fwd + fwd_overhead_per_layer
-                    new_bwd = old_bwd + mlp_delta_bwd + bwd_overhead_per_layer
+                    # DeepEP overlap: hide up to (efficiency × target A2A) behind
+                    # the layer's compute window, capped by that window.
+                    deepep_save_fwd = 0.0
+                    deepep_save_bwd = 0.0
+                    if deepep_active and deepep_eff > 0 and a2a_target_per_layer > 0:
+                        attn_info = layer_data.get("attention", {})
+                        attn_fwd = attn_info.get("forward_time_ms", 0)
+                        attn_bwd = attn_info.get("backward_time_ms", 0)
+                        deepep_save_fwd = min(deepep_eff * a2a_target_per_layer, attn_fwd + new_mlp_fwd)
+                        deepep_save_bwd = min(deepep_eff * a2a_target_per_layer, attn_bwd + new_mlp_bwd)
+
+                    new_fwd = old_fwd + mlp_delta_fwd + fwd_overhead_per_layer - deepep_save_fwd
+                    new_bwd = old_bwd + mlp_delta_bwd + bwd_overhead_per_layer - deepep_save_bwd
+                    new_fwd = max(new_fwd, 0.1)
+                    new_bwd = max(new_bwd, 0.1)
 
                     if is_rank_0 and moe_layers_adjusted == 0:
                         print("  MoE layer adjustment (per layer):")
@@ -4402,6 +4742,12 @@ def launch_projection_from_cli(args, overrides):
                         print(f"    MLP bwd: {mlp_bwd:.2f} → {new_mlp_bwd:.2f} ms (×{ep_mlp_scale:.3f})")
                         print(f"    A2A fwd delta: +{fwd_overhead_per_layer:.3f} ms")
                         print(f"    A2A bwd delta: +{bwd_overhead_per_layer:.3f} ms")
+                        if deepep_active and deepep_eff > 0:
+                            print(
+                                f"    DeepEP overlap (eff={deepep_eff:.2f}, "
+                                f"target A2A={a2a_target_per_layer:.3f} ms): "
+                                f"hidden fwd -{deepep_save_fwd:.3f} ms, bwd -{deepep_save_bwd:.3f} ms"
+                            )
                         print(f"    Layer fwd: {old_fwd:.2f} → {new_fwd:.2f} ms")
                         print(f"    Layer bwd: {old_bwd:.2f} → {new_bwd:.2f} ms")
 
@@ -4449,6 +4795,26 @@ def launch_projection_from_cli(args, overrides):
                     f"[Primus:Performance Projection] Auto-enabling zero-bubble scheduling "
                     f"for --pipeline-schedule-algorithm={scheduler_algorithm}"
                 )
+
+    # Activation recompute is incompatible with split-wgrad (zero-bubble)
+    # schedules: ZB defers the weight-grad (W) pass and pins the recomputed
+    # linear inputs until W runs, so BOTH the timing benefit and the memory
+    # accounting become invalid (see config_validation.assert_recompute_pipeline_compat).
+    # The explicit-config path is caught by that guard, but the simulator can
+    # otherwise auto-select zero-bubble under "auto"; force a recompute-compatible
+    # schedule (1f1b / interleaved-1f1b) whenever recompute is enabled.
+    if enable_zero_bubble and recompute_is_enabled(
+        training_config.model_parallel_config, module_cfg=original_module_config
+    ):
+        enable_zero_bubble = False
+        if scheduler_algorithm in ("all", "zerobubble", "zerobubble-heuristic", "seaailab-ilp"):
+            scheduler_algorithm = "auto"
+        if is_rank_0:
+            print(
+                "[Primus:Performance Projection] Activation recompute is enabled; "
+                "disabling zero-bubble/split-wgrad scheduling (incompatible: wgrad "
+                "closures pin recomputed inputs) and using a 1f1b/interleaved schedule."
+            )
 
     # Use ORIGINAL PP for pipeline simulation decision, not benchmark PP
     # If original PP > 1, we should run pipeline simulation even if we benchmarked with PP=1

--- a/primus/core/projection/simulation_backends/__init__.py
+++ b/primus/core/projection/simulation_backends/__init__.py
@@ -8,16 +8,24 @@ from primus.core.projection.simulation_backends.base import (
     GEMMSimulationBackend,
     SDPASimulationBackend,
     SimulationResult,
+    available_gemm_backends,
+    get_gemm_backend_factory,
+    register_gemm_backend,
 )
 from primus.core.projection.simulation_backends.factory import (
     get_gemm_simulation_backend,
     get_sdpa_simulation_backend,
+    list_available_gemm_backends,
 )
 
 __all__ = [
     "GEMMSimulationBackend",
     "SDPASimulationBackend",
     "SimulationResult",
+    "available_gemm_backends",
+    "get_gemm_backend_factory",
+    "register_gemm_backend",
     "get_gemm_simulation_backend",
     "get_sdpa_simulation_backend",
+    "list_available_gemm_backends",
 ]

--- a/primus/core/projection/simulation_backends/base.py
+++ b/primus/core/projection/simulation_backends/base.py
@@ -18,7 +18,7 @@ An SDPA simulation backend is provided in ``sdpa_simulator.py``.
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Tuple
 
 
 @dataclass
@@ -313,3 +313,44 @@ class SDPASimulationBackend(ABC):
             SimulationResult with forward_time_ms and backward_time_ms.
         """
         ...
+
+
+# =========================================================================
+# GEMM backend registry
+# =========================================================================
+# Backends register themselves here at import time so that neither the factory
+# nor the CLI has to hardcode any backend name.  The open-source tree ships only
+# ``origami`` (registered by ``origami_backend``).  Additional backends can be
+# added purely by being importable/installed — via the ``primus.gemm_backends``
+# entry-point group or the ``PRIMUS_GEMM_BACKEND_PLUGINS`` env var — with no
+# edits to any file in this package.
+#
+# A registered factory is any callable with the signature
+# ``(gpu_arch=None, gpu_clock_mhz=None, n_cu_override=None, **kwargs)`` that
+# returns a :class:`GEMMSimulationBackend`.
+GEMMBackendFactory = Callable[..., "GEMMSimulationBackend"]
+
+_GEMM_BACKEND_REGISTRY: Dict[str, GEMMBackendFactory] = {}
+
+
+def register_gemm_backend(name: str, factory: GEMMBackendFactory) -> None:
+    """Register a GEMM simulation backend factory under *name* (case-insensitive).
+
+    Safe to call multiple times; the last registration for a name wins.  Called
+    at module-import time by each backend module (see ``origami_backend``).
+    """
+    if not name or not isinstance(name, str):
+        raise ValueError(f"GEMM backend name must be a non-empty string, got {name!r}")
+    _GEMM_BACKEND_REGISTRY[name.lower().strip()] = factory
+
+
+def get_gemm_backend_factory(name: str) -> Optional[GEMMBackendFactory]:
+    """Return the registered factory for *name*, or ``None`` if not registered."""
+    if not name:
+        return None
+    return _GEMM_BACKEND_REGISTRY.get(name.lower().strip())
+
+
+def available_gemm_backends() -> Tuple[str, ...]:
+    """Return the sorted names of all currently registered GEMM backends."""
+    return tuple(sorted(_GEMM_BACKEND_REGISTRY))

--- a/primus/core/projection/simulation_backends/factory.py
+++ b/primus/core/projection/simulation_backends/factory.py
@@ -7,20 +7,93 @@
 """
 Factory functions for creating simulation backends.
 
-Backend selection for GEMM:
-  1. If ``PRIMUS_GEMM_BACKEND`` is set, use that backend explicitly.
-  2. Otherwise, use **origami** (the default, open-source backend).
+Backend selection for GEMM is **registry-driven** — no backend name is
+hardcoded here.  Backends register themselves with the shared registry (see
+``base.register_gemm_backend``) when their module is imported:
 
-SDPA always uses the built-in analytical simulator.
+  * The open-source tree ships only **origami** (``origami_backend``), which is
+    the default.
+  * Additional backends may be added without editing any file in this package.
+    They are discovered via, in order:
+      1. ``primus.gemm_backends`` entry points of installed packages;
+      2. module paths listed in the ``PRIMUS_GEMM_BACKEND_PLUGINS`` env var
+         (comma/semicolon separated).
+
+Selection order at call time: explicit ``backend_name`` → ``PRIMUS_GEMM_BACKEND``
+→ ``"origami"``.
+
+SDPA always uses the built-in analytical simulator (which prices its sub-GEMMs
+with whichever GEMM backend is selected).
 """
 
+import importlib
 import os
 from typing import Optional
 
 from primus.core.projection.simulation_backends.base import (
     GEMMSimulationBackend,
     SDPASimulationBackend,
+    available_gemm_backends,
+    get_gemm_backend_factory,
 )
+
+_DISCOVERY_DONE = False
+
+
+def _ensure_backends_discovered() -> None:
+    """Import backend modules so they self-register (idempotent).
+
+    This is the single discovery seam.  It never raises: a backend that fails to
+    import simply is not registered, and selecting it later yields a clear error.
+    """
+    global _DISCOVERY_DONE
+    if _DISCOVERY_DONE:
+        return
+
+    # 1. Built-in open-source backend(s).
+    for mod in ("primus.core.projection.simulation_backends.origami_backend",):
+        try:
+            importlib.import_module(mod)
+        except Exception:
+            pass
+
+    # 2. External backends declared as ``primus.gemm_backends`` entry points.
+    #    Convention: each entry point is a zero-arg ``register`` callable.
+    try:
+        from importlib.metadata import entry_points
+
+        eps = entry_points()
+        if hasattr(eps, "select"):  # Python >= 3.10
+            group = eps.select(group="primus.gemm_backends")
+        else:  # pragma: no cover - legacy
+            group = eps.get("primus.gemm_backends", [])
+        for ep in group:
+            try:
+                loaded = ep.load()
+                if callable(loaded):
+                    loaded()
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    # 3. External backends declared via env var (module paths to import).
+    raw = os.getenv("PRIMUS_GEMM_BACKEND_PLUGINS", "")
+    for mod in (m.strip() for m in raw.replace(";", ",").split(",")):
+        if mod:
+            try:
+                importlib.import_module(mod)
+            except Exception:
+                pass
+
+    _DISCOVERY_DONE = True
+
+
+def list_available_gemm_backends() -> tuple:
+    """Trigger discovery and return the sorted names of registered GEMM backends."""
+    _ensure_backends_discovered()
+    names = available_gemm_backends()
+    return names or ("origami",)
 
 
 def get_gemm_simulation_backend(
@@ -30,77 +103,99 @@ def get_gemm_simulation_backend(
     require_simulation: bool = True,
 ) -> GEMMSimulationBackend:
     """
-    Create and return the GEMM simulation backend (origami).
+    Create and return the GEMM simulation backend.
 
     Args:
-        backend_name: Explicit backend name. Currently only "origami" is supported.
-                      If None, defaults to origami.
+        backend_name: Explicit backend name (any registered backend, e.g.
+                      "origami").  If None, falls back to ``PRIMUS_GEMM_BACKEND``
+                      and finally defaults to "origami".
         gpu_arch: GPU architecture override (e.g. "gfx942", "mi300x", "mi325x").
         gpu_clock_mhz: Override the GPU compute clock frequency in MHz.
         require_simulation: If True (default), raise RuntimeError when the
-            origami library is not installed.  Set to False when only
+            selected backend is not available.  Set to False when only
             hardware-profile metadata (e.g. ``hbm_bandwidth_gbps``) is
-            needed — this avoids a hard dependency on origami in benchmark
-            mode.
+            needed — this avoids a hard dependency on the backend library in
+            benchmark mode.
 
     Returns:
         A GEMMSimulationBackend instance.
 
     Raises:
+        ValueError: If the requested backend name is not registered.
         RuntimeError: If require_simulation is True and the backend is not available.
     """
-    name = backend_name or os.getenv("PRIMUS_GEMM_BACKEND", None)
+    _ensure_backends_discovered()
 
+    name = backend_name or os.getenv("PRIMUS_GEMM_BACKEND", None)
     if name is not None:
         name = name.lower().strip()
+    if not name:
+        name = "origami"
 
     is_rank_0 = int(os.getenv("RANK", "0")) == 0
 
-    if name is not None and name != "origami":
-        raise ValueError(f"Unknown GEMM simulation backend: '{name}'. " f"Supported backend: 'origami'")
+    factory = get_gemm_backend_factory(name)
+    if factory is None:
+        supported = ", ".join(available_gemm_backends()) or "origami"
+        raise ValueError(
+            f"Unknown GEMM simulation backend: '{name}'. Supported backends: {supported}. "
+            "Extra backends can be added via the entry-point group 'primus.gemm_backends' "
+            "or the PRIMUS_GEMM_BACKEND_PLUGINS env var."
+        )
 
-    from primus.core.projection.simulation_backends.origami_backend import (
-        OrigamiGEMMBackend,
-    )
-
-    backend = OrigamiGEMMBackend(gpu_arch=gpu_arch, gpu_clock_mhz=gpu_clock_mhz)
+    backend = factory(gpu_arch=gpu_arch, gpu_clock_mhz=gpu_clock_mhz)
     if require_simulation and not backend.is_available():
         raise RuntimeError(
-            "Origami GEMM simulation backend is not available.\n" "Install it with: pip install origami"
+            f"GEMM simulation backend '{name}' is registered but not available in "
+            "this environment. Check that its underlying library is installed "
+            "(e.g. 'pip install origami')."
         )
 
     if is_rank_0 and require_simulation:
-        print("[Primus:Simulation] Using GEMM backend: origami")
+        print(f"[Primus:Simulation] Using GEMM backend: {name}")
     return backend
 
 
 def get_sdpa_simulation_backend(
     gpu_arch: Optional[str] = None,
     gpu_clock_mhz: Optional[int] = None,
+    backend_name: Optional[str] = None,
 ) -> SDPASimulationBackend:
     """
     Create and return the SDPA simulation backend.
 
-    Uses the Origami 1-CU tile-level model of the FAv3 (Flash Attention v3)
-    kernels.  Origami must be installed.
+    Models the FAv3 (Flash Attention v3) kernels, pricing the per-tile sub-GEMMs
+    with the selected GEMM backend (default origami).  The GEMM engine follows
+    the same registry-driven selection as ``get_gemm_simulation_backend``.
 
     Args:
         gpu_arch: GPU architecture override (e.g. "mi300x", "mi355x").
         gpu_clock_mhz: Override the GPU compute clock frequency in MHz.
+        backend_name: Explicit GEMM engine name.  If None, falls back to
+            ``PRIMUS_GEMM_BACKEND`` and finally "origami".
 
     Returns:
         An SDPASimulationBackend instance.
 
     Raises:
-        RuntimeError: If the Origami backend is not available.
+        RuntimeError: If the selected GEMM backend is not available.
     """
     from primus.core.projection.simulation_backends.sdpa_simulator import SDPASimulator
 
+    _ensure_backends_discovered()
+
+    name = (backend_name or os.getenv("PRIMUS_GEMM_BACKEND") or "origami").lower().strip()
+    # Fall back to the built-in origami engine if the requested GEMM backend is
+    # not registered in this environment.
+    if get_gemm_backend_factory(name) is None:
+        name = "origami"
+
     is_rank_0 = int(os.getenv("RANK", "0")) == 0
     if is_rank_0:
-        print("[Primus:Simulation] Using SDPA backend: sdpa_simulator (FAv3 Origami 1-CU)")
+        print(f"[Primus:Simulation] Using SDPA backend: sdpa_simulator (FAv3, {name} 1-CU)")
 
     return SDPASimulator(
         gpu_arch=gpu_arch,
         gpu_clock_mhz=gpu_clock_mhz,
+        gemm_backend=name,
     )

--- a/primus/core/projection/simulation_backends/factory.py
+++ b/primus/core/projection/simulation_backends/factory.py
@@ -55,6 +55,8 @@ def _ensure_backends_discovered() -> None:
         try:
             importlib.import_module(mod)
         except Exception:
+            # Best-effort discovery: a backend that fails to import simply stays
+            # unregistered; selecting it later raises a clear error.
             pass
 
     # 2. External backends declared as ``primus.gemm_backends`` entry points.
@@ -73,8 +75,10 @@ def _ensure_backends_discovered() -> None:
                 if callable(loaded):
                     loaded()
             except Exception:
+                # One misbehaving plugin must not block the others; skip it.
                 pass
     except Exception:
+        # Entry-point enumeration is optional/best-effort; never abort setup.
         pass
 
     # 3. External backends declared via env var (module paths to import).
@@ -84,6 +88,7 @@ def _ensure_backends_discovered() -> None:
             try:
                 importlib.import_module(mod)
             except Exception:
+                # Ignore a misconfigured plugin path so it can't break selection.
                 pass
 
     _DISCOVERY_DONE = True

--- a/primus/core/projection/simulation_backends/origami_backend.py
+++ b/primus/core/projection/simulation_backends/origami_backend.py
@@ -33,6 +33,7 @@ from typing import Dict, List, Optional, Tuple
 from primus.core.projection.simulation_backends.base import (
     GEMMSimulationBackend,
     SimulationResult,
+    register_gemm_backend,
 )
 
 # ---------------------------------------------------------------------------
@@ -468,3 +469,23 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
                 f"clock={clock_khz / 1e6:.1f} GHz{override_tag}{cu_tag}"
             )
         return hw
+
+
+# ---------------------------------------------------------------------------
+# Self-registration.  Importing this module registers the built-in ``origami``
+# GEMM backend with the shared registry (see ``base.register_gemm_backend``).
+# ---------------------------------------------------------------------------
+def _make_origami_backend(
+    gpu_arch=None,
+    gpu_clock_mhz=None,
+    n_cu_override=None,
+    **_kwargs,
+) -> OrigamiGEMMBackend:
+    return OrigamiGEMMBackend(
+        gpu_arch=gpu_arch,
+        gpu_clock_mhz=gpu_clock_mhz,
+        n_cu_override=n_cu_override,
+    )
+
+
+register_gemm_backend("origami", _make_origami_backend)

--- a/primus/core/projection/simulation_backends/origami_backend.py
+++ b/primus/core/projection/simulation_backends/origami_backend.py
@@ -61,6 +61,32 @@ def _try_import_origami():
     return _origami_available
 
 
+# Some origami builds accept a register-file capacity (``rf_capacity``)
+# parameter in ``get_hardware_for_arch`` — inserted between ``lds_capacity`` and
+# ``L2_capacity`` — while older/public builds expose only the 5-argument
+# signature ``(arch, N_CU, lds_capacity, L2_capacity, compute_clock_khz)``.
+# Detect support once (cached) and dispatch accordingly so the public tree runs
+# against either build without depending on a newer origami.
+_ORIGAMI_HW_ARCH_RF: Optional[bool] = None
+
+
+def _get_hardware_for_arch(arch_enum, n_cu, lds_capacity, rf_capacity, l2_capacity, clock_khz):
+    """Call ``origami.get_hardware_for_arch`` tolerating builds without rf_capacity."""
+    global _ORIGAMI_HW_ARCH_RF
+    if _ORIGAMI_HW_ARCH_RF is not False:
+        try:
+            hw = _origami.get_hardware_for_arch(
+                arch_enum, n_cu, lds_capacity, rf_capacity, l2_capacity, clock_khz
+            )
+            _ORIGAMI_HW_ARCH_RF = True
+            return hw
+        except TypeError:
+            if _ORIGAMI_HW_ARCH_RF is True:
+                raise
+            _ORIGAMI_HW_ARCH_RF = False
+    return _origami.get_hardware_for_arch(arch_enum, n_cu, lds_capacity, l2_capacity, clock_khz)
+
+
 # ---------------------------------------------------------------------------
 # Known hardware profiles for GPU-less simulation via get_hardware_for_arch.
 # ---------------------------------------------------------------------------
@@ -404,7 +430,7 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
                 clock_khz = self._clock_override_mhz * 1000
             n_cu = self._n_cu_override if self._n_cu_override is not None else profile.n_cu
             arch_enum = getattr(_origami.architecture_t, profile.arch_enum_name)
-            hw = _origami.get_hardware_for_arch(
+            hw = _get_hardware_for_arch(
                 arch_enum,
                 n_cu,
                 profile.lds_capacity,
@@ -460,7 +486,7 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
             clock_khz = self._clock_override_mhz * 1000
         n_cu = self._n_cu_override if self._n_cu_override is not None else profile.n_cu
         arch_enum = getattr(_origami.architecture_t, profile.arch_enum_name)
-        hw = _origami.get_hardware_for_arch(
+        hw = _get_hardware_for_arch(
             arch_enum,
             n_cu,
             profile.lds_capacity,

--- a/primus/core/projection/simulation_backends/origami_backend.py
+++ b/primus/core/projection/simulation_backends/origami_backend.py
@@ -61,29 +61,33 @@ def _try_import_origami():
     return _origami_available
 
 
-# Some origami builds accept a register-file capacity (``rf_capacity``)
-# parameter in ``get_hardware_for_arch`` — inserted between ``lds_capacity`` and
-# ``L2_capacity`` — while older/public builds expose only the 5-argument
-# signature ``(arch, N_CU, lds_capacity, L2_capacity, compute_clock_khz)``.
-# Detect support once (cached) and dispatch accordingly so the public tree runs
-# against either build without depending on a newer origami.
-_ORIGAMI_HW_ARCH_RF: Optional[bool] = None
+# Origami API-capability cache, populated lazily on first use.  Different
+# origami builds expose different signatures; we probe once and remember the
+# result so the public tree runs against either build without depending on a
+# newer origami.  Keys: ``"hw_arch_rf"`` -> whether ``get_hardware_for_arch``
+# accepts a register-file (``rf_capacity``) argument.
+_ORIGAMI_API_CAPS: Dict[str, bool] = {}
 
 
 def _get_hardware_for_arch(arch_enum, n_cu, lds_capacity, rf_capacity, l2_capacity, clock_khz):
-    """Call ``origami.get_hardware_for_arch`` tolerating builds without rf_capacity."""
-    global _ORIGAMI_HW_ARCH_RF
-    if _ORIGAMI_HW_ARCH_RF is not False:
+    """Call ``origami.get_hardware_for_arch`` tolerating builds without rf_capacity.
+
+    Newer origami builds accept a register-file capacity argument (inserted
+    between ``lds_capacity`` and ``L2_capacity``); older/public builds expose
+    only the 5-argument signature ``(arch, N_CU, lds_capacity, L2_capacity,
+    compute_clock_khz)``.
+    """
+    if _ORIGAMI_API_CAPS.get("hw_arch_rf", True):
         try:
             hw = _origami.get_hardware_for_arch(
                 arch_enum, n_cu, lds_capacity, rf_capacity, l2_capacity, clock_khz
             )
-            _ORIGAMI_HW_ARCH_RF = True
+            _ORIGAMI_API_CAPS["hw_arch_rf"] = True
             return hw
         except TypeError:
-            if _ORIGAMI_HW_ARCH_RF is True:
+            if _ORIGAMI_API_CAPS.get("hw_arch_rf") is True:
                 raise
-            _ORIGAMI_HW_ARCH_RF = False
+            _ORIGAMI_API_CAPS["hw_arch_rf"] = False
     return _origami.get_hardware_for_arch(arch_enum, n_cu, lds_capacity, l2_capacity, clock_khz)
 
 

--- a/primus/core/projection/simulation_backends/origami_backend.py
+++ b/primus/core/projection/simulation_backends/origami_backend.py
@@ -304,8 +304,14 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
         problem.b_mx_block_size = 0
 
         # ----- Select best config & predict latency (in clock cycles) -----
+        # Newer origami builds take a ``model_t`` selector as a 4th argument;
+        # the public/CI build exposes only the 3-argument signature.  Dispatch
+        # on availability so the public tree runs against either build.
         try:
-            result = _origami.select_config(problem, self._hardware, self._configs, _origami.model_t.gemm)
+            if hasattr(_origami, "model_t"):
+                result = _origami.select_config(problem, self._hardware, self._configs, _origami.model_t.gemm)
+            else:
+                result = _origami.select_config(problem, self._hardware, self._configs)
         except Exception as e:
             raise RuntimeError(
                 f"Origami select_config failed for " f"(M={m}, N={n}, K={k}, dtype={dtype}): {e}"

--- a/primus/core/projection/simulation_backends/origami_backend.py
+++ b/primus/core/projection/simulation_backends/origami_backend.py
@@ -74,6 +74,7 @@ class _HardwareProfile:
     l2_capacity: int  # bytes (per XCD)
     compute_clock_khz: int
     hbm_bandwidth_gbps: float = 5300.0  # peak HBM bandwidth (GB/s)
+    rf_capacity: int = 512 * 1024  # Register File (VGPR) capacity per CU in bytes
 
 
 _KNOWN_PROFILES: Dict[str, _HardwareProfile] = {
@@ -98,6 +99,13 @@ _DTYPE_MAP: Dict[str, str] = {
     "fp16": "f16",
     "fp32": "f32",
     "fp8": "bf8_fnuz",
+    # Origami has no microscaled / sub-8-bit path; model them as fp8-class
+    # (bf8_fnuz) rather than silently falling back to bf16.
+    "mx8": "bf8_fnuz",
+    "mx6": "bf8_fnuz",
+    "mx4": "bf8_fnuz",
+    "fp6": "bf8_fnuz",
+    "fp4": "bf8_fnuz",
 }
 
 # ---------------------------------------------------------------------------
@@ -271,7 +279,7 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
 
         # ----- Select best config & predict latency (in clock cycles) -----
         try:
-            result = _origami.select_config(problem, self._hardware, self._configs)
+            result = _origami.select_config(problem, self._hardware, self._configs, _origami.model_t.gemm)
         except Exception as e:
             raise RuntimeError(
                 f"Origami select_config failed for " f"(M={m}, N={n}, K={k}, dtype={dtype}): {e}"
@@ -400,6 +408,7 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
                 arch_enum,
                 n_cu,
                 profile.lds_capacity,
+                profile.rf_capacity,
                 profile.l2_capacity,
                 clock_khz,
             )
@@ -455,6 +464,7 @@ class OrigamiGEMMBackend(GEMMSimulationBackend):
             arch_enum,
             n_cu,
             profile.lds_capacity,
+            profile.rf_capacity,
             profile.l2_capacity,
             clock_khz,
         )

--- a/primus/core/projection/simulation_backends/sdpa_simulator.py
+++ b/primus/core/projection/simulation_backends/sdpa_simulator.py
@@ -487,7 +487,8 @@ class SDPASimulator(SDPASimulationBackend):
           Workgroups = ⌈S_K / 256⌉ × B × H_Q
         """
         assert self._tile_gemm is not None
-        N_CU = self._hw.n_cu
+        # Parallel-unit count for wave quantisation = physical CU count.
+        N_CU = getattr(self, "_tile_units", None) or self._hw.n_cu
         causal_factor = 0.5 if causal else 1.0
 
         # ==============================================================
@@ -512,7 +513,10 @@ class SDPASimulator(SDPASimulationBackend):
             dtype=dtype,
         )
 
-        fwd_time_ms = (r_fwd_qk.forward_time_ms + r_fwd_pv.forward_time_ms) * fwd_waves
+        # Causal masking halves the realised QKᵀ/PV work (FAv3 skips
+        # fully-masked KV tiles).  Applied to the *timing* here, not just the
+        # FLOP metadata below — otherwise a full-causal layer is ~2x overcounted.
+        fwd_time_ms = (r_fwd_qk.forward_time_ms + r_fwd_pv.forward_time_ms) * fwd_waves * causal_factor
 
         # ==============================================================
         # BACKWARD
@@ -564,7 +568,7 @@ class SDPASimulator(SDPASimulationBackend):
             + r_bwd_dv.forward_time_ms
             + r_bwd_dq.forward_time_ms
             + r_bwd_dk.forward_time_ms
-        ) * bwd_waves
+        ) * bwd_waves * causal_factor
 
         # ── Backward dQ atomics (latency-based model) ──
         # Each KV-workgroup atomically accumulates dQ via buffer_atomic_add_f32.
@@ -586,37 +590,8 @@ class SDPASimulator(SDPASimulationBackend):
         # ==============================================================
         # METADATA (FLOPs, bytes — for achieved-TFLOPS reporting)
         # ==============================================================
-        fwd_flops = (
-            2.0 * B * H_Q * S_Q * S_K * D_qk  # QKᵀ
-            + 2.0 * B * H_Q * S_Q * S_K * D_v  # PV
-            + 5.0 * B * H_Q * S_Q * S_K  # softmax
-        ) * causal_factor
-
-        bwd_flops = (
-            2.0 * B * H_Q * S_Q * S_K * D_qk  # QKᵀ recomp
-            + 2.0 * B * H_Q * S_Q * S_K * D_v  # dP
-            + 2.0 * B * H_Q * S_K * S_Q * D_v  # dV
-            + 2.0 * B * H_Q * S_Q * S_K * D_qk  # dQ
-            + 2.0 * B * H_Q * S_K * S_Q * D_qk  # dK
-            + 5.0 * B * H_Q * S_Q * S_K  # softmax bwd
-        ) * causal_factor
-
-        fwd_bytes = (
-            B * H_Q * S_Q * D_qk * bpe  # Q
-            + B * H_K * S_K * D_qk * bpe  # K
-            + B * H_K * S_K * D_v * bpe  # V
-            + B * H_Q * S_Q * D_v * bpe  # O
-            + B * H_Q * S_Q * 4  # logsumexp (fp32)
-        )
-        bwd_bytes = (
-            B * H_Q * S_Q * D_qk * bpe  # Q
-            + B * H_K * S_K * D_qk * bpe  # K
-            + B * H_K * S_K * D_v * bpe  # V
-            + B * H_Q * S_Q * D_v * bpe  # O
-            + B * H_Q * S_Q * D_v * bpe  # dO
-            + B * H_Q * S_Q * 4  # logsumexp (fp32)
-            + B * H_K * S_K * D_qk * bpe  # dK
-            + B * H_K * S_K * D_v * bpe  # dV
+        fwd_flops, bwd_flops, fwd_bytes, bwd_bytes = self._flops_bytes(
+            B, H_Q, S_Q, S_K, H_K, D_qk, D_v, causal_factor, bpe
         )
 
         fwd_achieved_tflops = (fwd_flops / (fwd_time_ms * 1e-3)) / 1e12 if fwd_time_ms > 0 else 0
@@ -669,6 +644,56 @@ class SDPASimulator(SDPASimulationBackend):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _flops_bytes(
+        self,
+        B: int,
+        H_Q: int,
+        S_Q: int,
+        S_K: int,
+        H_K: int,
+        D_qk: int,
+        D_v: int,
+        causal_factor: float,
+        bpe: int,
+    ):
+        """FLOPs and HBM bytes for the fwd/bwd SDPA (achieved-TFLOPS reporting).
+
+        Factored out so every pricing path reports identical FLOP/byte metadata.
+        """
+        fwd_flops = (
+            2.0 * B * H_Q * S_Q * S_K * D_qk  # QKᵀ
+            + 2.0 * B * H_Q * S_Q * S_K * D_v  # PV
+            + 5.0 * B * H_Q * S_Q * S_K  # softmax
+        ) * causal_factor
+
+        bwd_flops = (
+            2.0 * B * H_Q * S_Q * S_K * D_qk  # QKᵀ recomp
+            + 2.0 * B * H_Q * S_Q * S_K * D_v  # dP
+            + 2.0 * B * H_Q * S_K * S_Q * D_v  # dV
+            + 2.0 * B * H_Q * S_Q * S_K * D_qk  # dQ
+            + 2.0 * B * H_Q * S_K * S_Q * D_qk  # dK
+            + 5.0 * B * H_Q * S_Q * S_K  # softmax bwd
+        ) * causal_factor
+
+        fwd_bytes = (
+            B * H_Q * S_Q * D_qk * bpe  # Q
+            + B * H_K * S_K * D_qk * bpe  # K
+            + B * H_K * S_K * D_v * bpe  # V
+            + B * H_Q * S_Q * D_v * bpe  # O
+            + B * H_Q * S_Q * 4  # logsumexp (fp32)
+        )
+        bwd_bytes = (
+            B * H_Q * S_Q * D_qk * bpe  # Q
+            + B * H_K * S_K * D_qk * bpe  # K
+            + B * H_K * S_K * D_v * bpe  # V
+            + B * H_Q * S_Q * D_v * bpe  # O
+            + B * H_Q * S_Q * D_v * bpe  # dO
+            + B * H_Q * S_Q * 4  # logsumexp (fp32)
+            + B * H_K * S_K * D_qk * bpe  # dK
+            + B * H_K * S_K * D_v * bpe  # dV
+        )
+        return fwd_flops, bwd_flops, fwd_bytes, bwd_bytes
 
     def _bytes_per_element(self, dtype: str) -> int:
         return {"bf16": 2, "fp16": 2, "fp32": 4, "fp8": 1}.get(dtype, 2)

--- a/primus/core/projection/simulation_backends/sdpa_simulator.py
+++ b/primus/core/projection/simulation_backends/sdpa_simulator.py
@@ -158,6 +158,83 @@ _HW_PROFILES: Dict[str, GPUHardwareSpec] = {
     ),
 }
 
+# Default per-profile compute clocks (MHz) used to derive the scale factor when
+# ``--gpu-clock-mhz`` / ``PRIMUS_GPU_CLOCK_MHZ`` overrides the clock.
+_PROFILE_CLOCK_MHZ: Dict[str, int] = {
+    "mi300x": 2100,
+    "gfx942": 2100,
+    "mi325x": 2100,  # same gfx942 compute die as MI300X
+    "mi355x": 2100,
+    "gfx950": 2100,
+    "mi300a": 2100,
+}
+
+
+def _load_external_hw_profiles() -> None:
+    """Merge additional GPU compute profiles from external YAML files.
+
+    Profiles for architectures not shipped in-tree can be supplied via YAML files
+    whose directories are listed in the ``PRIMUS_HW_PROFILE_DIR`` env var
+    (comma/semicolon separated).  Each file has the form::
+
+        gpu_hardware_profiles:
+          <arch>:
+            peak_tflops_bf16: ...
+            peak_tflops_fp16: ...
+            peak_tflops_fp8: ...
+            hbm_bandwidth_gbps: ...
+            n_cu: ...
+            n_xcd: ...
+            base_clock_mhz: ...        # optional (for clock scaling)
+            aliases: [<name>, ...]     # optional
+
+    This function never raises: a missing dir / bad file is skipped so the
+    built-in default profiles always remain usable.
+    """
+    raw = os.getenv("PRIMUS_HW_PROFILE_DIR", "")
+    dirs = [d.strip() for d in raw.replace(";", ",").split(",") if d.strip()]
+    if not dirs:
+        return
+    try:
+        import glob
+
+        import yaml  # type: ignore[import-untyped]
+    except Exception:
+        return
+
+    for d in dirs:
+        for path in sorted(glob.glob(os.path.join(d, "*.yaml")) + glob.glob(os.path.join(d, "*.yml"))):
+            try:
+                with open(path, "r") as fh:
+                    doc = yaml.safe_load(fh) or {}
+                profiles = doc.get("gpu_hardware_profiles") or {}
+                for arch, fields in profiles.items():
+                    if not isinstance(fields, dict):
+                        continue
+                    arch_l = str(arch).lower().strip()
+                    spec = GPUHardwareSpec(
+                        peak_tflops_bf16=float(fields.get("peak_tflops_bf16", 0.0)),
+                        peak_tflops_fp16=float(fields.get("peak_tflops_fp16", 0.0)),
+                        peak_tflops_fp8=float(fields.get("peak_tflops_fp8", 0.0)),
+                        hbm_bandwidth_gbps=float(fields.get("hbm_bandwidth_gbps", 0.0)),
+                        n_cu=int(fields.get("n_cu", 304)),
+                        n_xcd=int(fields.get("n_xcd", 8)),
+                    )
+                    _HW_PROFILES[arch_l] = spec
+                    base_clock = fields.get("base_clock_mhz")
+                    if base_clock is not None:
+                        _PROFILE_CLOCK_MHZ[arch_l] = int(base_clock)
+                    for alias in fields.get("aliases", []) or []:
+                        alias_l = str(alias).lower().strip()
+                        _HW_PROFILES[alias_l] = spec
+                        if base_clock is not None:
+                            _PROFILE_CLOCK_MHZ[alias_l] = int(base_clock)
+            except Exception:
+                continue
+
+
+_load_external_hw_profiles()
+
 
 def _get_hardware_spec(
     gpu_arch: Optional[str] = None,
@@ -175,15 +252,8 @@ def _get_hardware_spec(
     # Apply clock override — scale TFLOPS linearly
     clock_override = gpu_clock_mhz or (int(v) if (v := os.getenv("PRIMUS_GPU_CLOCK_MHZ")) else None)
     if clock_override is not None:
-        # Derive the profile's implicit clock from a known reference.
-        _PROFILE_CLOCK_MHZ = {
-            "mi300x": 2100,
-            "gfx942": 2100,
-            "mi325x": 2100,  # same gfx942 compute die as MI300X
-            "mi355x": 2100,
-            "gfx950": 2100,
-            "mi300a": 2100,
-        }
+        # Derive the profile's implicit clock from a known reference (module-level
+        # table, extended by any external overlay profiles).
         base_clock = _PROFILE_CLOCK_MHZ.get(arch, 2100)
         scale = clock_override / base_clock
         spec = GPUHardwareSpec(
@@ -225,6 +295,7 @@ class SDPASimulator(SDPASimulationBackend):
         gpu_arch: Optional[str] = None,
         hardware_spec: Optional[GPUHardwareSpec] = None,
         gpu_clock_mhz: Optional[int] = None,
+        gemm_backend: Optional[str] = None,
     ):
         """
         Args:
@@ -233,25 +304,38 @@ class SDPASimulator(SDPASimulationBackend):
             hardware_spec: Override hardware spec directly.
             gpu_clock_mhz: Override the GPU compute clock frequency in MHz.
                 If provided, the profile's TFLOPS are scaled proportionally.
+            gemm_backend: Which registered GEMM engine prices the per-tile
+                FAv3 sub-GEMMs.  If *None*, falls back to ``PRIMUS_GEMM_BACKEND``
+                and finally "origami".
 
         Raises:
-            RuntimeError: If the Origami backend is not available.
+            RuntimeError: If the selected GEMM backend is not available.
         """
+        from primus.core.projection.simulation_backends.base import get_gemm_backend_factory
+        from primus.core.projection.simulation_backends.factory import _ensure_backends_discovered
+
         self._hw = hardware_spec or _get_hardware_spec(gpu_arch, gpu_clock_mhz)
 
-        # Create the Origami 1-CU backend for tile-level simulation.
+        _ensure_backends_discovered()
+        name = (gemm_backend or os.getenv("PRIMUS_GEMM_BACKEND") or "origami").lower().strip()
+        # Fall back to the built-in origami engine if the requested backend is
+        # not registered in this environment.
+        if get_gemm_backend_factory(name) is None:
+            name = "origami"
+        self._mode = name
+
+        # Create the 1-CU GEMM backend used to price the per-tile sub-GEMMs.
         # This is required — SDPA simulation cannot proceed without it.
-        self._tile_gemm = self._create_tile_gemm_backend(gpu_arch, gpu_clock_mhz)
+        self._tile_gemm = self._create_tile_gemm_backend(name, gpu_arch, gpu_clock_mhz)
         if self._tile_gemm is None:
             raise RuntimeError(
-                "SDPASimulator requires the Origami backend but it is not "
-                "available.  Please install the 'origami' package or ensure "
-                "primus.core.projection.simulation_backends.origami_backend "
-                "is importable."
+                f"SDPASimulator requires the '{name}' GEMM backend but it is not "
+                "available.  Install / provide it, or select an available backend "
+                "via PRIMUS_GEMM_BACKEND (registered backends self-register on import)."
             )
 
     def name(self) -> str:
-        return "sdpa_simulator (FAv3)"
+        return f"sdpa_simulator (FAv3, {self._mode} 1-CU)"
 
     def is_available(self) -> bool:
         return self._tile_gemm is not None and self._tile_gemm.is_available()
@@ -322,34 +406,38 @@ class SDPASimulator(SDPASimulationBackend):
 
     def _create_tile_gemm_backend(
         self,
+        backend_name: str,
         gpu_arch: Optional[str],
         gpu_clock_mhz: Optional[int],
     ):
-        """Try to create an Origami backend with 1 CU for per-tile simulation.
+        """Create the selected GEMM backend with 1 CU for per-tile simulation.
 
-        Returns the backend on success, or ``None`` if Origami is not available.
+        Uses the shared registry so any registered backend (default origami) can
+        price the FAv3 tiles.  Returns the backend on success, or ``None`` if it
+        is not available.
         """
-        try:
-            from primus.core.projection.simulation_backends.origami_backend import (
-                OrigamiGEMMBackend,
-            )
+        from primus.core.projection.simulation_backends.base import get_gemm_backend_factory
 
-            backend = OrigamiGEMMBackend(
+        is_rank_0 = int(os.getenv("RANK", "0")) == 0
+        try:
+            factory = get_gemm_backend_factory(backend_name)
+            if factory is None:
+                return None
+            backend = factory(
                 gpu_arch=gpu_arch,
                 gpu_clock_mhz=gpu_clock_mhz,
                 n_cu_override=1,
             )
             if backend.is_available():
-                is_rank_0 = int(os.getenv("RANK", "0")) == 0
                 if is_rank_0:
-                    print("[Primus:SDPA] Using Origami 1-CU tile-level simulation " "for Flash Attention")
+                    print(
+                        f"[Primus:SDPA] Using {backend_name} 1-CU tile-level "
+                        "simulation for Flash Attention"
+                    )
                 return backend
         except Exception as exc:
-            # If Origami is not available or fails to initialize, fall back to
-            # the analytic SDPA model by returning None here.
-            is_rank_0 = int(os.getenv("RANK", "0")) == 0
             if is_rank_0:
-                print("[Primus:SDPA] Origami 1-CU tile-level simulation disabled " f"due to error: {exc}")
+                print("[Primus:SDPA] 1-CU tile-level simulation disabled " f"due to error: {exc}")
         return None
 
     def _simulate_tile_level(

--- a/primus/core/projection/simulation_backends/sdpa_simulator.py
+++ b/primus/core/projection/simulation_backends/sdpa_simulator.py
@@ -311,8 +311,12 @@ class SDPASimulator(SDPASimulationBackend):
         Raises:
             RuntimeError: If the selected GEMM backend is not available.
         """
-        from primus.core.projection.simulation_backends.base import get_gemm_backend_factory
-        from primus.core.projection.simulation_backends.factory import _ensure_backends_discovered
+        from primus.core.projection.simulation_backends.base import (
+            get_gemm_backend_factory,
+        )
+        from primus.core.projection.simulation_backends.factory import (
+            _ensure_backends_discovered,
+        )
 
         self._hw = hardware_spec or _get_hardware_spec(gpu_arch, gpu_clock_mhz)
 
@@ -416,7 +420,9 @@ class SDPASimulator(SDPASimulationBackend):
         price the FAv3 tiles.  Returns the backend on success, or ``None`` if it
         is not available.
         """
-        from primus.core.projection.simulation_backends.base import get_gemm_backend_factory
+        from primus.core.projection.simulation_backends.base import (
+            get_gemm_backend_factory,
+        )
 
         is_rank_0 = int(os.getenv("RANK", "0")) == 0
         try:
@@ -563,12 +569,16 @@ class SDPASimulator(SDPASimulationBackend):
         )
 
         bwd_compute_ms = (
-            r_bwd_qk.forward_time_ms
-            + r_bwd_dp.forward_time_ms
-            + r_bwd_dv.forward_time_ms
-            + r_bwd_dq.forward_time_ms
-            + r_bwd_dk.forward_time_ms
-        ) * bwd_waves * causal_factor
+            (
+                r_bwd_qk.forward_time_ms
+                + r_bwd_dp.forward_time_ms
+                + r_bwd_dv.forward_time_ms
+                + r_bwd_dq.forward_time_ms
+                + r_bwd_dk.forward_time_ms
+            )
+            * bwd_waves
+            * causal_factor
+        )
 
         # ── Backward dQ atomics (latency-based model) ──
         # Each KV-workgroup atomically accumulates dQ via buffer_atomic_add_f32.

--- a/primus/core/projection/training_config.py
+++ b/primus/core/projection/training_config.py
@@ -35,6 +35,7 @@ class ModelParallelConfig:
     # Recomputation settings
     recompute_granularity: str = None  # "full" or "selective"
     recompute_num_layers: int = 0
+    recompute_method: str = None  # "uniform" (recompute every layer) or "block" (first N)
     # Megatron selective block recompute: global transformer layer indices (0..num_layers-1)
     recompute_layer_ids: Optional[List[int]] = None
     # Precision-aware optimizer (Megatron `--use-precision-aware-optimizer`).
@@ -66,6 +67,27 @@ class ModelConfig:
     v_head_dim: int = 0
     q_lora_rank: int = 0
     kv_lora_rank: int = 0
+    # DeepSeek-V4 custom attention (compressed/hierarchical/sliding-window)
+    compress_ratios: object = None  # per-layer schedule (list or "[...]" string)
+    hc_mult: int = 1  # multi-hyper-connection stream count
+    index_topk: int = 0  # CSA per-query selected keys
+    index_head_dim: int = 0  # indexer head dim
+    index_n_heads: int = 0  # indexer heads
+    attn_sliding_window: int = 0  # SWA local window
+    o_lora_rank: int = 0  # output-projection LoRA rank
+    o_groups: int = 1  # output-projection groups
+    # DeepSeek-V4 fused-attention kernel flags.  The production run scripts flip
+    # these on (run_deepseek_v4.sh / proj_dsv4.sh: --use_v4_triton_csa_attention),
+    # so the projection MUST see them to know the CSA top-K gather is fused
+    # in-kernel (roofline max(compute, memory)) rather than a separate additive
+    # pre-pass.  update_config_from_args copies them from args by field name;
+    # without these fields the CLI values were silently dropped and csa_fused
+    # was stuck at False -> gather over-counted on every CSA layer.
+    use_v4_triton_attention: bool = False
+    use_v4_triton_csa_attention: bool = False
+    use_v4_tilelang_attention: bool = False
+    use_v4_tilelang_csa_attention: bool = False
+    use_v4_fp8_indexer: bool = False
     # FFN & MoE
     swiglu: bool = False
     num_experts: int = 0
@@ -73,14 +95,25 @@ class ModelConfig:
     moe_pattern: list = None
     moe_router_topk: int = 0
     moe_shared_expert_intermediate_size: int = 0
+    # Optimizer (Muon adds Newton-Schulz orthogonalization compute on 2D weights)
+    optimizer: str = ""
+    muon_num_ns_steps: int = 0
     # Misc
     share_embeddings_and_output_weights: bool = False
     # Precision – None means bf16, "hybrid" means FP8-hybrid (linear GEMMs in FP8)
     fp8: str = None
+    # FP8 quantization recipe (e.g. "tensorwise", "blockwise", "mxfp8").  The
+    # microscaled recipe ("mxfp8") runs GEMMs in MX8 compute (scale 3/3).
+    fp8_recipe: str = None
 
     # Primus Turbo flags — used to select the grouped-GEMM performance model
     enable_primus_turbo: bool = False
     use_turbo_grouped_gemm: bool = False
+    # Megatron/Primus names the turbo grouped-MLP flag ``use_turbo_grouped_mlp``;
+    # carry it (and the legacy opt-in) so the profiler can pick the batched
+    # (near-ideal) grouped-GEMM model instead of the pessimistic sequential one.
+    use_turbo_grouped_mlp: bool = False
+    moe_use_legacy_grouped_gemm: bool = False
     use_turbo_deepep: bool = False  # DeepEP enables async A2A with compute overlap
     turbo_sync_free_moe_stage: int = 0  # 0=off, 1=fused router, 2=+DeepEP+grouped, 3=+fused act
 
@@ -97,6 +130,20 @@ class TrainingConfig:
     model_config: ModelConfig
     runtime_config: RuntimeConfig
     model_parallel_config: ModelParallelConfig
+
+
+def gemm_dtype_from_config(config) -> str:
+    """Return the GEMM compute-dtype string for the model's precision recipe.
+
+    Mirrors the reference GEMM path: FP8 with the microscaled recipe ("mxfp8")
+    runs MX8 compute (scale 3/3); other FP8 recipes run FP8; otherwise BF16.
+    Accepts anything exposing ``fp8`` / ``fp8_recipe`` attributes (ModelConfig
+    or raw args).
+    """
+    if not getattr(config, "fp8", None):
+        return "bf16"
+    recipe = (getattr(config, "fp8_recipe", None) or "").lower()
+    return "mx8" if recipe == "mxfp8" else "fp8"
 
 
 def update_config_from_args(config, args):

--- a/tests/unit_tests/core/projection/test_projection_extra.py
+++ b/tests/unit_tests/core/projection/test_projection_extra.py
@@ -126,7 +126,14 @@ def test_optimizer_num_params_includes_embedding_and_output():
     assert _opt().estimated_num_params() == _EXPECTED_DENSE_PARAMS
 
 
-def test_optimizer_step_time_follows_bandwidth_formula():
+def test_optimizer_step_time_follows_bandwidth_formula(monkeypatch):
+    # The optimizer step is memory-bound: step time = param-state bytes /
+    # (HBM bandwidth * HBM efficiency). The efficiency factor (env-tunable via
+    # PRIMUS_OPT_HBM_EFF) models the fact that the step is many small elementwise
+    # kernels that sustain only a fraction of peak. Pin it to 1.0 here to
+    # validate the underlying bandwidth-proportionality independent of the
+    # calibrated default.
+    monkeypatch.setenv("PRIMUS_OPT_HBM_EFF", "1.0")
     bw = 5300.0
     total_bytes = _EXPECTED_DENSE_PARAMS * _ADAM_BYTES_PER_PARAM
     assert _opt(bw=bw).estimated_step_time_ms() == pytest.approx(total_bytes / (bw * 1e9 / 1e3))


### PR DESCRIPTION
## Summary

This PR contains:

1. **Registry seam for GEMM simulation backends.**
   - Backends self-register via `register_gemm_backend()` and are discovered through
     the built-in `origami` backend, `primus.gemm_backends` entry points, and the
     `PRIMUS_GEMM_BACKEND_PLUGINS` env var.
   - The public tree has **no hardcoded backend names**. Optional backends are added
     purely additively by an internal overlay (entry point), and external hardware
     compute specs load from YAML via `PRIMUS_HW_PROFILE_DIR` instead of inline dicts.
   - Newer-Origami dtype / `rf_capacity` API alignment and an SDPA causal-timing fix.

2. **Projection-engine accuracy improvements**:
   - Attention profiler: compress-ratio-aware per-layer timing and sparse / top-K
     indexer costs.
   - MoE MLP: turbo grouped-GEMM performance model + explicit non-GEMM (JIT
     quant/dequant + per-group launch) overhead accounting.
   - Optimizer: pipeline-sharded optimizer-step accounting (critical-stage layer count).
   - Transformer layer: kernel-shape-padding balanced-routing benchmark, decomposed
     composite fallback, and selective-recompute backward cost.
   - Language-model / dense-MLP: compress-ratio-aware composition.
   - Benchmark utils: in-situ-depth measurement (HBM-pressure-aware).
   - Performance projection: compress-ratio-aware layer selection, uniform-recompute
     handling, distributed-optimizer grad-AllReduce overlap model, measured
     `optimizer.step()` benchmark, and a recompute / zero-bubble compatibility guard.
   - Training config: `recompute_method` + turbo grouped-MLP / legacy-grouped-gemm flags.


## Test plan

- [x] `black` (`--line-length=110`), `isort` (`--profile black`), and `autoflake`
      pass locally at the pinned pre-commit versions.
- [x] No merge-conflict markers; all touched files parse.
- [x] No new undefined-name regressions (remaining static-analysis findings pre-exist on `main`).
- [ ] Needs projection-author review (parallel implementations were reconciled by hand).
- [ ] Needs a live projection run on a supported GPU to validate numerics before merge
      (the benchmark / optimizer-step paths cannot be exercised in CI).