### PR TITLE
fix(megatron): checkpoint heterogeneous Flux layers independently

### DIFF
--- a/primus/backends/megatron/core/models/diffusion/flux/config.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/config.py
@@ -78,6 +78,8 @@ class FluxConfig(BaseDiffusionConfig):
         apply_rope_fusion: Whether to apply RoPE fusion optimization (default: False)
         add_qkv_bias: Whether to add bias to QKV projections (default: True)
         single_block_bias: Whether to add bias to single block linear layers (default: True)
+        hetereogenous_dist_checkpoint: Keep joint and single blocks in distinct
+            per-layer distributed-checkpoint namespaces (required, always True)
         activation_func: Activation function (default: openai_gelu_no_jit)
         use_te_rng_tracker: Whether to use Transformer Engine RNG tracker (default: False)
     """
@@ -91,6 +93,10 @@ class FluxConfig(BaseDiffusionConfig):
     # Architecture: Number of layers
     num_joint_layers: int = 19  # Default: Flux 12B
     num_single_layers: int = 38  # Default: Flux 12B
+    # Megatron preserves this misspelling in its public TransformerConfig API.
+    # Flux's joint and single blocks have different parameter sets and shapes,
+    # so they cannot share the homogeneous layer-stacked checkpoint namespace.
+    hetereogenous_dist_checkpoint: bool = True
 
     # Architecture: Dimensions (Flux standard: 3072)
     hidden_size: int = 3072
@@ -213,6 +219,12 @@ class FluxConfig(BaseDiffusionConfig):
         self.num_layers = self.num_joint_layers + self.num_single_layers
 
         super().__post_init__()  # BaseDiffusionConfig (mapping) -> TransformerConfig (validation)
+
+        if not self.hetereogenous_dist_checkpoint:
+            raise ValueError(
+                "Flux requires hetereogenous_dist_checkpoint=True because its joint "
+                "and single transformer blocks have different checkpoint schemas"
+            )
 
         # Xavier uniform for Megatron parallel linear layers (common Flux reference default).
         self.init_method = nn.init.xavier_uniform_

--- a/primus/backends/megatron/core/models/diffusion/flux/model.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/model.py
@@ -604,8 +604,8 @@ class Flux(DiffusionModule):
         indexed sharded keys (``transformer.layers.<i>.*``) are required here:
         the homogeneous layer-stacked path would leave unclaimed slots for the
         params absent in single blocks and raise a CheckpointingException at
-        save time. TransformerBlock.sharded_state_dict provides this
-        automatically, so no config toggle is needed.
+        save time. ``FluxConfig.hetereogenous_dist_checkpoint`` enables
+        TransformerBlock's supported per-layer checkpoint namespace.
 
         Args:
             prefix: Prefix for state dict keys (e.g., 'module.')
@@ -617,8 +617,8 @@ class Flux(DiffusionModule):
         """
         sharded_state_dict = {}
 
-        # Delegate transformer layers to TransformerBlock
-        # Handles heterogeneous layers automatically
+        # Delegate transformer layers to TransformerBlock. FluxConfig requires
+        # its heterogeneous per-layer checkpoint namespace.
         sharded_state_dict.update(
             self.transformer.sharded_state_dict(f"{prefix}transformer.", sharded_offsets, metadata)
         )

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
@@ -9,10 +9,6 @@ Tests FluxConfig and BaseDiffusionConfig validation, preset configurations.
 
 import pytest
 
-from tests.utils import skip_if_no_cuda
-
-skip_if_no_cuda()
-
 from primus.backends.megatron.core.models.diffusion.common import BaseDiffusionConfig
 from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
 from tests.utils import PrimusUT

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
@@ -40,6 +40,19 @@ class TestBaseDiffusionConfig(PrimusUT):
 class TestFluxConfig(PrimusUT):
     """Tests for FluxConfig class."""
 
+    def test_distributed_checkpoint_is_non_homogeneous(self):
+        """Flux must use per-layer checkpoint keys for its two block families."""
+        config = FluxConfig.flux_535m()
+        self.assertTrue(config.hetereogenous_dist_checkpoint)
+
+    def test_homogeneous_distributed_checkpoint_is_rejected(self):
+        """A homogeneous layer stack cannot represent Flux's parameter schemas."""
+        with self.assertRaisesRegex(
+            ValueError,
+            "Flux requires hetereogenous_dist_checkpoint=True",
+        ):
+            FluxConfig.flux_535m(hetereogenous_dist_checkpoint=False)
+
     def test_validation_positive_joint_layers(self):
         """Test validation fails for non-positive num_joint_layers."""
         with self.assertRaises(ValueError) as cm:

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
@@ -7,10 +7,6 @@ import pytest
 import torch
 from megatron.core.dist_checkpointing import load, save
 
-from tests.utils import skip_if_no_cuda
-
-skip_if_no_cuda()
-
 from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
 from primus.backends.megatron.core.models.diffusion.flux.model import Flux
 from tests.utils import PrimusUT
@@ -34,6 +30,11 @@ def _tiny_flux_config() -> FluxConfig:
     )
 
 
+def _runtime_device() -> torch.device:
+    """Use CUDA when available, otherwise run on CPU for CI coverage."""
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
 class TestFluxDistCheckpoint(PrimusUT):
     """Verify that joint and single blocks have independent checkpoint schemas."""
 
@@ -43,7 +44,7 @@ class TestFluxDistCheckpoint(PrimusUT):
 
     def test_adaln_uses_distinct_per_layer_sharded_keys(self):
         """The 6-chunk and 3-chunk adaLN weights must not share a global key."""
-        model = Flux(_tiny_flux_config()).cuda()
+        model = Flux(_tiny_flux_config()).to(_runtime_device())
         sharded_state_dict = model.sharded_state_dict()
 
         double_local_key = "transformer.layers.0.adaln.adaLN_modulation.1.weight"
@@ -61,7 +62,7 @@ class TestFluxDistCheckpoint(PrimusUT):
 
     def test_torch_dist_save_load_round_trip(self, tmp_path):
         """Save and restore both adaLN shapes through the real torch_dist backend."""
-        source = Flux(_tiny_flux_config()).cuda()
+        source = Flux(_tiny_flux_config()).to(_runtime_device())
         double_weight = source.transformer.layers[0].adaln.adaLN_modulation[-1].weight
         single_weight = source.transformer.layers[1].adaln.adaLN_modulation[-1].weight
         with torch.no_grad():
@@ -72,7 +73,7 @@ class TestFluxDistCheckpoint(PrimusUT):
         checkpoint_dir.mkdir()
         save({"model": source.sharded_state_dict()}, checkpoint_dir)
 
-        target = Flux(_tiny_flux_config()).cuda()
+        target = Flux(_tiny_flux_config()).to(_runtime_device())
         loaded = load({"model": target.sharded_state_dict()}, checkpoint_dir)
         target.load_state_dict(loaded["model"])
 

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Distributed-checkpoint regression tests for Flux's heterogeneous layers."""
+
+import pytest
+import torch
+from megatron.core.dist_checkpointing import load, save
+
+from tests.utils import skip_if_no_cuda
+
+skip_if_no_cuda()
+
+from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+from tests.utils import PrimusUT
+
+
+def _tiny_flux_config() -> FluxConfig:
+    """Build the smallest useful joint+single Flux model for checkpoint tests."""
+    return FluxConfig(
+        num_joint_layers=1,
+        num_single_layers=1,
+        hidden_size=16,
+        num_attention_heads=2,
+        ffn_hidden_size=64,
+        in_channels=4,
+        context_dim=16,
+        vec_in_dim=16,
+        model_channels=16,
+        axes_dim=(2, 2, 4),
+        transformer_impl="local",
+        params_dtype=torch.float32,
+    )
+
+
+class TestFluxDistCheckpoint(PrimusUT):
+    """Verify that joint and single blocks have independent checkpoint schemas."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        """Initialize single-rank model parallelism."""
+
+    def test_adaln_uses_distinct_per_layer_sharded_keys(self):
+        """The 6-chunk and 3-chunk adaLN weights must not share a global key."""
+        model = Flux(_tiny_flux_config()).cuda()
+        sharded_state_dict = model.sharded_state_dict()
+
+        double_local_key = "transformer.layers.0.adaln.adaLN_modulation.1.weight"
+        single_local_key = "transformer.layers.1.adaln.adaLN_modulation.1.weight"
+        double_weight = sharded_state_dict[double_local_key]
+        single_weight = sharded_state_dict[single_local_key]
+
+        assert double_weight.key == double_local_key
+        assert single_weight.key == single_local_key
+        assert double_weight.key != single_weight.key
+        assert double_weight.prepend_axis_num == 0
+        assert single_weight.prepend_axis_num == 0
+        assert double_weight.global_shape == (6 * model.hidden_size, model.hidden_size)
+        assert single_weight.global_shape == (3 * model.hidden_size, model.hidden_size)
+
+    def test_torch_dist_save_load_round_trip(self, tmp_path):
+        """Save and restore both adaLN shapes through the real torch_dist backend."""
+        source = Flux(_tiny_flux_config()).cuda()
+        double_weight = source.transformer.layers[0].adaln.adaLN_modulation[-1].weight
+        single_weight = source.transformer.layers[1].adaln.adaLN_modulation[-1].weight
+        with torch.no_grad():
+            double_weight.fill_(1.25)
+            single_weight.fill_(-2.5)
+
+        checkpoint_dir = tmp_path / "flux_torch_dist"
+        checkpoint_dir.mkdir()
+        save({"model": source.sharded_state_dict()}, checkpoint_dir)
+
+        target = Flux(_tiny_flux_config()).cuda()
+        loaded = load({"model": target.sharded_state_dict()}, checkpoint_dir)
+        target.load_state_dict(loaded["model"])
+
+        torch.testing.assert_close(
+            target.transformer.layers[0].adaln.adaLN_modulation[-1].weight,
+            double_weight,
+        )
+        torch.testing.assert_close(
+            target.transformer.layers[1].adaln.adaLN_modulation[-1].weight,
+            single_weight,
+        )


### PR DESCRIPTION
## Summary

Stacked on PR #970 for [Issue \#220](https://github.com/AMD-AGI/tiger-training-internal/issues/220).

Flux combines 19 joint and 38 single transformer blocks whose parameter schemas
differ. The homogeneous distributed-checkpoint path collapses them into one
layer-stacked namespace, so checkpoint validation sees both 6-chunk and 3-chunk
adaLN tensors under the same key and aborts before writing a checkpoint.

- Require Megatron's supported non-homogeneous, per-layer checkpoint namespace
  for every `FluxConfig`.
- Fail closed if a caller tries to select the invalid homogeneous layout.
- Add regression coverage for distinct adaLN keys and a real `torch_dist`
  save/load round trip.

## Test plan

- [x] `black --check` on all changed files.
- [x] Config regressions: default enables heterogeneous checkpointing; explicit
  disable is rejected (`2 passed` in the pinned v26.5 image).
- [ ] Tiny joint+single Flux `torch_dist` save/load round trip (GPU window
  pending; n15-09 currently has a foreign eight-GPU tenant).
- [ ] Issue 220 Option 6 `stage1` checkpoint save, then resumed `control`
  continuity smoke after review.
