### PR TITLE
fix(megatron): allow BF16 precision census

### DIFF
--- a/primus/backends/megatron/flux_pretrain_trainer.py
+++ b/primus/backends/megatron/flux_pretrain_trainer.py
@@ -54,8 +54,6 @@ def _emit_precision_linear_class_census(model) -> None:
     from megatron.core import parallel_state
 
     counts = _precision_linear_class_census(model)
-    if sum(counts.values()) <= 0:
-        raise RuntimeError("No MXFP4 or Float8 linear modules were instantiated")
     global_rank = (
         torch.distributed.get_rank() if torch.distributed.is_initialized() else int(os.getenv("RANK", "-1"))
     )

--- a/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
@@ -50,9 +50,7 @@ def test_precision_linear_class_census_reports_exact_classes():
     }
 
 
-def test_precision_linear_class_census_emits_zero_counts_for_bf16(
-    monkeypatch, capsys
-):
+def test_precision_linear_class_census_emits_zero_counts_for_bf16(monkeypatch, capsys):
     from megatron.core import parallel_state
 
     monkeypatch.setenv("PRIMUS_AUDIT_LINEAR_CLASS_CENSUS", "1")

--- a/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
@@ -9,6 +9,7 @@ from primus.backends.megatron.data.diffusion.task_encoders.image import (
 )
 from primus.backends.megatron.flux_pretrain_trainer import (
     FluxPretrainTrainer,
+    _emit_precision_linear_class_census,
     _precision_linear_class_census,
 )
 from primus.backends.megatron.patches.mlperf_warmup_patches import _is_resumed_training
@@ -46,6 +47,31 @@ def test_precision_linear_class_census_reports_exact_classes():
         "MXFP4RowParallelLinear": 1,
         "Float8ColumnParallelLinear": 1,
         "Float8RowParallelLinear": 0,
+    }
+
+
+def test_precision_linear_class_census_emits_zero_counts_for_bf16(
+    monkeypatch, capsys
+):
+    from megatron.core import parallel_state
+
+    monkeypatch.setenv("PRIMUS_AUDIT_LINEAR_CLASS_CENSUS", "1")
+    monkeypatch.setenv("RANK", "3")
+    monkeypatch.setattr(parallel_state, "get_data_parallel_rank", lambda: 3)
+
+    _emit_precision_linear_class_census(nn.Linear(2, 2))
+
+    line = capsys.readouterr().out.strip()
+    payload = json.loads(line.split("=", 1)[1])
+    assert payload == {
+        "data_parallel_rank": 3,
+        "global_rank": 3,
+        "classes": {
+            "MXFP4ColumnParallelLinear": 0,
+            "MXFP4RowParallelLinear": 0,
+            "Float8ColumnParallelLinear": 0,
+            "Float8RowParallelLinear": 0,
+        },
     }
 
 


### PR DESCRIPTION
## Summary

Allow the precision-class audit to report an all-zero MXFP4/FP8 census for native BF16 models. This keeps the audit fail-closed in the experiment validator while avoiding an unconditional model-startup failure for Option 7.

## Test plan

- [x] Added a unit test for the native BF16 zero-count payload
- [x] Python compilation passes
- [ ] Targeted unit test passes in the pinned runtime container
- [ ] Option 7 BF16-resume smoke passes
