### PR TITLE
Dev/jax maxtext v26.6 primus cli

### DIFF
--- a/examples/maxdiffusion/configs/MI300X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/flux_dev-pretrain.yaml
@@ -74,10 +74,11 @@ modules:
       output_dir: "./output/flux_dev-pretrain"
       base_output_directory: "./output/flux_dev-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image default
-      # log_period=100 emits nothing at 20 steps, so perf comes back empty and
-      # madengine silently reuses a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON metrics
       # here (max_utils.write_metrics_locally). This is the reliable perf source; the

--- a/examples/maxdiffusion/configs/MI300X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/wan2.1_1.3b-pretrain.yaml
@@ -84,10 +84,11 @@ modules:
       output_dir: "./output/wan2.1_1.3b-pretrain"
       base_output_directory: "./output/wan2.1_1.3b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image default
-      # log_period=100 emits nothing at 20 steps, so perf comes back empty and
-      # madengine silently reuses a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON metrics
       # here (max_utils.write_metrics_locally). This is the reliable perf source; the

--- a/examples/maxdiffusion/configs/MI300X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/wan2.1_14b-pretrain.yaml
@@ -70,10 +70,11 @@ modules:
       output_dir: "./output/wan2.1_14b-pretrain"
       base_output_directory: "./output/wan2.1_14b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image default
-      # log_period=100 emits nothing at 20 steps, so perf comes back empty and
-      # madengine silently reuses a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON metrics
       # here (max_utils.write_metrics_locally). This is the reliable perf source; the

--- a/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
@@ -73,10 +73,11 @@ modules:
       output_dir: "./output/flux_dev-pretrain"
       base_output_directory: "./output/flux_dev-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
-      # default log_period=100 emits nothing at 20 steps, so perf came back empty
-      # and madengine silently reused a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
       # metrics here (max_utils.write_metrics_locally). This is the reliable perf

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
@@ -76,10 +76,11 @@ modules:
       output_dir: "./output/wan2.1_1.3b-pretrain"
       base_output_directory: "./output/wan2.1_1.3b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
-      # default log_period=100 emits nothing at 20 steps, so perf came back empty
-      # and madengine silently reused a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
       # metrics here (max_utils.write_metrics_locally). This is the reliable perf

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
@@ -78,10 +78,11 @@ modules:
       output_dir: "./output/wan2.1_14b-pretrain"
       base_output_directory: "./output/wan2.1_14b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
-      # default log_period=100 emits nothing at 20 steps, so perf came back empty
-      # and madengine silently reused a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
       # metrics here (max_utils.write_metrics_locally). This is the reliable perf

--- a/examples/maxtext/configs/MI325X/deepseek_v2_16B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/deepseek_v2_16B-bf16-pretrain.yaml
@@ -1,0 +1,49 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2_16B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v2_16B.yaml
+    overrides:
+      run_name: "deepseek_v2_16b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      megablox: false
+      capacity_factor: 1.25
+      sparse_matmul: false
+      sharding_tolerance: 0.05
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 219.2/230.4 GB, pdbs 15 OOMs.
+      per_device_batch_size: 14
+      remat_policy: "minimal_flash"

--- a/examples/maxtext/configs/MI325X/deepseek_v2_16B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/deepseek_v2_16B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,58 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2_16B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v2_16B.yaml
+    overrides:
+      run_name: "deepseek_v2_16b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      megablox: false
+      capacity_factor: 1.25
+      sparse_matmul: false
+      sharding_tolerance: 0.05
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 219.3/230.4 GB, pdbs 15 OOMs.
+      per_device_batch_size: 14
+      remat_policy: "minimal_flash"
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"
+
+      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
+      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
+      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
+      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
+      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI325X/gemma4_26B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_26B-bf16-pretrain.yaml
@@ -1,0 +1,53 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_26B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_26B.yaml
+    overrides:
+      run_name: "gemma4_26b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy (MoE: shard experts)
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      # v26.6 (rocm-main) maxtext: use reference dot_product attention. The
+      # efficient attention kernels do not support gemma4's bidirectional
+      # sliding-window layers with synthetic (unpacked) data and abort with
+      # "Sliding window attention requires context parallelism with load-balanced
+      # ring strategy and packing enabled". max_target_length is reduced to 4096
+      # because MoE + dot_product compilation is very heavy at 8192.
+      # Mirrors the MI355X configs validated in the v26.6 MAD sweep (fc4dc19b).
+      attention: "dot_product"
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 130.5/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap) and well under budget, so this one has
+      # real headroom left -- step size, not memory, was the limit here.
+      per_device_batch_size: 13
+      remat_policy: "full"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1

--- a/examples/maxtext/configs/MI325X/gemma4_26B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_26B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,81 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_26B-fp8-pretrain}
+workspace: ./output
+
+# STATUS (MI300X / gfx942, maxtext release/v26.6): DOES NOT RUN.
+# Blocked upstream in the MoE + fp8 path, not by anything configurable here.
+# RoutedMoE.dense_matmul builds its fp8 einsum module inside the traced einsum
+# (get_einsum -> quant.einsum(**kw)(*args)), so the module's setup() allocates the
+# amax-history/scale variables under a trace and they escape during
+# setup_initial_state:
+#   UnexpectedTracerError: ... intermediate value with type float32[1024] ...
+# Verified on 2026-08-10 that this is not a config problem:
+#   quantization: "fp8"        -> leaks from flax Fp8DotGeneralBase.setup
+#   quantization: "nanoo_fp8"  -> leaks from maxtext Fp8Einsum.setup (quantizations.py:345)
+#   sparse_matmul: true        -> AttributeError: 'NANOOFp8Quantization' has no 'quant_dg'
+#                                 (the sparse MoE path only supports AQT quantization)
+# The other MoE fp8 configs (e.g. mixtral_8x7B-nanoo_fp8) DO train, so this is
+# specific to gemma4, which additionally scans its local/global layers internally
+# (gemma4.py _scan_local_layers -> nnx_scan.apply_scanned_layers).
+# The bf16 gemma4_26B config trains normally; use that until MaxText moves the fp8
+# einsum construction out of the traced call.
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_26B.yaml
+    overrides:
+      run_name: "gemma4_26b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy (MoE: shard experts)
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      # Same attention constraint as the bf16 gemma4 configs: the efficient kernels
+      # reject gemma4's bidirectional sliding-window layers on synthetic (unpacked) data.
+      attention: "dot_product"
+      max_target_length: 4096
+      # MI300X has less HBM (192GB) than MI355X; conservative default, untuned on gfx942.
+      per_device_batch_size: 1
+      remat_policy: "full"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+
+      # quantization (nanoo_fp8)
+      # MaxText picks the fp8 implementation from this string and the two are
+      # vendor-specific (see layers/quantizations.py): "fp8" -> Fp8Quantization,
+      # documented "for NVIDIA GPUs"; "nanoo_fp8" -> NANOOFp8Quantization, "for AMD
+      # MI300/MI325 GPUs", using the e4m3fnuz/e5m2fnuz types gfx942 implements.
+      # This config previously asked for "fp8" (copied from MI355X, where gfx950
+      # does support OCP e4m3fn). nanoo_fp8 is the right choice for this hardware
+      # and matches every other MI300X fp8 config, though see the STATUS note above:
+      # neither value gets gemma4 MoE past the tracer leak.
+      quantization: "nanoo_fp8"
+
+      # v26.6 fp8-MoE fix, as for the other MoE fp8 configs: the legacy per-module
+      # linen Fp8Einsum needs an active Linen binding scope, which the pure-NNX
+      # decoder does not provide. Required (and verified sufficient) for
+      # mixtral_8x7B-nanoo_fp8; necessary but not sufficient for gemma4.
+      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI325X/gemma4_31B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_31B-bf16-pretrain.yaml
@@ -1,0 +1,47 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_31B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_31B.yaml
+    overrides:
+      run_name: "gemma4_31b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_tensor_sequence_parallelism: -1
+
+      remat_policy: "full"
+      # v26.6 (rocm-main) maxtext: use reference dot_product attention. The
+      # efficient attention kernels do not support gemma4's bidirectional
+      # sliding-window layers with synthetic (unpacked) data and abort with
+      # "Sliding window attention requires context parallelism with load-balanced
+      # ring strategy and packing enabled".
+      # The attention choice mirrors the MI355X configs validated in the v26.6 MAD
+      # sweep (fc4dc19b); seq len is 8192.
+      attention: "dot_product"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 218.7/230.4 GB, pdbs 6 OOMs.
+      per_device_batch_size: 5

--- a/examples/maxtext/configs/MI325X/gemma4_31B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_31B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,62 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_31B-fp8-pretrain}
+workspace: ./output
+
+# STATUS (MI300X / gfx942, maxtext release/v26.6): DOES NOT RUN.
+# The attention fix below clears the sliding-window assertion and the model then
+# compiles for ~10 min, but the run aborts in collective init:
+#   F rendezvous.cc:161] Termination timeout for `[0] first call before collective
+#   operation: kind=kAllGather` of 40 seconds exceeded   -> SIGABRT (signal 6)
+# Unlike gemma4_26B-fp8 this is not the MoE fp8 tracer leak (31B is Dense); it looks
+# like the RCCL init problem the MI355X configs guard against with a block of
+# NCCL/HSA env (NCCL_PROTO=Simple, GPU_MAX_HW_QUEUES, HIP_FORCE_DEV_KERNARG,
+# RCCL_MSCCL_ENABLE), which the MI300X configs do not carry. Porting those knobs is
+# the untested next step. The bf16 gemma4_31B config trains normally
+# (245 TFLOP/s/device, seq 4096).
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_31B.yaml
+    overrides:
+      run_name: "gemma4_31b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_tensor_sequence_parallelism: -1
+
+      remat_policy: "full"
+      # Same attention constraint as the bf16 gemma4 configs: the efficient kernels
+      # reject gemma4's bidirectional sliding-window layers on synthetic (unpacked)
+      # data. gemma4_31B is Dense, so the fp8-MoE pure_nnx_decoder pin does not apply.
+      attention: "dot_product"
+      max_target_length: 8192
+      # MI300X has less HBM (192GB) than MI355X; conservative default, untuned on gfx942.
+      per_device_batch_size: 1
+
+      # quantization (nanoo_fp8)
+      # Vendor-specific in MaxText (see layers/quantizations.py): "fp8" selects
+      # Fp8Quantization, documented "for NVIDIA GPUs"; "nanoo_fp8" selects
+      # NANOOFp8Quantization, "for AMD MI300/MI325 GPUs", using the e4m3fnuz/e5m2fnuz
+      # types gfx942 implements. Matches every other MI300X fp8 config.
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/grok1-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/grok1-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,59 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:grok1-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: grok1.yaml
+    overrides:
+      run_name: "grok1_training"
+      base_output_directory: "./output"
+      steps: 50
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: 8
+
+      per_device_batch_size: 4
+
+      profiler: ""
+      upload_all_profiler_results: true
+      skip_first_n_steps_for_profiler: 3
+      profiler_steps: 1
+
+      remat_policy: "full"
+      use_iota_embed: true
+      scan_layers: true
+
+      logits_dot_in_fp32: false
+      dtype: "bfloat16"
+      quantization: "nanoo_fp8"
+      quantize_kvcache: false
+      kv_quant_axis: "heads_and_dkv"
+      kv_quant_dtype: "int8"
+      weight_dtype: "bfloat16"
+      checkpoint_is_quantized: false
+      shardy: false
+
+      sparse_matmul: false # ValueError("Sparse matmul doesn't support using expert and pipeline parallelism together.")
+      megablox: false
+      max_target_length: 8192           # Increased from 4096
+      capacity_factor: 1

--- a/examples/maxtext/configs/MI325X/llama2_70B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_70B-bf16-pretrain.yaml
@@ -1,0 +1,45 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_70B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_70B.yaml
+    overrides:
+      run_name: "llama2_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 226.7/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a slightly larger value may fit.
+      per_device_batch_size: 22

--- a/examples/maxtext/configs/MI325X/llama2_70B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_70B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,48 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_70B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_70B.yaml
+    overrides:
+      run_name: "llama2_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 225.0/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a slightly larger value may fit.
+      per_device_batch_size: 22
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/llama2_7B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_7B-bf16-pretrain.yaml
@@ -1,0 +1,38 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_7B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_7B.yaml
+    overrides:
+      run_name: "llama2_7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 225.4/230.4 GB, pdbs 19 OOMs.
+      per_device_batch_size: 18

--- a/examples/maxtext/configs/MI325X/llama2_7B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_7B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,41 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_7B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_7B.yaml
+    overrides:
+      run_name: "llama2_7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 222.6/230.4 GB, pdbs 19 OOMs.
+      per_device_batch_size: 18
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/llama3.3_70B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3.3_70B-bf16-pretrain.yaml
@@ -1,0 +1,44 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3.3_70B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3.3_70B.yaml
+    overrides:
+      run_name: "llama3.3_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 229.7/230.4 GB, pdbs 12 OOMs.
+      per_device_batch_size: 11

--- a/examples/maxtext/configs/MI325X/llama3_70B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3_70B-bf16-pretrain.yaml
@@ -1,0 +1,44 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3_70B.yaml
+    overrides:
+      run_name: "llama3_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 229.7/230.4 GB, pdbs 12 OOMs.
+      per_device_batch_size: 11

--- a/examples/maxtext/configs/MI325X/llama3_8B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3_8B-bf16-pretrain.yaml
@@ -1,0 +1,38 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_8B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3_8B.yaml
+    overrides:
+      run_name: "llama3_8b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 224.4/230.4 GB, pdbs 9 OOMs.
+      per_device_batch_size: 8

--- a/examples/maxtext/configs/MI325X/llama3_8B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3_8B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,41 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_8B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3_8B.yaml
+    overrides:
+      run_name: "llama3_8b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 224.4/230.4 GB, pdbs 9 OOMs.
+      per_device_batch_size: 8
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/mixtral_8x22B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/mixtral_8x22B-bf16-pretrain.yaml
@@ -1,0 +1,42 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x22B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: mixtral_8x22B.yaml
+    overrides:
+      run_name: "mixtral_8x22b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 219.8/230.4 GB, pdbs 7 OOMs.
+      per_device_batch_size: 6
+      remat_policy: "save_dot_with_context_except_mlp"

--- a/examples/maxtext/configs/MI325X/mixtral_8x7B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/mixtral_8x7B-bf16-pretrain.yaml
@@ -1,0 +1,43 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x7B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: mixtral_8x7B.yaml
+    overrides:
+      run_name: "mixtral_8x7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 217.6/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a larger value may fit.
+      per_device_batch_size: 27
+      remat_policy: "save_dot_with_context_except_mlp"

--- a/examples/maxtext/configs/MI325X/mixtral_8x7B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/mixtral_8x7B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,52 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x7B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: mixtral_8x7B.yaml
+    overrides:
+      run_name: "mixtral_8x7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 219.9/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a larger value may fit.
+      per_device_batch_size: 29
+      remat_policy: "save_dot_with_context_except_mlp"
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"
+
+      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
+      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
+      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
+      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
+      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI325X/qwen3_14B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_14B-bf16-pretrain.yaml
@@ -1,0 +1,39 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_14B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_14B.yaml
+    overrides:
+      run_name: "qwen3_14b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      # training
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 214.2/230.4 GB, pdbs 6 OOMs.
+      per_device_batch_size: 5
+      remat_policy: "minimal_flash"

--- a/examples/maxtext/configs/MI325X/qwen3_14B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_14B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,42 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_14B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_14B.yaml
+    overrides:
+      run_name: "qwen3_14b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      # training
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 214.2/230.4 GB, pdbs 6 OOMs.
+      per_device_batch_size: 5
+      remat_policy: "minimal_flash"
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/qwen3_30B_A3B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_30B_A3B-bf16-pretrain.yaml
@@ -1,0 +1,44 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_30B_A3B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_30B_A3B.yaml
+    overrides:
+      run_name: "qwen3_30b_a3b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 227.9/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), but little headroom is left.
+      per_device_batch_size: 10
+      remat_policy: "minimal"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1

--- a/examples/maxtext/configs/MI325X/qwen3_30B_A3B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_30B_A3B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,53 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_30B_A3B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_30B_A3B.yaml
+    overrides:
+      run_name: "qwen3_30b_a3b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 227.9/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), but little headroom is left.
+      per_device_batch_size: 10
+      remat_policy: "minimal"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"
+
+      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
+      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
+      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
+      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
+      pure_nnx_decoder: false

--- a/primus/backends/maxdiffusion/maxdiffusion_pretrain_trainer.py
+++ b/primus/backends/maxdiffusion/maxdiffusion_pretrain_trainer.py
@@ -37,7 +37,7 @@ The MaxDiffusion-touching (JAX) work happens inside ``train()`` and within the
 """
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from primus.core.trainer.base_trainer import BaseTrainer
 from primus.core.utils.module_utils import (
@@ -204,7 +204,10 @@ class MaxDiffusionPretrainTrainer(BaseTrainer):
         module_name, trainer_path, init_kwargs = _FAMILY_SPECS[self._family]
 
         from maxdiffusion import pyconfig
-        from maxdiffusion.train_utils import transformer_engine_context, validate_train_config
+        from maxdiffusion.train_utils import (
+            transformer_engine_context,
+            validate_train_config,
+        )
 
         log_rank_0(f"Executing MaxDiffusion {self._family} pretrain...")
         try:
@@ -258,4 +261,6 @@ class MaxDiffusionPretrainTrainer(BaseTrainer):
             try:
                 os.unlink(self._yaml_path)
             except OSError as e:
-                error_rank_0(f"MaxDiffusionPretrainTrainer: failed to delete temp YAML {self._yaml_path}: {e}")
+                error_rank_0(
+                    f"MaxDiffusionPretrainTrainer: failed to delete temp YAML {self._yaml_path}: {e}"
+                )

--- a/primus/backends/maxdiffusion/patches/throughput_patches.py
+++ b/primus/backends/maxdiffusion/patches/throughput_patches.py
@@ -65,6 +65,7 @@ _FLUX_MODEL_NAMES = frozenset({"flux", "flux-dev", "flux-schnell"})
 
 _work_per_step: Dict[str, float] = {}
 _enabled = True
+_tensorboard_hint_logged = False
 
 
 def _config_keys(config: Any) -> Dict[str, Any]:
@@ -227,8 +228,9 @@ def patch_maxdiffusion_throughput(ctx: PatchContext) -> None:
         return
 
     # Reset in case a previous run in this process left state behind.
-    global _enabled
+    global _enabled, _tensorboard_hint_logged
     _enabled = True
+    _tensorboard_hint_logged = False
     _work_per_step.clear()
 
     upstream_record_scalar_metrics = train_utils.record_scalar_metrics
@@ -260,6 +262,7 @@ def patch_maxdiffusion_throughput(ctx: PatchContext) -> None:
             upstream_write_metrics_to_tensorboard(writer, metrics, step, config)
             return
 
+        global _tensorboard_hint_logged
         if jax.process_index() == 0:
             max_logging.log(step_line)
             for metric_name in metrics.get("scalar", []):
@@ -267,8 +270,14 @@ def patch_maxdiffusion_throughput(ctx: PatchContext) -> None:
             for metric_name in metrics.get("scalars", []):
                 writer.add_scalars(metric_name, metrics["scalars"][metric_name], step)
 
-            if step % config.log_period == 0:
+            # Upstream reprints the tensorboard hint on every log_period, which
+            # at log_period=1 doubles the length of the step log to repeat a
+            # string that never changes.
+            if not _tensorboard_hint_logged:
+                _tensorboard_hint_logged = True
                 max_logging.log(f"To see full metrics 'tensorboard --logdir={config.tensorboard_dir}'")
+
+            if step % config.log_period == 0:
                 writer.flush()
 
     train_utils.record_scalar_metrics = record_scalar_metrics

--- a/primus/backends/maxdiffusion/patches/throughput_patches.py
+++ b/primus/backends/maxdiffusion/patches/throughput_patches.py
@@ -152,7 +152,9 @@ def _resolve_work_per_step(config: Any) -> Dict[str, float]:
     # data_sharding spreads the batch over every mesh axis, so a step trains
     # per_device_batch_size samples on each of jax.device_count() devices --
     # the same normalization calculate_tflops uses for TFLOP/s/device.
-    global_samples = float(keys.get("global_batch_size_to_train_on") or per_device_samples * jax.device_count())
+    global_samples = float(
+        keys.get("global_batch_size_to_train_on") or per_device_samples * jax.device_count()
+    )
 
     work = {"per_device_samples": per_device_samples, "global_samples": global_samples}
 

--- a/primus/backends/maxdiffusion/patches/throughput_patches.py
+++ b/primus/backends/maxdiffusion/patches/throughput_patches.py
@@ -1,0 +1,277 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion Throughput Patch
+
+MaxDiffusion's per-step line reports step time, FLOP rate and loss, but nothing
+that says how much *data* a step moved::
+
+    completed step: 18, seconds: 11.722, TFLOP/s/device: 348.548, loss: 1.540
+
+This patch adds throughput to that line and to the metrics stream::
+
+    completed step: 18, seconds: 11.722, TFLOP/s/device: 348.548,
+    Tokens/s/device: 6756.526, Samples/s/device: 0.0853,
+    Frames/s/device: 7.251, loss: 1.540
+
+Everything is per device, like the ``TFLOP/s/device`` it sits next to:
+
+``Samples/s/device``
+    Videos (or images) per second per GPU. Defined for every model family.
+``Frames/s/device``
+    Video frames per second per GPU, i.e. ``Samples/s/device * num_frames``.
+    Only emitted for families whose config describes frames.
+``Tokens/s/device``
+    Patchified latent tokens per second per GPU: 79,200 tokens for a
+    720x1280x85 WAN video, 1,024 for a 512px FLUX image. Derived from the same
+    shape ``calculate_{wan,flux}_tflops`` feeds its FLOP count, so token rate
+    and FLOP rate always describe the same work, and unlike samples or frames
+    it stays comparable across resolutions and clip lengths. Omitted for the
+    UNet families (SD 1.x/2.x, SDXL, DreamBooth), which have no equivalent
+    notion of a token.
+
+The ``Tokens/s/device`` name matches MaxText's step line on purpose:
+``parse_metrics_for_maxtext`` in ``tools/daily/daily_report.py`` then works
+unchanged on MaxDiffusion logs.
+
+The same numbers are written into ``metrics["scalar"]`` as ``perf/*`` entries
+before any consumer runs, so they also reach TensorBoard and ``metrics_file``
+alongside the upstream perf scalars, together with the cluster-wide
+``perf/samples_per_second``, ``perf/frames_per_second`` and
+``perf/tokens_per_second`` totals.
+"""
+
+from typing import Any, Dict, Optional
+
+from primus.core.patches import PatchContext, register_patch
+from primus.core.utils.module_utils import error_rank_0, log_rank_0, warning_rank_0
+
+# WAN and FLUX both encode with a VAE that downsamples 8x in H and W and then
+# patchify the latents 2x2 before the transformer blocks; WAN additionally
+# compresses 4x along time.
+_VAE_SCALE_FACTOR_SPATIAL = 8
+_WAN_VAE_SCALE_FACTOR_TEMPORAL = 4
+_TRANSFORMER_PATCH_SIZE = 2
+
+# Model families whose sample -> token expansion is known. UNet families
+# (SD 1.x/2.x, SDXL, DreamBooth) have no comparable token count, and LTX-Video
+# uses a different VAE geometry, so they report samples only.
+_WAN_MODEL_NAMES = frozenset({"wan2.1", "wan2.2"})
+_FLUX_MODEL_NAMES = frozenset({"flux", "flux-dev", "flux-schnell"})
+
+_work_per_step: Dict[str, float] = {}
+_enabled = True
+
+
+def _config_keys(config: Any) -> Dict[str, Any]:
+    """Return the config as a plain dict.
+
+    ``HyperParameters.__getattr__`` raises ``ValueError`` (not
+    ``AttributeError``) for unknown keys, so ``getattr(config, k, default)``
+    is not safe here; MaxDiffusion configs differ per model family.
+    """
+    return config.get_keys()
+
+
+def _effective_video_dims(keys: Dict[str, Any]) -> Dict[str, Any]:
+    """Frame geometry the data iterator actually produces.
+
+    ``get_wan_dimension`` honours ``synthetic_override_{height,width,num_frames}``
+    -- and only those three -- when the synthetic iterator builds a batch, while
+    ``WanTrainer.calculate_tflops`` always reads the plain config keys. Rates are
+    reported for the shape that is really trained on, and a divergence is worth
+    flagging because it means the upstream TFLOP/s number describes a different
+    video than the one in the batch.
+    """
+    synthetic = keys.get("dataset_type") == "synthetic"
+    dims = {}
+    mismatched = []
+    for name in ("height", "width", "num_frames"):
+        configured = keys.get(name)
+        override = keys.get(f"synthetic_override_{name}") if synthetic else None
+        dims[name] = override or configured
+        if override and configured and override != configured:
+            mismatched.append(f"{name}: data={override} vs config={configured}")
+
+    if mismatched:
+        warning_rank_0(
+            "[Patch:maxdiffusion.throughput] Synthetic data shape differs from the config shape "
+            f"({', '.join(mismatched)}). Throughput follows the data; TFLOP/s/device does not."
+        )
+    return dims
+
+
+def _tokens_per_sample(keys: Dict[str, Any], dims: Dict[str, Any]) -> Optional[int]:
+    """Transformer tokens one sample expands into, or None where undefined.
+
+    Both branches rebuild the latent sequence length that the data iterator and
+    ``calculate_{wan,flux}_tflops`` use, so Tokens/s and TFLOP/s describe the
+    same work. Text-conditioning tokens are excluded: they are a fixed
+    per-sample cost that does not scale with resolution or clip length.
+    """
+    if keys.get("model_name") in _WAN_MODEL_NAMES:
+        height, width, num_frames = dims["height"], dims["width"], dims["num_frames"]
+        if not height or not width or not num_frames:
+            return None
+
+        latent_frames = (num_frames - 1) // _WAN_VAE_SCALE_FACTOR_TEMPORAL + 1
+        latent_positions = (
+            (height // _VAE_SCALE_FACTOR_SPATIAL) * (width // _VAE_SCALE_FACTOR_SPATIAL) * latent_frames
+        )
+        return int(latent_positions // _TRANSFORMER_PATCH_SIZE**2)
+
+    if keys.get("flux_name") in _FLUX_MODEL_NAMES:
+        resolution = keys.get("resolution")
+        if not resolution:
+            return None
+
+        latent_side = resolution // (_VAE_SCALE_FACTOR_SPATIAL * _TRANSFORMER_PATCH_SIZE)
+        return int(latent_side * latent_side)
+
+    return None
+
+
+def _resolve_work_per_step(config: Any) -> Dict[str, float]:
+    """Samples/tokens/frames one training step consumes. Constant, so cached."""
+    if _work_per_step:
+        return _work_per_step
+
+    import jax
+
+    keys = _config_keys(config)
+    per_device_samples = float(keys.get("per_device_batch_size") or 0.0)
+    if per_device_samples <= 0:
+        # Raise rather than report zeros; the caller disables the patch.
+        raise ValueError(f"unusable per_device_batch_size={keys.get('per_device_batch_size')!r}")
+
+    # data_sharding spreads the batch over every mesh axis, so a step trains
+    # per_device_batch_size samples on each of jax.device_count() devices --
+    # the same normalization calculate_tflops uses for TFLOP/s/device.
+    global_samples = float(keys.get("global_batch_size_to_train_on") or per_device_samples * jax.device_count())
+
+    work = {"per_device_samples": per_device_samples, "global_samples": global_samples}
+
+    dims = _effective_video_dims(keys)
+    tokens_per_sample = _tokens_per_sample(keys, dims)
+    if tokens_per_sample:
+        work["per_device_tokens"] = tokens_per_sample * per_device_samples
+        work["global_tokens"] = tokens_per_sample * global_samples
+
+    num_frames = dims["num_frames"]
+    if num_frames:
+        work["per_device_frames"] = float(num_frames) * per_device_samples
+        work["global_frames"] = float(num_frames) * global_samples
+
+    _work_per_step.update(work)
+    log_rank_0(
+        f"[Patch:maxdiffusion.throughput] Per step: {global_samples:g} samples "
+        f"({per_device_samples:g}/device), {work.get('per_device_frames', 0):g} frames/device, "
+        f"{work.get('per_device_tokens', 0):g} tokens/device"
+    )
+    return _work_per_step
+
+
+def _throughput_scalars(config: Any, step_time_seconds: float) -> Dict[str, float]:
+    if step_time_seconds <= 0:
+        return {}
+
+    work = _resolve_work_per_step(config)
+    scalars = {
+        "perf/samples_per_second": work["global_samples"] / step_time_seconds,
+        "perf/samples_per_second_per_device": work["per_device_samples"] / step_time_seconds,
+    }
+    if "per_device_tokens" in work:
+        scalars["perf/tokens_per_second"] = work["global_tokens"] / step_time_seconds
+        scalars["perf/tokens_per_second_per_device"] = work["per_device_tokens"] / step_time_seconds
+    if "per_device_frames" in work:
+        scalars["perf/frames_per_second"] = work["global_frames"] / step_time_seconds
+        scalars["perf/frames_per_second_per_device"] = work["per_device_frames"] / step_time_seconds
+    return scalars
+
+
+def _format_step_line(scalars: Dict[str, Any], step: Any) -> str:
+    """Upstream's step line, widened with whichever throughput metrics exist."""
+    message = "completed step: {}, seconds: {:.3f}, TFLOP/s/device: {:.3f}".format(
+        step,
+        scalars["perf/step_time_seconds"],
+        scalars["perf/per_device_tflops_per_sec"],
+    )
+    if "perf/tokens_per_second_per_device" in scalars:
+        message += ", Tokens/s/device: {:.3f}".format(scalars["perf/tokens_per_second_per_device"])
+    if "perf/samples_per_second_per_device" in scalars:
+        message += ", Samples/s/device: {:.4f}".format(scalars["perf/samples_per_second_per_device"])
+    if "perf/frames_per_second_per_device" in scalars:
+        message += ", Frames/s/device: {:.3f}".format(scalars["perf/frames_per_second_per_device"])
+    return message + ", loss: {:.3f}".format(float(scalars["learning/loss"]))
+
+
+@register_patch(
+    patch_id="maxdiffusion.throughput",
+    backend="maxdiffusion",
+    phase="before_train",
+    description="Report sample/token throughput in MaxDiffusion step metrics",
+    condition=lambda ctx: True,  # Always enabled
+)
+def patch_maxdiffusion_throughput(ctx: PatchContext) -> None:
+    """Add throughput to ``train_utils`` metric recording and step logging."""
+    del ctx
+
+    try:
+        from maxdiffusion import max_logging, pyconfig, train_utils
+    except ImportError as exc:  # noqa: BLE001 - never abort a run over metrics
+        error_rank_0(f"[Patch:maxdiffusion.throughput] Failed to import maxdiffusion.train_utils: {exc!r}")
+        return
+
+    # Reset in case a previous run in this process left state behind.
+    global _enabled
+    _enabled = True
+    _work_per_step.clear()
+
+    upstream_record_scalar_metrics = train_utils.record_scalar_metrics
+    upstream_write_metrics_to_tensorboard = train_utils.write_metrics_to_tensorboard
+
+    def record_scalar_metrics(metrics, step_time_delta, per_device_tflops, lr):
+        upstream_record_scalar_metrics(metrics, step_time_delta, per_device_tflops, lr)
+
+        # pyconfig.config is only populated once pyconfig.initialize() has run,
+        # which happens after this patch is installed.
+        global _enabled
+        if not _enabled or pyconfig.config is None:
+            return
+        try:
+            metrics["scalar"].update(_throughput_scalars(pyconfig.config, step_time_delta.total_seconds()))
+        except Exception as exc:  # noqa: BLE001 - a metric must not kill training
+            _enabled = False
+            warning_rank_0(f"[Patch:maxdiffusion.throughput] Disabled after error: {exc!r}")
+
+    def write_metrics_to_tensorboard(writer, metrics, step, config):
+        """Upstream ``train_utils.write_metrics_to_tensorboard`` with a wider step line."""
+        import jax
+        import numpy as np
+
+        try:
+            step_line = _format_step_line(metrics["scalar"], step)
+        except (KeyError, TypeError, ValueError) as exc:  # unexpected metric set
+            warning_rank_0(f"[Patch:maxdiffusion.throughput] Falling back to upstream step line: {exc!r}")
+            upstream_write_metrics_to_tensorboard(writer, metrics, step, config)
+            return
+
+        if jax.process_index() == 0:
+            max_logging.log(step_line)
+            for metric_name in metrics.get("scalar", []):
+                writer.add_scalar(metric_name, np.array(metrics["scalar"][metric_name]), step)
+            for metric_name in metrics.get("scalars", []):
+                writer.add_scalars(metric_name, metrics["scalars"][metric_name], step)
+
+            if step % config.log_period == 0:
+                max_logging.log(f"To see full metrics 'tensorboard --logdir={config.tensorboard_dir}'")
+                writer.flush()
+
+    train_utils.record_scalar_metrics = record_scalar_metrics
+    train_utils.write_metrics_to_tensorboard = write_metrics_to_tensorboard
+
+    log_rank_0("[Patch:maxdiffusion.throughput] MaxDiffusion throughput metrics patched successfully.")

--- a/primus/backends/maxtext/env_spec.py
+++ b/primus/backends/maxtext/env_spec.py
@@ -38,7 +38,6 @@ import os
 from typing import List
 
 from primus.core.backend.env_registry import (
-    ARCH_ALL,
     ARCH_GFX942,
     ARCH_GFX950,
     MODE_XLA_MERGE,
@@ -82,12 +81,14 @@ def maxtext_env_defaults() -> List[EnvVar]:
     """
     entries: List[EnvVar] = [
         # ---- XLA / JAX ----
-        EnvVar("XLA_FLAGS", _build_xla_flags(), mode=MODE_XLA_MERGE,
-               note="managed XLA knobs incl. autotune (fp8 MoE NaN fix)"),
-        EnvVar("XLA_PYTHON_CLIENT_MEM_FRACTION", ".97",
-               note="avoid HSA OOM during multi-node"),
-        EnvVar("TF_CPP_MIN_LOG_LEVEL", "2",
-               note="suppress benign JAX/MaxText shutdown errors"),
+        EnvVar(
+            "XLA_FLAGS",
+            _build_xla_flags(),
+            mode=MODE_XLA_MERGE,
+            note="managed XLA knobs incl. autotune (fp8 MoE NaN fix)",
+        ),
+        EnvVar("XLA_PYTHON_CLIENT_MEM_FRACTION", ".97", note="avoid HSA OOM during multi-node"),
+        EnvVar("TF_CPP_MIN_LOG_LEVEL", "2", note="suppress benign JAX/MaxText shutdown errors"),
         # ---- Transformer Engine (NVTE) ----
         EnvVar("NVTE_ALLOW_NONDETERMINISTIC_ALGO", "1"),
         EnvVar("NVTE_USE_HIPBLASLT", "1"),
@@ -107,10 +108,13 @@ def maxtext_env_defaults() -> List[EnvVar]:
         # a shared empty default (base_env.sh / run_pretrain.sh), so owning it in
         # the adapter would only create a cosmetic empty-vs-VERSION cross-path diff.
         # ---- Architecture-gated (the ONLY two arch differences) ----
-        EnvVar("RCCL_WARP_SPEED_AUTO", "0", arch=ARCH_GFX950,
-               note="gfx950 WarpSpeed default-on can cause NaN losses"),
-        EnvVar("HSA_NO_SCRATCH_RECLAIM", "1", arch=ARCH_GFX942,
-               note="gfx942 scratch-reclaim stability"),
+        EnvVar(
+            "RCCL_WARP_SPEED_AUTO",
+            "0",
+            arch=ARCH_GFX950,
+            note="gfx950 WarpSpeed default-on can cause NaN losses",
+        ),
+        EnvVar("HSA_NO_SCRATCH_RECLAIM", "1", arch=ARCH_GFX942, note="gfx942 scratch-reclaim stability"),
     ]
 
     # Multi-node JAX coordinator: derive from MASTER_ADDR/PORT so both the

--- a/primus/configs/models/maxdiffusion/flux_dev.yaml
+++ b/primus/configs/models/maxdiffusion/flux_dev.yaml
@@ -20,7 +20,7 @@ metrics_file: "" # for testing, local file that stores scalar metrics. If empty,
 write_metrics: True
 
 timing_metrics_file: "" # for testing, local file that stores function timing metrics such as state creation, compilation. If empty, no metrics are written.
-write_timing_metrics: True 
+write_timing_metrics: True
 
 gcs_metrics: False
 # If true save config to GCS in {base_output_directory}/{run_name}/
@@ -66,12 +66,12 @@ attention: 'cudnn_flash_te' # Supported attention: dot_product, flash, cudnn_fla
 # If mask_padding_tokens is True, we pass in segment ids to splash attention to avoid attending to padding tokens.
 # Else we do not pass in segment ids and on vpu bound hardware like trillium this is faster.
 # However, when padding tokens are significant, this will lead to worse quality and should be set to True.
-mask_padding_tokens: True 
+mask_padding_tokens: True
 # Maxdiffusion has 2 types of attention sharding strategies:
 # 1. attention_sharding_uniform = True : same sequence sharding rules applied for q in both (self and cross attention)
 # 2. attention_sharding_uniform = False : Heads are sharded uniformly across devices for self attention while sequence is sharded
 #    in cross attention q.
-attention_sharding_uniform: True 
+attention_sharding_uniform: True
 
 flash_block_sizes: {}
 # Use the following flash_block_sizes on v6e (Trillium) due to larger vmem.
@@ -299,6 +299,5 @@ controlnet_image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Goo
 quantization: ''
 # Shard the range finding operation for quantization. By default this is set to number of slices.
 quantization_local_shard_count: -1
-use_qwix_quantization: False 
+use_qwix_quantization: False
 compile_topology_num_slices: -1 # Number of target slices, set to a positive integer.
-

--- a/primus/configs/models/maxdiffusion/wan2.1_1.3b.yaml
+++ b/primus/configs/models/maxdiffusion/wan2.1_1.3b.yaml
@@ -20,7 +20,7 @@ metrics_file: "" # for testing, local file that stores scalar metrics. If empty,
 write_metrics: True
 
 timing_metrics_file: "" # for testing, local file that stores function timing metrics such as state creation, compilation. If empty, no metrics are written.
-write_timing_metrics: True 
+write_timing_metrics: True
 
 gcs_metrics: False
 # If true save config to GCS in {base_output_directory}/{run_name}/
@@ -66,12 +66,12 @@ flash_min_seq_length: 0
 # If mask_padding_tokens is True, we pass in segment ids to splash attention to avoid attending to padding tokens.
 # Else we do not pass in segment ids and on vpu bound hardware like trillium this is faster.
 # However, when padding tokens are significant, this will lead to worse quality and should be set to True.
-mask_padding_tokens: True 
+mask_padding_tokens: True
 # Maxdiffusion has 2 types of attention sharding strategies:
 # 1. attention_sharding_uniform = True : same sequence sharding rules applied for q in both (self and cross attention)
 # 2. attention_sharding_uniform = False : Heads are sharded uniformly across devices for self attention while sequence is sharded
 #    in cross attention q.
-attention_sharding_uniform: True 
+attention_sharding_uniform: True
 dropout: 0.1
 
 flash_block_sizes: {

--- a/primus/configs/models/maxdiffusion/wan2.1_14b.yaml
+++ b/primus/configs/models/maxdiffusion/wan2.1_14b.yaml
@@ -20,7 +20,7 @@ metrics_file: "" # for testing, local file that stores scalar metrics. If empty,
 write_metrics: True
 
 timing_metrics_file: "" # for testing, local file that stores function timing metrics such as state creation, compilation. If empty, no metrics are written.
-write_timing_metrics: True 
+write_timing_metrics: True
 
 gcs_metrics: False
 # If true save config to GCS in {base_output_directory}/{run_name}/
@@ -66,12 +66,12 @@ flash_min_seq_length: 0
 # If mask_padding_tokens is True, we pass in segment ids to splash attention to avoid attending to padding tokens.
 # Else we do not pass in segment ids and on vpu bound hardware like trillium this is faster.
 # However, when padding tokens are significant, this will lead to worse quality and should be set to True.
-mask_padding_tokens: True 
+mask_padding_tokens: True
 # Maxdiffusion has 2 types of attention sharding strategies:
 # 1. attention_sharding_uniform = True : same sequence sharding rules applied for q in both (self and cross attention)
 # 2. attention_sharding_uniform = False : Heads are sharded uniformly across devices for self attention while sequence is sharded
 #    in cross attention q.
-attention_sharding_uniform: True 
+attention_sharding_uniform: True
 dropout: 0.1
 
 flash_block_sizes: {

--- a/primus/core/backend/env_registry.py
+++ b/primus/core/backend/env_registry.py
@@ -89,9 +89,7 @@ def detect_gpu_arch() -> str:
     arch = "unknown"
     rocminfo = shutil.which("rocminfo") or "/opt/rocm/bin/rocminfo"
     try:
-        out = subprocess.run(
-            [rocminfo], capture_output=True, text=True, timeout=15
-        ).stdout
+        out = subprocess.run([rocminfo], capture_output=True, text=True, timeout=15).stdout
         for cand in (ARCH_GFX950, ARCH_GFX942):
             if cand in out:
                 arch = cand

--- a/primus/core/runtime/logging.py
+++ b/primus/core/runtime/logging.py
@@ -40,9 +40,7 @@ from primus.core.utils.module_utils import debug_rank_all, set_logging_rank
 
 # PRIMUS_LOG_LEVEL follows shell conventions; loguru spells some levels differently.
 _ENV_LEVEL_ALIASES = {"WARN": "WARNING", "FATAL": "CRITICAL"}
-_LOGURU_LEVELS = frozenset(
-    {"TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"}
-)
+_LOGURU_LEVELS = frozenset({"TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"})
 
 
 _LEVEL_SEVERITY = {


### PR DESCRIPTION
## Summary

Two independent pieces of work. Both are confined to `examples/` and
`primus/backends/`; no `third_party/` submodule is touched.

**MI325X maxtext configs (22 files).** Copied from the MI300X set, then
`per_device_batch_size` tuned on tus1-p3-g26 (8x MI325X, 256GB HBM vs 192GB on
MI300X) so the suite uses the memory the larger cards actually have instead of
inheriting MI300X limits. Each value is the largest that completed 3 training
steps against the 230.4GB per-device budget. 12 of the 19 tuned configs are
pinned by a real OOM one step higher; the remaining 7 stopped at the sweep's
attempt cap while still passing and are annotated in-file as not OOM-pinned.
grok1, gemma4_26B and gemma4_31B nanoo_fp8 were excluded from the sweep and keep
their MI300X batch sizes.

**MaxDiffusion throughput metrics.** The step line carried step time, FLOP rate
and loss but no throughput, so benchmark runs had no sample or token rate to
compare across resolutions and clip lengths.

Before:

    completed step: 18, seconds: 11.722, TFLOP/s/device: 348.548, loss: 1.540

After:

    completed step: 18, seconds: 11.716, TFLOP/s/device: 348.750, Tokens/s/device: 6760.245, Samples/s/device: 0.0854, Frames/s/device: 7.255, loss: 1.540

- `Samples/s/device` — videos or images per second per GPU. Defined for every
  model family.
- `Frames/s/device` — `Samples/s/device * num_frames`, emitted only for families
  whose config describes frames.
- `Tokens/s/device` — patchified latent tokens per second per GPU: 79,200 for a
  720x1280x85 WAN video, 1,024 for a 512px FLUX image. Rebuilt from the same
  latent geometry `calculate_{wan,flux}_tflops` bills its FLOPs for, and omitted
  for the UNet families (SD 1.x/2.x, SDXL) which have no equivalent notion.
  Named to match MaxText's step line so existing log parsers apply.

This is implemented as a `before_train` patch under
`primus/backends/maxdiffusion/patches/`, the same mechanism as the existing
logger patch, rather than editing `third_party/maxdiffusion`, so it survives
submodule updates. The values are added to `metrics["scalar"]` before any
consumer runs, so they also reach TensorBoard and `metrics_file` alongside the
cluster-wide `perf/samples_per_second`, `perf/frames_per_second` and
`perf/tokens_per_second` totals.

Two follow-ups in the same area: the tensorboard hint is now logged once per run
instead of on every `log_period` (the configs pin `log_period: 1`, so it was
doubling the length of the step log), and the `log_period` comment in the six
maxdiffusion configs is corrected — it claimed the value gated the
`completed step:` line, which it never did.

## Verification

- Recomputing the FLOP model from the checkpoint geometry with the patch's token
  count reproduces the trainer's own `Calculated TFLOPs per pass: 4085.7969` to a
  relative error of 3.7e-9, confirming the token rate and the FLOP rate describe
  the same sequence.
- Reported step time averages 11.719s against 11.750s of wall clock between
  consecutive log lines, so 0.26% falls outside the measured window.
- Metric injection happens before the metrics-file write and the TensorBoard
  queue, and the double-buffered step-to-metric pairing is preserved.
- Degradation paths: an unknown model family reports samples only; an unusable
  `per_device_batch_size` warns once, disables, and falls back to the
  byte-identical upstream line.

## Test plan

- [x] wan2.1_1.3b on MI300X, 20 steps: 348.88 TFLOP/s/device, 6762.7
      Tokens/s/device, 7.258 Frames/s/device
- [x] MI325X 1-node suite, steady-state means over steps 2-18:

      wan2.1_1.3b   11.722s   348.56 TFLOP/s/dev   6756.5 Tok/s/dev   7.251 Frames/s/dev
      wan2.1_14b    65.730s   322.62 TFLOP/s/dev   1204.9 Tok/s/dev   1.293 Frames/s/dev
      flux_dev       1.194s   432.30 TFLOP/s/dev   6862.2 Tok/s/dev   (no frames, image model)

- [ ] MI355X maxdiffusion configs not re-run; only a comment changed there.

## Note for whoever aggregates these numbers

Warmup must be excluded. Steps 0 and 1 are compilation (368s and 1032s in the
MI300X run), and averaging them in skews step time by +628% and the rates by
-10.3%. `tools/daily/daily_report.py` currently averages every matched step.