### PR TITLE
fix(megatron): stop the Mamba ROCm patch from aborting non-Mamba runs

### DIFF
--- a/.github/workflows/docker/Dockerfile
+++ b/.github/workflows/docker/Dockerfile
@@ -81,6 +81,19 @@ RUN PT_LIB=$(python3 -c "import primus_turbo, os; print(os.path.join(os.path.dir
     cd / && rm -rf /tmp/rocshmem_team_shim
 
 # ---------------------------------------------------------------------------
+# Remove the CUDA-only CUTLASS DSL stack
+# ---------------------------------------------------------------------------
+# The base image's mamba-ssm pins quack-kernels, which pulls nvidia-cutlass-dsl.
+# Its MLIR Python bindings and the FlyDSL ones installed with Primus-Turbo above
+# share one process-wide nanobind type registry, so whichever loads second aborts
+# (AMD-AGI/Primus#955). No ROCm path can run these CUDA-only kernels. Done in
+# this layer because the base image is already published carrying them; names
+# that are not installed are skipped instead of failing the build.
+RUN pip3 uninstall -y quack-kernels nvidia-cutlass-dsl \
+    nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-core \
+    nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13
+
+# ---------------------------------------------------------------------------
 # Install Triton
 # ---------------------------------------------------------------------------
 RUN cd /opt && \

--- a/primus/backends/megatron/patches/mamba_rocm_patches.py
+++ b/primus/backends/megatron/patches/mamba_rocm_patches.py
@@ -14,13 +14,30 @@ ROCm-specific correctness issues.
 
 import torch
 
-from primus.core.patches import PatchContext, register_patch
+from primus.core.patches import PatchContext, get_param, register_patch
 from primus.core.utils.module_utils import log_rank_0
 
+# Megatron-Bridge configs carry no ``model_type``, they name models by recipe.
+# Both of these end up in MCoreMambaModel (zebra_llama is a Mamba+MLA hybrid).
+_BRIDGE_MAMBA_RECIPES = ("mamba", "zebra_llama")
 
-def _is_rocm(ctx: PatchContext) -> bool:
-    """Return True when running on an AMD ROCm platform."""
-    return getattr(torch.version, "hip", None) is not None
+
+def _is_rocm_mamba_run(ctx: PatchContext) -> bool:
+    """Return True on ROCm for a run that actually builds Mamba layers.
+
+    Applying the patch imports ``mamba_ssm``, which reaches quack-kernels and
+    CUTLASS DSL, whose MLIR bindings then abort the process on FlyDSL's already
+    in nanobind's registry -- killing runs with no Mamba layer at all (#955).
+    Genuine Mamba runs import ``mamba_ssm`` anyway, so those are protected by
+    ``purge_cutlass_dsl`` in tools/installation/setup.sh, not by this gate.
+    """
+    if getattr(torch.version, "hip", None) is None:
+        return False
+    # Megatron: plain Mamba and the hybrids both set ``model_type: mamba``.
+    if get_param(ctx, "model_type") == "mamba":
+        return True
+    recipe = str(get_param(ctx, "recipe", "") or "")
+    return any(family in recipe for family in _BRIDGE_MAMBA_RECIPES)
 
 
 def _make_triton_wrapper(original_fn):
@@ -42,7 +59,7 @@ def _make_triton_wrapper(original_fn):
         "Disable Triton buffer_ops in Mamba _chunk_state_bwd_db backward pass "
         "to work around ROCm-specific correctness issues."
     ),
-    condition=_is_rocm,
+    condition=_is_rocm_mamba_run,
     tags=["rocm", "mamba"],
 )
 def patch_mamba_rocm_chunk_state_bwd_db(ctx: PatchContext):

--- a/tools/installation/setup.sh
+++ b/tools/installation/setup.sh
@@ -102,12 +102,6 @@ CAUSAL_CONV1D_BRANCH="e940ead2fd962c56854455017541384909ca669f"
 MAMBA_REPO="https://github.com/AndreasKaratzas/mamba.git"
 MAMBA_BRANCH="enable-primus-hybrid-models"
 TVM_FFI_VERSION="0.1.11"
-# mamba_ssm pins quack-kernels==0.3.1, which asks for `nvidia-cutlass-dsl>=4.4.1`
-# with no upper bound. 4.6.x restructured the DSL and dropped cute.core.ThrCopy,
-# which quack 0.3.1 imports, so `import mamba_ssm` dies with AttributeError.
-# 4.5.3 is the newest release quack 0.3.1 still works with. Note pip cannot pick
-# it on its own: 4.5.3 was published after 4.6.0 but sorts lower.
-CUTLASS_DSL_VERSION="4.5.3"
 PRIMUS_REPO="https://github.com/AMD-AGI/Primus.git"
 # Latest commit on `release/v26.5` branch. Committed on 2026-07-22.
 PRIMUS_BRANCH="b511d1b66b0068715308ea9bfe8ba147ea1a3860"
@@ -518,6 +512,31 @@ stage_causal_conv1d() {
     rm -rf "$SRC_DIR/causal-conv1d"
 }
 
+# mamba_ssm pins quack-kernels, which pulls nvidia-cutlass-dsl. Its MLIR Python
+# bindings and FlyDSL's (installed with Primus-Turbo) share one process-wide
+# nanobind type registry, so whichever loads second aborts (AMD-AGI/Primus#955).
+# No ROCm path can run these CUDA-only kernels and mamba's ops/cute/mamba3, their
+# only importer, degrades silently without them: mamba_370M ran 50 iterations to
+# bit-identical loss and grad norm after removal.
+purge_cutlass_dsl() {
+    local pkgs
+    pkgs="$(python - <<'PY'
+import importlib.metadata as md
+
+names = set()
+for dist in md.distributions():
+    name = dist.metadata["Name"] or ""
+    if name.lower().startswith(("quack-kernels", "nvidia-cutlass-dsl")):
+        names.add(name)
+print(" ".join(sorted(names)))
+PY
+)"
+    [ -n "$pkgs" ] || { log "No CUTLASS DSL packages installed; nothing to purge"; return 0; }
+    log "Uninstalling CUDA-only CUTLASS DSL stack: $pkgs"
+    # shellcheck disable=SC2086  # deliberate word splitting: one package per arg
+    $PIP uninstall -y $pkgs || die "failed to uninstall: $pkgs"
+}
+
 stage_mamba() {
     reload_env
     log "Building mamba @ $MAMBA_BRANCH"
@@ -527,18 +546,16 @@ stage_mamba() {
     # of every unpinned dep as .egg files, clobbering our pins (it pulled
     # transformers 5.x, removed accelerate/trl, and dragged in NVIDIA CUDA
     # packages). pip respects already-installed versions.
-    # Install the CUTLASS DSL pin before mamba, not after: quack's `>=4.4.1` is
-    # then already satisfied so pip keeps 4.5.3 instead of pulling 4.6.x and
-    # needing a downgrade, which would strand the 4.6-only libs-core/libs-cu12
-    # packages as orphans that make `pip check` complain.
     ( cd "$SRC_DIR/mamba" \
         && pipi "apache-tvm-ffi==${TVM_FFI_VERSION}" \
-        && pipi "nvidia-cutlass-dsl==${CUTLASS_DSL_VERSION}" \
         && pipi --no-build-isolation . ) || die "mamba build failed"
     rm -rf "$SRC_DIR/mamba"
+    # Ahead of the check below, which then doubles as proof mamba survives it.
+    purge_cutlass_dsl
     python -c "import mamba_ssm" 2>/dev/null \
-        || die "mamba_ssm cannot be imported. If this is the cute/CUTLASS path,
-  check whether quack-kernels still works with nvidia-cutlass-dsl==${CUTLASS_DSL_VERSION}."
+        || die "mamba_ssm cannot be imported after purge_cutlass_dsl removed
+  quack-kernels. Gate the import instead of putting the packages back --
+  restoring nvidia-cutlass-dsl reintroduces Primus#955."
 }
 
 # Megatron's dataset indexing imports a pybind11 extension that has to be


### PR DESCRIPTION
## What happens

`mamba_rocm_patches` was gated on the platform alone, so every ROCm job applied
it, and applying it imports `mamba_ssm`. That import is wider than the two
`ops.triton` submodules suggest: reaching a submodule first runs
`mamba_ssm/__init__.py`, which goes `modules.mamba3` -> `ops.cute.mamba3` ->
`quack` -> `cutlass`.

`nvidia-cutlass-dsl` carries its own build of the MLIR Python bindings and
FlyDSL (loaded by any Primus-Turbo config) carries another. Both use nanobind,
which keeps a single process-wide type registry, so whichever loads second
aborts the process:

```
Critical nanobind error: refusing to add duplicate key "ERROR" to enumeration "flydsl._mlir._mlir_libs._mlir.ir.DiagnosticSeverity"!
```

The `flydsl.` prefix is the load order: Turbo first, CUTLASS second.
`gpt_oss_20B` has no Mamba layer at all and still died on it.

CI stays green by accident: the published images install CUTLASS through the
legacy `python setup.py install` path, which buries it in an egg outside
`sys.path`, so `import cutlass` fails and the cute path is skipped silently.
Install it normally, as `tools/installation/setup.sh` did, and the crash shows
up.

## Changes

- **Gate the patch on runs that actually build Mamba layers.** Megatron sets
  `model_type: mamba` for plain and hybrid models; Megatron-Bridge configs have
  no `model_type` and name models by recipe, so `mamba.mamba2` and `zebra_llama`
  (a Mamba+MLA hybrid that also builds `MCoreMambaModel`) are matched there.
  Without the Bridge half, bridge Mamba runs would silently lose the buffer_ops
  correctness workaround.
- **Keep quack-kernels and nvidia-cutlass-dsl out of the environment.** The gate
  only spares models that never touch Mamba; a real Mamba run imports
  `mamba_ssm` while building the model regardless, so the packages have to go.
  They are CUDA-only kernels no ROCm path can run, and their only importer
  (`ops/cute/mamba3`) degrades silently without them. Removed in `setup.sh` for
  bare-metal installs and in the CI image layer, which is what covers the
  already-published base images.
- **Retire the `nvidia-cutlass-dsl==4.5.3` pin.** It existed only because quack
  0.3.1 imports `cute.core.ThrCopy`, which 4.6.x dropped. With the packages
  purged before the `import mamba_ssm` check, the pin has nothing left to do.

## Verification

- Gate truth table, 11 cases: Megatron `gpt`/`deepseek_v3` skip and `mamba`
  applies; Bridge `mamba.mamba2` and `zebra_llama` apply while `llama.llama3`
  and the MLPerf llama2 recipe skip; a missing `module_config` and empty params
  return False instead of raising.
- Real `run_patches` path on MI300X in a purged environment: with
  `model_type=mamba` both `ssd_chunk_state` and `ssd_combined` end up wrapped,
  with `gpt` neither is touched.
- `purge_cutlass_dsl` on `rocm/primus:v26.5`: enumerates all five packages,
  uninstalls cleanly, is idempotent, leaves nothing behind, and `mamba_ssm` plus
  both patch targets still import afterwards.
- Removing the packages is functionally free on ROCm: `mamba_370M` for 50
  iterations gives bit-identical loss and grad norm before and after, with
  throughput inside run-to-run noise.
- A/B on `gpt_oss_20B`, 8x MI300X: ungated aborts with the #955 output, gated
  trains 20 iterations to loss 11.075.
- `shellcheck`, `black --line-length=110` and `isort --profile black` pass.
