### PR TITLE
feat(megatron): add sampled Flux weight-state audit

### DIFF
--- a/primus/backends/megatron/training/diffusion/forward_step.py
+++ b/primus/backends/megatron/training/diffusion/forward_step.py
@@ -17,9 +17,13 @@ Supported data formats (framework-standard keys):
 Architecture follows functional composition for clarity and testability.
 """
 
+import hashlib
 import json
 import logging
 import os
+import stat
+import tempfile
+from pathlib import Path
 from typing import Optional, Tuple
 
 import torch
@@ -38,6 +42,8 @@ from primus.backends.megatron.training.diffusion.timestep_sampling import (
 )
 
 logger = logging.getLogger(__name__)
+_EMITTED_MODEL_WEIGHT_ITERATIONS: set[int] = set()
+_MODEL_WEIGHT_AUDIT_CONTEXT_UNSET = object()
 
 
 def _emit_batch_fingerprint(batch: dict, step_count: int, *, is_training: bool = True) -> None:
@@ -79,6 +85,427 @@ def _emit_batch_fingerprint(batch: dict, step_count: int, *, is_training: bool =
     # this launch path, so a bare print leaves the audit reporting zero markers
     # on a healthy run. Logging and fd 2 both survive.
     logger.info("PRIMUS_BATCH_FINGERPRINT=%s", json.dumps(payload, sort_keys=True))
+
+
+def _parse_model_weight_steps(value: str) -> set[int]:
+    """Parse completed training iterations requested for weight auditing."""
+    steps = set()
+    for token in value.split(","):
+        token = token.strip()
+        if not token or not token.isdigit() or int(token) <= 0:
+            raise RuntimeError(
+                "PRIMUS_AUDIT_MODEL_WEIGHT_STEPS must be a comma-separated " "list of positive integers"
+            )
+        step = int(token)
+        if step in steps:
+            raise RuntimeError("PRIMUS_AUDIT_MODEL_WEIGHT_STEPS contains duplicate step " f"{step}")
+        steps.add(step)
+    if not steps:
+        raise RuntimeError("PRIMUS_AUDIT_MODEL_WEIGHT_STEPS is empty")
+    return steps
+
+
+def _sample_model_weights(model, sample_size: int) -> dict:
+    """Return deterministic, low-overhead per-parameter weight samples."""
+    if sample_size <= 0:
+        raise ValueError("sample_size must be positive")
+
+    metadata = []
+    sampled_tensors = []
+    for name, parameter in sorted(model.named_parameters(), key=lambda item: item[0]):
+        tensor = parameter.detach().reshape(-1)
+        if tensor.numel() == 0:
+            continue
+        count = min(sample_size, tensor.numel())
+        indices = torch.arange(count, device=tensor.device, dtype=torch.int64) * tensor.numel() // count
+        sampled = tensor.index_select(0, indices).to(dtype=torch.float32)
+        metadata.append(
+            {
+                "name": name,
+                "shape": list(parameter.shape),
+                "dtype": str(parameter.dtype),
+                "numel": parameter.numel(),
+                "sample_count": count,
+                "requires_grad": parameter.requires_grad,
+            }
+        )
+        sampled_tensors.append(sampled)
+
+    if not sampled_tensors:
+        raise RuntimeError("model-weight audit found no parameters")
+    devices = {tensor.device for tensor in sampled_tensors}
+    if len(devices) != 1:
+        raise RuntimeError(
+            "model-weight audit requires all sampled parameters on one device, "
+            f"found {sorted(map(str, devices))}"
+        )
+
+    combined = torch.cat(sampled_tensors).cpu()
+    parameters = []
+    offset = 0
+    total_sum = 0.0
+    total_sum_squares = 0.0
+    total_absmax = 0.0
+    total_nonfinite_count = 0
+    all_finite = True
+    for item in metadata:
+        count = item["sample_count"]
+        sample = combined[offset : offset + count]
+        offset += count
+        finite_mask = torch.isfinite(sample)
+        nonfinite_count = int((~finite_mask).sum().item())
+        finite = nonfinite_count == 0
+        sample_sum = float(sample.double().sum().item()) if finite else None
+        sample_sum_squares = float(sample.double().square().sum().item()) if finite else None
+        sample_absmax = float(sample.abs().max().item()) if finite else None
+        item.update(
+            {
+                "sample_finite": finite,
+                "sample_nonfinite_count": nonfinite_count,
+                "sample_sum": sample_sum,
+                "sample_sum_squares": sample_sum_squares,
+                "sample_absmax": sample_absmax,
+                "sample_sha256": hashlib.sha256(sample.contiguous().numpy().tobytes()).hexdigest(),
+            }
+        )
+        parameters.append(item)
+        all_finite = all_finite and finite
+        total_nonfinite_count += nonfinite_count
+        if finite:
+            total_sum += sample_sum
+            total_sum_squares += sample_sum_squares
+            total_absmax = max(total_absmax, sample_absmax)
+
+    return {
+        "parameter_count": len(parameters),
+        "parameter_numel": sum(item["numel"] for item in parameters),
+        "sample_count": combined.numel(),
+        "sample_finite": all_finite,
+        "sample_nonfinite_count": total_nonfinite_count,
+        "sample_sum": total_sum if all_finite else None,
+        "sample_sum_squares": total_sum_squares if all_finite else None,
+        "sample_absmax": total_absmax if all_finite else None,
+        "parameters": parameters,
+    }
+
+
+def _model_weight_iteration_coordinate() -> tuple[int, int, int, int]:
+    """Return canonical completed/next iterations and current run metadata.
+
+    Megatron restores ``args.iteration`` from the checkpoint before entering
+    the training loop. The pinned Megatron training loop then records its
+    active completed-iteration coordinate in ``args.curr_iteration`` before
+    every ``train_step`` while leaving ``args.iteration`` at the restored
+    baseline. Prefer that active coordinate when present and retain the
+    restored value as the resume-safe fallback.
+
+    Forward-call counts are deliberately excluded: gradient accumulation can
+    change, and Megatron may replay a forward before any optimizer update.
+    Neither event is allowed to shift the Megatron training-loop coordinate.
+    """
+    from megatron.core.num_microbatches_calculator import get_num_microbatches
+    from megatron.training import get_args
+
+    args = get_args()
+    restored_iteration = getattr(args, "iteration", None)
+    if (
+        isinstance(restored_iteration, bool)
+        or not isinstance(restored_iteration, int)
+        or restored_iteration < 0
+    ):
+        raise RuntimeError("model-weight audit requires args.iteration to be a nonnegative integer")
+
+    completed_iteration = getattr(args, "curr_iteration", restored_iteration)
+    if (
+        isinstance(completed_iteration, bool)
+        or not isinstance(completed_iteration, int)
+        or completed_iteration < 0
+    ):
+        raise RuntimeError(
+            "model-weight audit requires args.curr_iteration to be a nonnegative integer when present"
+        )
+    if completed_iteration < restored_iteration:
+        raise RuntimeError(
+            "model-weight audit requires args.curr_iteration to be at least the restored args.iteration"
+        )
+
+    train_iters = getattr(args, "train_iters", None)
+    if isinstance(train_iters, bool) or not isinstance(train_iters, int) or train_iters <= 0:
+        raise RuntimeError("model-weight audit requires args.train_iters to be a positive integer")
+
+    num_microbatches = get_num_microbatches()
+    if isinstance(num_microbatches, bool) or not isinstance(num_microbatches, int) or num_microbatches <= 0:
+        raise RuntimeError(
+            "model-weight audit requires get_num_microbatches() to return a " "positive integer"
+        )
+    return completed_iteration, completed_iteration + 1, num_microbatches, train_iters
+
+
+def _reject_json_constant(value: str):
+    raise ValueError(f"non-standard JSON constant {value}")
+
+
+def _encode_strict_json(payload: dict) -> bytes:
+    """Encode one deterministic JSON object with no non-finite constants."""
+    if not isinstance(payload, dict):
+        raise TypeError("model-weight audit payload must be a JSON object")
+    return (
+        json.dumps(
+            payload,
+            sort_keys=True,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode()
+
+
+def _read_strict_json(path: Path) -> dict:
+    """Read a regular, non-symlink JSON object and reject non-finite values."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    descriptor = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise RuntimeError(f"model-weight audit output is not a regular file: {path}")
+        handle = os.fdopen(descriptor)
+        descriptor = None
+        with handle:
+            payload = json.load(handle, parse_constant=_reject_json_constant)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"model-weight audit output is not a JSON object: {path}")
+    # json.load(parse_constant=...) rejects NaN/Infinity tokens. Re-encoding
+    # additionally rejects valid JSON numbers that overflow to Python infinity
+    # (for example 1e9999).
+    _encode_strict_json(payload)
+    return payload
+
+
+def _model_weight_summary_identity(payload: dict) -> tuple[dict, bool]:
+    """Return restart identity while validating replay-variant provenance."""
+    provenance_fields = {"forward_step_count", "num_microbatches"}
+    present_fields = provenance_fields.intersection(payload)
+    if present_fields and present_fields != provenance_fields:
+        missing = sorted(provenance_fields - present_fields)
+        raise RuntimeError(
+            "model-weight audit output has incomplete replay provenance; " f"missing fields: {missing}"
+        )
+
+    has_provenance = bool(present_fields)
+    identity = dict(payload)
+    if has_provenance:
+        for field in sorted(provenance_fields):
+            value = identity.pop(field)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise RuntimeError(f"model-weight audit output field {field} must be a positive integer")
+    return identity, has_provenance
+
+
+def _write_model_weight_summary_once(output: Path, payload: dict) -> None:
+    """Publish one strict JSON record atomically without overwriting."""
+    encoded = _encode_strict_json(payload)
+    identity, has_provenance = _model_weight_summary_identity(payload)
+    encoded_identity = _encode_strict_json(identity)
+    descriptor, temporary_value = tempfile.mkstemp(
+        dir=output.parent,
+        prefix=f".{output.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_value)
+    try:
+        os.fchmod(descriptor, 0o600)
+        handle = os.fdopen(descriptor, "wb")
+        descriptor = None
+        with handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary, output, follow_symlinks=False)
+        except FileExistsError:
+            existing = _read_strict_json(output)
+            existing_identity, existing_has_provenance = _model_weight_summary_identity(existing)
+            if (
+                existing_has_provenance != has_provenance
+                or _encode_strict_json(existing_identity) != encoded_identity
+            ):
+                raise RuntimeError(
+                    "model-weight audit output already exists with different " f"content: {output}"
+                )
+        else:
+            directory_flags = os.O_RDONLY
+            if hasattr(os, "O_DIRECTORY"):
+                directory_flags |= os.O_DIRECTORY
+            directory_descriptor = os.open(output.parent, directory_flags)
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def _model_weight_audit_context(step_count: int, *, is_training: bool):
+    """Validate audit configuration on every rank before rank-zero selection."""
+    raw_steps = os.getenv("PRIMUS_AUDIT_MODEL_WEIGHT_STEPS")
+    if raw_steps is None:
+        return None
+    if not is_training or os.getenv("PRIMUS_SYNTHETIC_WARMUP_ACTIVE") == "1":
+        return None
+
+    completed_iterations = _parse_model_weight_steps(raw_steps)
+    (
+        completed_training_iteration,
+        next_training_iteration,
+        num_microbatches,
+        train_iters,
+    ) = _model_weight_iteration_coordinate()
+    terminal_iterations = sorted(step for step in completed_iterations if step >= train_iters)
+    if terminal_iterations:
+        first_terminal = terminal_iterations[0]
+        raise RuntimeError(
+            "model-weight audit cannot safely sample completed iteration "
+            f"{first_terminal} with train_iters={train_iters}: overlap-param-gather "
+            "buffers are refreshed by the next model forward, so selected completed "
+            f"iteration {first_terminal} requires training through at least {first_terminal + 1}"
+        )
+
+    raw_sample_size = os.getenv("PRIMUS_AUDIT_MODEL_WEIGHT_SAMPLE_SIZE", "256")
+    if not raw_sample_size.isdigit() or not 1 <= int(raw_sample_size) <= 4096:
+        raise RuntimeError("PRIMUS_AUDIT_MODEL_WEIGHT_SAMPLE_SIZE must be an integer in [1, 4096]")
+    sample_size = int(raw_sample_size)
+
+    output_value = os.getenv("PRIMUS_AUDIT_MODEL_WEIGHT_PATH")
+    if not output_value:
+        raise RuntimeError("PRIMUS_AUDIT_MODEL_WEIGHT_PATH is required when weight auditing is enabled")
+    output_directory = Path(output_value)
+    if not output_directory.is_absolute():
+        raise RuntimeError("PRIMUS_AUDIT_MODEL_WEIGHT_PATH must be absolute")
+
+    if isinstance(step_count, bool) or not isinstance(step_count, int) or step_count <= 0:
+        raise RuntimeError("model-weight audit requires step_count to be a positive integer")
+    forward_step_count = step_count
+
+    # Every deterministic check above runs on every training rank. Branching
+    # earlier can leave peers entering model collectives after rank zero fails.
+    global_rank = (
+        torch.distributed.get_rank() if torch.distributed.is_initialized() else int(os.getenv("RANK", "-1"))
+    )
+    if global_rank != 0:
+        return None
+
+    return {
+        "completed_iterations": completed_iterations,
+        "global_rank": global_rank,
+        "completed_training_iteration": completed_training_iteration,
+        "next_training_iteration": next_training_iteration,
+        "num_microbatches": num_microbatches,
+        "sample_size": sample_size,
+        "output_directory": output_directory,
+        "forward_step_count": forward_step_count,
+    }
+
+
+def _emit_model_weight_summary(
+    model,
+    step_count: int,
+    *,
+    is_training: bool = True,
+    audit_context=_MODEL_WEIGHT_AUDIT_CONTEXT_UNSET,
+) -> None:
+    """Write one rank-0 sampled weight summary at requested training steps."""
+    context = (
+        _model_weight_audit_context(step_count, is_training=is_training)
+        if audit_context is _MODEL_WEIGHT_AUDIT_CONTEXT_UNSET
+        else audit_context
+    )
+    if context is None:
+        return
+    completed_iterations = context["completed_iterations"]
+    global_rank = context["global_rank"]
+    completed_training_iteration = context["completed_training_iteration"]
+    next_training_iteration = context["next_training_iteration"]
+    num_microbatches = context["num_microbatches"]
+    sample_size = context["sample_size"]
+    output_directory = context["output_directory"]
+    forward_step_count = context["forward_step_count"]
+    if (
+        completed_training_iteration not in completed_iterations
+        or completed_training_iteration in _EMITTED_MODEL_WEIGHT_ITERATIONS
+    ):
+        return
+
+    output_directory.mkdir(parents=True, exist_ok=True)
+    output = output_directory / f"completed_iteration_{completed_training_iteration:07d}.json"
+
+    payload = {
+        "version": 1,
+        "global_rank": global_rank,
+        "completed_training_iteration": completed_training_iteration,
+        "next_training_iteration": next_training_iteration,
+        "forward_step_count": forward_step_count,
+        # Audit convention: zero means the first eligible audit forward for
+        # this completed iteration. It is not arithmetic on cumulative calls.
+        "microbatch_index": 0,
+        "num_microbatches": num_microbatches,
+        "sample_size_per_parameter": sample_size,
+        **_sample_model_weights(model, sample_size),
+    }
+    try:
+        _write_model_weight_summary_once(output, payload)
+    except BaseException:
+        _EMITTED_MODEL_WEIGHT_ITERATIONS.discard(completed_training_iteration)
+        raise
+
+    _EMITTED_MODEL_WEIGHT_ITERATIONS.add(completed_training_iteration)
+    logger.info(
+        "PRIMUS_MODEL_WEIGHT_SUMMARY=%s",
+        json.dumps(
+            {
+                "path": str(output),
+                "sample_count": payload["sample_count"],
+                "sample_finite": payload["sample_finite"],
+                "completed_training_iteration": completed_training_iteration,
+                "next_training_iteration": next_training_iteration,
+                "forward_step_count": forward_step_count,
+            },
+            sort_keys=True,
+            allow_nan=False,
+        ),
+    )
+
+
+def _emit_model_weight_summary_after_forward(
+    model_output,
+    model,
+    step_count: int,
+    *,
+    is_training: bool = True,
+    audit_context=_MODEL_WEIGHT_AUDIT_CONTEXT_UNSET,
+):
+    """Audit an already-evaluated model forward and return its output unchanged.
+
+    Using this helper as a wrapper around ``model(...)`` makes Python finish the
+    model call and all forward pre-hooks before auditing. This is required for
+    current distributed-optimizer buffers when ``overlap_param_gather`` is on.
+    The real call site carries its pre-forward validated context into this
+    wrapper, which still runs before backward and the optimizer update.
+    """
+    _emit_model_weight_summary(
+        model,
+        step_count,
+        is_training=is_training,
+        audit_context=audit_context,
+    )
+    return model_output
 
 
 def prepare_flux_latents(
@@ -198,6 +625,37 @@ def prepare_flux_latents(
 _eager_prepare_flux_latents = prepare_flux_latents
 
 
+def _is_validation_forward(model, _batch=None) -> bool:
+    """Classify from rank-consistent model state, not rank-local batch data."""
+    return not model.training
+
+
+def _pregenerated_diffusion_inputs(
+    batch,
+    *,
+    tp_size,
+    is_validation,
+    compute_dtype,
+    tensor_parallel,
+):
+    """Return deterministic inputs without splitting TP collective participation."""
+    if tp_size == 1:
+        return batch.get("noise"), batch.get("timesteps")
+    if not is_validation:
+        return None, None
+
+    # Evaluation mode is rank-consistent, so every TP rank enters this
+    # collective even though only TP rank zero owns ``batch``.
+    batch_timesteps = tensor_parallel.broadcast_data(
+        ["timesteps"],
+        batch,
+        compute_dtype,
+    ).get("timesteps")
+    if not batch_timesteps.is_cuda:
+        batch_timesteps = batch_timesteps.cuda(non_blocking=True)
+    return None, batch_timesteps
+
+
 def flux_forward_step_func(
     data_iterator,
     model,
@@ -257,9 +715,10 @@ def flux_forward_step_func(
             to isolate training random ops from model forward RNG consumption
             (default: False).
         step_count: Monotonically increasing counter identifying this forward
-            call. Used to derive a unique per-step RNG seed. Managed by the
-            caller (DiffusionPretrainTrainer) and reconstructed from checkpoint
-            state on resume as iteration * num_microbatches.
+            call. Used only to derive a per-step RNG seed and as audit
+            provenance; training-loop coordinates come from Megatron iteration
+            state. Managed by the caller (DiffusionPretrainTrainer) and
+            reconstructed on resume as iteration * num_microbatches.
 
     Returns:
         Tuple of (noise_pred, clean_latents, noise, loss_mask, metrics_dict, is_validation)
@@ -268,7 +727,7 @@ def flux_forward_step_func(
         - noise: Sampled noise [B, C, H, W]
         - loss_mask: Optional mask for variable-length sequences [B] or None
         - metrics_dict: Dictionary with training metrics
-        - is_validation: True when batch contains "timestep" key (MLPerf validation mode)
+        - is_validation: True when the model is in evaluation mode
     """
     # Reseed default CUDA generator per step to isolate training random ops
     # (noise, timesteps, CFG dropout) from model forward RNG consumption.
@@ -486,18 +945,27 @@ def flux_forward_step_func(
     # ~0.015-0.030 (the 10% unconditional samples pay a ~0.15-0.30 MSE
     # penalty), which is enough to materially shift the convergence-crossing
     # step, so we keep it off to match the submission configuration.
-    is_validation = False
-    if batch is not None and "timestep" in batch:
-        is_validation = True
-        val_timesteps = batch["timestep"].float() / 8.0
+    # Evaluation mode is identical on every tensor-parallel rank, including
+    # ranks where ``batch`` is intentionally None. Batch-local classification
+    # can split ranks before model collectives when TP > 1.
+    is_validation = _is_validation_forward(model, batch)
+    if batch is not None and is_validation and "timestep" in batch:
+        val_timesteps = batch["timestep"].to(dtype=compute_dtype) / 8.0
         batch["timesteps"] = val_timesteps
-    elif batch is not None and not model.training:
-        is_validation = True
+    elif batch is not None and is_validation:
         batch_size_val = pooled_prompt_embeds.shape[0]
         val_idx = torch.arange(batch_size_val, device="cuda") % 8
         batch["timestep"] = val_idx
         val_timesteps = val_idx.to(dtype=compute_dtype) / 8.0
         batch["timesteps"] = val_timesteps
+
+    # Validate every rank before noise preparation and the expensive model
+    # forward, then carry rank zero's parsed context through publication.
+    # Direct emitter calls build and validate the same context themselves.
+    model_weight_audit_context = _model_weight_audit_context(
+        step_count,
+        is_training=not is_validation,
+    )
 
     if batch is not None:
         _emit_batch_fingerprint(
@@ -537,23 +1005,13 @@ def flux_forward_step_func(
         )
 
         # Extract pre-generated noise/timesteps from batch (deterministic tests)
-        batch_noise = None
-        batch_timesteps = None
-        if batch is not None:
-            if tp_size == 1:
-                batch_noise = batch.get("noise")
-                batch_timesteps = batch.get("timesteps")
-            else:
-                if "noise" in batch:
-                    batch_noise = tensor_parallel.broadcast_data(["noise"], batch, compute_dtype).get("noise")
-                    if not batch_noise.is_cuda:
-                        batch_noise = batch_noise.cuda(non_blocking=True)
-                if "timesteps" in batch:
-                    batch_timesteps = tensor_parallel.broadcast_data(["timesteps"], batch, compute_dtype).get(
-                        "timesteps"
-                    )
-                    if not batch_timesteps.is_cuda:
-                        batch_timesteps = batch_timesteps.cuda(non_blocking=True)
+        batch_noise, batch_timesteps = _pregenerated_diffusion_inputs(
+            batch,
+            tp_size=tp_size,
+            is_validation=is_validation,
+            compute_dtype=compute_dtype,
+            tensor_parallel=tensor_parallel,
+        )
 
         # Prepare latents (noise, packing, scheduling).
         # Eager wrapper — see _eager_prepare_flux_latents NOTE for why compile
@@ -619,14 +1077,23 @@ def flux_forward_step_func(
     timesteps_norm = sigma_1d.to(dtype=packed_noisy_latents.dtype)
 
     with torch.amp.autocast("cuda", enabled=True, dtype=compute_dtype):
-        noise_pred = model(
-            img=packed_noisy_latents,
-            txt=prompt_embeds,
-            y=pooled_prompt_embeds,
-            timesteps=timesteps_norm,
-            img_ids=img_ids,
-            txt_ids=text_ids,
-            guidance=guidance_vec,
+        # The model call is evaluated before the wrapper. With
+        # overlap_param_gather, this guarantees every forward pre-hook has
+        # refreshed its distributed-optimizer parameter buffer before sampling.
+        noise_pred = _emit_model_weight_summary_after_forward(
+            model(
+                img=packed_noisy_latents,
+                txt=prompt_embeds,
+                y=pooled_prompt_embeds,
+                timesteps=timesteps_norm,
+                img_ids=img_ids,
+                txt_ids=text_ids,
+                guidance=guidance_vec,
+            ),
+            model,
+            step_count,
+            is_training=not is_validation,
+            audit_context=model_weight_audit_context,
         )
 
         # Unpack latents from sequence format

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_flux_forward_step_e2e.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_flux_forward_step_e2e.py
@@ -157,7 +157,8 @@ class TestFluxForwardStepE2E:
         )
 
     def test_validation_with_timestep_key(self, model, scheduler):
-        """Batch with 'timestep' key triggers validation mode."""
+        """Evaluation mode marks a pre-sampled timestep batch as validation."""
+        model.eval()
         batch = self._make_presampled_batch()
         batch["timestep"] = torch.arange(2)
         data_iterator = iter([batch])
@@ -176,6 +177,8 @@ class TestFluxForwardStepE2E:
         assert is_validation is True
         # The forward step writes derived timesteps (timestep / 8.0) into the batch.
         assert "timesteps" in batch
+        expected_dtype = torch.bfloat16 if model.config.bf16 else model.config.params_dtype
+        assert batch["timesteps"].dtype == expected_dtype
         assert torch.equal(
             batch["timesteps"].float().cpu(),
             torch.arange(2).float() / 8.0,

--- a/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
@@ -1,7 +1,11 @@
 import json
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
+import torch
 import torch.nn as nn
 
 from primus.backends.megatron.data.diffusion.task_encoders.image import (
@@ -15,11 +19,64 @@ from primus.backends.megatron.flux_pretrain_trainer import (
 )
 from primus.backends.megatron.patches.mlperf_warmup_patches import _is_resumed_training
 from primus.backends.megatron.training.diffusion.forward_step import (
+    _EMITTED_MODEL_WEIGHT_ITERATIONS,
     _emit_batch_fingerprint,
+    _emit_model_weight_summary,
+    _emit_model_weight_summary_after_forward,
+    _encode_strict_json,
+    _is_validation_forward,
+    _model_weight_audit_context,
+    _model_weight_iteration_coordinate,
+    _parse_model_weight_steps,
+    _pregenerated_diffusion_inputs,
+    _read_strict_json,
+    _sample_model_weights,
+    _write_model_weight_summary_once,
 )
 
 _FORWARD_STEP_LOGGER = "primus.backends.megatron.training.diffusion.forward_step"
 _FLUX_TRAINER_LOGGER = "primus.backends.megatron.flux_pretrain_trainer"
+_UNSET = object()
+
+
+@pytest.fixture(autouse=True)
+def _clear_emitted_model_weight_iterations():
+    _EMITTED_MODEL_WEIGHT_ITERATIONS.clear()
+    yield
+    _EMITTED_MODEL_WEIGHT_ITERATIONS.clear()
+
+
+def _set_training_state(
+    monkeypatch,
+    *,
+    iteration,
+    train_iters=20_000,
+    curr_iteration=_UNSET,
+    num_microbatches=1,
+):
+    from megatron import training as megatron_training
+    from megatron.core import num_microbatches_calculator
+
+    args = SimpleNamespace(iteration=iteration, train_iters=train_iters)
+    if curr_iteration is not _UNSET:
+        args.curr_iteration = curr_iteration
+    microbatch_state = {"value": num_microbatches}
+    monkeypatch.setattr(megatron_training, "get_args", lambda: args)
+    monkeypatch.setattr(
+        num_microbatches_calculator,
+        "get_num_microbatches",
+        lambda: microbatch_state["value"],
+    )
+    return args, microbatch_state
+
+
+def _enable_weight_audit(monkeypatch, output, *, steps, sample_size=3, rank=0):
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: False)
+    monkeypatch.delenv("PRIMUS_SYNTHETIC_WARMUP_ACTIVE", raising=False)
+    monkeypatch.setenv("RANK", str(rank))
+    monkeypatch.setenv("PRIMUS_AUDIT_MODEL_WEIGHT_STEPS", steps)
+    monkeypatch.setenv("PRIMUS_AUDIT_MODEL_WEIGHT_SAMPLE_SIZE", str(sample_size))
+    monkeypatch.setenv("PRIMUS_AUDIT_MODEL_WEIGHT_PATH", str(output))
 
 
 def test_sample_key_fingerprint_is_order_sensitive():
@@ -77,12 +134,14 @@ def test_precision_linear_class_census_emits_zero_counts_for_bf16(monkeypatch, c
 
     _emit_precision_linear_class_census(nn.Linear(2, 2))
 
-    line = next(
+    marker_lines = [
         record.message
         for record in caplog.records
-        if record.message.startswith("PRIMUS_LINEAR_CLASS_CENSUS=")
-    )
-    payload = json.loads(line.split("=", 1)[1])
+        if record.name == _FLUX_TRAINER_LOGGER
+        and record.message.startswith("PRIMUS_LINEAR_CLASS_CENSUS=")
+    ]
+    assert len(marker_lines) == 1
+    payload = json.loads(marker_lines[0].split("=", 1)[1])
     assert payload == {
         "data_parallel_rank": 3,
         "global_rank": 3,
@@ -206,3 +265,625 @@ def test_emit_batch_fingerprint_logs_rank_local_payload(monkeypatch, caplog):
         "sample_keys_sha256": "a" * 64,
         "step": 6,
     }
+
+
+def test_parse_model_weight_steps_is_fail_closed():
+    assert _parse_model_weight_steps("5120, 8192") == {5120, 8192}
+    with pytest.raises(RuntimeError, match="duplicate step 5120"):
+        _parse_model_weight_steps("5120,5120")
+    with pytest.raises(RuntimeError, match="positive integers"):
+        _parse_model_weight_steps("5120,not-a-step")
+    for invalid in ("", "0", "-1", "1,"):
+        with pytest.raises(RuntimeError):
+            _parse_model_weight_steps(invalid)
+
+
+def test_sample_model_weights_is_deterministic_and_sensitive():
+    model = nn.Sequential(nn.Linear(4, 3, bias=True), nn.Linear(3, 2, bias=False))
+    with torch.no_grad():
+        for index, parameter in enumerate(model.parameters()):
+            parameter.copy_(
+                torch.arange(parameter.numel(), dtype=parameter.dtype).reshape_as(parameter) + index
+            )
+
+    first = _sample_model_weights(model, sample_size=4)
+    second = _sample_model_weights(model, sample_size=4)
+    assert first == second
+    assert first["sample_finite"]
+    assert first["parameter_count"] == 3
+
+    with torch.no_grad():
+        model[0].weight.flatten()[0].add_(1)
+    changed = _sample_model_weights(model, sample_size=4)
+    first_by_name = {item["name"]: item for item in first["parameters"]}
+    changed_by_name = {item["name"]: item for item in changed["parameters"]}
+    assert changed_by_name["0.weight"]["sample_sha256"] != first_by_name["0.weight"]["sample_sha256"]
+
+
+def test_sample_model_weights_serializes_nonfinite_values_as_strict_json():
+    model = nn.Linear(4, 2, bias=False)
+    with torch.no_grad():
+        model.weight.flatten()[0] = torch.nan
+        model.weight.flatten()[2] = torch.inf
+
+    summary = _sample_model_weights(model, sample_size=4)
+
+    assert summary["sample_finite"] is False
+    assert summary["sample_nonfinite_count"] == 2
+    assert summary["sample_sum"] is None
+    assert summary["sample_sum_squares"] is None
+    assert summary["sample_absmax"] is None
+    json.dumps(summary, allow_nan=False)
+
+
+def test_model_weight_iteration_coordinate_uses_canonical_megatron_iteration(monkeypatch):
+    args, microbatches = _set_training_state(
+        monkeypatch,
+        iteration=5120,
+        num_microbatches=4,
+    )
+
+    assert _model_weight_iteration_coordinate() == (5120, 5121, 4, 20_000)
+
+    microbatches["value"] = 8
+    assert _model_weight_iteration_coordinate() == (5120, 5121, 8, 20_000)
+
+    # The pinned Megatron loop keeps args.iteration at the restored checkpoint
+    # and advances args.curr_iteration immediately before each train_step.
+    args.curr_iteration = 8192
+    assert _model_weight_iteration_coordinate() == (8192, 8193, 8, 20_000)
+
+
+@pytest.mark.parametrize("iteration", [None, True, -1, 1.5])
+def test_model_weight_iteration_coordinate_rejects_invalid_restored_iteration(monkeypatch, iteration):
+    _set_training_state(monkeypatch, iteration=iteration)
+
+    with pytest.raises(RuntimeError, match="args.iteration"):
+        _model_weight_iteration_coordinate()
+
+
+@pytest.mark.parametrize("num_microbatches", [None, True, 0, -1, 1.5])
+def test_model_weight_iteration_coordinate_rejects_invalid_microbatch_metadata(monkeypatch, num_microbatches):
+    _set_training_state(
+        monkeypatch,
+        iteration=0,
+        num_microbatches=num_microbatches,
+    )
+
+    with pytest.raises(RuntimeError, match="positive integer"):
+        _model_weight_iteration_coordinate()
+
+
+@pytest.mark.parametrize("curr_iteration", [None, True, -1, 1.5])
+def test_model_weight_iteration_coordinate_rejects_invalid_active_iteration(monkeypatch, curr_iteration):
+    _set_training_state(
+        monkeypatch,
+        iteration=0,
+        curr_iteration=curr_iteration,
+    )
+
+    with pytest.raises(RuntimeError, match="args.curr_iteration"):
+        _model_weight_iteration_coordinate()
+
+
+def test_emit_model_weight_summary_uses_resume_coordinate_and_suppresses_replays(
+    monkeypatch, tmp_path, caplog
+):
+    output = tmp_path / "weights"
+    model = nn.Linear(4, 2)
+    _, microbatches = _set_training_state(
+        monkeypatch,
+        iteration=5120,
+        num_microbatches=4,
+    )
+    _enable_weight_audit(monkeypatch, output, steps="5120,8192")
+    caplog.set_level("INFO", logger=_FORWARD_STEP_LOGGER)
+
+    # step_count is deliberately unrelated to the training-loop coordinate.
+    _emit_model_weight_summary(model, step_count=999_999)
+
+    record_path = output / "completed_iteration_0005120.json"
+    record = json.loads(record_path.read_text())
+    assert record["completed_training_iteration"] == 5120
+    assert record["next_training_iteration"] == 5121
+    assert record["forward_step_count"] == 999_999
+    assert record["microbatch_index"] == 0
+    assert record["num_microbatches"] == 4
+    assert record["sample_size_per_parameter"] == 3
+    assert record["sample_finite"]
+    assert any(record.message.startswith("PRIMUS_MODEL_WEIGHT_SUMMARY=") for record in caplog.records)
+
+    original = record_path.read_bytes()
+    microbatches["value"] = 8
+    _emit_model_weight_summary(model, step_count=1)
+    assert record_path.read_bytes() == original
+    assert list(output.glob("*.json")) == [record_path]
+    assert not list(output.glob("*.tmp"))
+
+
+def test_emit_model_weight_summary_uses_active_iteration_after_resume(monkeypatch, tmp_path):
+    output = tmp_path / "weights"
+    model = nn.Linear(2, 2)
+    _set_training_state(
+        monkeypatch,
+        iteration=5120,
+        curr_iteration=8192,
+        num_microbatches=4,
+    )
+    _enable_weight_audit(monkeypatch, output, steps="8192")
+
+    _emit_model_weight_summary(model, step_count=13)
+
+    record = json.loads((output / "completed_iteration_0008192.json").read_text())
+    assert record["completed_training_iteration"] == 8192
+    assert record["next_training_iteration"] == 8193
+    assert record["forward_step_count"] == 13
+
+
+def test_emit_model_weight_summary_rejects_terminal_requested_iteration(monkeypatch, tmp_path):
+    output = tmp_path / "weights"
+    model = nn.Linear(2, 2)
+    _set_training_state(
+        monkeypatch,
+        iteration=5120,
+        train_iters=8192,
+    )
+    _enable_weight_audit(monkeypatch, output, steps="5120,8192")
+
+    with pytest.raises(RuntimeError, match="iteration 8192 requires training through at least 8193"):
+        _emit_model_weight_summary(model, step_count=5121)
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("train_iters", [None, True, 0, -1, 1.5])
+def test_emit_model_weight_summary_rejects_invalid_train_iters(monkeypatch, tmp_path, train_iters):
+    output = tmp_path / "weights"
+    _set_training_state(
+        monkeypatch,
+        iteration=0,
+        train_iters=train_iters,
+    )
+    _enable_weight_audit(monkeypatch, output, steps="1")
+
+    with pytest.raises(RuntimeError, match="args.train_iters"):
+        _emit_model_weight_summary(nn.Linear(2, 2), step_count=1)
+    assert not output.exists()
+
+
+def test_emit_model_weight_summary_restart_allows_changed_replay_provenance(monkeypatch, tmp_path):
+    output = tmp_path / "weights"
+    model = nn.Linear(2, 2)
+    _, microbatches = _set_training_state(monkeypatch, iteration=5120)
+    _enable_weight_audit(monkeypatch, output, steps="5120")
+
+    _emit_model_weight_summary(model, step_count=5121)
+    _EMITTED_MODEL_WEIGHT_ITERATIONS.clear()
+    original = (output / "completed_iteration_0005120.json").read_bytes()
+    microbatches["value"] = 4
+    _emit_model_weight_summary(model, step_count=7)
+
+    assert (output / "completed_iteration_0005120.json").read_bytes() == original
+    assert not list(output.glob("*.tmp"))
+
+
+def test_emit_model_weight_summary_rejects_conflicting_restart(monkeypatch, tmp_path):
+    output = tmp_path / "weights"
+    model = nn.Linear(2, 2)
+    _set_training_state(monkeypatch, iteration=5120)
+    _enable_weight_audit(monkeypatch, output, steps="5120")
+
+    _emit_model_weight_summary(model, step_count=5121)
+    _EMITTED_MODEL_WEIGHT_ITERATIONS.clear()
+    with torch.no_grad():
+        model.weight.flatten()[0].add_(1)
+
+    with pytest.raises(RuntimeError, match="already exists with different content"):
+        _emit_model_weight_summary(model, step_count=5121)
+    assert not list(output.glob("*.tmp"))
+
+
+def test_emit_model_weight_summary_requires_rank_zero(monkeypatch, tmp_path):
+    class TraversalForbidden:
+        def named_parameters(self):
+            raise AssertionError("rank one must not traverse parameters")
+
+    output = tmp_path / "weights"
+    _set_training_state(monkeypatch, iteration=5120)
+    _enable_weight_audit(monkeypatch, output, steps="5120", rank=1)
+
+    _emit_model_weight_summary(TraversalForbidden(), step_count=5121)
+
+    assert not output.exists()
+
+
+def test_rank_one_rejects_terminal_selection_before_model_traversal(monkeypatch, tmp_path):
+    class TraversalForbidden:
+        def named_parameters(self):
+            raise AssertionError("terminal validation must precede model traversal")
+
+    output = tmp_path / "weights"
+    _set_training_state(
+        monkeypatch,
+        iteration=5120,
+        train_iters=8192,
+    )
+    _enable_weight_audit(monkeypatch, output, steps="8192", rank=1)
+
+    with pytest.raises(RuntimeError, match="iteration 8192 requires training through at least 8193"):
+        _emit_model_weight_summary(TraversalForbidden(), step_count=5121)
+    assert not output.exists()
+
+
+def test_validation_forward_classification_is_batch_independent_across_tp_ranks():
+    model = nn.Linear(2, 2)
+    model.eval()
+
+    # Loader and non-loader tensor-parallel ranks see a batch and None,
+    # respectively, but both classify the model's eval forward identically.
+    assert _is_validation_forward(model, {"timestep": torch.tensor([0])}) is True
+    assert _is_validation_forward(model, None) is True
+
+    model.train()
+    assert _is_validation_forward(model, {"timestep": torch.tensor([0])}) is False
+    assert _is_validation_forward(model, None) is False
+
+
+@pytest.mark.parametrize("owns_batch", [True, False])
+def test_tp_validation_timesteps_broadcast_on_every_rank(owns_batch):
+    timestep = SimpleNamespace(is_cuda=True)
+
+    class FakeTensorParallel:
+        def __init__(self):
+            self.calls = []
+
+        def broadcast_data(self, keys, batch, dtype):
+            self.calls.append((keys, batch, dtype))
+            return {"timesteps": timestep}
+
+    tensor_parallel = FakeTensorParallel()
+    batch = {"timesteps": timestep} if owns_batch else None
+    noise, observed_timesteps = _pregenerated_diffusion_inputs(
+        batch,
+        tp_size=2,
+        is_validation=True,
+        compute_dtype=torch.bfloat16,
+        tensor_parallel=tensor_parallel,
+    )
+
+    assert noise is None
+    assert observed_timesteps is timestep
+    assert tensor_parallel.calls == [
+        (["timesteps"], batch, torch.bfloat16),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("sample", "0", "SAMPLE_SIZE"),
+        ("sample", "4097", "SAMPLE_SIZE"),
+        ("path", None, "PATH is required"),
+        ("path", "relative/weights", "PATH must be absolute"),
+        ("step_count", 0, "step_count"),
+        ("step_count", True, "step_count"),
+    ],
+)
+def test_rank_one_rejects_bad_audit_configuration_before_model_traversal(
+    monkeypatch, tmp_path, field, value, message
+):
+    class TraversalForbidden:
+        def named_parameters(self):
+            raise AssertionError("configuration validation must precede model traversal")
+
+    output = tmp_path / "weights"
+    _set_training_state(monkeypatch, iteration=1, train_iters=2)
+    _enable_weight_audit(monkeypatch, output, steps="1", rank=1)
+    step_count = 1
+    if field == "sample":
+        monkeypatch.setenv("PRIMUS_AUDIT_MODEL_WEIGHT_SAMPLE_SIZE", value)
+    elif field == "path":
+        if value is None:
+            monkeypatch.delenv("PRIMUS_AUDIT_MODEL_WEIGHT_PATH")
+        else:
+            monkeypatch.setenv("PRIMUS_AUDIT_MODEL_WEIGHT_PATH", value)
+    else:
+        step_count = value
+
+    with pytest.raises(RuntimeError, match=message):
+        _emit_model_weight_summary(TraversalForbidden(), step_count=step_count)
+    assert not output.exists()
+
+
+def test_rank_zero_reuses_prevalidated_sample_size_and_output_path(monkeypatch, tmp_path):
+    output = tmp_path / "weights"
+    model = nn.Linear(2, 2)
+    _set_training_state(monkeypatch, iteration=1, train_iters=2)
+    _enable_weight_audit(monkeypatch, output, steps="1", sample_size=2)
+    context = _model_weight_audit_context(17, is_training=True)
+
+    monkeypatch.setenv("PRIMUS_AUDIT_MODEL_WEIGHT_SAMPLE_SIZE", "invalid-after-preflight")
+    monkeypatch.setenv("PRIMUS_AUDIT_MODEL_WEIGHT_PATH", "relative/after-preflight")
+    _emit_model_weight_summary(
+        model,
+        step_count=17,
+        audit_context=context,
+    )
+
+    record = json.loads((output / "completed_iteration_0000001.json").read_text())
+    assert record["sample_size_per_parameter"] == 2
+    assert record["forward_step_count"] == 17
+
+
+def test_emit_model_weight_summary_env_unset_does_not_traverse_model(monkeypatch):
+    class TraversalForbidden:
+        def named_parameters(self):
+            raise AssertionError("model traversal must stay behind the opt-in gate")
+
+    monkeypatch.delenv("PRIMUS_AUDIT_MODEL_WEIGHT_STEPS", raising=False)
+
+    def distributed_state_forbidden():
+        raise AssertionError("distributed state must stay behind the opt-in gate")
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", distributed_state_forbidden)
+    _emit_model_weight_summary(TraversalForbidden(), step_count=1)
+
+
+def test_emit_model_weight_summary_skips_synthetic_warmup_before_traversal(monkeypatch, tmp_path):
+    class TraversalForbidden:
+        def named_parameters(self):
+            raise AssertionError("synthetic warmup must not traverse parameters")
+
+    output = tmp_path / "weights"
+    _enable_weight_audit(monkeypatch, output, steps="1")
+    monkeypatch.setenv("PRIMUS_SYNTHETIC_WARMUP_ACTIVE", "1")
+
+    _emit_model_weight_summary(TraversalForbidden(), step_count=1)
+    assert not output.exists()
+
+
+def test_emit_model_weight_summary_skips_validation_before_traversal(monkeypatch, tmp_path):
+    class TraversalForbidden:
+        def named_parameters(self):
+            raise AssertionError("validation must not traverse parameters")
+
+    output = tmp_path / "weights"
+    _enable_weight_audit(monkeypatch, output, steps="1")
+
+    _emit_model_weight_summary(TraversalForbidden(), step_count=1, is_training=False)
+    assert not output.exists()
+
+
+def test_emit_model_weight_summary_does_not_mutate_cpu_rng(monkeypatch, tmp_path):
+    output = tmp_path / "weights"
+    model = nn.Linear(4, 2)
+    _set_training_state(monkeypatch, iteration=1, train_iters=2)
+    _enable_weight_audit(monkeypatch, output, steps="1")
+
+    def cuda_seed_forbidden(*_args, **_kwargs):
+        raise AssertionError("weight auditing must not reseed CUDA RNG")
+
+    monkeypatch.setattr(torch.cuda, "manual_seed", cuda_seed_forbidden)
+    torch.manual_seed(1234)
+    before = torch.random.get_rng_state().clone()
+
+    _emit_model_weight_summary(model, step_count=987)
+
+    assert torch.equal(torch.random.get_rng_state(), before)
+
+
+def test_model_weight_summary_observes_forward_pre_hook_weight(monkeypatch, tmp_path):
+    output = tmp_path / "weights"
+    model = nn.Linear(1, 1, bias=False)
+    with torch.no_grad():
+        model.weight.fill_(1)
+
+    def refresh_parameter(module, _inputs):
+        with torch.no_grad():
+            module.weight.fill_(7)
+
+    model.register_forward_pre_hook(refresh_parameter)
+    _set_training_state(monkeypatch, iteration=5, train_iters=6)
+    _enable_weight_audit(monkeypatch, output, steps="5", sample_size=1)
+    context = _model_weight_audit_context(123, is_training=True)
+
+    model_output = _emit_model_weight_summary_after_forward(
+        model(torch.ones(1, 1)),
+        model,
+        step_count=123,
+        audit_context=context,
+    )
+
+    record = json.loads((output / "completed_iteration_0000005.json").read_text())
+    assert model_output.item() == 7
+    assert record["sample_sum"] == 7
+    assert record["parameters"][0]["sample_sum"] == 7
+
+
+def _publish_and_capture(output, payload):
+    try:
+        _write_model_weight_summary_once(output, payload)
+    except BaseException as error:
+        return error
+    return None
+
+
+def test_atomic_concurrent_identical_publication_is_idempotent(monkeypatch, tmp_path):
+    output = tmp_path / "summary.json"
+    payload = {"version": 1, "value": 7}
+    barrier = threading.Barrier(2)
+    real_link = os.link
+
+    def racing_link(*args, **kwargs):
+        barrier.wait(timeout=5)
+        return real_link(*args, **kwargs)
+
+    monkeypatch.setattr(os, "link", racing_link)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: _publish_and_capture(output, payload), range(2)))
+
+    assert results == [None, None]
+    assert _read_strict_json(output) == payload
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_atomic_concurrent_different_publication_fails_closed(monkeypatch, tmp_path):
+    output = tmp_path / "summary.json"
+    payloads = [{"version": 1, "value": 7}, {"version": 1, "value": 8}]
+    barrier = threading.Barrier(2)
+    real_link = os.link
+
+    def racing_link(*args, **kwargs):
+        barrier.wait(timeout=5)
+        return real_link(*args, **kwargs)
+
+    monkeypatch.setattr(os, "link", racing_link)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda payload: _publish_and_capture(output, payload), payloads))
+
+    assert sum(result is None for result in results) == 1
+    errors = [result for result in results if result is not None]
+    assert len(errors) == 1
+    assert isinstance(errors[0], RuntimeError)
+    assert "different content" in str(errors[0])
+    assert _read_strict_json(output) in payloads
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_restart_canonicalizes_key_order_and_whitespace(tmp_path):
+    output = tmp_path / "summary.json"
+    original = b'{\n  "value": 7,\n  "version": 1\n}\n'
+    output.write_bytes(original)
+
+    _write_model_weight_summary_once(output, {"version": 1, "value": 7})
+
+    assert output.read_bytes() == original
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+@pytest.mark.parametrize(
+    ("existing", "payload"),
+    [
+        ({"version": True, "global_rank": False}, {"version": 1, "global_rank": 0}),
+        ({"version": 1.0, "global_rank": 0}, {"version": 1, "global_rank": 0}),
+    ],
+)
+def test_restart_rejects_json_type_conflicts(tmp_path, existing, payload):
+    output = tmp_path / "summary.json"
+    output.write_bytes(_encode_strict_json(existing))
+
+    with pytest.raises(RuntimeError, match="different content"):
+        _write_model_weight_summary_once(output, payload)
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        {"version": 1, "forward_step_count": False, "num_microbatches": 1},
+        {"version": 1, "forward_step_count": 7},
+    ],
+)
+def test_restart_rejects_malformed_replay_provenance(tmp_path, existing):
+    output = tmp_path / "summary.json"
+    output.write_bytes(_encode_strict_json(existing))
+    payload = {
+        "version": 1,
+        "forward_step_count": 7,
+        "num_microbatches": 1,
+    }
+
+    with pytest.raises(RuntimeError, match="replay provenance|positive integer"):
+        _write_model_weight_summary_once(output, payload)
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+@pytest.mark.parametrize("encoded", [b'{"value":NaN}\n', b'{"value":1e9999}\n'])
+def test_read_strict_json_rejects_nonfinite_payloads(tmp_path, encoded):
+    output = tmp_path / "summary.json"
+    output.write_bytes(encoded)
+
+    with pytest.raises(ValueError):
+        _read_strict_json(output)
+
+
+def test_read_strict_json_closes_descriptor_on_parse_failure(monkeypatch, tmp_path):
+    output = tmp_path / "summary.json"
+    output.write_text("{not-json}\n")
+    real_open = os.open
+    opened_descriptors = []
+
+    def capture_open(*args, **kwargs):
+        descriptor = real_open(*args, **kwargs)
+        opened_descriptors.append(descriptor)
+        return descriptor
+
+    monkeypatch.setattr(os, "open", capture_open)
+    with pytest.raises(json.JSONDecodeError):
+        _read_strict_json(output)
+
+    assert len(opened_descriptors) == 1
+    with pytest.raises(OSError):
+        os.fstat(opened_descriptors[0])
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW is unavailable")
+def test_publication_rejects_symlink_target(tmp_path):
+    target = tmp_path / "target.json"
+    target.write_bytes(_encode_strict_json({"version": 1}))
+    output = tmp_path / "summary.json"
+    output.symlink_to(target)
+
+    with pytest.raises(OSError):
+        _write_model_weight_summary_once(output, {"version": 1})
+    assert output.is_symlink()
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_publication_rejects_nonregular_target(tmp_path):
+    output = tmp_path / "summary.json"
+    output.mkdir()
+
+    with pytest.raises((OSError, RuntimeError), match="regular file|directory"):
+        _write_model_weight_summary_once(output, {"version": 1})
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_file_fsync_failure_closes_descriptor_and_removes_temporary(monkeypatch, tmp_path):
+    output = tmp_path / "summary.json"
+    fsync_descriptors = []
+
+    def fail_file_fsync(descriptor):
+        fsync_descriptors.append(descriptor)
+        raise OSError("injected file fsync failure")
+
+    monkeypatch.setattr(os, "fsync", fail_file_fsync)
+    with pytest.raises(OSError, match="file fsync"):
+        _write_model_weight_summary_once(output, {"version": 1})
+
+    assert len(fsync_descriptors) == 1
+    with pytest.raises(OSError):
+        os.fstat(fsync_descriptors[0])
+    assert not output.exists()
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_directory_fsync_failure_closes_descriptor_and_removes_temporary(monkeypatch, tmp_path):
+    output = tmp_path / "summary.json"
+    real_fsync = os.fsync
+    fsync_descriptors = []
+
+    def fail_directory_fsync(descriptor):
+        fsync_descriptors.append(descriptor)
+        if len(fsync_descriptors) == 2:
+            raise OSError("injected directory fsync failure")
+        return real_fsync(descriptor)
+
+    monkeypatch.setattr(os, "fsync", fail_directory_fsync)
+    with pytest.raises(OSError, match="directory fsync"):
+        _write_model_weight_summary_once(output, {"version": 1})
+
+    assert len(fsync_descriptors) == 2
+    with pytest.raises(OSError):
+        os.fstat(fsync_descriptors[1])
+    assert output.exists()
+    assert not list(tmp_path.glob("*.tmp"))

--- a/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
@@ -137,8 +137,7 @@ def test_precision_linear_class_census_emits_zero_counts_for_bf16(monkeypatch, c
     marker_lines = [
         record.message
         for record in caplog.records
-        if record.name == _FLUX_TRAINER_LOGGER
-        and record.message.startswith("PRIMUS_LINEAR_CLASS_CENSUS=")
+        if record.name == _FLUX_TRAINER_LOGGER and record.message.startswith("PRIMUS_LINEAR_CLASS_CENSUS=")
     ]
     assert len(marker_lines) == 1
     payload = json.loads(marker_lines[0].split("=", 1)[1])


### PR DESCRIPTION
## Summary

Tracks [Issue \#220](https://github.com/AMD-AGI/tiger-training-internal/issues/220), Task 9 Option 9.

Add an opt-in Flux audit that records deterministic rank-zero parameter samples after selected completed training iterations. This lets early MXFP4, FP8, and BF16 forks compare model drift without extra full optimizer checkpoints or changes to Torch RNG state.

- Sample after the model forward so overlapped distributed-optimizer gathers have refreshed every parameter buffer.
- Record per-parameter shape, dtype, finite counts, sampled moments, and SHA256.
- Publish one strict JSON file per completed iteration using atomic, no-overwrite semantics; identical restarts are idempotent and conflicting output fails closed.
- Skip validation and synthetic warmup, and explicitly record completed-iteration, next-iteration, forward-counter, and microbatch coordinates.

## Test plan

- [x] Changed modules compile with `py_compile`
- [x] `git diff --check`
- [ ] CI formatting and dependency checks
- [ ] Targeted audit-marker tests in the pinned v26.5 container
- [ ] Real Megatron wrapper smoke verifies post-gather step-5,120 and step-8,192 snapshots