### PR TITLE
feat(megatron): select MXFP4 forward precision

### DIFF
--- a/docs/04-technical-guides/diffusion-models/mxfp4_training.md
+++ b/docs/04-technical-guides/diffusion-models/mxfp4_training.md
@@ -8,7 +8,10 @@ MXFP4 stores activations and weights in 4-bit microscale floating-point with one
 
 - Uses a **local spec** (`PrimusTurboMXFP4LocalSpecProvider`) with **no Transformer Engine dependency**—MXFP4 linear layers are self-contained autograd `Function`s that call Primus-Turbo's `gemm_fp4_impl` directly, so the path is `torch.compile`-friendly with minimal graph breaks.
 - Keeps **attention, optimizer state / main params, and inter-rank communication in BF16**. Only the MMA inputs of the column- and row-parallel linears are quantized.
-- Supports two backward modes via `mxfp4_backward_precision`: pure **MXFP4** (default) or **FP8** hybrid (E5M2 backward with tensorwise scaling on HipBLASLt).
+- Selects forward and backward precision independently. Forward supports
+  **MXFP4** (default), tensorwise **FP8 E4M3**, or **BF16** through
+  `mxfp4_forward_precision`; backward supports MXFP4 or tensorwise FP8 E5M2
+  through `mxfp4_backward_precision`.
 - Dispatches the FP4 GEMM through Primus-Turbo's pluggable backend layer, which can route to either AITER (recommended for MI355X) or HipBLASLt.
 
 ## Table of contents
@@ -67,6 +70,7 @@ The relevant overrides in [`examples/megatron/configs/MI355X/diffusion/flux_12b_
 # MXFP4 precision
 fp4: "mxfp4"
 fp4_recipe: "mxfp4"              # default is "nvfp4" in trainer_base.yaml; must override
+mxfp4_forward_precision: "mxfp4"  # "mxfp4", "fp8", or "bf16"
 mxfp4_backward_precision: "mxfp4"  # "mxfp4" (pure) or "fp8" (hybrid)
 
 # Local spec + Primus-Turbo
@@ -86,6 +90,7 @@ gradient_accumulation_fusion: false
 |------|--------|-------|
 | `fp4` | `"mxfp4"` | Top-level switch to enable FP4. |
 | `fp4_recipe` | `"mxfp4"` for this guide | Default in [`primus/configs/modules/megatron/trainer_base.yaml`](../../../primus/configs/modules/megatron/trainer_base.yaml) is `nvfp4`; the MXFP4 config overrides it. |
+| `mxfp4_forward_precision` | `"mxfp4"`, `"fp8"`, or `"bf16"` | Selects only the forward linear GEMMs. FP8 uses dynamic tensorwise E4M3 on HipBLASLt; BF16 uses the native linear operation. MXFP4 tensors are still prepared for backward when `mxfp4_backward_precision: "mxfp4"`. |
 | `mxfp4_backward_precision` | `"mxfp4"` or `"fp8"` | Exhaustive set (checked by branch in [`primus_turbo_mxfp4_local.py`](../../../primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py)). `"fp8"` uses E5M2 with tensorwise HipBLASLt for backward. |
 | `mxfp4_gradient_stochastic_rounding` | `true` / `false` | Optional. Enables SR on FP4 gradient quantization. |
 
@@ -198,7 +203,7 @@ Formal A/B benchmarks vs BF16 and FP8 (delayed and tensorwise) are pending and w
 - MXFP4 spec provider: [`primus/backends/megatron/core/extensions/primus_turbo_local_spec.py`](../../../primus/backends/megatron/core/extensions/primus_turbo_local_spec.py) (`PrimusTurboMXFP4LocalSpecProvider`).
 - MXFP4 linear-layer autograd / fwd-bwd: [`primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py`](../../../primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py).
 - Config schema defaults: [`primus/configs/modules/megatron/trainer_base.yaml`](../../../primus/configs/modules/megatron/trainer_base.yaml).
-- Dataclass field `mxfp4_backward_precision`: [`primus/backends/megatron/core/models/diffusion/common/config.py`](../../../primus/backends/megatron/core/models/diffusion/common/config.py).
+- Dataclass fields `mxfp4_forward_precision` and `mxfp4_backward_precision`: [`primus/backends/megatron/core/models/diffusion/common/config.py`](../../../primus/backends/megatron/core/models/diffusion/common/config.py).
 - FP4 backend selection (Primus-Turbo): `primus_turbo/common/constants.py`, `primus_turbo/pytorch/core/backend.py`, `primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py`.
 - AITER tuned-config loader: `aiter/jit/core.py` (`AITER_CONFIG_GEMM_A4W4`).
 - AITER A4W4 dispatch + hit/miss logging: `aiter/ops/gemm_op_a4w4.py`.

--- a/examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml
+++ b/examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp4.yaml
@@ -141,6 +141,7 @@ modules:
 
       fp4: "mxfp4"
       fp4_recipe: "mxfp4"
+      mxfp4_forward_precision: "mxfp4"  # "mxfp4", "fp8", or "bf16"
       mxfp4_backward_precision: "mxfp4"  # "mxfp4" (pure) or "fp8" (hybrid)
 
       empty_unused_memory_level: 0

--- a/primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py
@@ -12,7 +12,8 @@ and call check_mxfp4_support() global state.
 Key properties:
 - Uses setup_context pattern with primitive-only args so torch.compile
   can trace through without graph breaks.
-- Two backward modes: pure MXFP4 or hybrid (FP4 fwd / FP8 bwd).
+- Independently selects MXFP4, FP8, or BF16 forward precision and
+  MXFP4 or FP8 backward precision.
 - gemm_fp4_impl and gemm_fp8_impl are torch.library.custom_op with register_fake.
 - Zero TransformerEngine dependencies.
 - Requires tensor_model_parallel_size=1, no GAF, no sequence_parallel.
@@ -229,6 +230,14 @@ _quantize_mxfp4_dual_op.register_autograd(
 _FP4_DTYPE = torch.float4_e2m1fn_x2
 _GRAN_VALUE = ScalingGranularity.MX_BLOCKWISE.value
 _DEFAULT_BACKEND = BackendType.HIPBLASLT.value
+_FORWARD_PRECISION_MXFP4 = 0
+_FORWARD_PRECISION_FP8 = 1
+_FORWARD_PRECISION_BF16 = 2
+_FORWARD_PRECISION_VALUES = {
+    "mxfp4": _FORWARD_PRECISION_MXFP4,
+    "fp8": _FORWARD_PRECISION_FP8,
+    "bf16": _FORWARD_PRECISION_BF16,
+}
 
 
 def _quantize_input_dual(input_2d, preshuffle):
@@ -291,9 +300,13 @@ def _quantize_grad_dual(grad_2d, preshuffle, use_sr=True):
 class MXFP4LinearFunction(torch.autograd.Function):
     """MXFP4 linear (Y = X @ W^T) with MX block-of-32 scaling.
 
-    Two modes via backward_is_fp8 bool primitive:
-    - Pure MXFP4: forward + backward both use FP4 quantization + gemm_fp4_impl
-    - Hybrid: forward uses FP4, backward re-quantizes saved BF16 to FP8 tensorwise
+    Forward and backward precision are independent:
+    - Forward: MXFP4, dynamic tensorwise FP8 E4M3, or BF16.
+    - Backward: MXFP4 or dynamic tensorwise FP8 E5M2.
+
+    MXFP4 backward always uses the transposed MXFP4 tensors prepared during
+    forward. This keeps its memory and compute path identical when only the
+    forward GEMM moves to higher precision.
 
     Uses setup_context pattern with primitive-only args for torch.compile.
     """
@@ -308,6 +321,10 @@ class MXFP4LinearFunction(torch.autograd.Function):
         fp8_gran_value,
         fp8_backend_value,
         use_gradient_sr,
+        forward_precision_value=_FORWARD_PRECISION_MXFP4,
+        fp8_fwd_dtype=None,
+        fp8_fwd_gran_value=0,
+        fp8_fwd_backend_value=0,
     ):
         out_dtype = input.dtype
         orig_shape = input.shape
@@ -316,19 +333,39 @@ class MXFP4LinearFunction(torch.autograd.Function):
         a_fp4, a_scale, a_t_fp4, a_t_scale = _quantize_input_dual(input_2d, preshuffle)
         b_fp4, b_scale, b_t_fp4, b_t_scale = _quantize_weight_dual(weight, preshuffle)
 
-        output = gemm_fp4_impl(
-            a_fp4,
-            a_scale,
-            False,
-            b_fp4,
-            b_scale,
-            True,
-            out_dtype,
-            False,
-            granularity=_GRAN_VALUE,
-            default_backend=_DEFAULT_BACKEND,
-            preshuffled=preshuffle,
-        )
+        if forward_precision_value == _FORWARD_PRECISION_MXFP4:
+            output = gemm_fp4_impl(
+                a_fp4,
+                a_scale,
+                False,
+                b_fp4,
+                b_scale,
+                True,
+                out_dtype,
+                False,
+                granularity=_GRAN_VALUE,
+                default_backend=_DEFAULT_BACKEND,
+                preshuffled=preshuffle,
+            )
+        elif forward_precision_value == _FORWARD_PRECISION_FP8:
+            a_fp8, a_scale_inv = _quantize_fp8_tw(input_2d, fp8_fwd_dtype)
+            b_fp8, b_scale_inv = _quantize_fp8_tw(weight, fp8_fwd_dtype)
+            output = gemm_fp8_impl(
+                a_fp8,
+                a_scale_inv,
+                False,
+                b_fp8,
+                b_scale_inv,
+                True,
+                out_dtype,
+                False,
+                granularity=fp8_fwd_gran_value,
+                default_backend=fp8_fwd_backend_value,
+            )
+        elif forward_precision_value == _FORWARD_PRECISION_BF16:
+            output = torch.nn.functional.linear(input_2d, weight)
+        else:
+            raise ValueError(f"Unsupported MXFP4 forward precision value: {forward_precision_value}")
         output = output.reshape(*orig_shape[:-1], output.shape[-1])
 
         if backward_is_fp8:
@@ -348,6 +385,7 @@ class MXFP4LinearFunction(torch.autograd.Function):
 
     @staticmethod
     def setup_context(ctx, inputs, output):
+        ctx.num_inputs = len(inputs)
         (
             _,
             _,
@@ -357,7 +395,7 @@ class MXFP4LinearFunction(torch.autograd.Function):
             fp8_gran_value,
             fp8_backend_value,
             use_gradient_sr,
-        ) = inputs
+        ) = inputs[:8]
 
         ctx.preshuffle = preshuffle
         ctx.backward_is_fp8 = backward_is_fp8
@@ -458,7 +496,7 @@ class MXFP4LinearFunction(torch.autograd.Function):
                 preshuffled=preshuffle,
             )
 
-        return grad_input, grad_weight, None, None, None, None, None, None
+        return (grad_input, grad_weight) + (None,) * (ctx.num_inputs - 2)
 
 
 # ---------------------------------------------------------------------------
@@ -492,8 +530,26 @@ class MXFP4ColumnParallelLinear(ColumnParallelLinear):
 
         self._preshuffle = _enable_preshuffle()
         _assert_preshuffle_contract(self.config, self._preshuffle)
+        self._forward_precision = getattr(self.config, "mxfp4_forward_precision", "mxfp4")
+        if self._forward_precision not in _FORWARD_PRECISION_VALUES:
+            raise ValueError(
+                "mxfp4_forward_precision must be one of "
+                f"{tuple(_FORWARD_PRECISION_VALUES)}, got {self._forward_precision!r}"
+            )
+        self._forward_precision_value = _FORWARD_PRECISION_VALUES[self._forward_precision]
         self._backward_is_fp8 = getattr(self.config, "mxfp4_backward_precision", "mxfp4") == "fp8"
         self._use_gradient_sr = getattr(self.config, "mxfp4_gradient_stochastic_rounding", False)
+
+        if self._forward_precision == "fp8":
+            from primus_turbo.pytorch.core.low_precision import float8_e4m3
+
+            self._fp8_fwd_dtype = float8_e4m3
+            self._fp8_fwd_gran_value = ScalingGranularity.TENSORWISE.value
+            self._fp8_fwd_backend_value = BackendType.HIPBLASLT.value
+        else:
+            self._fp8_fwd_dtype = None
+            self._fp8_fwd_gran_value = 0
+            self._fp8_fwd_backend_value = 0
 
         if self._backward_is_fp8:
             from primus_turbo.pytorch.core.low_precision import float8_e5m2
@@ -518,6 +574,10 @@ class MXFP4ColumnParallelLinear(ColumnParallelLinear):
             self._fp8_gran_value,
             self._fp8_backend_value,
             self._use_gradient_sr,
+            self._forward_precision_value,
+            self._fp8_fwd_dtype,
+            self._fp8_fwd_gran_value,
+            self._fp8_fwd_backend_value,
         )
         output = result[0]
 
@@ -552,8 +612,26 @@ class MXFP4RowParallelLinear(RowParallelLinear):
 
         self._preshuffle = _enable_preshuffle()
         _assert_preshuffle_contract(self.config, self._preshuffle)
+        self._forward_precision = getattr(self.config, "mxfp4_forward_precision", "mxfp4")
+        if self._forward_precision not in _FORWARD_PRECISION_VALUES:
+            raise ValueError(
+                "mxfp4_forward_precision must be one of "
+                f"{tuple(_FORWARD_PRECISION_VALUES)}, got {self._forward_precision!r}"
+            )
+        self._forward_precision_value = _FORWARD_PRECISION_VALUES[self._forward_precision]
         self._backward_is_fp8 = getattr(self.config, "mxfp4_backward_precision", "mxfp4") == "fp8"
         self._use_gradient_sr = getattr(self.config, "mxfp4_gradient_stochastic_rounding", False)
+
+        if self._forward_precision == "fp8":
+            from primus_turbo.pytorch.core.low_precision import float8_e4m3
+
+            self._fp8_fwd_dtype = float8_e4m3
+            self._fp8_fwd_gran_value = ScalingGranularity.TENSORWISE.value
+            self._fp8_fwd_backend_value = BackendType.HIPBLASLT.value
+        else:
+            self._fp8_fwd_dtype = None
+            self._fp8_fwd_gran_value = 0
+            self._fp8_fwd_backend_value = 0
 
         if self._backward_is_fp8:
             from primus_turbo.pytorch.core.low_precision import float8_e5m2
@@ -578,6 +656,10 @@ class MXFP4RowParallelLinear(RowParallelLinear):
             self._fp8_gran_value,
             self._fp8_backend_value,
             self._use_gradient_sr,
+            self._forward_precision_value,
+            self._fp8_fwd_dtype,
+            self._fp8_fwd_gran_value,
+            self._fp8_fwd_backend_value,
         )
         output = result[0]
 

--- a/primus/backends/megatron/core/models/diffusion/common/config.py
+++ b/primus/backends/megatron/core/models/diffusion/common/config.py
@@ -183,8 +183,7 @@ class BaseDiffusionConfig(TransformerConfig):
 
         if self.mxfp4_backward_precision not in {"mxfp4", "fp8"}:
             raise ValueError(
-                "mxfp4_backward_precision must be 'mxfp4' or 'fp8', "
-                f"got {self.mxfp4_backward_precision!r}"
+                "mxfp4_backward_precision must be 'mxfp4' or 'fp8', " f"got {self.mxfp4_backward_precision!r}"
             )
 
         if self.in_channels <= 0:

--- a/primus/backends/megatron/core/models/diffusion/common/config.py
+++ b/primus/backends/megatron/core/models/diffusion/common/config.py
@@ -32,6 +32,8 @@ class BaseDiffusionConfig(TransformerConfig):
         fp8_scaling_strategy: FP8 scaling strategy for local spec provider (default: 'dynamic')
         fp8_force_nt_layout: FP8 backward GEMM layout (default: False)
         fp8_reduce_amax: Whether to allreduce amax across ranks (default: False)
+        mxfp4_forward_precision: MXFP4 forward precision, 'mxfp4', 'fp8', or 'bf16'
+            (default: 'mxfp4')
         mxfp4_backward_precision: MXFP4 backward precision, 'mxfp4' or 'fp8' (default: 'mxfp4')
         mxfp4_gradient_stochastic_rounding: Stochastic rounding on gradients (default: False)
         sensitive_layers_enabled: Enable sensitive layer configuration (default: False)
@@ -70,6 +72,11 @@ class BaseDiffusionConfig(TransformerConfig):
 
     # Whether to allreduce amax across DP/TP ranks for delayed FP8 scaling
     fp8_reduce_amax: bool = False
+
+    # MXFP4 forward precision: "mxfp4" (pure), "fp8", or "bf16".
+    # The latter two retain MXFP4 backward unless the backward knob below is
+    # independently changed.
+    mxfp4_forward_precision: str = "mxfp4"
 
     # MXFP4 backward precision: "mxfp4" (pure) or "fp8" (hybrid)
     mxfp4_backward_precision: str = "mxfp4"
@@ -168,6 +175,18 @@ class BaseDiffusionConfig(TransformerConfig):
         Raises:
             ValueError: If configuration is invalid
         """
+        if self.mxfp4_forward_precision not in {"mxfp4", "fp8", "bf16"}:
+            raise ValueError(
+                "mxfp4_forward_precision must be 'mxfp4', 'fp8', or 'bf16', "
+                f"got {self.mxfp4_forward_precision!r}"
+            )
+
+        if self.mxfp4_backward_precision not in {"mxfp4", "fp8"}:
+            raise ValueError(
+                "mxfp4_backward_precision must be 'mxfp4' or 'fp8', "
+                f"got {self.mxfp4_backward_precision!r}"
+            )
+
         if self.in_channels <= 0:
             raise ValueError(f"in_channels must be positive, got {self.in_channels}")
 

--- a/primus/backends/megatron/flux_pretrain_trainer.py
+++ b/primus/backends/megatron/flux_pretrain_trainer.py
@@ -46,6 +46,21 @@ def _precision_linear_class_census(model) -> dict[str, int]:
     return {name: observed.get(name, 0) for name in PRECISION_LINEAR_CLASSES}
 
 
+def _mxfp4_gemm_mode_census(model) -> dict[str, int]:
+    """Count the effective forward/backward modes of instantiated MXFP4 linears."""
+    observed = Counter()
+    for module in model.modules():
+        if type(module).__name__ not in {
+            "MXFP4ColumnParallelLinear",
+            "MXFP4RowParallelLinear",
+        }:
+            continue
+        forward_precision = getattr(module, "_forward_precision", "mxfp4")
+        backward_precision = "fp8" if getattr(module, "_backward_is_fp8", False) else "mxfp4"
+        observed[f"{forward_precision}_forward_{backward_precision}_backward"] += 1
+    return dict(sorted(observed.items()))
+
+
 def _emit_precision_linear_class_census(model) -> None:
     """Emit the actually instantiated precision-linear classes on every rank."""
     if os.getenv("PRIMUS_AUDIT_LINEAR_CLASS_CENSUS") != "1":
@@ -66,6 +81,19 @@ def _emit_precision_linear_class_census(model) -> None:
     # this launch path, so a bare print leaves the audit reporting zero markers
     # on a healthy run. Logging and fd 2 both survive.
     logger.info("PRIMUS_LINEAR_CLASS_CENSUS=%s", json.dumps(payload, sort_keys=True))
+    modes = _mxfp4_gemm_mode_census(model)
+    if modes:
+        logger.info(
+            "PRIMUS_MXFP4_GEMM_MODE_CENSUS=%s",
+            json.dumps(
+                {
+                    "global_rank": global_rank,
+                    "data_parallel_rank": parallel_state.get_data_parallel_rank(),
+                    "modes": modes,
+                },
+                sort_keys=True,
+            ),
+        )
 
 
 def _restore_chimera_rng_state(args) -> None:
@@ -544,6 +572,7 @@ class FluxPretrainTrainer(DiffusionPretrainTrainer):
             {
                 "fp4": fp4_enabled,
                 "fp4_recipe": fp4_recipe,
+                "mxfp4_forward_precision": getattr(params, "mxfp4_forward_precision", "mxfp4"),
                 "mxfp4_backward_precision": getattr(params, "mxfp4_backward_precision", "mxfp4"),
             }
         )
@@ -741,6 +770,7 @@ class FluxPretrainTrainer(DiffusionPretrainTrainer):
                 "fp8_force_nt_layout",
                 "fp4",
                 "fp4_recipe",
+                "mxfp4_forward_precision",
                 "mxfp4_backward_precision",
                 "mxfp4_gradient_stochastic_rounding",
                 "sensitive_layers_enabled",

--- a/tests/integration_tests/backends/megatron/diffusion/distributed/test_flux_mxfp4_local_spec.py
+++ b/tests/integration_tests/backends/megatron/diffusion/distributed/test_flux_mxfp4_local_spec.py
@@ -202,27 +202,28 @@ class TestFluxMXFP4LocalSpec(PrimusUT):
 
         assert has_mxfp4_grad, "No MXFP4 linear has a weight gradient in hybrid mode"
 
-    @pytest.mark.parametrize("forward_precision", ["fp8", "bf16"])
     @requires_mxfp4
-    def test_flux_535m_high_precision_forward_mxfp4_backward(self, forward_precision):
+    def test_flux_535m_high_precision_forward_mxfp4_backward(self):
         """Higher-precision forward retains MXFP4 modules and finite gradients."""
-        config = self._make_mxfp4_config(mxfp4_forward_precision=forward_precision)
-        model = Flux(config).cuda().to(torch.bfloat16)
-        model.train()
+        for forward_precision in ("fp8", "bf16"):
+            with self.subTest(forward_precision=forward_precision):
+                config = self._make_mxfp4_config(mxfp4_forward_precision=forward_precision)
+                model = Flux(config).cuda().to(torch.bfloat16)
+                model.train()
 
-        precision_modules = [
-            module
-            for module in model.modules()
-            if isinstance(module, (MXFP4ColumnParallelLinear, MXFP4RowParallelLinear))
-        ]
-        assert precision_modules
-        assert all(module._forward_precision == forward_precision for module in precision_modules)
-        assert all(not module._backward_is_fp8 for module in precision_modules)
+                precision_modules = [
+                    module
+                    for module in model.modules()
+                    if isinstance(module, (MXFP4ColumnParallelLinear, MXFP4RowParallelLinear))
+                ]
+                assert precision_modules
+                assert all(module._forward_precision == forward_precision for module in precision_modules)
+                assert all(not module._backward_is_fp8 for module in precision_modules)
 
-        output = model(*self._make_inputs(batch_size=2))
-        assert torch.isfinite(output).all()
-        output.sum().backward()
-        assert any(
-            module.weight.grad is not None and torch.isfinite(module.weight.grad).all()
-            for module in precision_modules
-        )
+                output = model(*self._make_inputs(batch_size=2))
+                assert torch.isfinite(output).all()
+                output.sum().backward()
+                assert any(
+                    module.weight.grad is not None and torch.isfinite(module.weight.grad).all()
+                    for module in precision_modules
+                )

--- a/tests/integration_tests/backends/megatron/diffusion/distributed/test_flux_mxfp4_local_spec.py
+++ b/tests/integration_tests/backends/megatron/diffusion/distributed/test_flux_mxfp4_local_spec.py
@@ -201,3 +201,28 @@ class TestFluxMXFP4LocalSpec(PrimusUT):
                     break
 
         assert has_mxfp4_grad, "No MXFP4 linear has a weight gradient in hybrid mode"
+
+    @pytest.mark.parametrize("forward_precision", ["fp8", "bf16"])
+    @requires_mxfp4
+    def test_flux_535m_high_precision_forward_mxfp4_backward(self, forward_precision):
+        """Higher-precision forward retains MXFP4 modules and finite gradients."""
+        config = self._make_mxfp4_config(mxfp4_forward_precision=forward_precision)
+        model = Flux(config).cuda().to(torch.bfloat16)
+        model.train()
+
+        precision_modules = [
+            module
+            for module in model.modules()
+            if isinstance(module, (MXFP4ColumnParallelLinear, MXFP4RowParallelLinear))
+        ]
+        assert precision_modules
+        assert all(module._forward_precision == forward_precision for module in precision_modules)
+        assert all(not module._backward_is_fp8 for module in precision_modules)
+
+        output = model(*self._make_inputs(batch_size=2))
+        assert torch.isfinite(output).all()
+        output.sum().backward()
+        assert any(
+            module.weight.grad is not None and torch.isfinite(module.weight.grad).all()
+            for module in precision_modules
+        )

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
@@ -32,14 +32,13 @@ class TestBaseDiffusionConfig(PrimusUT):
             config.validate()
         self.assertIn("in_channels must be positive", str(cm.exception))
 
-    @pytest.mark.parametrize("forward_precision", ["mxfp4", "fp8", "bf16"])
-    def test_mxfp4_forward_precision_values(self, forward_precision):
-        config = BaseDiffusionConfig(
-            num_attention_heads=8,
-            num_layers=1,
-            mxfp4_forward_precision=forward_precision,
-        )
-        self.assertEqual(config.mxfp4_forward_precision, forward_precision)
+    def test_mxfp4_forward_precision_values(self):
+        for forward_precision in ("mxfp4", "fp8", "bf16"):
+            with self.subTest(forward_precision=forward_precision):
+                config = FluxConfig.flux_535m(
+                    mxfp4_forward_precision=forward_precision,
+                )
+                self.assertEqual(config.mxfp4_forward_precision, forward_precision)
 
     def test_invalid_mxfp4_forward_precision_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "mxfp4_forward_precision"):

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
@@ -32,6 +32,31 @@ class TestBaseDiffusionConfig(PrimusUT):
             config.validate()
         self.assertIn("in_channels must be positive", str(cm.exception))
 
+    @pytest.mark.parametrize("forward_precision", ["mxfp4", "fp8", "bf16"])
+    def test_mxfp4_forward_precision_values(self, forward_precision):
+        config = BaseDiffusionConfig(
+            num_attention_heads=8,
+            num_layers=1,
+            mxfp4_forward_precision=forward_precision,
+        )
+        self.assertEqual(config.mxfp4_forward_precision, forward_precision)
+
+    def test_invalid_mxfp4_forward_precision_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "mxfp4_forward_precision"):
+            BaseDiffusionConfig(
+                num_attention_heads=8,
+                num_layers=1,
+                mxfp4_forward_precision="fp16",
+            )
+
+    def test_invalid_mxfp4_backward_precision_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "mxfp4_backward_precision"):
+            BaseDiffusionConfig(
+                num_attention_heads=8,
+                num_layers=1,
+                mxfp4_backward_precision="bf16",
+            )
+
 
 class TestFluxConfig(PrimusUT):
     """Tests for FluxConfig class."""

--- a/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
@@ -19,6 +19,7 @@ from primus.backends.megatron.training.diffusion.forward_step import (
 )
 
 _FORWARD_STEP_LOGGER = "primus.backends.megatron.training.diffusion.forward_step"
+_FLUX_TRAINER_LOGGER = "primus.backends.megatron.flux_pretrain_trainer"
 
 
 def test_sample_key_fingerprint_is_order_sensitive():
@@ -66,16 +67,21 @@ def test_mxfp4_gemm_mode_census_reports_forward_backward_split():
     }
 
 
-def test_precision_linear_class_census_emits_zero_counts_for_bf16(monkeypatch, capsys):
+def test_precision_linear_class_census_emits_zero_counts_for_bf16(monkeypatch, caplog):
     from megatron.core import parallel_state
 
     monkeypatch.setenv("PRIMUS_AUDIT_LINEAR_CLASS_CENSUS", "1")
     monkeypatch.setenv("RANK", "3")
     monkeypatch.setattr(parallel_state, "get_data_parallel_rank", lambda: 3)
+    caplog.set_level("INFO", logger=_FLUX_TRAINER_LOGGER)
 
     _emit_precision_linear_class_census(nn.Linear(2, 2))
 
-    line = capsys.readouterr().out.strip()
+    line = next(
+        record.message
+        for record in caplog.records
+        if record.message.startswith("PRIMUS_LINEAR_CLASS_CENSUS=")
+    )
     payload = json.loads(line.split("=", 1)[1])
     assert payload == {
         "data_parallel_rank": 3,

--- a/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
@@ -10,6 +10,7 @@ from primus.backends.megatron.data.diffusion.task_encoders.image import (
 from primus.backends.megatron.flux_pretrain_trainer import (
     FluxPretrainTrainer,
     _emit_precision_linear_class_census,
+    _mxfp4_gemm_mode_census,
     _precision_linear_class_census,
 )
 from primus.backends.megatron.patches.mlperf_warmup_patches import _is_resumed_training
@@ -47,6 +48,21 @@ def test_precision_linear_class_census_reports_exact_classes():
         "MXFP4RowParallelLinear": 1,
         "Float8ColumnParallelLinear": 1,
         "Float8RowParallelLinear": 0,
+    }
+
+
+def test_mxfp4_gemm_mode_census_reports_forward_backward_split():
+    mxfp4_column = type("MXFP4ColumnParallelLinear", (nn.Module,), {})()
+    mxfp4_column._forward_precision = "fp8"
+    mxfp4_column._backward_is_fp8 = False
+    mxfp4_row = type("MXFP4RowParallelLinear", (nn.Module,), {})()
+    mxfp4_row._forward_precision = "bf16"
+    mxfp4_row._backward_is_fp8 = False
+    model = nn.ModuleList([mxfp4_column, mxfp4_row, nn.Linear(2, 2)])
+
+    assert _mxfp4_gemm_mode_census(model) == {
+        "bf16_forward_mxfp4_backward": 1,
+        "fp8_forward_mxfp4_backward": 1,
     }
 
 

--- a/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
+++ b/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
@@ -6,7 +6,7 @@ Unit tests for compile-friendly MXFP4 linear layers (primus_turbo_mxfp4_local).
 
 Tests cross-validation against Primus-Turbo's FP4GemmMXFunction reference,
 torch.compile graph-break validation, Megatron linear backward flow,
-2-step training loop, hybrid (FP4 fwd / FP8 bwd) mode, and init guards.
+2-step training loop, independent forward/backward precision, and init guards.
 """
 
 import functools
@@ -188,6 +188,54 @@ class TestMXFP4CrossValidation(PrimusUT):
             f"(max abs diff vs Primus-Turbo PR #383 reference: {(x.grad - x_ref.grad).abs().max().item():.6e})"
         )
 
+    @pytest.mark.parametrize("forward_precision", ["fp8", "bf16"])
+    @requires_mxfp4
+    def test_high_precision_forward_with_mxfp4_backward(self, forward_precision):
+        from primus_turbo.pytorch.core.backend import BackendType
+        from primus_turbo.pytorch.core.low_precision import (
+            ScalingGranularity,
+            float8_e4m3,
+        )
+
+        from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
+            MXFP4LinearFunction,
+            _FORWARD_PRECISION_VALUES,
+            _enable_preshuffle,
+        )
+
+        torch.manual_seed(42)
+        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+        preshuffle = _enable_preshuffle()
+
+        output = MXFP4LinearFunction.apply(
+            x,
+            w,
+            preshuffle,
+            False,
+            None,
+            0,
+            0,
+            False,
+            _FORWARD_PRECISION_VALUES[forward_precision],
+            float8_e4m3 if forward_precision == "fp8" else None,
+            ScalingGranularity.TENSORWISE.value if forward_precision == "fp8" else 0,
+            BackendType.HIPBLASLT.value if forward_precision == "fp8" else 0,
+        )[0]
+        output.square().mean().backward()
+
+        reference = torch.nn.functional.linear(x.detach(), w.detach())
+        signal = (reference.float() ** 2).mean()
+        noise = ((output.float() - reference.float()) ** 2).mean()
+        if forward_precision == "bf16":
+            assert torch.equal(output, reference)
+        else:
+            snr_db = 10 * torch.log10(signal / noise).item()
+            assert snr_db > 10, f"FP8 forward SNR {snr_db:.1f} dB is below 10 dB"
+
+        assert torch.isfinite(x.grad).all()
+        assert torch.isfinite(w.grad).all()
+
 
 # ---------------------------------------------------------------------------
 # torch.compile graph-break validation
@@ -253,6 +301,45 @@ class TestMXFP4Compile(PrimusUT):
             ScalingGranularity.TENSORWISE.value,
             BackendType.HIPBLASLT.value,
             False,
+        )
+
+        assert explanation.graph_break_count == 0, (
+            f"Expected 0 graph breaks, got {explanation.graph_break_count}. "
+            f"Reasons: {explanation.break_reasons}"
+        )
+
+    @pytest.mark.parametrize("forward_precision", ["fp8", "bf16"])
+    @requires_mxfp4
+    def test_no_graph_break_high_precision_forward(self, forward_precision):
+        from primus_turbo.pytorch.core.backend import BackendType
+        from primus_turbo.pytorch.core.low_precision import (
+            ScalingGranularity,
+            float8_e4m3,
+        )
+
+        from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
+            MXFP4LinearFunction,
+            _FORWARD_PRECISION_VALUES,
+            _enable_preshuffle,
+        )
+
+        torch._dynamo.reset()
+        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+        w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda")
+
+        explanation = torch._dynamo.explain(MXFP4LinearFunction.apply)(
+            x,
+            w,
+            _enable_preshuffle(),
+            False,
+            None,
+            0,
+            0,
+            False,
+            _FORWARD_PRECISION_VALUES[forward_precision],
+            float8_e4m3 if forward_precision == "fp8" else None,
+            ScalingGranularity.TENSORWISE.value if forward_precision == "fp8" else 0,
+            BackendType.HIPBLASLT.value if forward_precision == "fp8" else 0,
         )
 
         assert explanation.graph_break_count == 0, (

--- a/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
+++ b/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
@@ -188,9 +188,8 @@ class TestMXFP4CrossValidation(PrimusUT):
             f"(max abs diff vs Primus-Turbo PR #383 reference: {(x.grad - x_ref.grad).abs().max().item():.6e})"
         )
 
-    @pytest.mark.parametrize("forward_precision", ["fp8", "bf16"])
     @requires_mxfp4
-    def test_high_precision_forward_with_mxfp4_backward(self, forward_precision):
+    def test_high_precision_forward_with_mxfp4_backward(self):
         from primus_turbo.pytorch.core.backend import BackendType
         from primus_turbo.pytorch.core.low_precision import (
             ScalingGranularity,
@@ -198,43 +197,45 @@ class TestMXFP4CrossValidation(PrimusUT):
         )
 
         from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
-            MXFP4LinearFunction,
             _FORWARD_PRECISION_VALUES,
+            MXFP4LinearFunction,
             _enable_preshuffle,
         )
 
-        torch.manual_seed(42)
-        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-        w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-        preshuffle = _enable_preshuffle()
+        for forward_precision in ("fp8", "bf16"):
+            with self.subTest(forward_precision=forward_precision):
+                torch.manual_seed(42)
+                x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+                w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+                preshuffle = _enable_preshuffle()
 
-        output = MXFP4LinearFunction.apply(
-            x,
-            w,
-            preshuffle,
-            False,
-            None,
-            0,
-            0,
-            False,
-            _FORWARD_PRECISION_VALUES[forward_precision],
-            float8_e4m3 if forward_precision == "fp8" else None,
-            ScalingGranularity.TENSORWISE.value if forward_precision == "fp8" else 0,
-            BackendType.HIPBLASLT.value if forward_precision == "fp8" else 0,
-        )[0]
-        output.square().mean().backward()
+                output = MXFP4LinearFunction.apply(
+                    x,
+                    w,
+                    preshuffle,
+                    False,
+                    None,
+                    0,
+                    0,
+                    False,
+                    _FORWARD_PRECISION_VALUES[forward_precision],
+                    float8_e4m3 if forward_precision == "fp8" else None,
+                    ScalingGranularity.TENSORWISE.value if forward_precision == "fp8" else 0,
+                    BackendType.HIPBLASLT.value if forward_precision == "fp8" else 0,
+                )[0]
+                output.square().mean().backward()
 
-        reference = torch.nn.functional.linear(x.detach(), w.detach())
-        signal = (reference.float() ** 2).mean()
-        noise = ((output.float() - reference.float()) ** 2).mean()
-        if forward_precision == "bf16":
-            assert torch.equal(output, reference)
-        else:
-            snr_db = 10 * torch.log10(signal / noise).item()
-            assert snr_db > 10, f"FP8 forward SNR {snr_db:.1f} dB is below 10 dB"
+                reference = torch.nn.functional.linear(x.detach(), w.detach())
+                signal = (reference.float() ** 2).mean()
+                noise = ((output.float() - reference.float()) ** 2).mean()
+                if forward_precision == "bf16":
+                    assert torch.equal(output, reference)
+                else:
+                    snr_db = 10 * torch.log10(signal / noise).item()
+                    assert snr_db > 10, f"FP8 forward SNR {snr_db:.1f} dB is below 10 dB"
 
-        assert torch.isfinite(x.grad).all()
-        assert torch.isfinite(w.grad).all()
+                assert torch.isfinite(x.grad).all()
+                assert torch.isfinite(w.grad).all()
 
 
 # ---------------------------------------------------------------------------
@@ -308,9 +309,8 @@ class TestMXFP4Compile(PrimusUT):
             f"Reasons: {explanation.break_reasons}"
         )
 
-    @pytest.mark.parametrize("forward_precision", ["fp8", "bf16"])
     @requires_mxfp4
-    def test_no_graph_break_high_precision_forward(self, forward_precision):
+    def test_no_graph_break_high_precision_forward(self):
         from primus_turbo.pytorch.core.backend import BackendType
         from primus_turbo.pytorch.core.low_precision import (
             ScalingGranularity,
@@ -318,34 +318,36 @@ class TestMXFP4Compile(PrimusUT):
         )
 
         from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
-            MXFP4LinearFunction,
             _FORWARD_PRECISION_VALUES,
+            MXFP4LinearFunction,
             _enable_preshuffle,
         )
 
-        torch._dynamo.reset()
-        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
-        w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda")
+        for forward_precision in ("fp8", "bf16"):
+            with self.subTest(forward_precision=forward_precision):
+                torch._dynamo.reset()
+                x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+                w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda")
 
-        explanation = torch._dynamo.explain(MXFP4LinearFunction.apply)(
-            x,
-            w,
-            _enable_preshuffle(),
-            False,
-            None,
-            0,
-            0,
-            False,
-            _FORWARD_PRECISION_VALUES[forward_precision],
-            float8_e4m3 if forward_precision == "fp8" else None,
-            ScalingGranularity.TENSORWISE.value if forward_precision == "fp8" else 0,
-            BackendType.HIPBLASLT.value if forward_precision == "fp8" else 0,
-        )
+                explanation = torch._dynamo.explain(MXFP4LinearFunction.apply)(
+                    x,
+                    w,
+                    _enable_preshuffle(),
+                    False,
+                    None,
+                    0,
+                    0,
+                    False,
+                    _FORWARD_PRECISION_VALUES[forward_precision],
+                    float8_e4m3 if forward_precision == "fp8" else None,
+                    ScalingGranularity.TENSORWISE.value if forward_precision == "fp8" else 0,
+                    BackendType.HIPBLASLT.value if forward_precision == "fp8" else 0,
+                )
 
-        assert explanation.graph_break_count == 0, (
-            f"Expected 0 graph breaks, got {explanation.graph_break_count}. "
-            f"Reasons: {explanation.break_reasons}"
-        )
+                assert explanation.graph_break_count == 0, (
+                    f"Expected 0 graph breaks, got {explanation.graph_break_count}. "
+                    f"Reasons: {explanation.break_reasons}"
+                )
 
     @requires_mxfp4
     def test_compiled_forward_matches_eager(self):


### PR DESCRIPTION
## Summary

Tracks [Issue 220](https://github.com/AMD-AGI/tiger-training-internal/issues/220).

Add independent MXFP4 forward precision selection so late recovery runs can use FP8 or BF16 forward GEMMs while keeping MXFP4 data- and weight-gradient GEMMs.

- Add fail-closed `mxfp4_forward_precision` config plumbing and runtime mode census.
- Reuse existing FP8 and BF16 operators; no new kernel implementation.
- Cover direct autograd, compile, Flux integration, config validation, and audit modes.

## Test plan

- [x] Python compile check
- [x] `git diff --check`
- [ ] Targeted CPU-safe unit tests in the v26.5 container
- [ ] MI355X direct linear and Flux 535M forward/backward tests
- [ ] Option 6/7 resume smoke with exact mode census