### PR TITLE
test(megatron): cover compiled MXFP4 backward

### DIFF
--- a/tests/unit_tests/backends/megatron/diffusion/training/test_flux_model_creation.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_flux_model_creation.py
@@ -245,6 +245,23 @@ class TestFluxModelCreation:
         assert config.fp8_dot_product_attention is False
         assert config.fp8_multi_head_attention is False
 
+    def test_build_flux_config_from_yaml_mxfp4_precision_settings(self, monkeypatch: pytest.MonkeyPatch):
+        backend_args = SimpleNamespace(
+            mock_data=True,
+            fp4="mxfp4",
+            fp4_recipe="mxfp4",
+            mxfp4_forward_precision="bf16",
+            mxfp4_backward_precision="mxfp4",
+        )
+
+        trainer = _build_flux_trainer(monkeypatch, backend_args)
+        config = trainer._build_flux_config_from_yaml()
+
+        assert config.fp4 == "mxfp4"
+        assert config.fp4_recipe == "mxfp4"
+        assert config.mxfp4_forward_precision == "bf16"
+        assert config.mxfp4_backward_precision == "mxfp4"
+
     def test_create_model_does_not_overwrite_existing_torch_compile_attrs(
         self, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
+++ b/tests/unit_tests/backends/megatron/test_diffusion_audit_markers.py
@@ -95,6 +95,31 @@ def test_precision_linear_class_census_emits_zero_counts_for_bf16(monkeypatch, c
     }
 
 
+def test_precision_linear_class_census_emits_mxfp4_gemm_modes(monkeypatch, caplog):
+    from megatron.core import parallel_state
+
+    monkeypatch.setenv("PRIMUS_AUDIT_LINEAR_CLASS_CENSUS", "1")
+    monkeypatch.setenv("RANK", "5")
+    monkeypatch.setattr(parallel_state, "get_data_parallel_rank", lambda: 5)
+    caplog.set_level("INFO", logger=_FLUX_TRAINER_LOGGER)
+
+    mxfp4_column = type("MXFP4ColumnParallelLinear", (nn.Module,), {})()
+    mxfp4_column._forward_precision = "fp8"
+    mxfp4_column._backward_is_fp8 = False
+    _emit_precision_linear_class_census(nn.ModuleList([mxfp4_column]))
+
+    line = next(
+        record.message
+        for record in caplog.records
+        if record.message.startswith("PRIMUS_MXFP4_GEMM_MODE_CENSUS=")
+    )
+    assert json.loads(line.split("=", 1)[1]) == {
+        "data_parallel_rank": 5,
+        "global_rank": 5,
+        "modes": {"fp8_forward_mxfp4_backward": 1},
+    }
+
+
 def test_emit_batch_fingerprint_is_fail_closed(monkeypatch):
     monkeypatch.setenv("PRIMUS_AUDIT_BATCH_FINGERPRINTS", "1")
     with pytest.raises(RuntimeError, match="no valid sample-key fingerprint"):

--- a/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
+++ b/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
@@ -350,6 +350,61 @@ class TestMXFP4Compile(PrimusUT):
                 )
 
     @requires_mxfp4
+    def test_compiled_backward_matches_eager_high_precision_forward(self):
+        from primus_turbo.pytorch.core.backend import BackendType
+        from primus_turbo.pytorch.core.low_precision import (
+            ScalingGranularity,
+            float8_e4m3,
+        )
+
+        from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
+            _FORWARD_PRECISION_VALUES,
+            MXFP4LinearFunction,
+            _enable_preshuffle,
+        )
+
+        for forward_precision in ("fp8", "bf16"):
+            with self.subTest(forward_precision=forward_precision):
+                torch._dynamo.reset()
+                torch.manual_seed(42)
+                x_eager = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+                w_eager = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda", requires_grad=True)
+                x_compiled = x_eager.detach().clone().requires_grad_(True)
+                w_compiled = w_eager.detach().clone().requires_grad_(True)
+                upstream = torch.randn(128, 512, dtype=torch.bfloat16, device="cuda")
+                preshuffle = _enable_preshuffle()
+                forward_precision_value = _FORWARD_PRECISION_VALUES[forward_precision]
+                fp8_dtype = float8_e4m3 if forward_precision == "fp8" else None
+                fp8_granularity = ScalingGranularity.TENSORWISE.value if forward_precision == "fp8" else 0
+                fp8_backend = BackendType.HIPBLASLT.value if forward_precision == "fp8" else 0
+
+                def forward(x, weight):
+                    return MXFP4LinearFunction.apply(
+                        x,
+                        weight,
+                        preshuffle,
+                        False,
+                        None,
+                        0,
+                        0,
+                        False,
+                        forward_precision_value,
+                        fp8_dtype,
+                        fp8_granularity,
+                        fp8_backend,
+                    )[0]
+
+                eager_output = forward(x_eager, w_eager)
+                eager_output.backward(upstream)
+
+                compiled_output = torch.compile(forward, fullgraph=True)(x_compiled, w_compiled)
+                compiled_output.backward(upstream)
+
+                assert torch.equal(compiled_output, eager_output)
+                assert torch.equal(x_compiled.grad, x_eager.grad)
+                assert torch.equal(w_compiled.grad, w_eager.grad)
+
+    @requires_mxfp4
     def test_compiled_forward_matches_eager(self):
         from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
             MXFP4LinearFunction,


### PR DESCRIPTION
## Summary

Closes the post-merge review gap from PR #986.

Adds regression coverage for FP8/BF16 forward with MXFP4 backward through `torch.compile`, including exact eager/compiled output and gradient comparisons. It also covers YAML-to-`FluxConfig` precision propagation and runtime mode-census emission.

## Test plan

- [x] 35 config and audit tests passed
- [x] Compiled-backward checks passed for FP8 and BF16 forward modes
- [x] Flux 535M forward-only integration test passed
- [x] `black` formatting verified
- [x] GPU memory returned to idle
