### PR TITLE
ci(docker): shallow-clone build-time git deps to cut build-docker time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -681,12 +681,12 @@ jobs:
           repository: AMD-AGI/Primus-Turbo
           path: Primus-Turbo
           ref: ${{ env.PRIMUS_TURBO_COMMIT }}
-      - name: Init Primus-Turbo submodules (full clone)
+      - name: Init Primus-Turbo submodules (shallow)
         working-directory: Primus-Turbo
         run: |
           rm -rf 3rdparty/composable_kernel .git/modules/3rdparty/composable_kernel
           git submodule sync --recursive
-          git submodule update --init --recursive
+          git submodule update --init --recursive --depth 1 --filter=blob:none
       - run: echo "Begin Primus-Turbo Install."
       - name: Install Primus-Turbo
         run: |

--- a/.github/workflows/docker/Dockerfile
+++ b/.github/workflows/docker/Dockerfile
@@ -38,18 +38,18 @@ ENV HCC_AMDGPU_TARGET="gfx942,gfx950"
 
 RUN pip3 uninstall aiter amd-aiter -y || true && \
     cd /opt && \
-    git clone https://github.com/ROCm/aiter.git && \
+    git clone --filter=blob:none https://github.com/ROCm/aiter.git && \
     cd aiter && \
     git checkout -f ${PRIMUS_TURBO_AITER_COMMIT} && \
     git submodule sync && \
-    git submodule update --init --recursive && \
+    git submodule update --init --recursive --depth 1 --filter=blob:none && \
     PREBUILD_KERNELS=3 pip install --no-cache-dir --use-pep517 .
 
 RUN cd /opt && \
-    git clone https://github.com/AMD-AGI/Primus-Turbo.git && \
+    git clone --filter=blob:none https://github.com/AMD-AGI/Primus-Turbo.git && \
     cd Primus-Turbo && \
     git checkout ${PRIMUS_TURBO_COMMIT} && \
-    git submodule update --init --recursive && \
+    git submodule update --init --recursive --depth 1 --filter=blob:none && \
     pip3 install -r requirements.txt && \
     pip3 install --no-build-isolation . -v
 
@@ -72,7 +72,7 @@ RUN pip3 uninstall -y quack-kernels nvidia-cutlass-dsl \
 # Install Triton
 # ---------------------------------------------------------------------------
 RUN cd /opt && \
-    git clone https://github.com/triton-lang/triton.git && \
+    git clone --filter=blob:none https://github.com/triton-lang/triton.git && \
     cd triton && \
     git checkout ${TRITON_COMMIT} && \
     pip3 install -r python/requirements.txt && \
@@ -92,7 +92,7 @@ RUN TORCH_META=$(python3 -c "import importlib.metadata as m; print(m.distributio
 # ---------------------------------------------------------------------------
 RUN if [ "$PRIMUS_TURBO_FRAMEWORK" != "JAX" ]; then \
     cd /opt && \
-    git clone https://github.com/uccl-project/uccl.git && \
+    git clone --filter=blob:none https://github.com/uccl-project/uccl.git && \
     cd uccl && \
     git checkout ${UCCL_COMMIT} && \
     cd ep && TORCH_CUDA_ARCH_LIST="gfx942,gfx950" python3 setup.py build && cd .. && \

--- a/.github/workflows/docker/Dockerfile.ainic
+++ b/.github/workflows/docker/Dockerfile.ainic
@@ -67,8 +67,8 @@ RUN cd ${WORKDIR} && \
 # Build rccl
 # ---------------------------------------------------------------------------
 RUN cd ${WORKDIR} && \
-    git clone https://github.com/ROCm/rccl.git && \
-    cd rccl && git checkout rocm-7.1.0 && \
+    git clone --branch rocm-7.1.0 --single-branch --depth 1 https://github.com/ROCm/rccl.git && \
+    cd rccl && \
     ./install.sh -l --prefix build/ --disable-msccl-kernel \
         --amdgpu_targets="gfx950" 2>&1 | tee log_rccl_install.txt
 
@@ -80,8 +80,8 @@ ENV RCCL_HOME=${WORKDIR}/rccl
 
 # RUN apt-get install -y --allow-unauthenticated libionic-dev && \
 RUN cd ${WORKDIR} && \
-    git clone https://github.com/rocm/amd-anp.git && \
-    cd amd-anp && git checkout tags/v1.3.0 && \
+    git clone --branch v1.3.0 --single-branch --depth 1 https://github.com/rocm/amd-anp.git && \
+    cd amd-anp && \
     make -j 16 RCCL_HOME=${RCCL_HOME} \
                 MPI_INCLUDE=${MPI_PATH}/include/ \
                 MPI_LIB_PATH=${MPI_PATH}/lib/ \


### PR DESCRIPTION
## Summary

- `aiter`, `Primus-Turbo`, `triton`, `uccl` in `.github/workflows/docker/Dockerfile` were full-history `git clone`s, and their pinned submodules (`composable_kernel`, `hipify_torch`) were fetched via `git submodule update --init --recursive` with no depth limit — observed taking 30-45min on their own on a slow outbound link.
- Switch main-repo clones that checkout an arbitrary pinned SHA to partial clone (`--filter=blob:none`): keeps the full commit graph (so any SHA is still reachable) but defers blob content until checkout.
- Switch submodule updates (pinned to exact SHAs) to `--depth 1 --filter=blob:none`: GitHub allows shallow-fetching an arbitrary reachable SHA, so this skips the submodule's full history entirely.
- `rccl` / `amd-anp` in `Dockerfile.ainic` checkout fixed tags, so those go straight to `git clone --branch <tag> --single-branch --depth 1`.
- Same submodule fix applied to the `run-unittest-jax` job's "Init Primus-Turbo submodules" step in `ci.yaml`.

## Test plan

- [x] Trigger `build-docker` on a PR and compare wall-clock time against a recent run on the same runner
- [x] Confirm the built image still resolves to the exact pinned commits/tags for aiter, Primus-Turbo, triton, uccl, rccl, amd-anp