### PR TITLE
feat(projection): enable DLRM-v4 (TorchRec/HSTU) via workload registry

### DIFF
--- a/primus/core/projection/examples/project_dlrm.py
+++ b/primus/core/projection/examples/project_dlrm.py
@@ -1,0 +1,173 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Run a first-principles projection of a DLRM-v4 (TorchRec / HSTU) ranker.
+
+This is a self-contained entry point that does NOT require a full primus
+launcher config: it builds a projection ``TrainingConfig`` directly, resolves
+the ``torchrec_dlrm`` workload through the workload registry, builds the
+profiler tree, and prints the parameter / memory breakdown plus a first-cut
+throughput estimate priced with the shared GEMM/SDPA simulation backends.
+
+Defaults reproduce the Yambda-5B DLRM-v4 ranker from the gap report:
+  5 HSTU layers, D=512, 4 heads, d_qk=d_v=128, max_seq_len=4096, jagged ~0.4,
+  11 sparse tables (~560 GB fp32 params), 8x GPU single node.
+
+Usage:
+  python -m primus.core.projection.examples.project_dlrm
+  python -m primus.core.projection.examples.project_dlrm --gpu-arch mi300x --nnodes 1 --gpus-per-node 8
+"""
+
+import argparse
+import os
+
+from primus.core.projection.module_profilers.language_model import build_profiler
+from primus.core.projection.simulation_backends.factory import (
+    get_gemm_simulation_backend,
+    get_sdpa_simulation_backend,
+)
+from primus.core.projection.training_config import (
+    ModelConfig,
+    ModelParallelConfig,
+    RuntimeConfig,
+    TrainingConfig,
+)
+from primus.core.projection.workload_registry import resolve_top_level_spec
+
+
+def build_yambda_config(args) -> TrainingConfig:
+    total_embed_bytes = args.embedding_gb * (1024**3)
+    total_rows = int(total_embed_bytes / args.embedding_param_bytes / args.embedding_dim)
+
+    model = ModelConfig(
+        num_layers=args.num_layers,
+        hidden_size=args.hidden_size,
+        # sparse embeddings
+        num_embedding_tables=args.num_tables,
+        embedding_total_rows=total_rows,
+        embedding_dim=args.embedding_dim,
+        embedding_default_pooling_factor=args.pooling_factor,
+        embedding_sharding="row",
+        embedding_param_bytes=args.embedding_param_bytes,
+        embedding_hbm_fraction=args.hbm_fraction,
+        # HSTU
+        hstu_num_heads=args.num_heads,
+        hstu_qk_dim=args.qk_dim,
+        hstu_v_dim=args.v_dim,
+        hstu_max_seq_len=args.max_seq_len,
+        hstu_fill_factor=args.fill_factor,
+        num_attention_heads=args.num_heads,
+        kv_channels=args.qk_dim,
+        # dense MLPs
+        dense_input_dim=args.dense_input_dim,
+        dlrm_bottom_mlp=args.bottom_mlp,
+        dlrm_over_mlp=args.over_mlp,
+    )
+    runtime = RuntimeConfig(
+        global_batch_size=args.global_batch_size,
+        micro_batch_size=args.micro_batch_size,
+        sequence_length=args.max_seq_len,
+        data_parallel_size=args.gpus_per_node * args.nnodes // args.tp,
+    )
+    mp = ModelParallelConfig(tensor_model_parallel_size=args.tp)
+    return TrainingConfig(
+        model_config=model,
+        runtime_config=runtime,
+        model_parallel_config=mp,
+        framework="torchrec_dlrm",
+    )
+
+
+def _gb(x):
+    return f"{x / (1024**3):.2f} GB"
+
+
+def main():
+    p = argparse.ArgumentParser(description="Project a DLRM-v4 (HSTU) ranker.")
+    p.add_argument("--num-layers", type=int, default=5)
+    p.add_argument("--hidden-size", type=int, default=512)
+    p.add_argument("--num-heads", type=int, default=4)
+    p.add_argument("--qk-dim", type=int, default=128)
+    p.add_argument("--v-dim", type=int, default=128)
+    p.add_argument("--max-seq-len", type=int, default=4096)
+    p.add_argument("--fill-factor", type=float, default=0.4)
+    p.add_argument("--num-tables", type=int, default=11)
+    p.add_argument("--embedding-gb", type=float, default=560.0, help="total embedding param bytes (GB)")
+    p.add_argument("--embedding-dim", type=int, default=512)
+    p.add_argument("--embedding-param-bytes", type=int, default=4)
+    p.add_argument("--pooling-factor", type=int, default=20)
+    p.add_argument("--hbm-fraction", type=float, default=1.0)
+    p.add_argument("--dense-input-dim", type=int, default=512)
+    p.add_argument("--bottom-mlp", type=int, nargs="*", default=[512, 512])
+    p.add_argument("--over-mlp", type=int, nargs="*", default=[512, 256, 1])
+    p.add_argument("--global-batch-size", type=int, default=8192)
+    p.add_argument("--micro-batch-size", type=int, default=1024)
+    p.add_argument("--tp", type=int, default=1)
+    p.add_argument("--nnodes", type=int, default=1)
+    p.add_argument("--gpus-per-node", type=int, default=8)
+    p.add_argument("--gpu-arch", type=str, default="mi300x")
+    args = p.parse_args()
+
+    # World size is read from the environment by the profilers/collectives.
+    os.environ["NNODES"] = str(args.nnodes)
+    os.environ["GPUS_PER_NODE"] = str(args.gpus_per_node)
+    world = args.nnodes * args.gpus_per_node
+
+    config = build_yambda_config(args)
+
+    spec = resolve_top_level_spec(config)
+    profiler = build_profiler(spec)
+
+    gemm = get_gemm_simulation_backend(gpu_arch=args.gpu_arch)
+    sdpa = get_sdpa_simulation_backend(gpu_arch=args.gpu_arch)
+    profiler.set_simulation_backends(gemm_backend=gemm, sdpa_backend=sdpa)
+
+    emb = profiler.sub_profilers["sparse_embedding"]
+    total_params = profiler.estimated_num_params(None)
+    per_rank_params = profiler.estimated_num_params(0)
+    hbm_bytes, ddr_bytes = emb.param_bytes_by_tier(0)
+    bpp = profiler.get_num_bytes_per_param()
+
+    print("=" * 78)
+    print(
+        f"DLRM-v4 (HSTU) projection  --  world={world} ({args.nnodes}x{args.gpus_per_node}), arch={args.gpu_arch}"
+    )
+    print("=" * 78)
+    print("[Model]")
+    print(
+        f"  HSTU layers          : {args.num_layers}  (D={args.hidden_size}, heads={args.num_heads}, "
+        f"d_qk={args.qk_dim}, d_v={args.v_dim})"
+    )
+    print(
+        f"  seq_len (padded)     : {args.max_seq_len}  fill={args.fill_factor}  "
+        f"(effective ~{int(args.max_seq_len * args.fill_factor)})"
+    )
+    print(
+        f"  sparse tables        : {args.num_tables}  dim={args.embedding_dim}  "
+        f"pooling={args.pooling_factor}  ({args.embedding_param_bytes}B/param)"
+    )
+    print("[Parameters]")
+    print(f"  total params         : {total_params / 1e9:.2f} B")
+    print(f"  per-rank params      : {per_rank_params / 1e9:.2f} B   (row-sharded across {world} ranks)")
+    print(f"  embedding HBM tier   : {_gb(hbm_bytes)}   DDR/UVM tier: {_gb(ddr_bytes)}")
+    print(f"  bytes/param (static) : {bpp:.2f}  ->  ~{_gb(per_rank_params * bpp)} static/rank")
+    print("[Throughput]")
+    step = profiler.project_step()
+    print(f"  forward              : {step['forward_ms']:.2f} ms")
+    print(f"  backward             : {step['backward_ms']:.2f} ms")
+    print(f"  embedding all-to-all : {step['comm_ms']:.2f} ms")
+    print(f"  step time            : {step['step_ms']:.2f} ms")
+    print(
+        f"  per-HSTU-layer       : fwd {step['hstu_layer_fwd_ms']:.3f} ms / bwd {step['hstu_layer_bwd_ms']:.3f} ms"
+    )
+    print(f"  samples/s (global)   : {step['samples_per_s']:,.0f}")
+    print(f"  samples/s per GPU    : {step['samples_per_s_per_gpu']:,.0f}")
+    print("=" * 78)
+
+
+if __name__ == "__main__":
+    main()

--- a/primus/core/projection/memory_projection/benchmark.py
+++ b/primus/core/projection/memory_projection/benchmark.py
@@ -34,13 +34,11 @@ from primus.core.projection.memory_projection.extrapolation import (
     extrapolate_per_rank_peak,
 )
 from primus.core.projection.memory_projection.reports import print_per_rank_breakdown
-from primus.core.projection.module_profilers.language_model import (
-    build_profiler,
-    get_language_model_profiler_spec,
-)
+from primus.core.projection.module_profilers.language_model import build_profiler
 from primus.core.projection.training_config import (
     convert_primus_config_to_projection_config,
 )
+from primus.core.projection.workload_registry import resolve_top_level_spec
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
@@ -300,8 +298,8 @@ def launch_projection_from_cli(args, overrides):
         if metadata.get("benchmark_num_experts") is not None:
             bench_training_config.model_config.num_experts = int(metadata["benchmark_num_experts"])
 
-    target_profiler = build_profiler(get_language_model_profiler_spec(target_training_config))
-    bench_profiler = build_profiler(get_language_model_profiler_spec(bench_training_config))
+    target_profiler = build_profiler(resolve_top_level_spec(target_training_config))
+    bench_profiler = build_profiler(resolve_top_level_spec(bench_training_config))
 
     # ── Extract bench measurement ──
     bm: BenchMeasurement = extract_bench_measurement(profiling_results)

--- a/primus/core/projection/memory_projection/simulate.py
+++ b/primus/core/projection/memory_projection/simulate.py
@@ -22,13 +22,11 @@ from typing import Optional
 
 from primus.core.launcher.parser import load_primus_config
 from primus.core.projection.config_validation import assert_recompute_pipeline_compat
-from primus.core.projection.module_profilers.language_model import (
-    build_profiler,
-    get_language_model_profiler_spec,
-)
+from primus.core.projection.module_profilers.language_model import build_profiler
 from primus.core.projection.training_config import (
     convert_primus_config_to_projection_config,
 )
+from primus.core.projection.workload_registry import resolve_top_level_spec
 
 
 def print_profiler_hierarchy(profiler, batch_size, seq_len, rank=None, name="root", depth=0, visited=None):
@@ -106,7 +104,7 @@ def project_from_config(
         primus_config=primus_config,
         pipeline_schedule_algorithm=pipeline_schedule_algorithm,
     )
-    model_profiler_spec = get_language_model_profiler_spec(training_config)
+    model_profiler_spec = resolve_top_level_spec(training_config)
     model_profiler = build_profiler(model_profiler_spec)
 
     seq_len = training_config.runtime_config.sequence_length

--- a/primus/core/projection/module_profilers/dlrm.py
+++ b/primus/core/projection/module_profilers/dlrm.py
@@ -1,0 +1,250 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+DLRM-v4 (TorchRec / HSTU ranker) top-level profiler.
+
+Assembles the workload profiler tree for a generative recommender:
+
+    sparse embeddings  ->  (dense bottom MLP)  ->  N x HSTU layers  ->  over MLP
+
+and provides both the **memory-projection** contract (``estimated_num_params``,
+``estimated_activation_memory``, ``get_num_bytes_per_param``) and a first-cut
+**throughput** estimate (:meth:`project_step`) priced with the shared GEMM/SDPA
+simulation backends plus the embedding all-to-all collective.
+
+Registered under the ``torchrec_dlrm`` framework via the workload registry.
+"""
+
+import os
+from typing import List, Optional, Tuple
+
+from primus.core.projection.base_module_profiler import BaseModuleProfiler
+from primus.core.projection.module_profilers.hstu import HSTULayerProfiler
+from primus.core.projection.module_profilers.sparse_embedding import (
+    SparseEmbeddingProfiler,
+)
+from primus.core.projection.profiler_spec import ModuleProfilerSpec
+from primus.core.projection.training_config import gemm_dtype_from_config
+
+
+def _as_list(val) -> List[int]:
+    if val is None:
+        return []
+    if isinstance(val, str):
+        try:
+            val = eval(val)
+        except Exception:
+            return []
+    if isinstance(val, (int, float)):
+        return [int(val)]
+    return [int(x) for x in val]
+
+
+def _mlp_layers(input_dim: int, widths: List[int]) -> List[Tuple[int, int]]:
+    """Return [(in, out), ...] GEMM shapes for an MLP stack."""
+    layers = []
+    prev = input_dim
+    for w in widths:
+        if prev > 0 and w > 0:
+            layers.append((prev, w))
+        prev = w
+    return layers
+
+
+class DLRMProfiler(BaseModuleProfiler):
+    def __init__(self, config, sub_profilers=None):
+        super().__init__(config, sub_profilers)
+        self._gemm_backend = None
+        self._sdpa_backend = None
+
+    # -- backend wiring --------------------------------------------------------
+    def set_simulation_backends(self, gemm_backend=None, sdpa_backend=None):
+        self._gemm_backend = gemm_backend
+        self._sdpa_backend = sdpa_backend
+        hstu = self.sub_profilers.get("hstu_layer") if self.sub_profilers else None
+        if hstu is not None and hasattr(hstu, "set_simulation_backends"):
+            hstu.set_simulation_backends(gemm_backend, sdpa_backend)
+        emb = self.sub_profilers.get("sparse_embedding") if self.sub_profilers else None
+        if emb is not None:
+            if hasattr(emb, "set_gemm_backend") and gemm_backend is not None:
+                emb.set_gemm_backend(gemm_backend)
+            if hasattr(emb, "set_simulation_mode"):
+                emb.set_simulation_mode(True)
+
+    # -- geometry helpers ------------------------------------------------------
+    def _num_layers(self) -> int:
+        return max(1, int(self.config.model_config.num_layers or 1))
+
+    def _dense_dim(self) -> int:
+        mc = self.config.model_config
+        return int(mc.hidden_size or mc.embedding_dim or 0)
+
+    def _bottom_mlp_layers(self) -> List[Tuple[int, int]]:
+        mc = self.config.model_config
+        return _mlp_layers(int(mc.dense_input_dim or 0), _as_list(mc.dlrm_bottom_mlp))
+
+    def _over_mlp_layers(self) -> List[Tuple[int, int]]:
+        mc = self.config.model_config
+        # Interaction input ~= (#tables + 1 dense) x D collapsed to D by HSTU output.
+        n_tables = int(mc.num_embedding_tables or 0)
+        dim = int(mc.embedding_dim or mc.hidden_size or 0)
+        inter_dim = (n_tables + 1) * dim if dim else 0
+        return _mlp_layers(inter_dim, _as_list(mc.dlrm_over_mlp))
+
+    def _mlp_params(self, layers: List[Tuple[int, int]]) -> int:
+        return int(sum(i * o for i, o in layers))
+
+    # -- params ----------------------------------------------------------------
+    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+        total = 0
+        emb = self.sub_profilers["sparse_embedding"]
+        total += emb.estimated_num_params(rank)
+        hstu = self.sub_profilers["hstu_layer"]
+        total += self._num_layers() * hstu.estimated_num_params(rank)
+        total += self._mlp_params(self._bottom_mlp_layers())
+        total += self._mlp_params(self._over_mlp_layers())
+        return int(total)
+
+    def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:
+        act = 0
+        act += self.sub_profilers["sparse_embedding"].estimated_activation_memory(batch_size, seq_len)
+        act += self._num_layers() * self.sub_profilers["hstu_layer"].estimated_activation_memory(
+            batch_size, seq_len
+        )
+        return int(act)
+
+    def get_num_bytes_per_param(self) -> float:
+        """Bytes-per-parameter for the static (weights+grad+optimizer) block.
+
+        DLRM memory is dominated by the sparse tables, whose per-param cost
+        differs from the dense blocks: embedding tables are stored at
+        ``embedding_param_bytes`` with a single fp32 optimizer moment
+        (row-wise Adagrad is standard), while the small dense HSTU/MLP block
+        uses the usual bf16 params+grad + fp32 Adam state.  We return the
+        param-count-weighted blend so the memory reporter's
+        ``params x bytes_per_param`` stays representative.
+        """
+        mc = self.config.model_config
+        emb_params = self.sub_profilers["sparse_embedding"].estimated_num_params(None)
+        dense_params = max(
+            0,
+            self._num_layers() * self.sub_profilers["hstu_layer"].estimated_num_params(None)
+            + self._mlp_params(self._bottom_mlp_layers())
+            + self._mlp_params(self._over_mlp_layers()),
+        )
+        emb_bpp = float(int(mc.embedding_param_bytes or 4)) + 4.0  # param + 1 fp32 moment
+        dense_bpp = 4.0 + 10.0  # bf16 param+grad + fp32 Adam (2+4+4)
+        total = emb_params + dense_params
+        if total <= 0:
+            return dense_bpp
+        return (emb_params * emb_bpp + dense_params * dense_bpp) / total
+
+    # -- throughput ------------------------------------------------------------
+    def _mlp_step_ms(self, layers: List[Tuple[int, int]], batch: int, dtype: str) -> Tuple[float, float]:
+        fwd = bwd = 0.0
+        for in_dim, out_dim in layers:
+            g = self._gemm_backend.simulate_gemm(batch, out_dim, in_dim, dtype=dtype)
+            fwd += g.forward_time_ms
+            bwd += g.backward_time_ms or (2.0 * g.forward_time_ms)
+        return fwd, bwd
+
+    def _embedding_a2a_ms(self, batch: int) -> float:
+        """Embedding all-to-all: exchange pooled outputs across the sharded world."""
+        mc = self.config.model_config
+        n_tables = int(mc.num_embedding_tables or 0)
+        dim = int(mc.embedding_dim or mc.hidden_size or 0)
+        world = int(os.getenv("NNODES", "1")) * int(os.getenv("GPUS_PER_NODE", "8"))
+        if world <= 1 or n_tables == 0 or dim == 0:
+            return 0.0
+        try:
+            from primus.core.projection.module_profilers import (
+                collective_args,
+                collective_model,
+            )
+
+            gpn = int(os.getenv("GPUS_PER_NODE", "8"))
+            nnodes = max(1, world // gpn)
+            cargs = collective_args.get_default_args(num_nodes=nnodes, gpus_per_node=gpn)
+            msg_bytes = batch * n_tables * dim * 2  # pooled bf16 payload per rank
+            us = collective_model.alltoall(cargs, msg_bytes, world, groups=["dp"])
+            return float(us) / 1000.0  # us -> ms
+        except Exception:
+            return 0.0
+
+    def project_step(self, batch_size: Optional[int] = None, seq_len: Optional[int] = None) -> dict:
+        """First-cut per-step timing + throughput for a DLRM-v4 training step.
+
+        Returns a dict with forward/backward/comm ms, step ms, and samples/s.
+        Requires simulation backends (call ``set_simulation_backends`` first).
+        """
+        if self._gemm_backend is None or self._sdpa_backend is None:
+            raise RuntimeError("DLRMProfiler.project_step requires simulation backends.")
+        rc = self.config.runtime_config
+        mc = self.config.model_config
+        local_bs = int(batch_size or rc.micro_batch_size or 1)
+        slen = int(seq_len or rc.sequence_length or mc.hstu_max_seq_len or 1)
+        dtype = gemm_dtype_from_config(mc)
+
+        emb = self.sub_profilers["sparse_embedding"]
+        hstu = self.sub_profilers["hstu_layer"]
+
+        fwd = emb.measured_forward_time(local_bs, slen)
+        bwd = emb.measured_backward_time(local_bs, slen)
+
+        layer_fwd = hstu.measured_forward_time(local_bs, slen)
+        layer_bwd = hstu.measured_backward_time(local_bs, slen)
+        fwd += self._num_layers() * layer_fwd
+        bwd += self._num_layers() * layer_bwd
+
+        bmf, bmb = self._mlp_step_ms(self._bottom_mlp_layers(), local_bs, dtype)
+        omf, omb = self._mlp_step_ms(self._over_mlp_layers(), local_bs, dtype)
+        fwd += bmf + omf
+        bwd += bmb + omb
+
+        comm = self._embedding_a2a_ms(local_bs)
+        step_ms = fwd + bwd + comm
+
+        world = int(os.getenv("NNODES", "1")) * int(os.getenv("GPUS_PER_NODE", "8"))
+        global_bs = int(rc.global_batch_size or (local_bs * world))
+        samples_per_s = (global_bs / (step_ms / 1000.0)) if step_ms > 0 else 0.0
+
+        return {
+            "forward_ms": fwd,
+            "backward_ms": bwd,
+            "comm_ms": comm,
+            "step_ms": step_ms,
+            "hstu_layer_fwd_ms": layer_fwd,
+            "hstu_layer_bwd_ms": layer_bwd,
+            "num_layers": self._num_layers(),
+            "local_batch_size": local_bs,
+            "global_batch_size": global_bs,
+            "world_size": world,
+            "samples_per_s": samples_per_s,
+            "samples_per_s_per_gpu": samples_per_s / max(1, world),
+        }
+
+    # -- perf-path compatibility (unused by memory path) -----------------------
+    def measured_forward_time(self, batch_size: int, seq_len: int) -> float:
+        return self.project_step(batch_size, seq_len)["forward_ms"]
+
+    def measured_backward_time(self, batch_size: int, seq_len: int) -> float:
+        return self.project_step(batch_size, seq_len)["backward_ms"]
+
+    def measured_activation_memory(self, batch_size: int, seq_len: int) -> int:
+        return self.estimated_activation_memory(batch_size, seq_len)
+
+
+def get_dlrm_profiler_spec(config) -> ModuleProfilerSpec:
+    """Top-level profiler spec for a DLRM-v4 (TorchRec/HSTU) ranker."""
+    return ModuleProfilerSpec(
+        profiler=DLRMProfiler,
+        config=config,
+        sub_profiler_specs={
+            "sparse_embedding": SparseEmbeddingProfiler,
+            "hstu_layer": HSTULayerProfiler,
+        },
+    )

--- a/primus/core/projection/module_profilers/hstu.py
+++ b/primus/core/projection/module_profilers/hstu.py
@@ -1,0 +1,169 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+HSTU (Hierarchical Sequential Transduction Unit) layer profiler.
+
+HSTU is the transformer-like block used by DLRM-v4 rankers (Meta's generative
+recommenders / Yambda-5B).  It differs from a standard attention layer in ways
+that matter for projection:
+
+* a **single fused UVQK projection** produces four streams (U gate, V value,
+  Q query, K key) in one GEMM instead of separate Q/K/V projections;
+* the sequence is **jagged** -- padded to ``max_seq_len`` but only a fraction
+  (``hstu_fill_factor``, ~0.4 for Yambda) of the positions are valid, so the
+  attention core does far less work than a fixed-length model of the same
+  padded length;
+* the attention output is **SiLU-gated by U** before the output projection.
+
+We price it first-principles with the shared GEMM/SDPA simulation backends:
+
+  1. fused UVQK GEMM:  [T, D] * [D, H*(2*d_qk + 2*d_v)]
+  2. attention core:   SDPA over the *effective* (fill-adjusted) sequence,
+     head_dim = d_qk, head_dim_v = d_v, causal
+  3. output GEMM:      [T, H*d_v] * [H*d_v, D]
+
+Norms / SiLU gating are memory-bound and added as a small HBM term.
+"""
+
+from typing import Optional
+
+from primus.core.projection.base_module_profiler import BaseModuleProfiler
+from primus.core.projection.training_config import gemm_dtype_from_config
+
+_PEAK_HBM_BYTES_PER_MS = 4.0e9  # ~4 TB/s (MI300-class), bytes/ms
+_ELEMENTWISE_HBM_FRACTION = 0.60  # SiLU/norm streaming efficiency
+
+
+class HSTULayerProfiler(BaseModuleProfiler):
+    def __init__(self, config, sub_profilers=None):
+        super().__init__(config, sub_profilers)
+        self._gemm_backend = None
+        self._sdpa_backend = None
+        self._cached = None
+        self._cache_key = None
+
+    # -- backend wiring (mirrors DenseTransformerLayerProfiler) ----------------
+    def set_simulation_backends(self, gemm_backend=None, sdpa_backend=None):
+        self._gemm_backend = gemm_backend
+        self._sdpa_backend = sdpa_backend
+        self._cached = None
+        self._cache_key = None
+
+    def set_gemm_backend(self, backend):
+        self._gemm_backend = backend
+
+    def set_sdpa_backend(self, backend):
+        self._sdpa_backend = backend
+
+    def set_layer_module(self, module):
+        self._cached = None
+        self._cache_key = None
+
+    # -- geometry --------------------------------------------------------------
+    def _geom(self):
+        mc = self.config.model_config
+        D = int(mc.hidden_size or mc.embedding_dim or 0)
+        H = int(mc.hstu_num_heads or mc.num_attention_heads or 1)
+        d_qk = int(mc.hstu_qk_dim or mc.kv_channels or (D // max(1, H)))
+        d_v = int(mc.hstu_v_dim or d_qk)
+        return D, H, d_qk, d_v
+
+    def _tp(self) -> int:
+        return max(1, int(self.config.model_parallel_config.tensor_model_parallel_size or 1))
+
+    def _uvqk_out(self, H, d_qk, d_v) -> int:
+        # U, V (d_v each) + Q, K (d_qk each), per head.
+        return H * (2 * d_qk + 2 * d_v)
+
+    # -- params ----------------------------------------------------------------
+    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+        D, H, d_qk, d_v = self._geom()
+        uvqk = D * self._uvqk_out(H, d_qk, d_v)
+        out = (H * d_v) * D
+        total = uvqk + out
+        if rank is not None:
+            total = total // self._tp()  # heads sharded across TP
+        return int(total)
+
+    # -- activation ------------------------------------------------------------
+    def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:
+        D, H, d_qk, d_v = self._geom()
+        tp = self._tp()
+        # Padded sequence drives the buffer sizes; UVQK stream is the largest.
+        uvqk_width = self._uvqk_out(H, d_qk, d_v) // tp
+        return int(batch_size * seq_len * (D + uvqk_width) * 2)  # bf16
+
+    # -- compute ---------------------------------------------------------------
+    def _effective_seq(self, seq_len: int) -> int:
+        fill = float(getattr(self.config.model_config, "hstu_fill_factor", 1.0) or 1.0)
+        fill = min(1.0, max(0.01, fill))
+        return max(1, int(round(seq_len * fill)))
+
+    def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, float, int]:
+        D, H, d_qk, d_v = self._geom()
+        tp = self._tp()
+        dtype = gemm_dtype_from_config(self.config.model_config)
+        eff_seq = self._effective_seq(seq_len)
+        tokens = batch_size * eff_seq  # jagged: only valid positions do work
+        heads_per_rank = max(1, H // tp)
+
+        fwd = 0.0
+        bwd = 0.0
+
+        # 1. Fused UVQK projection GEMM: [T, D] x [D, H*(2 d_qk + 2 d_v)]/tp
+        uvqk_n = self._uvqk_out(heads_per_rank, d_qk, d_v)
+        g = self._gemm_backend.simulate_gemm(tokens, uvqk_n, D, dtype=dtype)
+        fwd += g.forward_time_ms
+        bwd += g.backward_time_ms or (2.0 * g.forward_time_ms)
+
+        # 2. Attention core (gated dot-product) over the effective sequence.
+        s = self._sdpa_backend.simulate_sdpa(
+            batch_size=batch_size,
+            num_heads=heads_per_rank,
+            seq_len=eff_seq,
+            head_dim=d_qk,
+            causal=True,
+            dtype="bf16",
+            head_dim_v=d_v,
+        )
+        fwd += s.forward_time_ms
+        bwd += s.backward_time_ms or (2.0 * s.forward_time_ms)
+
+        # 3. Output projection GEMM: [T, H*d_v]/tp x [H*d_v, D]
+        o = self._gemm_backend.simulate_gemm(tokens, D, heads_per_rank * d_v, dtype=dtype)
+        fwd += o.forward_time_ms
+        bwd += o.backward_time_ms or (2.0 * o.forward_time_ms)
+
+        # 4. SiLU gating (U) + norms: memory-bound elementwise over the UVQK + D
+        #    activation footprint.
+        elem_bytes = tokens * (uvqk_n + D) * 2  # bf16 read+op
+        elem_ms = elem_bytes / (_PEAK_HBM_BYTES_PER_MS * _ELEMENTWISE_HBM_FRACTION)
+        fwd += elem_ms
+        bwd += elem_ms
+
+        return (fwd, bwd, self.estimated_activation_memory(batch_size, seq_len))
+
+    def _results(self, batch_size: int, seq_len: int):
+        key = (batch_size, seq_len)
+        if self._cached is None or self._cache_key != key:
+            if self._gemm_backend is None or self._sdpa_backend is None:
+                raise RuntimeError(
+                    "HSTULayerProfiler requires GEMM and SDPA simulation backends; "
+                    "call set_simulation_backends() first."
+                )
+            self._cached = self._get_simulated_results(batch_size, seq_len)
+            self._cache_key = key
+        return self._cached
+
+    def measured_forward_time(self, batch_size: int, seq_len: int) -> float:
+        return self._results(batch_size, seq_len)[0]
+
+    def measured_backward_time(self, batch_size: int, seq_len: int) -> float:
+        return self._results(batch_size, seq_len)[1]
+
+    def measured_activation_memory(self, batch_size: int, seq_len: int) -> int:
+        return self._results(batch_size, seq_len)[2]

--- a/primus/core/projection/module_profilers/sparse_embedding.py
+++ b/primus/core/projection/module_profilers/sparse_embedding.py
@@ -1,0 +1,178 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Sparse-embedding profiler for DLRM-v4 / TorchRec rankers.
+
+Unlike a language model's single dense vocab table, a production ranker holds
+many large embedding tables (11 tables / ~560 GB of parameters for Yambda-5B)
+that are sharded across the *whole* world by TorchRec/DMP.  The parameter count
+is therefore dominated by these tables and is asymmetric across ranks, and the
+runtime cost is a **memory-bound sparse gather** (random-access row reads +
+pooling), not a GEMM.
+
+This profiler models, first-principles:
+
+* **Params** -- sum(rows_t * dim) over tables, sharded across the embedding shard
+  group (row/table-wise sharding spreads them over the world; data sharding
+  replicates them per rank).
+* **Memory tiering** -- ``embedding_hbm_fraction`` of the table bytes live in HBM;
+  the rest lives on DDR/UVM and is streamed over the host link.  Reported via
+  :meth:`param_bytes_by_tier` so the memory model can account for the DDR tier
+  separately instead of assuming everything sits in HBM.
+* **Compute** -- forward gather = (sum pooling_factor * dim * param_bytes) random
+  reads + pooled-output write, priced at an effective (random-access) HBM
+  bandwidth; the DDR-resident share is priced at the (much lower) host-link
+  bandwidth.  Backward is the scatter-add of the same footprint.
+"""
+
+import os
+from typing import Optional
+
+from primus.core.projection.base_module_profiler import BaseModuleProfiler
+
+# Random-access sparse gather sustains only a fraction of peak HBM bandwidth.
+_GATHER_HBM_FRACTION = 0.30
+_PEAK_HBM_BYTES_PER_MS = 4.0e9  # ~4 TB/s (MI300-class), bytes/ms
+# Host link (DDR/UVM streaming of non-resident tables), bytes/ms.
+_HOST_LINK_BYTES_PER_MS = 6.0e7  # ~60 GB/s effective PCIe/xGMI host transfer
+
+
+def _as_int_list(val, n, default):
+    """Coerce a per-table field (list | "[...]" | scalar | None) to a length-n list."""
+    if val is None:
+        return [default] * n
+    if isinstance(val, str):
+        try:
+            val = eval(val)  # config values are trusted (same pattern as moe_layer_freq)
+        except Exception:
+            val = default
+    if isinstance(val, (int, float)):
+        return [int(val)] * n
+    lst = [int(x) for x in val]
+    if len(lst) < n:
+        lst = lst + [default] * (n - len(lst))
+    return lst[:n]
+
+
+class SparseEmbeddingProfiler(BaseModuleProfiler):
+    def __init__(self, config, sub_profilers=None):
+        super().__init__(config, sub_profilers)
+        self._simulation_mode = True  # DLRM path is analytical (no eager module)
+        self._cached = None
+        self._cache_key = None
+
+    # -- compatibility hooks (mirror EmbeddingProfiler / leaf profilers) -------
+    def set_module(self, module):
+        self._cached = None
+        self._cache_key = None
+
+    def set_simulation_mode(self, enabled: bool = True):
+        self._simulation_mode = enabled
+
+    def set_gemm_backend(self, backend):
+        # Embedding gather is memory-bound; the GEMM backend is only used to read
+        # a peak-HBM-bandwidth number when available.
+        self._gemm_backend = backend
+
+    # -- table geometry --------------------------------------------------------
+    def _tables(self):
+        mc = self.config.model_config
+        n = int(mc.num_embedding_tables or 0)
+        if n <= 0:
+            return [], 0, []
+        dim = int(mc.embedding_dim or mc.hidden_size or 0)
+        rows = mc.embedding_table_rows
+        if rows is None:
+            total = int(mc.embedding_total_rows or 0)
+            per = total // n if n else 0
+            rows = [per] * n
+        else:
+            rows = _as_int_list(rows, n, int((mc.embedding_total_rows or 0) // max(1, n)))
+        pooling = _as_int_list(mc.embedding_pooling_factor, n, int(mc.embedding_default_pooling_factor or 1))
+        return rows, dim, pooling
+
+    def _shard_group_size(self) -> int:
+        """Number of ranks the embedding tables are sharded across.
+
+        Row/table-wise sharding (the TorchRec/DMP default) spreads tables over
+        the whole world; ``data`` sharding replicates them per rank.
+        """
+        mc = self.config.model_config
+        if str(getattr(mc, "embedding_sharding", "row")).lower() == "data":
+            return 1
+        world = int(os.getenv("NNODES", "1")) * int(os.getenv("GPUS_PER_NODE", "8"))
+        return max(1, world)
+
+    # -- params ----------------------------------------------------------------
+    def _total_embedding_params(self) -> int:
+        rows, dim, _ = self._tables()
+        return int(sum(r * dim for r in rows))
+
+    def estimated_num_params(self, rank: Optional[int] = None) -> int:
+        total = self._total_embedding_params()
+        if rank is None:
+            return total
+        return total // self._shard_group_size()
+
+    def param_bytes_by_tier(self, rank: Optional[int] = 0) -> tuple[int, int]:
+        """Return (hbm_bytes, ddr_bytes) of embedding params for this rank."""
+        mc = self.config.model_config
+        params = self.estimated_num_params(rank)
+        total_bytes = params * int(mc.embedding_param_bytes or 4)
+        hbm_frac = float(getattr(mc, "embedding_hbm_fraction", 1.0) or 1.0)
+        hbm_frac = min(1.0, max(0.0, hbm_frac))
+        hbm = int(total_bytes * hbm_frac)
+        return hbm, total_bytes - hbm
+
+    # -- activation ------------------------------------------------------------
+    def estimated_activation_memory(self, batch_size: int, seq_len: int) -> int:
+        rows, dim, _ = self._tables()
+        n = len(rows)
+        # Pooled output: one D-vector per table per sample (bf16 activations).
+        return int(batch_size * n * dim * 2)
+
+    # -- compute ---------------------------------------------------------------
+    def _get_simulated_results(self, batch_size: int, seq_len: int) -> tuple[float, float, int]:
+        rows, dim, pooling = self._tables()
+        n = len(rows)
+        param_bytes = int(self.config.model_config.embedding_param_bytes or 4)
+        hbm_frac = min(
+            1.0, max(0.0, float(getattr(self.config.model_config, "embedding_hbm_fraction", 1.0) or 1.0))
+        )
+
+        # Rows gathered per sample across all tables (sum pooling factor), times
+        # the local batch, each row = dim * param_bytes.
+        rows_gathered = batch_size * sum(pooling)
+        gather_bytes = rows_gathered * dim * param_bytes
+        output_bytes = batch_size * n * dim * 2  # pooled write (bf16)
+
+        hbm_bytes = gather_bytes * hbm_frac + output_bytes
+        ddr_bytes = gather_bytes * (1.0 - hbm_frac)
+
+        fwd = hbm_bytes / (_PEAK_HBM_BYTES_PER_MS * _GATHER_HBM_FRACTION)
+        if ddr_bytes > 0:
+            fwd += ddr_bytes / _HOST_LINK_BYTES_PER_MS
+        fwd = max(0.01, fwd)
+        # Backward is the scatter-add of the same gathered rows (read-modify-write).
+        bwd = 2.0 * fwd
+        return (fwd, bwd, self.estimated_activation_memory(batch_size, seq_len))
+
+    def _results(self, batch_size: int, seq_len: int):
+        key = (batch_size, seq_len)
+        if self._cached is None or self._cache_key != key:
+            self._cached = self._get_simulated_results(batch_size, seq_len)
+            self._cache_key = key
+        return self._cached
+
+    def measured_forward_time(self, batch_size: int, seq_len: int) -> float:
+        return self._results(batch_size, seq_len)[0]
+
+    def measured_backward_time(self, batch_size: int, seq_len: int) -> float:
+        return self._results(batch_size, seq_len)[1]
+
+    def measured_activation_memory(self, batch_size: int, seq_len: int) -> int:
+        return self._results(batch_size, seq_len)[2]

--- a/primus/core/projection/training_config.py
+++ b/primus/core/projection/training_config.py
@@ -120,6 +120,48 @@ class ModelConfig:
     # Loss fusion – fuses cross-entropy with output layer avoiding full logits materialisation
     cross_entropy_loss_fusion: bool = False
 
+    # ------------------------------------------------------------------
+    # Sparse-embedding + HSTU (DLRM-v4 / TorchRec ranker) fields.
+    #
+    # These are additive and default to the inert values used by the
+    # language-model path (num_embedding_tables=0 -> no sparse arch), so an
+    # LLM config is unaffected.  A DLRM workload populates them and the
+    # ``torchrec_dlrm`` workload spec assembles the sparse-embedding + HSTU
+    # profilers from them.
+    # ------------------------------------------------------------------
+    # Sparse embeddings (TorchRec/DMP EmbeddingBagCollection).
+    num_embedding_tables: int = 0
+    # Per-table row (cardinality) counts; if unset, ``embedding_total_rows`` is
+    # split evenly across ``num_embedding_tables``.
+    embedding_table_rows: object = None  # list[int] | "[...]" | None
+    embedding_total_rows: int = 0
+    embedding_dim: int = 0  # per-table embedding width (D); defaults to hidden_size
+    # Average number of lookups per sample per table (pooling factor); a scalar
+    # or a per-table list.  Drives the sparse gather byte-traffic and the
+    # embedding all-to-all message size.
+    embedding_pooling_factor: object = None  # int | list[int] | None
+    embedding_default_pooling_factor: int = 1
+    # Sharding of the embedding tables across the model-parallel mesh.
+    embedding_sharding: str = "row"  # row | column | table | data
+    # Stored precision of the embedding parameters (fp32 tables are common).
+    embedding_param_bytes: int = 4
+    # Memory tiering: fraction of embedding parameters resident in HBM; the
+    # remainder lives on DDR/UVM (host) and is streamed over the host link.
+    embedding_hbm_fraction: float = 1.0
+
+    # HSTU (Hierarchical Sequential Transduction Unit) attention block.
+    hstu_num_heads: int = 0
+    hstu_qk_dim: int = 0  # per-head query/key dim (d_qk)
+    hstu_v_dim: int = 0  # per-head value dim (d_v)
+    hstu_max_seq_len: int = 0
+    # Jagged-sequence fill factor: mean valid tokens / padded max_seq_len
+    # (HSTU sequences are variable length; ~0.4 is typical for Yambda-5B).
+    hstu_fill_factor: float = 1.0
+    # DLRM dense (bottom) and interaction (top/over) MLP layer widths.
+    dlrm_bottom_mlp: object = None  # list[int] | None
+    dlrm_over_mlp: object = None  # list[int] | None
+    dense_input_dim: int = 0  # width of the dense (continuous) feature vector
+
 
 @dataclass
 class TrainingConfig:
@@ -130,6 +172,10 @@ class TrainingConfig:
     model_config: ModelConfig
     runtime_config: RuntimeConfig
     model_parallel_config: ModelParallelConfig
+    # Workload framework this config describes.  Read by the workload registry
+    # (``resolve_top_level_spec``) to pick the top-level profiler tree.  Defaults
+    # to ``megatron`` so the language-model path is unchanged.
+    framework: str = "megatron"
 
 
 def gemm_dtype_from_config(config) -> str:
@@ -232,11 +278,53 @@ def megatron_derive_default_args(args):
     return args
 
 
+# Frameworks whose profiler tree is a sparse-embedding + HSTU recommender
+# (DLRM-v4).  They share the ``dlrm`` config-derivation path and are resolved to
+# the ``torchrec_dlrm`` workload spec by the workload registry.
+_DLRM_FRAMEWORKS = ("torchrec_dlrm", "torchrec", "dlrm", "dlrm_v4")
+
+
+def dlrm_derive_default_args(args):
+    """Fill in derived defaults for a DLRM-v4 (TorchRec/HSTU) config.
+
+    Kept intentionally light: it only normalises the naming differences the
+    dataclass copy (``update_config_from_args``) relies on and derives the data
+    parallel size the same way the Megatron path does.  Everything else is
+    copied straight from the workload args by field name.
+    """
+    world_size = int(os.getenv("NNODES", "1")) * int(os.getenv("GPUS_PER_NODE", "8"))
+
+    # HSTU sequence length maps onto the generic ``sequence_length`` slot so the
+    # activation/attention machinery sees it without special-casing.
+    if getattr(args, "sequence_length", None) in (None, 0) and getattr(args, "hstu_max_seq_len", 0):
+        args.sequence_length = args.hstu_max_seq_len
+
+    # DLRM sparse embeddings dominate params; hidden_size defaults to the
+    # embedding width when the ranker doesn't carry a separate hidden dim.
+    if getattr(args, "hidden_size", 0) in (None, 0) and getattr(args, "embedding_dim", 0):
+        args.hidden_size = args.embedding_dim
+    if getattr(args, "embedding_dim", 0) in (None, 0) and getattr(args, "hidden_size", 0):
+        args.embedding_dim = args.hidden_size
+
+    tp = getattr(args, "tensor_model_parallel_size", 1) or 1
+    pp = getattr(args, "pipeline_model_parallel_size", 1) or 1
+    cp = getattr(args, "context_parallel_size", 1) or 1
+    if not getattr(args, "data_parallel_size", None):
+        args.data_parallel_size = max(1, world_size // (tp * pp * cp))
+    if getattr(args, "context_parallel_size", None) is not None:
+        args.context_model_parallel_size = args.context_parallel_size
+
+    return args
+
+
 def convert_primus_config_to_projection_config(primus_config) -> TrainingConfig:
     args = primus_config.get_module_config("pre_trainer")
-    framework = getattr(args, "framework", "")
-    if framework == "megatron":
+    framework = getattr(args, "framework", "") or ""
+    fw = framework.lower().strip()
+    if fw == "megatron":
         args = megatron_derive_default_args(args)
+    elif fw in _DLRM_FRAMEWORKS:
+        args = dlrm_derive_default_args(args)
     else:
         raise NotImplementedError(f"Unsupported framework: {framework}")
 
@@ -248,6 +336,7 @@ def convert_primus_config_to_projection_config(primus_config) -> TrainingConfig:
         model_config=model_config,
         runtime_config=runtime_config,
         model_parallel_config=model_parallel_config,
+        framework=fw or "megatron",
     )
 
     return training_config

--- a/primus/core/projection/workload_registry.py
+++ b/primus/core/projection/workload_registry.py
@@ -1,0 +1,125 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Workload (framework) registry for the projection tool.
+
+The projection driver used to hardcode ``get_language_model_profiler_spec`` as
+the one and only top-level profiler tree, which silently assumed every workload
+is a Megatron-style dense/MoE language model.  That coupling is the single thing
+that blocks projecting any non-language-model workload (e.g. a TorchRec/DLRM
+ranker) even when every underlying compute/memory op is already modelled.
+
+This module breaks that coupling: selection is registry-driven and no workload
+name is hardcoded at the call sites.  A workload maps a ``framework`` string to
+a spec factory -- a callable ``(config: TrainingConfig) -> ModuleProfilerSpec``
+that returns the root of the profiler tree for that workload.  The driver builds
+the profiler from whatever spec the registry returns; the rest of the pipeline
+(``build_profiler`` and the ``ModuleProfilerSpec`` walk) is already workload
+agnostic.
+
+Built-in workloads (``megatron``, ``torchrec_dlrm``) self-register on first use.
+Out-of-tree code can register additional workloads by importing this module and
+calling ``register_workload(name, spec_factory)`` at its own import time.
+
+Selection at call time: explicit ``framework`` arg -> ``config.framework`` ->
+``PRIMUS_WORKLOAD`` env var -> ``"megatron"``.
+"""
+
+import os
+from typing import Callable, Dict, Optional, Tuple
+
+# A workload spec factory turns a projection TrainingConfig into the root
+# ModuleProfilerSpec of that workload's profiler tree.
+WorkloadSpecFactory = Callable[..., "object"]
+
+_WORKLOAD_REGISTRY: Dict[str, WorkloadSpecFactory] = {}
+
+
+def register_workload(name: str, spec_factory: WorkloadSpecFactory) -> None:
+    """Register a workload spec factory under *name* (case-insensitive).
+
+    Safe to call multiple times; the last registration for a name wins.
+    """
+    if not name or not isinstance(name, str):
+        raise ValueError(f"Workload framework name must be a non-empty string, got {name!r}")
+    if not callable(spec_factory):
+        raise TypeError(f"Workload spec factory for '{name}' must be callable, got {spec_factory!r}")
+    _WORKLOAD_REGISTRY[name.lower().strip()] = spec_factory
+
+
+def get_workload_spec_factory(name: str) -> Optional[WorkloadSpecFactory]:
+    """Return the registered spec factory for *name*, or ``None`` if not registered."""
+    if not name:
+        return None
+    _ensure_builtins_registered()
+    return _WORKLOAD_REGISTRY.get(name.lower().strip())
+
+
+def available_workloads() -> Tuple[str, ...]:
+    """Return the sorted names of all registered workloads."""
+    _ensure_builtins_registered()
+    return tuple(sorted(_WORKLOAD_REGISTRY))
+
+
+def _ensure_builtins_registered() -> None:
+    """Register the in-tree workloads on first use (idempotent).
+
+    Imports are done lazily here (not at module top level) so importing this
+    registry has no hard dependency on the profiler package, which pulls in the
+    training config and every module profiler.  A function attribute (rather than
+    a module global) tracks the one-time registration.
+    """
+    if getattr(_ensure_builtins_registered, "_done", False):
+        return
+    _ensure_builtins_registered._done = True
+
+    # Language model (Megatron) -- the default; preserves historical behaviour.
+    from primus.core.projection.module_profilers.language_model import (
+        get_language_model_profiler_spec,
+    )
+
+    register_workload("megatron", get_language_model_profiler_spec)
+
+    # DLRM-v4 (TorchRec / HSTU ranker), under every alias the config converter
+    # accepts so ``framework: dlrm`` / ``torchrec`` all resolve.
+    from primus.core.projection.module_profilers.dlrm import get_dlrm_profiler_spec
+
+    for alias in ("torchrec_dlrm", "torchrec", "dlrm", "dlrm_v4"):
+        register_workload(alias, get_dlrm_profiler_spec)
+
+
+def resolve_top_level_spec(config, framework: Optional[str] = None):
+    """Resolve and build the top-level ``ModuleProfilerSpec`` for *config*.
+
+    This is the single seam the projection drivers call instead of hardcoding
+    ``get_language_model_profiler_spec``.
+
+    Selection order: explicit ``framework`` arg -> ``config.framework`` ->
+    ``PRIMUS_WORKLOAD`` env var -> ``"megatron"``.
+
+    Raises:
+        ValueError: if the selected framework has no registered workload.
+    """
+    _ensure_builtins_registered()
+
+    name = framework or getattr(config, "framework", None) or os.getenv("PRIMUS_WORKLOAD", None)
+    if name is not None:
+        name = str(name).lower().strip()
+    if not name:
+        name = "megatron"
+
+    factory = get_workload_spec_factory(name)
+    if factory is None:
+        supported = ", ".join(available_workloads()) or "megatron"
+        raise ValueError(
+            f"Unknown projection workload framework: '{name}'. Supported workloads: {supported}. "
+            "Register additional workloads by calling register_workload(name, spec_factory)."
+        )
+
+    if int(os.getenv("RANK", "0")) == 0:
+        print(f"[Primus:Projection] Using workload: {name}")
+    return factory(config)


### PR DESCRIPTION
Add a framework->profiler workload registry (mirroring the GEMM-backend registry) so the projection tool is no longer hardcoded to Megatron language models. megatron stays the default; the memory/perf drivers resolve the top-level spec through resolve_top_level_spec().

Enable DLRM-v4 rankers end-to-end:
- training_config: framework field + sparse-embedding/HSTU config fields; open the framework gate for dlrm/torchrec aliases.
- sparse_embedding profiler: table params, row-wise world sharding, HBM/DDR tiering, random-access gather byte-traffic.
- hstu profiler: fused UVQK GEMM, jagged fill-factor SDPA, SiLU gating, output GEMM (priced via GEMM/SDPA backends).
- dlrm root profiler + get_dlrm_profiler_spec; registered as torchrec_dlrm.
- examples/project_dlrm.py: self-contained runnable projection entry.

LLM/megatron path unchanged.