### PR TITLE
Qwen3-30B MI355X: adopt tuned defaults (recompute/batch)

### DIFF
--- a/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_30B_A3B-BF16-pretrain.yaml
@@ -41,7 +41,7 @@ modules:
       # recompute
       recompute_granularity: full # full, selective
       recompute_method: block # uniform, block
-      recompute_num_layers: 5 # int
+      recompute_num_layers: 0 # int
 
       # parallel
       tensor_model_parallel_size: ${PRIMUS_TP:1}

--- a/examples/megatron/configs/MI355X/qwen3_30B_A3B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_30B_A3B-FP8-pretrain.yaml
@@ -22,8 +22,8 @@ modules:
 
       # hyper parameters
       train_iters: 50
-      micro_batch_size: 6
-      global_batch_size: 48
+      micro_batch_size: 8
+      global_batch_size: 512
       seq_length: ${PRIMUS_SEQ_LENGTH:4096}
       max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1.0e-5
@@ -41,7 +41,7 @@ modules:
       # recompute
       recompute_granularity: full # full, selective
       recompute_method: block # uniform, block
-      recompute_num_layers: 5 # int
+      recompute_num_layers: 0 # int
 
       # parallel
       tensor_model_parallel_size: ${PRIMUS_TP:1}


### PR DESCRIPTION
## Summary

Updates the two Qwen3-30B-A3B MI355X Megatron configs to the tuned settings that recover significant throughput vs the shipped defaults. Measured on AAC16 MI355X (single node, 8xGPU), publishing quality (3-repeat steady-state mean), image `primus_the_rock_rocm7.15_20260728`.

| Config | Change | Shipped tps | Tuned tps | Δ |
|---|---|---|---|---|
| Qwen3-30B BF16 | `recompute_num_layers` 5 → 0 | 24,623 (published ref) | 29,209 | **+19%** |
| Qwen3-30B FP8 | `micro_batch_size` 6 → 8, `global_batch_size` 48 → 512, `recompute_num_layers` 5 → 0 | 25,489 (published ref) | 30,140 | **+18%** |

Both tuned configs now meet/beat the v26.3 published reference. Root causes: the shipped BF16 config over-checkpointed (full recompute unnecessary at this size given available HBM headroom, ~82%); the shipped FP8 config used a very small global batch (48) that under-utilized grad accumulation.

## ⚠️ Required companion setting — allocator flag

The tuned runs set the env var **`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`**, which cannot be expressed in the YAML. At `recompute_num_layers: 0` these configs run at ~82–84% peak HBM **with** this flag; without it, allocator fragmentation may push them to OOM.

Before this merges, please confirm one of:
- the launch path (`run_pretrain.sh` / runner) sets `expandable_segments` for MI355X by default, **or**
- the configs are verified to hold at `recompute 0` without the flag, **or**
- the flag requirement is documented alongside these configs.

## Test plan
- [ ] Re-run both configs on MI355X single node, confirm no OOM and tps within ~2% of the numbers above
- [ ] Confirm behavior with and without `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`