### PR TITLE
[CP] Add MLPerf Llama 3.1 8B Docker launcher and update MI355X benchmark configs (#1012)

### DIFF
--- a/examples/mlperf/llama3.1_8b/README.md
+++ b/examples/mlperf/llama3.1_8b/README.md
@@ -4,16 +4,6 @@ MLPerf-compliant LLama3.1 8B pretraining using Primus
 
 ## Setup
 
-### Start Docker Image
-
-```bash
-export MLPERF_PAT=<your_github_pat>
-docker run -it     --device /dev/dri     --device /dev/kfd     --device /dev/infiniband     --network host --ipc host     --group-add video     --cap-add SYS_PTRACE     --security-opt seccomp=unconfined     --privileged     -v $HOME:$HOME   --shm-size 128G     --name primus_training_env rocm/primus:v26.5
-
-cd /workspace/Primus
-```
-
-
 ### Configuration
 
 - **Model**: LLama3.1 8B (4096 hidden, 32 layers, 32 attention heads)
@@ -21,14 +11,6 @@ cd /workspace/Primus
 - **Precision**: MXFP4
 - **Data**: C4 dataset (tokenized)
 
-## Key Files
-
-- `configs/MI355X/llama3.1_8B-pretrain-FP4.yaml` - Model and training config
-    - Update `train_data_path` and `train_data_path` to your local downloaded location
-- `config_MI355X_1x8x1.sh` - System config and env vars
-   - Update `PRIMUS_PATH` to clone Primus Repo
-   - Update `EXP`to `<PRIMUS_PATH>/examples/mlperf/configs/MI355X/llama3.1_8B-pretrain-FP4.yaml`
-- `run_and_time.sh` - Run script
 
 ### Data
 
@@ -37,11 +19,68 @@ Download preprocessed C4 dataset:
 ```bash
 mkdir -p /data/mlperf_llama31_8b
 cd /data/mlperf_llama31_8b
-bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) \
-    -d data https://training.mlcommons-storage.org/metadata/llama-3-1-8b-preprocessed-c4-dataset.uri
+
+# data
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d data https://training.mlcommons-storage.org/metadata/llama-3-1-8b-preprocessed-c4-dataset.uri
+
+# model
+bash <(curl -s https://raw.githubusercontent.com/mlcommons/r2-downloader/refs/heads/main/mlc-r2-downloader.sh) -d model https://training.mlcommons-storage.org/metadata/llama-3-1-8b-tokenizer.uri
+
 ```
 
-### How to run
+## Run with Docker (recommended)
+
+Run the launcher from the host. It starts the container, mounts the Primus
+checkout and data directories, loads the selected system configuration, and
+runs the requested number of experiments.
+
+```bash
+cd /path/to/Primus
+
+export DATADIR=/data/mlperf_llama31_8b/data
+export MODELDIR=/data/mlperf_llama31_8b/model
+export LOGDIR=/data/mlperf_llama31_8b/results
+
+# Optional; these are the defaults.
+export CONT=rocm/primus:v26.5
+export DGXSYSTEM=MI355X_1x8x1
+export NEXP=1
+
+# Optional host runtime tunables before each trial (cpupower, THP, drop_caches; see runtime_tunables.sh):
+# export RUN_RUNTIME_TUNABLES=1
+
+bash examples/mlperf/llama3.1_8b/run_with_docker.sh
+```
+
+`DATADIR` must contain the preprocessed C4 dataset. If `MODELDIR` exists and
+is nonempty, it is mounted at `/model` and used as the local tokenizer. If a
+local tokenizer is unavailable, omit `MODELDIR` (or point it to an empty
+directory) and export a Hugging Face token:
+
+```bash
+export HF_TOKEN=<your_huggingface_token>
+bash examples/mlperf/llama3.1_8b/run_with_docker.sh
+```
+
+
+## Run inside an existing container
+
+### Start Docker Image
+
+```bash
+docker run -it     --device /dev/dri     --device /dev/kfd     --device /dev/infiniband     --network host --ipc host     --group-add video     --cap-add SYS_PTRACE     --security-opt seccomp=unconfined     --privileged     -v $HOME:$HOME   --shm-size 128G     --name primus_training_env rocm/primus:v26.5
+
+cd /workspace/Primus
+```
+
+### Key Files
+
+- `configs/MI355X/llama3.1_8B-pretrain-FP4.yaml` - Model and training config
+    - Update `train_data_path` and `train_data_path` to your local downloaded location
+- `config_MI355X_1x8x1.sh` - System config and env vars
+   - Update `PRIMUS_PATH` to clone Primus Repo
+   - Update `EXP`to `<PRIMUS_PATH>/examples/mlperf/configs/MI355X/llama3.1_8B-pretrain-FP4.yaml`
+- `run_and_time.sh` - Run script
 
 ```bash
 export HF_TOKEN=<your_huggingface_token>
@@ -51,3 +90,4 @@ bash run_and_time.sh
 ## Notes
 
 - `log_interval: 99999999` suppresses regular Primus logs
+- `RUN_RUNTIME_TUNABLES` defaults to `0`; set `RUN_RUNTIME_TUNABLES=1` to run `runtime_tunables.sh` on the host before each trial (some steps require `sudo`).

--- a/examples/mlperf/llama3.1_8b/configs/MI355X/llama3.1_8B-pretrain-FP4.yaml
+++ b/examples/mlperf/llama3.1_8b/configs/MI355X/llama3.1_8B-pretrain-FP4.yaml
@@ -11,6 +11,8 @@ modules:
     # model to run
     model: llama3.1_8B.yaml
     overrides:
+      # Use /model when mounted (MLPerf local tokenizer); otherwise fall back to HF hub id.
+      tokenizer_model: ${PRIMUS_TOKENIZER_MODEL:meta-llama/Llama-3.1-8B}
       # --- Logging Config ---
       stage: mlperf_pretrain
       disable_wandb: true

--- a/examples/mlperf/llama3.1_8b/run_and_time.sh
+++ b/examples/mlperf/llama3.1_8b/run_and_time.sh
@@ -27,6 +27,18 @@ echo "Rank:   ${NODE_RANK}"
 echo "Master: ${MASTER_ADDR}:${MASTER_PORT}"
 echo "============================================"
 
+# Prefer an explicit tokenizer override, then a mounted local tokenizer
+# (/model), and otherwise keep the yaml HuggingFace default.
+if [[ -n "${PRIMUS_TOKENIZER_MODEL:-}" ]]; then
+    echo "Tokenizer: ${PRIMUS_TOKENIZER_MODEL} (environment override)"
+elif [[ -d /model && -n "$(ls -A /model 2>/dev/null)" ]]; then
+    export PRIMUS_TOKENIZER_MODEL=/model
+    echo "Tokenizer: /model (local mount)"
+else
+    unset PRIMUS_TOKENIZER_MODEL
+    echo "Tokenizer: meta-llama/Llama-3.1-8B (HuggingFace default)"
+fi
+
 # Start timing
 start=$(date +%s)
 start_fmt=$(date +%Y-%m-%d\ %r)

--- a/examples/mlperf/llama3.1_8b/run_with_docker.sh
+++ b/examples/mlperf/llama3.1_8b/run_with_docker.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+# Host-side MLPerf Llama3.1-8B pretraining launcher (Primus + Docker).
+#
+# Orchestrates N timed training trials in a long-lived container, matching the
+# MLPerf submission flow in training_results_v6.0 (llama31_8b/run_with_docker.sh)
+# and the Primus examples/mlperf/llama2_70b/run_with_docker.sh layout.
+#
+# Prerequisites on the host:
+#   - Docker + ROCm devices (/dev/kfd, /dev/dri)
+#   - Primus repo (this script lives under examples/mlperf/llama3.1_8b/)
+#   - Writable DATADIR (preprocessed C4 dataset under .../data; see README.md)
+#   - Writable MODELDIR (Llama 3.1 8B tokenizer under .../model; see README.md)
+#   - Writable LOGDIR (trial logs + /results artifacts inside the container)
+#   - HF_TOKEN (Hugging Face hub access for model assets / dataset hooks)
+#
+# Quick start:
+#   export DATADIR=/data/mlperf_llama31_8b/data
+#   export MODELDIR=/data/mlperf_llama31_8b/model
+#   export LOGDIR=/data/mlperf_llama31_8b/results
+#   export CONT=rocm/primus:v26.5
+#   export DGXSYSTEM=MI355X_1x8x1
+#   export HF_TOKEN=<your_token>
+#   bash examples/mlperf/llama3.1_8b/run_with_docker.sh
+#
+# Interactive (prompts for HF_TOKEN, image, NEXP, paths):
+#   INTERACTIVE=1 bash examples/mlperf/llama3.1_8b/run_with_docker.sh
+#
+# Quiet MLPerf submission logging (:::MLLOG + timing only):
+#   SUBMISSION_QUIET=1 bash examples/mlperf/llama3.1_8b/run_with_docker.sh
+#
+# Host runtime tunables before each trial (cpupower, THP, drop_caches; see runtime_tunables.sh):
+#   RUN_RUNTIME_TUNABLES=1 bash examples/mlperf/llama3.1_8b/run_with_docker.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRIMUS_HOST="${PRIMUS_HOST:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
+
+# Defaults (override via env or INTERACTIVE prompts)
+: "${DGXSYSTEM:=MI355X_1x8x1}"
+: "${CONT:=rocm/primus:v26.5}"
+: "${DATADIR:=${HOME}/data/mlperf_llama31_8b/data}"
+: "${MODELDIR:=$(dirname "${DATADIR}")/model}"
+: "${LOGDIR:=$(dirname "${DATADIR}")/results}"
+: "${NEXP:=1}"
+: "${CONT_NAME:=mlperf_llama31_8b_pretrain_primus}"
+: "${CLEAR_CACHES:=0}"
+: "${CHECK_COMPLIANCE:=0}"
+: "${MLPERF_RULESET:=6.0.0}"
+: "${DATESTAMP:=$(date +'%y%m%d%H%M%S')}"
+: "${INTERACTIVE:=0}"
+: "${SUBMISSION_QUIET:=0}"
+: "${RUN_RUNTIME_TUNABLES:=0}"
+
+# Map DGXSYSTEM (e.g. MI355X_1x8x1) -> PRIMUS_GPU_MODEL for primus-env when rocm-smi is unavailable in Docker.
+if [[ -z "${PRIMUS_GPU_MODEL:-}" && "${DGXSYSTEM}" =~ ^(MI[0-9]+[A-Z]*) ]]; then
+    export PRIMUS_GPU_MODEL="${BASH_REMATCH[1]}"
+fi
+
+readonly _runtime_tunables="${SCRIPT_DIR}/runtime_tunables.sh"
+
+prompt_if_interactive() {
+    local var_name="$1"
+    local prompt_text="$2"
+    local default_val="${3:-}"
+    local current_val="${!var_name:-}"
+
+    if [[ "${INTERACTIVE}" != "1" ]]; then
+        return 0
+    fi
+    if [[ -n "${current_val}" ]]; then
+        read -r -p "${prompt_text} [${current_val}]: " _input || true
+        if [[ -n "${_input}" ]]; then
+            printf -v "${var_name}" '%s' "${_input}"
+        fi
+    else
+        read -r -p "${prompt_text}${default_val:+ [${default_val}]}: " _input || true
+        if [[ -n "${_input}" ]]; then
+            printf -v "${var_name}" '%s' "${_input}"
+        elif [[ -n "${default_val}" ]]; then
+            printf -v "${var_name}" '%s' "${default_val}"
+        fi
+    fi
+}
+
+prompt_if_interactive "CONT" "Docker image (CONT)"
+prompt_if_interactive "NEXP" "Number of experiments (NEXP)" "1"
+prompt_if_interactive "DATADIR" "Data directory on host (mounted at /data)" "${DATADIR}"
+prompt_if_interactive "MODELDIR" "Tokenizer directory on host (mounted at /model)" "${MODELDIR}"
+prompt_if_interactive "LOGDIR" "Log/results directory on host (mounted at /results)" "${LOGDIR}"
+prompt_if_interactive "DGXSYSTEM" "DGXSYSTEM (config file suffix)" "${DGXSYSTEM}"
+
+readonly _config_file="${SCRIPT_DIR}/config_${DGXSYSTEM}.sh"
+
+if [[ ! -f "${_config_file}" ]]; then
+    echo "[ERROR] Config not found: ${_config_file} (set DGXSYSTEM correctly)" >&2
+    exit 1
+fi
+
+if [[ ! -d "${PRIMUS_HOST}" ]]; then
+    echo "[ERROR] Primus repo not found: ${PRIMUS_HOST} (set PRIMUS_HOST)" >&2
+    exit 1
+fi
+
+mkdir -p "${DATADIR}" "${LOGDIR}" "${LOGDIR}/artifacts"
+
+_use_model_mount=0
+if [[ -d "${MODELDIR}" && -n "$(ls -A "${MODELDIR}" 2>/dev/null)" ]]; then
+    _use_model_mount=1
+else
+    echo "[INFO] MODELDIR not found or empty (${MODELDIR}); skipping /model mount."
+    echo "[INFO] Training will use the default HuggingFace tokenizer (meta-llama/Llama-3.1-8B)."
+    if [[ -z "${HF_TOKEN:-}" ]]; then
+        if [[ "${INTERACTIVE}" == "1" ]] || [[ -t 0 ]]; then
+            read -rsp "Hugging Face HF_TOKEN (required without MODELDIR): " HF_TOKEN
+            echo
+            export HF_TOKEN
+        fi
+    fi
+    if [[ -z "${HF_TOKEN:-}" ]]; then
+        echo "[ERROR] HF_TOKEN is required when MODELDIR is missing or empty." >&2
+        exit 1
+    fi
+fi
+
+readonly _logfile_base="${LOGDIR}/${DATESTAMP}"
+readonly _cont_name="${CONT_NAME}"
+readonly _primus_mount="/workspace/Primus"
+readonly _example_dir="${_primus_mount}/examples/mlperf/llama3.1_8b"
+
+_cont_mounts=(
+    "--volume=${PRIMUS_HOST}:${_primus_mount}"
+    "--volume=${DATADIR}:/data"
+    "--volume=${LOGDIR}:/results"
+)
+if [[ "${_use_model_mount}" == "1" ]]; then
+    _cont_mounts+=("--volume=${MODELDIR}:/model")
+fi
+if [[ -d /opt/rocm ]]; then
+    _cont_mounts+=("--volume=/opt/rocm:/opt/rocm:ro")
+fi
+
+# Container Python/torchrun live in /opt/venv (rocm/primus image). Do not inject the host PATH.
+_container_path="/opt/venv/bin:/opt/rocm/bin:/usr/local/bin:/usr/bin:/bin"
+
+_extra_env=(
+    "--env=PATH=${_container_path}"
+    "--env=VENV_ACTIVATE=/opt/venv/bin/activate"
+    "--env=PRIMUS_AUTO_INSTALL=0"
+    "--env=PRIMUS_GPU_MODEL=${PRIMUS_GPU_MODEL:-MI355X}"
+    "--env=PRIMUS_PATH=${_primus_mount}"
+    "--env=DATADIR=/data"
+    "--env=DATA_PATH=/data"
+    "--env=HF_HOME=/data/.cache/huggingface"
+    "--env=ENABLE_MLLOG=1"
+    "--env=DGXSYSTEM=${DGXSYSTEM}"
+    "--env=LOGDIR=/results"
+)
+if [[ -n "${HF_TOKEN:-}" ]]; then
+    _extra_env+=("--env=HF_TOKEN=${HF_TOKEN}")
+fi
+
+if [[ "${SUBMISSION_QUIET}" == "1" ]]; then
+    _extra_env+=(
+        "--env=PRIMUS_LOG_SUPPRESSION=1"
+        "--env=MLPERF_VERBOSE_LOGS=0"
+        "--env=PRIMUS_LOG_GPU_MEM=0"
+        "--env=VERBOSE_TRAINING_LOG=0"
+    )
+fi
+
+# Export values from config_${DGXSYSTEM}.sh for docker exec.
+mapfile -t _config_env < <(
+    env -i HOME="${HOME}" PATH="${PATH}" bash -c "
+        set -a
+        source '${_config_file}'
+        set +a
+        env
+    " | grep -E -v '^(PWD|SHLVL|_|OLDPWD)=' || true
+)
+_config_docker_env=()
+for v in "${_config_env[@]}"; do
+    # Never override container PATH/PYTHONHOME from a host-side config source.
+    case "${v}" in PATH=*|PYTHONHOME=*|HOME=* ) continue ;; esac
+    _config_docker_env+=("--env=${v}")
+done
+
+_base_exec_env=("${_config_docker_env[@]}" "${_extra_env[@]}")
+
+cleanup_docker() {
+    if docker ps -a --format '{{.Names}}' | grep -qx "${_cont_name}"; then
+        docker container rm -f "${_cont_name}" >/dev/null 2>&1 || true
+    fi
+}
+cleanup_docker
+trap 'cleanup_docker' EXIT
+
+echo "[INFO] Primus host path:  ${PRIMUS_HOST}"
+echo "[INFO] Docker image:      ${CONT}"
+echo "[INFO] Data mount:        ${DATADIR} -> /data"
+if [[ "${_use_model_mount}" == "1" ]]; then
+    echo "[INFO] Model mount:       ${MODELDIR} -> /model"
+else
+    echo "[INFO] Model mount:       (skipped; no local tokenizer)"
+fi
+echo "[INFO] Results mount:     ${LOGDIR} -> /results"
+echo "[INFO] Experiments:       ${NEXP}"
+echo "[INFO] Container name:    ${_cont_name}"
+
+if [[ "${DGXSYSTEM}" == MI* ]]; then
+    docker run --rm --init --detach \
+        --net=host --uts=host --ipc=host \
+        --device=/dev/dri --device=/dev/kfd --device=/dev/infiniband \
+        --security-opt=seccomp=unconfined \
+        --group-add=video \
+        --cap-add=SYS_PTRACE \
+        --cap-add=CAP_SYS_ADMIN \
+        --privileged \
+        --shm-size=128g \
+        --ulimit=memlock=-1 \
+        --ulimit=stack=67108864 \
+        --name="${_cont_name}" "${_cont_mounts[@]}" \
+        -e IMAGE_NAME="${CONT}" \
+        "${CONT}" sleep infinity
+else
+    docker run --rm --init --detach \
+        --net=host --uts=host --ipc=host \
+        --gpus=all \
+        --ulimit=memlock=-1 \
+        --ulimit=stack=67108864 \
+        --security-opt=seccomp=unconfined \
+        --name="${_cont_name}" "${_cont_mounts[@]}" \
+        -e IMAGE_NAME="${CONT}" \
+        "${CONT}" sleep infinity
+fi
+
+sleep 3
+docker exec "${_cont_name}" true
+
+# Editable Primus from the host mount (ML deps including mlperf-logging come from the image venv).
+_setup_env=("${_base_exec_env[@]}")
+docker exec "${_setup_env[@]}" "${_cont_name}" bash -lc "
+set -e
+pip install -q -e '${_primus_mount}' --no-deps 2>/dev/null || true
+if ! python -c 'import primus_mllog' 2>/dev/null; then
+    echo '[INFO] primus_mllog not found; installing pinned mlperf-common package.'
+    pip install -q \
+        'git+https://github.com/AMD-AGI/mlperf-common.git@56d8ca70f60f866312add84adfea66f5447a4c86'
+else
+    echo '[INFO] primus_mllog is already installed; skipping installation.'
+fi
+python -c 'import primus_mllog'
+echo '[INFO] Container Primus editable install complete.'
+"
+
+_run_cmd="bash ${_example_dir}/run_and_time.sh"
+
+for _experiment_index in $(seq 1 "${NEXP}"); do
+    echo "============================================"
+    echo "Beginning trial ${_experiment_index} of ${NEXP}"
+    echo "============================================"
+
+    if [[ "${RUN_RUNTIME_TUNABLES}" == "1" && -x "${_runtime_tunables}" ]]; then
+        bash "${_runtime_tunables}"
+    fi
+
+    if [[ "${CLEAR_CACHES}" == "1" ]]; then
+        echo "[INFO] Clearing host page cache before trial ${_experiment_index}..."
+        sync
+        if [[ -w /proc/sys/vm/drop_caches ]]; then
+            echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null || true
+        else
+            sudo sysctl vm.drop_caches=3 >/dev/null 2>&1 || true
+        fi
+    fi
+
+    _run_env=("${_base_exec_env[@]}" --env="SEED=${RANDOM}")
+
+    set +e
+    docker exec "${_run_env[@]}" "${_cont_name}" bash -lc "${_run_cmd}" \
+        2>&1 | grep --line-buffered -v "connected peer ranks" \
+        | tee "${_logfile_base}_${_experiment_index}.log"
+    _trial_exit=${PIPESTATUS[0]}
+    set -e
+
+    if [[ "${_trial_exit}" -ne 0 ]]; then
+        echo "[ERROR] Trial ${_experiment_index} failed with exit code ${_trial_exit}" >&2
+        exit "${_trial_exit}"
+    fi
+
+    if [[ -f "${LOGDIR}/mlperf_logging.out" ]]; then
+        cp -f "${LOGDIR}/mlperf_logging.out" "${LOGDIR}/artifacts/mlperf_logging_${DATESTAMP}_${_experiment_index}.out" || true
+    fi
+    _train_log="${PRIMUS_HOST}/examples/mlperf/llama3.1_8b/train.mlperfpretrain.exp.log"
+    if [[ -f "${_train_log}" ]]; then
+        cp -f "${_train_log}" "${LOGDIR}/artifacts/train_${DATESTAMP}_${_experiment_index}.log" || true
+    fi
+
+    if [[ "${CHECK_COMPLIANCE}" == "1" ]]; then
+        docker exec "${_run_env[@]}" "${_cont_name}" bash -lc \
+            "python3 -m mlperf_logging.compliance_checker --usage training \
+             --ruleset '${MLPERF_RULESET}' \
+             --log_output '/results/compliance_${DATESTAMP}_${_experiment_index}.out' \
+             '/results/${DATESTAMP}_${_experiment_index}.log'" \
+            || echo "[WARN] Compliance check failed for trial ${_experiment_index} (non-blocking)"
+    fi
+done
+
+echo "[OK] Completed ${NEXP} trial(s). Logs: ${_logfile_base}_*.log"
+echo "[OK] MLLOG (last trial): ${LOGDIR}/mlperf_logging.out"

--- a/examples/mlperf/llama3.1_8b/runtime_tunables.sh
+++ b/examples/mlperf/llama3.1_8b/runtime_tunables.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# MLPerf host runtime tunables (MI355X submission reference).
+# Run on the **host** before each timed trial (see run_with_docker.sh).
+# Steps are best-effort; missing tools or permissions are ignored.
+
+set +e
+
+echo "[runtime_tunables] Applying host performance settings..."
+
+if [[ -w /proc/sys/vm/drop_caches ]] 2>/dev/null; then
+    sync
+    echo 3 >/proc/sys/vm/drop_caches 2>/dev/null
+else
+    sync
+    sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null
+fi
+
+sudo modprobe amdgpu 2>/dev/null
+if command -v rocm_agent_enumerator &>/dev/null; then
+    rocm_agent_enumerator >/dev/null 2>&1
+fi
+
+if command -v cpupower &>/dev/null; then
+    sudo cpupower idle-set -d 2 >/dev/null 2>&1
+    sudo cpupower frequency-set -g performance >/dev/null 2>&1
+fi
+
+for _sysctl in \
+    /proc/sys/kernel/nmi_watchdog \
+    /proc/sys/kernel/numa_balancing \
+    /proc/sys/kernel/randomize_va_space
+do
+    if [[ -w "${_sysctl}" ]] 2>/dev/null; then
+        echo 0 >"${_sysctl}" 2>/dev/null
+    else
+        sudo sh -c "echo 0 > ${_sysctl}" 2>/dev/null
+    fi
+done
+
+for _thp in \
+    /sys/kernel/mm/transparent_hugepage/enabled \
+    /sys/kernel/mm/transparent_hugepage/defrag
+do
+    if [[ -w "${_thp}" ]] 2>/dev/null; then
+        echo always >"${_thp}" 2>/dev/null
+    else
+        sudo sh -c "echo always > ${_thp}" 2>/dev/null
+    fi
+done
+
+echo "[runtime_tunables] Done."

--- a/examples/torchtitan/configs/MI355X/llama3.1_405B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_405B-BF16-pretrain.yaml
@@ -17,6 +17,9 @@ modules:
 
       training:
         local_batch_size: 2
+        steps: 50
+        seq_len: 8192
+        mock_data: true
 
       optimizer:
         lr: 8.0e-5

--- a/examples/torchtitan/configs/MI355X/llama3.1_405B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_405B-FP8-pretrain.yaml
@@ -20,6 +20,7 @@ modules:
         global_batch_size: 192
         steps: 50
         seq_len: 8192
+        mock_data: true
 
       # profiling:
       #   enable_profiling: false

--- a/examples/torchtitan/configs/MI355X/llama3.1_70B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_70B-BF16-pretrain.yaml
@@ -25,7 +25,7 @@ modules:
       training:
         local_batch_size: 6
         seq_len: 8192
-        mock_data: false
+        mock_data: true
         steps: 50
         gc_freq: 100
 

--- a/examples/torchtitan/configs/MI355X/llama3.1_70B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_70B-FP8-pretrain.yaml
@@ -31,7 +31,7 @@ modules:
         local_batch_size: 6
         global_batch_size: 96
         seq_len: 8192
-        mock_data: false
+        mock_data: true
         steps: 50
         gc_freq: 100
 

--- a/examples/torchtitan/configs/MI355X/llama3.1_8B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_8B-BF16-pretrain.yaml
@@ -26,7 +26,7 @@ modules:
       training:
         local_batch_size: 6
         seq_len: 8192
-        mock_data: false
+        mock_data: true
         steps: 50
         gc_freq: 100
 

--- a/examples/torchtitan/configs/MI355X/llama3.1_8B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_8B-FP8-pretrain.yaml
@@ -25,7 +25,7 @@ modules:
       training:
         local_batch_size: 8
         seq_len: 8192
-        mock_data: false
+        mock_data: true
         steps: 50
         gc_freq: 100
 


### PR DESCRIPTION
## Summary

- Add a host-side MLPerf Llama 3.1 8B Docker launcher (`run_with_docker.sh`), optional `runtime_tunables.sh`, and README updates aligned with the llama2_70b submission flow.
- Improve `run_and_time.sh` tokenizer selection (`PRIMUS_TOKENIZER_MODEL` override, local `/model` mount fallback).
- Enable short MI355X TorchTitan/Megatron pretrain benchmark settings (`mock_data`, short `steps` where applicable) for Llama 3.1 8B/70B/405B and DeepSeek v3 16B configs.

## Test plan

- [ ] Run `bash examples/mlperf/llama3.1_8b/run_with_docker.sh` on MI355X with valid `DATADIR` / `MODELDIR` / `HF_TOKEN`
- [ ] Verify optional host tunables: `RUN_RUNTIME_TUNABLES=1 bash examples/mlperf/llama3.1_8b/run_with_docker.sh`
- [ ] Smoke-test TorchTitan/Megatron configs: `primus-cli direct -- train pretrain --config
examples/torchtitan/configs/MI355X/llama3.1_8B-BF16-pretrain.yaml`


Made with [Cursor](https://cursor.com)

---------