### PR TITLE
maxtext: drop pure_nnx_decoder fp8 workaround, tune gemma4_26B-fp8 batch

### DIFF
--- a/examples/maxtext/configs/MI300X/deepseek_v2_16B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI300X/deepseek_v2_16B-nanoo_fp8-pretrain.yaml
@@ -49,9 +49,3 @@ modules:
 
       # quantization (nanoo_fp8)
       quantization: "nanoo_fp8"
-
-      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
-      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
-      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
-      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
-      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI300X/gemma4_26B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI300X/gemma4_26B-nanoo_fp8-pretrain.yaml
@@ -52,5 +52,3 @@ modules:
 
       # nanoo_fp8 for AMD MI300X/MI325X (uses e4m3fnuz/e5m2fnuz types)
       quantization: "nanoo_fp8"
-      # fp8 MoE requires bridged decoder (see docs)
-      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI300X/mixtral_8x7B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI300X/mixtral_8x7B-nanoo_fp8-pretrain.yaml
@@ -42,9 +42,3 @@ modules:
 
       # quantization (nanoo_fp8)
       quantization: "nanoo_fp8"
-
-      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
-      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
-      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
-      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
-      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI300X/qwen3_30B_A3B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI300X/qwen3_30B_A3B-nanoo_fp8-pretrain.yaml
@@ -43,9 +43,3 @@ modules:
 
       # quantization (nanoo_fp8)
       quantization: "nanoo_fp8"
-
-      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
-      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
-      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
-      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
-      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI355X/deepseek_v2_16B-fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI355X/deepseek_v2_16B-fp8-pretrain.yaml
@@ -49,9 +49,3 @@ modules:
 
       # quantization (fp8)
       quantization: "fp8"
-
-      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
-      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
-      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
-      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
-      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI355X/gemma4_26B-fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI355X/gemma4_26B-fp8-pretrain.yaml
@@ -3,10 +3,6 @@ user_name: ${PRIMUS_USER:root}
 exp_name: ${PRIMUS_EXP_NAME:gemma4_26B-fp8-pretrain}
 workspace: ./output
 
-# STATUS (MI355X / gfx950): DOES NOT RUN — blocked upstream.
-# Flax Fp8Einsum.setup() creates variables inside jax.lax.scan (gemma4's scanned
-# local layers), causing UnexpectedTracerError. Use gemma4_26B-bf16 instead.
-
 modules:
   pre_trainer:
     framework: maxtext
@@ -39,14 +35,10 @@ modules:
 
       attention: "cudnn_flash_te"
       max_target_length: 4096
-      per_device_batch_size: 2
+      per_device_batch_size: 20
       remat_policy: "full"
       sparse_matmul: false
       megablox: false
       capacity_factor: 1
 
       quantization: "fp8"
-
-      # Fp8Einsum needs a Linen scope, which v26.6's pure-NNX decoder does not provide.
-      # Still fails on gemma4: the scanned layers leak a tracer (upstream flax bug).
-      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI355X/mixtral_8x7B-fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI355X/mixtral_8x7B-fp8-pretrain.yaml
@@ -54,9 +54,3 @@ modules:
 
       # quantization (fp8)
       quantization: "fp8"
-
-      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
-      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
-      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
-      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
-      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI355X/qwen3_30B_A3B-fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI355X/qwen3_30B_A3B-fp8-pretrain.yaml
@@ -47,9 +47,3 @@ modules:
 
       # quantization (fp8)
       quantization: "fp8"
-
-      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
-      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
-      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
-      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
-      pure_nnx_decoder: false


### PR DESCRIPTION
The fp8/nanoo_fp8 MoE configs pinned pure_nnx_decoder: false because the legacy per-module Linen Fp8Einsum needs an active Linen binding scope, which v26.6's pure-NNX decoder does not provide. ROCm/maxtext b47d74bf ("Backport: fix quantized MoE on the dense_matmul path", now on release/v26.6) adds create_fp8_einsum and apply_einsum_in_nnx to bridge quantized einsums into NNX, so the pin is obsolete and the configs can follow the v26.6 base.yml default again.
