### PR TITLE
perf(megatron): avoid full logits copy in fused cross-entropy

### DIFF
--- a/primus/backends/megatron/patches/mamba_fused_ce_patches.py
+++ b/primus/backends/megatron/patches/mamba_fused_ce_patches.py
@@ -91,8 +91,14 @@ def _fused_cross_entropy_loss(self, hidden_states, labels, output_weight, runtim
             weight=output_weight,
             runtime_gather_output=runtime_gather_output,
         )
-        logits_2d = logits.permute(1, 0, 2).reshape(b * s, -1)
-        labels_1d = labels.reshape(b * s)
+        # logits is [s, b, vocab] (contiguous). Do NOT permute to [b, s, vocab] --
+        # that forces a full copy of the (huge) logits tensor in both the forward
+        # and its mirror in the backward (~170 ms/step for a 128k vocab at
+        # micro_batch 128 here; verified 963 -> 792 ms/it on GDN-pure 300M).
+        # Cross-entropy is an order-invariant mean, so flatten logits with a free
+        # view in [s, b] token order and reorder the (tiny) labels to match.
+        logits_2d = logits.reshape(s * b, -1)
+        labels_1d = labels.transpose(0, 1).reshape(s * b)
         loss = self._fused_ce(logits_2d, labels_1d)
         return loss.expand(b, s)
     else:


### PR DESCRIPTION
## Summary

The fused cross-entropy path permuted logits from `[s, b, vocab]` to `[b, s, vocab]` before flattening them. That permute is not free: it materializes a full second copy of the largest tensor in the step, and the backward pays for the mirror of it.

Cross-entropy is an order-invariant mean over tokens, so the already-contiguous `[s, b]` layout can be flattened with a zero-cost view, provided the labels are reordered to match. The labels are smaller than the logits by the size of the vocabulary, so transposing those instead is effectively free.

## Measured

GDN-pure 300M, 8x MI355X, seq 2048, micro-batch 128, vocab 128256:

| | ms/iter |
|---|---|
| before | 963 |
| after | **792** |

This is the largest single lever in the MI355X linear-attention recipe: it is what moves GDN-pure from slower than the Flash-Linear-Attention reference to faster than it at the same batch.

## Validation

- A 500-step GDN-pure 300M run reproduces the same step-500 loss as before the change (4.963021), bit-identical across two different nodes, confirming the reordering does not perturb the computation.
- KDA-pure 300M uses the same path and is unchanged in loss.
