### PR TITLE
perf(mlp): add opt-in fused SwiGLU+fc2 via FLA swiglu_linear

### DIFF
--- a/primus/backends/megatron/patches/_source_patch_utils.py
+++ b/primus/backends/megatron/patches/_source_patch_utils.py
@@ -82,6 +82,42 @@ def patch_method_source(
     return new_func
 
 
+def patch_method_source_multi(
+    cls: Any,
+    method_name: str,
+    replacements: "list[tuple[str, str]]",
+) -> Callable:
+    """Apply several ``(anchor, replacement)`` rewrites to one method in one pass.
+
+    A method can only be source-patched *once*: ``inspect.getsource`` cannot read
+    a function that was already rebuilt by ``exec``, so a second
+    :func:`patch_method_source` call on the same method raises ``OSError``.
+    Batching the rewrites keeps multiple independent injections possible.
+    """
+    original = getattr(cls, method_name)
+    source = inspect.getsource(original)
+    for ori_code, new_code in replacements:
+        assert ori_code in source, (
+            f"[SourcePatch] Anchor not found in {cls.__name__}.{method_name}; "
+            f"upstream source may have changed. Anchor: {ori_code!r}"
+        )
+        source = source.replace(ori_code, new_code)
+    modified_source = textwrap.dedent(source)
+
+    wrapper_source = "class _PrimusPatchWrapper:\n" + textwrap.indent(modified_source, "    ")
+    namespace: dict = {}
+    exec(wrapper_source, original.__globals__, namespace)  # noqa: S102
+    wrapper_cls = namespace["_PrimusPatchWrapper"]
+    new_func = wrapper_cls.__dict__[original.__name__]
+    if new_func.__closure__:
+        for cell in new_func.__closure__:
+            if cell.cell_contents is wrapper_cls:
+                cell.cell_contents = cls
+    new_func.__qualname__ = f"{cls.__qualname__}.{method_name}"
+    setattr(cls, method_name, new_func)
+    return new_func
+
+
 def patch_function_source(
     module: Any,
     function_name: str,

--- a/primus/backends/megatron/patches/fla_runtime_patches.py
+++ b/primus/backends/megatron/patches/fla_runtime_patches.py
@@ -81,6 +81,7 @@ from primus.core.utils.module_utils import log_rank_0
 
 _FLA_RUNTIME_KNOBS: tuple = (
     ("use_fla_fused_swiglu", "PRIMUS_FLA_SWIGLU", True),
+    ("use_fla_fused_swiglu_linear", "PRIMUS_FLA_SWIGLU_LINEAR", False),
     ("use_fla_fused_rmsnorm", "PRIMUS_FLA_NORM", False),
     ("use_fla_fused_gated_norm", "PRIMUS_FLA_NORM", False),
     ("use_fla_short_conv", "PRIMUS_FLA_CONV", False),

--- a/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
+++ b/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
@@ -11,14 +11,38 @@ MLP FLA SwiGLU Patch
 Routes ``MLP``'s gated-linear-unit activation through
 flash-linear-attention's (FLA) Triton-fused ``swiglu`` kernel (one fwd + one
 bwd kernel) instead of Megatron's naive two-kernel ``silu(x_glu) * x_linear``,
-saving ~20 ms/iter on GDN/KDA/Mamba hybrid training. Only takes effect when
-``config.gated_linear_unit`` and the activation is ``F.silu`` -- i.e. it is a
-no-op for GeLU-based MLPs, MoE, and any config where
-``use_te_activation_func`` / ``bias_activation_fusion`` are already handling
-the activation through a different (already-fused) code path.
+saving ~20 ms/iter on GDN/KDA/Mamba hybrid training.
+
+Only takes effect for plain, unclamped SwiGLU: ``config.gated_linear_unit`` with
+``F.silu``, no ``use_te_activation_func`` module slot, no
+``activation_func_clamp_value`` and no ``glu_linear_offset``. ``F.silu`` on its
+own is not a sufficient test -- Kimi K3 keeps that config value only to satisfy
+the whitelist in ``TransformerConfig.__post_init__`` while supplying the real,
+soft-clamped ``SituActivation`` through the module slot, and DeepSeek-V4 style
+configs reach the eager ``glu()`` with a clamp bound. FLA's kernels implement
+neither, so those configs fall through to Megatron's own code, as do GeLU-based
+MLPs and MoE.
 
 Toggle: ``args.use_fla_fused_swiglu`` (resolved by ``fla_runtime_patches.py``
 from ``PRIMUS_FLA_SWIGLU`` / YAML ``use_fla_fused_swiglu``, default True).
+
+Memory variant: ``args.use_fla_fused_swiglu_linear`` (default False) goes one
+step further and fuses the activation *into* ``linear_fc2`` via FLA's
+``swiglu_linear``. Megatron computes ``swiglu`` as its own op and then feeds the
+result to ``linear_fc2``, which saves that ffn-wide tensor for its weight
+gradient; ``swiglu_linear`` instead saves only the two fc1 halves and recomputes
+the activation in the backward. That removes one ffn-wide tensor per MLP layer
+(measured 0.188 GiB per unit micro-batch on GDN-300M, ffn 4096, seq 2048 -- the
+entire measured activation gap vs FLA).
+
+Correctness note: this bypasses ``linear_fc2``'s
+``linear_with_grad_accumulation_and_async_allreduce``, so the fc2 weight
+gradient lands in ``param.grad`` instead of being fused straight into
+``param.main_grad``. That is safe -- Megatron's DDP backward post-hook folds
+``param.grad`` into ``main_grad`` whenever ``grad_added_to_main_grad`` is False
+-- but it does forgo the wgrad-accumulation fusion, so the path is gated to the
+simple case it was measured on: TP=1, no sequence parallel, no bias, no
+per-token scaling, non-expert MLPs.
 
 Source-string rewrite style: the injection points sit inside ``MLP.__init__``
 and the non-fused branch of ``MLP.forward``, which a plain wrapper cannot
@@ -26,11 +50,30 @@ reach without duplicating the whole (large) method body.
 """
 
 from primus.backends.megatron.patches._patch_guard import is_patched, mark_patched
-from primus.backends.megatron.patches._source_patch_utils import patch_method_source
+from primus.backends.megatron.patches._source_patch_utils import (
+    patch_method_source,
+    patch_method_source_multi,
+)
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.core.utils.module_utils import log_rank_0
 
 _PATCH_KEY = "megatron.mlp.fla_swiglu"
+
+# `activation_func == F.silu` alone does not mean "plain SwiGLU". Kimi K3 keeps
+# that value only to satisfy the whitelist in TransformerConfig.__post_init__
+# while routing the real, soft-clamped activation through the `activation_func`
+# module slot (`use_te_activation_func`, mlp.py:226); DeepSeek-V4 style configs
+# instead reach the eager `glu()` with a clamp bound and/or a non-zero
+# `glu_linear_offset`. FLA's kernels implement none of that, so both fused paths
+# below are restricted to the plain, unclamped, zero-offset case and everything
+# else falls through to Megatron's own code.
+_PLAIN_SWIGLU_COND = (
+    "self.config.gated_linear_unit\n"
+    "                    and self.config.activation_func == F.silu\n"
+    "                    and not getattr(self.config, 'use_te_activation_func', False)\n"
+    "                    and getattr(self.config, 'activation_func_clamp_value', None) is None\n"
+    "                    and not getattr(self.config, 'glu_linear_offset', 0)"
+)
 
 # Inserted right before linear_fc2 construction in MLP.__init__, mirroring
 # where megatron_patches/03-mlp-fla-swiglu.patch spliced in its detection.
@@ -39,14 +82,42 @@ _INIT_NEW = (
     "from megatron.training import get_args as _get_args\n"
     "        self._use_fla_swiglu = False\n"
     "        if getattr(_get_args(), 'use_fla_fused_swiglu', True):\n"
-    "            if self.config.gated_linear_unit and self.config.activation_func == F.silu:\n"
+    "            if (" + _PLAIN_SWIGLU_COND + "):\n"
     "                try:\n"
     "                    from fla.modules.activations import swiglu as _fla_swiglu\n"
     "                    self._use_fla_swiglu = True\n"
     "                    self._fla_swiglu_fn = _fla_swiglu\n"
     "                except ImportError:\n"
     "                    pass\n"
+    "        self._use_fla_swiglu_linear = False\n"
+    "        if getattr(_get_args(), 'use_fla_fused_swiglu_linear', False):\n"
+    "            if (" + _PLAIN_SWIGLU_COND + "\n"
+    "                    and self.config.tensor_model_parallel_size == 1\n"
+    "                    and not self.config.sequence_parallel\n"
+    "                    and not self.config.add_bias_linear\n"
+    "                    and not is_expert):\n"
+    "                try:\n"
+    "                    from fla.modules.activations import swiglu_linear as _fla_swiglu_linear\n"
+    "                    self._use_fla_swiglu_linear = True\n"
+    "                    self._fla_swiglu_linear_fn = _fla_swiglu_linear\n"
+    "                except ImportError:\n"
+    "                    pass\n"
     "\n        " + _INIT_ORI
+)
+
+# Inserted at the top of MLP.forward's activation section: when the fused
+# swiglu+fc2 path is active we short-circuit both the activation and linear_fc2,
+# so the ffn-wide activation output is never saved for backward.
+_FWD_FUSED_ORI = 'nvtx_range_push(suffix="activation")'
+_FWD_FUSED_NEW = (
+    "if (getattr(self, '_use_fla_swiglu_linear', False)\n"
+    "                and per_token_scale is None and bias_parallel is None):\n"
+    "            x_glu, x_linear = torch.chunk(intermediate_parallel, 2, dim=-1)\n"
+    "            output = self._fla_swiglu_linear_fn(\n"
+    "                x_glu, x_linear, self.linear_fc2.weight, None\n"
+    "            )\n"
+    "            return output, None\n"
+    "        " + _FWD_FUSED_ORI
 )
 
 # Inserted in MLP.forward's non-fused-bias-activation branch, in place of the
@@ -69,12 +140,19 @@ def _install_mlp_fla_swiglu_patch() -> None:
         return
 
     patch_method_source(MLP, "__init__", _INIT_ORI, _INIT_NEW)
-    patch_method_source(MLP, "forward", _FORWARD_ORI, _FORWARD_NEW)
+    # Both forward rewrites must go in one pass: a method can only be
+    # source-patched once (inspect.getsource cannot re-read an exec'd function).
+    patch_method_source_multi(
+        MLP,
+        "forward",
+        [(_FWD_FUSED_ORI, _FWD_FUSED_NEW), (_FORWARD_ORI, _FORWARD_NEW)],
+    )
 
     mark_patched(MLP, _PATCH_KEY)
     log_rank_0(
         f"[Patch:{_PATCH_KEY}] Patched MLP.__init__/forward to use FLA's Triton "
-        "swiglu kernel when use_fla_fused_swiglu is set."
+        "swiglu kernel when use_fla_fused_swiglu is set, and to fuse swiglu into "
+        "linear_fc2 when use_fla_fused_swiglu_linear is set."
     )
 
 
@@ -88,7 +166,8 @@ def _install_mlp_fla_swiglu_patch() -> None:
     ),
     # Runs after fla_runtime_knobs (priority=-100) has resolved args.use_fla_fused_swiglu.
     priority=50,
-    condition=lambda ctx: getattr(get_args(ctx), "use_fla_fused_swiglu", False),
+    condition=lambda ctx: getattr(get_args(ctx), "use_fla_fused_swiglu", False)
+    or getattr(get_args(ctx), "use_fla_fused_swiglu_linear", False),
 )
 def patch_mlp_fla_swiglu(ctx: PatchContext) -> None:
     _install_mlp_fla_swiglu_patch()


### PR DESCRIPTION
## Summary

Megatron computes `swiglu` as its own op and hands the result to `linear_fc2`, which saves that ffn-wide tensor for its weight gradient. Flash-Linear-Attention's `swiglu_linear` instead saves only the two `fc1` halves and recomputes the activation in the backward, removing one ffn-wide saved tensor per MLP layer.

This adds that path behind `use_fla_fused_swiglu_linear` (env `PRIMUS_FLA_SWIGLU_LINEAR`), **off by default**.

## Measured

GDN-300M, ffn 4096, seq 2048, 8x MI355X:

| | peak VRAM @ mbs 128 | throughput |
|---|---|---|
| off (default) | 204.3 GB | baseline |
| on | **181.8 GB** | ~3.8% slower |

That is 0.188 GiB per unit micro-batch, which accounts for essentially the entire measured activation-memory gap against the Flash-Linear-Attention reference at equal batch. It is a memory-for-speed trade, hence the default-off.

## Restricting both paths to plain SwiGLU

`config.activation_func == F.silu` is not a sufficient test for "this is plain SwiGLU", and the new fc2 path made that latent problem reachable. It returns before `mlp.py`'s `use_te_activation_func` module-slot branch, so on a Kimi K3 model — which keeps `activation_func = F.silu` purely to satisfy the whitelist in `TransformerConfig.__post_init__` while supplying the real, soft-clamped `SituActivation` through `MLPSubmodules` — it would have silently substituted plain SiLU x up. DeepSeek-V4 style configs hit the same class of problem through the eager `glu()`, which applies `activation_func_clamp_value` and `glu_linear_offset` that FLA's kernels do not implement.

Both gates, the new one and the pre-existing `use_fla_fused_swiglu`, now additionally require no `use_te_activation_func`, no `activation_func_clamp_value` and no `glu_linear_offset`. Those configs fall through to Megatron's own code. Verified against the four relevant cases:

| config | fused path taken |
|---|---|
| GDN / KDA (plain SwiGLU) | yes |
| Kimi K3 (module-slot `SituActivation`) | no |
| DeepSeek-V4 style (clamped `glu`) | no |
| non-zero `glu_linear_offset` | no |

## Other scope and safety notes

The fused path bypasses `linear_fc2`'s `linear_with_grad_accumulation_and_async_allreduce`, so the fc2 weight gradient lands in `param.grad` rather than being fused straight into `param.main_grad`. That is safe: Megatron's DDP backward post-hook folds `param.grad` into `main_grad` whenever `grad_added_to_main_grad` is False. It does forgo the wgrad-accumulation fusion, so the path is additionally gated to TP=1, no sequence parallel, no bias, no per-token scaling, non-expert MLPs.

## Note on `patch_method_source_multi`

A method can only be source-patched once, because `inspect.getsource` cannot re-read a function that was already rebuilt by `exec`; a second `patch_method_source` call on the same method raises `OSError`. This change needs two independent rewrites of `MLP.forward`, so the new helper applies a list of `(anchor, replacement)` pairs in a single pass. Each anchor is asserted present, so an upstream source change surfaces as a clear error rather than a silently skipped patch.

## Validation

- Loss parity against the default path at matched batch.
- Memory drop reproduces the predicted 0.188 GiB per unit micro-batch at both small and large batch.
- All three patch anchors confirmed still unique in the pinned Megatron `mlp.py`.
