### PR TITLE
chore(MI355X): apply the optimal fusion recipe to the 1B configs

### DIFF
--- a/examples/megatron/configs/MI355X/gdn_1B_BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gdn_1B_BF16-pretrain.yaml
@@ -15,15 +15,40 @@ modules:
 
       eval_iters: 0
 
-      num_workers: 0
+      num_workers: 32
       create_attention_mask_in_dataloader: false
 
       profile: false
       use_pytorch_profiler: false
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
+      log_interval: 10
+      tensorboard_log_interval: 10
 
-      # MI355X max batch (8 GPUs): MBS=2, GBS=16 — HIPBLASLT kernel limit
+      # --- Optimal MI355X fusion recipe (see zebra_parity README §8) ---
+      # fused_ce_mode 2 = materialize bf16 logits + fused Triton CE (no-permute
+      # copy) == FLA's exact CE computation; ~30% faster than the chunked
+      # default (mode 1). FLA fused SwiGLU/RMSNorm/short-conv match FLA
+      # bit-for-bit and remove per-layer transposes/copies.
+      fused_ce_mode: 2
+      fused_ce_chunks: 8
+      use_fla_fused_swiglu: true
+      # NOTE: use_fla_fused_rmsnorm is intentionally left OFF. On this build the
+      # hylo hybrid_block residual-fusion path (hybrid_block.py:369) unpacks
+      # exactly 2 values from pre_mlp_layernorm; FLA's fused RMSNorm returns a
+      # different arity -> "too many values to unpack". Keep the Megatron norm.
+      use_fla_short_conv: true
+      # bias_swiglu_fusion stays at its default (on): turning it off alongside
+      # the FLA fused SwiGLU measured ~24 ms/it slower at MBS=32 (561.5 ->
+      # 586.3) with identical peak memory.
+      empty_cache_interval: 128
+      check_for_nan_in_loss_and_grad: false
+      barrier_with_L1_time: false
+
+      # GBS=16 is the FLA loss-parity recipe (small global batch), which pins
+      # MBS=2 on 8 GPUs. Unlike KDA, GDN has no hipBLASLt shape limit — raise
+      # MBS+GBS together for throughput (verified MBS=32/GBS=256 -> ~77k
+      # tok/s/GPU at 39% VRAM).
       train_iters: 50
       micro_batch_size: 2
       global_batch_size: 16

--- a/examples/megatron/configs/MI355X/kda_1B_BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/kda_1B_BF16-pretrain.yaml
@@ -15,15 +15,45 @@ modules:
 
       eval_iters: 0
 
-      num_workers: 0
+      num_workers: 32
       create_attention_mask_in_dataloader: false
 
       profile: false
       use_pytorch_profiler: false
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
+      log_interval: 10
+      tensorboard_log_interval: 10
 
-      # MI355X max batch (8 GPUs): MBS=2, GBS=16 — HIPBLASLT kernel limit
+      # --- Optimal MI355X fusion recipe (see zebra_parity README §8) ---
+      # fused_ce_mode 2 = materialize bf16 logits + fused Triton CE (no-permute
+      # copy) == FLA's exact CE computation; ~30% faster than the chunked
+      # default (mode 1) and more parity-accurate. FLA fused SwiGLU/RMSNorm/
+      # short-conv match FLA bit-for-bit and remove per-layer transposes/copies.
+      fused_ce_mode: 2
+      fused_ce_chunks: 8
+      use_fla_fused_swiglu: true
+      # NOTE: use_fla_fused_rmsnorm is intentionally left OFF. On this build the
+      # hylo hybrid_block residual-fusion path (hybrid_block.py:369) unpacks
+      # exactly 2 values from pre_mlp_layernorm; FLA's fused RMSNorm returns a
+      # different arity -> "too many values to unpack". Keep the Megatron norm.
+      use_fla_short_conv: true
+      # bias_swiglu_fusion stays at its default (on): turning it off alongside
+      # the FLA fused SwiGLU measured ~24 ms/it slower at MBS=32 (592.3 ->
+      # 616.4) with identical peak memory.
+      empty_cache_interval: 128
+      check_for_nan_in_loss_and_grad: false
+      barrier_with_L1_time: false
+
+      # GBS=16 here is the FLA loss-parity recipe (FLA reference used global
+      # batch 16), which pins MBS=2 on 8 GPUs. The previous "HIPBLASLT kernel
+      # limit" that ALSO blocked raising the batch is now fixed: KDA's fused
+      # in_proj width (2192) fell in a hipBLASLt bf16 dead zone on gfx950 and
+      # is padded to 2560 in kimi_delta_attention.py, so MBS/GBS can now be
+      # scaled for throughput. With the optimal fusion recipe above, verified
+      # MBS=32/GBS=256 -> ~98k tok/s/GPU inst (~1505 TFLOP/s) at 48% VRAM,
+      # 0 hipBLASLt errors. Raise both together for throughput runs; keep
+      # GBS=16 for FLA parity.
       train_iters: 50
       micro_batch_size: 2
       global_batch_size: 16
@@ -50,6 +80,8 @@ modules:
       # Use KDA hybrid spec with hybrid_attention_ratio=0.0 (pure KDA)
       spec: ['primus.backends.megatron.core.models.hybrid.hybrid_mamba_mla_layer_specs', 'kda_hybrid_stack_spec']
       use_fla_triton_kda: true
+      use_fla_kda_in_kernel_gate: true
+      use_fla_fused_norm_gated: true
 
       # Tokenizer
       tokenizer_type: HuggingFaceTokenizer


### PR DESCRIPTION
## Summary

Applies the measured-optimal MI355X fusion recipe to `gdn_1B_BF16-pretrain.yaml` and `kda_1B_BF16-pretrain.yaml`: `fused_ce_mode: 2` with the FLA fused SwiGLU and short conv, KDA's in-kernel gate and fused gated norm, plus dataloader workers and 10-step logging.

Two settings that were previously assumed are now measured and justified in the file itself.

**`bias_swiglu_fusion: false` is dropped.** Alongside the FLA fused SwiGLU, disabling it is slower at no memory saving. Measured at micro-batch 32, 120 steps:

| 1B @ mbs 32 | `bias_swiglu_fusion: false` | default (on) | peak VRAM |
|---|---|---|---|
| GDN | 586.3 ms/iter | **561.5** | 128.7 GB both |
| KDA | 616.4 ms/iter | **592.3** | 120.5 GB both |

About 4% on both models, in the same direction, at identical peak memory.

**`use_fla_fused_rmsnorm` stays off here, and the file now says why.** It is spec-dependent rather than universally good: the TE-spec hylo `hybrid_block` residual-fusion path unpacks exactly two values from `pre_mlp_layernorm`, while the FLA fused norm returns a different arity. It is enabled in the no-TE 300M configs, where it works and is worth roughly 30 ms/iter.

The KDA file also records that its micro-batch is no longer pinned at 2, now that the fused `in_proj` is padded past the hipBLASLt bf16 dead zone.

## Notes

- Stacked on #1007, which is where these config files exist; merge after it.
- The micro-batch 32 comparison above was run with the configs' own `mock_data: true`, so it measures step time only. Both arms are identical in that respect.
