### PR TITLE
chore(MI355X): add 300M GDN/KDA pure pretrain configs

### DIFF
--- a/examples/megatron/configs/MI355X/gdn_300M_BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gdn_300M_BF16-pretrain.yaml
@@ -1,0 +1,113 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gdn_300M_BF16-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    model: gdn_300M.yaml
+    overrides:
+      wandb_project: "Primus_Hylo_300M_GDN_Pure_Pretrain"
+      stderr_sink_level: DEBUG
+
+      eval_iters: 0
+
+      num_workers: 32
+      create_attention_mask_in_dataloader: false
+
+      profile: false
+      use_pytorch_profiler: false
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+      log_interval: 10
+      tensorboard_log_interval: 10
+
+      # --- Optimal MI355X fusion recipe (see zebra_parity README §8) ---
+      # fused_ce_mode 2 = materialize bf16 logits + fused Triton CE (no-permute
+      # copy) == FLA's exact CE computation; ~30% faster than the chunked
+      # default (mode 1). FLA fused SwiGLU/RMSNorm/short-conv match FLA
+      # bit-for-bit and remove per-layer transposes/copies.
+      fused_ce_mode: 2
+      fused_ce_chunks: 8
+      use_fla_fused_swiglu: true
+      # use_fla_fused_rmsnorm + gated_norm WORK on the _no_te spec (no arity
+      # error) and recover ~30 ms/it on GDN-pure 300M -- they only break on the
+      # TE-spec 1B hybrid_block, so they stay OFF in gdn_1B_BF16 but ON here.
+      # Do NOT set bias_swiglu_fusion:false here: with the FLA fused SwiGLU it
+      # costs ~15 ms/it. Together these match the zebra_parity report (~677 ms).
+      use_fla_fused_rmsnorm: true
+      use_fla_fused_gated_norm: true
+      use_fla_short_conv: true
+      no_persist_layer_norm: true
+      check_for_nan_in_loss_and_grad: false
+      barrier_with_L1_time: false
+
+      # GBS=16 is the FLA loss-parity recipe (small global batch), which pins
+      # MBS=2 on 8 GPUs. For throughput, raise MBS and GBS together: MBS=128 is
+      # the largest that fits in CE mode 2 (MBS=192 OOMs) and measures ~385k
+      # tok/s/GPU at 204 GB, 71% of the 288 GB card. See zebra_parity §10b.1
+      # (speed vs FLA) and §10b.2 (max batch).
+      train_iters: 50
+      micro_batch_size: 2
+      global_batch_size: 16
+
+      seq_length: 2048
+      max_position_embeddings: 2048
+      original_max_position_embeddings: 2048
+
+      # Optimizer — matched to FLA:
+      #   lr=2e-4, cosine (min_lr_rate=0.1 → min_lr=2e-5)
+      #   AdamW, beta1=0.9, beta2=0.95, weight_decay=0.01
+      #   max_grad_norm=1.0, warmup_steps=200
+      clip_grad: 1.0
+      lr: 2.0e-4
+      min_lr: 2.0e-5
+      lr_warmup_iters: 200
+      lr_decay_iters: 76294
+      lr_decay_style: cosine
+      weight_decay: 0.01
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: false
+
+      # Pure GDN hybrid spec (hybrid_attention_ratio=0.0 → all GDN, no MLA)
+      spec: ['primus.backends.megatron.core.models.hybrid.hybrid_mamba_mla_layer_specs', 'gdn_hybrid_stack_spec_no_te']
+
+      # Tokenizer
+      tokenizer_type: HuggingFaceTokenizer
+      tokenizer_model: meta-llama/Llama-3.2-1B
+
+      # Parallelism
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      overlap_grad_reduce: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+
+      # Data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # Checkpoints
+      finetune: false
+      auto_continue_train: true
+      load: null
+      save: ./output/gdn_300M_BF16-pretrain
+      save_interval: 2048
+      disable_last_saving: false
+      ckpt_format: torch
+
+      # Turbo
+      enable_primus_turbo: false
+      use_turbo_attention: false
+
+      # Context parallel
+      context_parallel_size: 1

--- a/examples/megatron/configs/MI355X/kda_300M_BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/kda_300M_BF16-pretrain.yaml
@@ -1,0 +1,122 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:kda_300M_BF16-pretrain}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    model: kda_300M.yaml
+    overrides:
+      wandb_project: "Primus_Hylo_300M_KDA_Pure_Pretrain"
+      stderr_sink_level: DEBUG
+
+      eval_iters: 0
+
+      num_workers: 32
+      create_attention_mask_in_dataloader: false
+
+      profile: false
+      use_pytorch_profiler: false
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+      log_interval: 10
+      tensorboard_log_interval: 10
+
+      # --- Optimal MI355X fusion recipe (see zebra_parity README §8) ---
+      # fused_ce_mode 2 = materialize bf16 logits + fused Triton CE (no-permute
+      # copy) == FLA's exact CE computation; ~30% faster than the chunked
+      # default (mode 1) and more parity-accurate. FLA fused SwiGLU/RMSNorm/
+      # short-conv match FLA bit-for-bit and remove per-layer transposes/copies.
+      fused_ce_mode: 2
+      fused_ce_chunks: 8
+      use_fla_fused_swiglu: true
+      # use_fla_fused_rmsnorm WORKS on the _no_te spec (no arity error) and
+      # recovers ~30 ms/it -- it only breaks on the TE-spec 1B hybrid_block, so
+      # it stays OFF in kda_1B_BF16 but ON here. Do NOT set bias_swiglu_fusion:
+      # false with the FLA fused SwiGLU (~15 ms/it). KDA's fused gated norm is
+      # enabled below via use_fla_fused_norm_gated.
+      use_fla_fused_rmsnorm: true
+      use_fla_short_conv: true
+      no_persist_layer_norm: true
+      check_for_nan_in_loss_and_grad: false
+      barrier_with_L1_time: false
+
+      # GBS=16 here is the FLA loss-parity recipe (FLA reference used global
+      # batch 16), which pins MBS=2 on 8 GPUs. For throughput, raise MBS and GBS
+      # together: MBS=128 is the largest that fits in CE mode 2 (MBS=192 OOMs)
+      # and measures ~374k tok/s/GPU at 206 GB, 71% of the 288 GB card. See
+      # zebra_parity §10b.1 (speed vs FLA) and §10b.2 (max batch).
+      #
+      # The hipBLASLt bf16 dead zone that pins the *1B* KDA config to MBS=2 does
+      # not apply at this size: the fused in_proj width here is 1160, far below
+      # the 2176..2304 band, so it is left at its native width. Padding it to
+      # 1536 would measure ~1.3% faster (512 tiles better than 8*145), but it
+      # would change in_proj's parameter shape -- ~2.2 GB more peak memory and
+      # checkpoints that no longer load against the native width.
+      train_iters: 50
+      micro_batch_size: 2
+      global_batch_size: 16
+
+      seq_length: 2048
+      max_position_embeddings: 2048
+      original_max_position_embeddings: 2048
+
+      # Optimizer — matched to FLA:
+      #   lr=2e-4, cosine (min_lr_rate=0.1 → min_lr=2e-5)
+      #   AdamW, beta1=0.9, beta2=0.95, weight_decay=0.01
+      #   max_grad_norm=1.0, warmup_steps=200
+      clip_grad: 1.0
+      lr: 2.0e-4
+      min_lr: 2.0e-5
+      lr_warmup_iters: 200
+      lr_decay_iters: 76294
+      lr_decay_style: cosine
+      weight_decay: 0.01
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: false
+
+      # Use KDA hybrid spec with hybrid_attention_ratio=0.0 (pure KDA)
+      spec: ['primus.backends.megatron.core.models.hybrid.hybrid_mamba_mla_layer_specs', 'kda_hybrid_stack_spec_no_te']
+      use_fla_triton_kda: true
+      use_fla_kda_in_kernel_gate: true
+      use_fla_fused_norm_gated: true
+
+      # Tokenizer
+      tokenizer_type: HuggingFaceTokenizer
+      tokenizer_model: meta-llama/Llama-3.2-1B
+
+      # Parallelism
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      expert_model_parallel_size: 1
+      overlap_grad_reduce: false
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      use_torch_fsdp2: false
+      use_distributed_optimizer: true
+
+      # Data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # Checkpoints
+      finetune: false
+      auto_continue_train: true
+      load: null
+      save: ./output/kda_300M_BF16-pretrain
+      save_interval: 2048
+      disable_last_saving: false
+      ckpt_format: torch
+
+      # Turbo
+      enable_primus_turbo: false
+      use_turbo_attention: false
+
+      # Context parallel
+      context_parallel_size: 1


### PR DESCRIPTION
## Summary

Adds the two pure 300M MI355X pretrain configs, `gdn_300M_BF16-pretrain.yaml` and `kda_300M_BF16-pretrain.yaml`, matching the recipes used for the Flash-Linear-Attention parity study.

Both sit on the no-TE specs, where the FLA fused RMSNorm (and, for GDN, the fused gated norm) work without the arity error the TE-spec 1B `hybrid_block` hits, and are worth roughly 30 ms/iter over the Megatron norm. Both use `fused_ce_mode: 2` with the FLA fused SwiGLU and short conv.

`micro_batch_size: 2` / `global_batch_size: 16` reproduces the FLA loss-parity recipe, which used a small global batch. The comments record the throughput mode separately: micro-batch 128 is the largest that fits in CE mode 2 and measures about 385k tok/s/GPU for GDN and 374k for KDA, at roughly 71% of the 288 GB card.

The KDA file also notes that the hipBLASLt bf16 dead zone which pins the 1B config's micro-batch does not apply at this size: the fused `in_proj` width here is 1160, far below the affected band, so it runs at its native width and its checkpoints stay compatible with the released 300M KDA model.

## Notes

- Stacked on #1007, which introduces the `gdn_300M.yaml` / `kda_300M.yaml` model definitions these reference; merge after it.
