### PR TITLE
ci: bump Primus-Turbo for flydsl compile cache fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ env:
   # (weekend cron, or a manual run with full_tests=true) adds the
   # @pytest.mark.weekly siblings and the slow unit tests.
   PRIMUS_CI_FULL: ${{ (github.event_name == 'schedule' || github.event.inputs.full_tests == 'true') && '1' || '0' }}
-  PRIMUS_TURBO_COMMIT: 22e544d56820674fcc4c8faf64651af99a5cd686 # feat(moe): fused MXFP8 mega MoE (dispatch+FC1, FC2+combine) (#456)
+  PRIMUS_TURBO_COMMIT: 7bedebe5c0a06ebf5b94777b1cc68ec6d7e12807 # fix(flydsl): restore the LDS-repack cache modifiers dropped by the grouped-GEMM rewrite
   PRIMUS_TURBO_AITER_COMMIT: 0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e # AITER v0.1.14.post1 (tag commit) — required by Primus-Turbo main aiter_utils.py
   #ROCSHMEM_COMMIT: 17ff985c026f9f97f85068647e863ab541dd5645 # Update version to 3.2.0 for 7.2.0 rocm release (#351) (#355)
   UCCL_COMMIT: 5afb4117893c58cc0c8557d9286336141a301053 # [EP]: fix fp8 error of internode_ll on amd gfx950 arch. (#710)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ env:
   # (weekend cron, or a manual run with full_tests=true) adds the
   # @pytest.mark.weekly siblings and the slow unit tests.
   PRIMUS_CI_FULL: ${{ (github.event_name == 'schedule' || github.event.inputs.full_tests == 'true') && '1' || '0' }}
-  PRIMUS_TURBO_COMMIT: 7bedebe5c0a06ebf5b94777b1cc68ec6d7e12807 # fix(flydsl): restore the LDS-repack cache modifiers dropped by the grouped-GEMM rewrite
+  PRIMUS_TURBO_COMMIT: 7bedebe5c0a06ebf5b94777b1cc68ec6d7e12807 # fix(flydsl): compile-cache fixes (restore LDS-repack modifiers; drop m_total from cache key) (#478, #473)
   PRIMUS_TURBO_AITER_COMMIT: 0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e # AITER v0.1.14.post1 (tag commit) — required by Primus-Turbo main aiter_utils.py
   #ROCSHMEM_COMMIT: 17ff985c026f9f97f85068647e863ab541dd5645 # Update version to 3.2.0 for 7.2.0 rocm release (#351) (#355)
   UCCL_COMMIT: 5afb4117893c58cc0c8557d9286336141a301053 # [EP]: fix fp8 error of internode_ll on amd gfx950 arch. (#710)


### PR DESCRIPTION
## Summary
- Bump `PRIMUS_TURBO_COMMIT` from `22e544d5` to `7bedebe5` in CI to pick up two Primus-Turbo flydsl fixes:
  - **#478** — restore the LDS-repack cache modifiers dropped by the grouped-GEMM rewrite
  - **#473** — remove `m_total` from the flydsl compile cache key

## Test plan
- [ ] CI passes with the updated Primus-Turbo pin
- [ ] FlyDSL grouped-GEMM / MXFP8 paths compile and run without cache-key or LDS-repack regressions
