### PR TITLE
fix(pipeline): clamp warmup for short batches

### DIFF
--- a/primus/backends/megatron/core/pipeline_parallel/zerobubble/__init__.py
+++ b/primus/backends/megatron/core/pipeline_parallel/zerobubble/__init__.py
@@ -7,6 +7,13 @@
 # See LICENSE for license information.
 ###############################################################################
 
-from .runtime import get_zero_bubble_forward_backward_func
-
 __all__ = ["get_zero_bubble_forward_backward_func"]
+
+
+def get_zero_bubble_forward_backward_func(*args, **kwargs):
+    """Load the PuLP-backed zero-bubble runtime only when it is requested."""
+    from .runtime import (
+        get_zero_bubble_forward_backward_func as _get_zero_bubble_forward_backward_func,
+    )
+
+    return _get_zero_bubble_forward_backward_func(*args, **kwargs)

--- a/primus/core/pipeline_parallel/scheduler/algorithms/basic_1f1b.py
+++ b/primus/core/pipeline_parallel/scheduler/algorithms/basic_1f1b.py
@@ -42,7 +42,7 @@ class Schedule1F1B(PipelineScheduleAlgo):
 
         for rank in range(self.pp_size):
             # warmup
-            warm_up_phases = self.pp_size - rank - 1
+            warm_up_phases = min(self.pp_size - rank - 1, self.micro_batches)
             for i in range(warm_up_phases):
                 recv_node, send_node = self.generate_send_recv_nodes(rank, i, 0, FuncType.F)
                 if recv_node is not None:

--- a/primus/core/pipeline_parallel/scheduler/algorithms/interleaved_1f1b.py
+++ b/primus/core/pipeline_parallel/scheduler/algorithms/interleaved_1f1b.py
@@ -107,7 +107,10 @@ class ScheduleInterleaved1F1B(PipelineScheduleAlgo):
             # Build schedule for each chunk with timing information
             rank_schedule = schedule_table[rank]
 
-            num_of_warmup_phases = (self.pp_size - 1 - rank) * 2 + (self.vpp_size - 1) * self.pp_size
+            num_of_warmup_phases = min(
+                (self.pp_size - 1 - rank) * 2 + (self.vpp_size - 1) * self.pp_size,
+                self.micro_batches * self.vpp_size,
+            )
 
             fwd_chunk = 0
             bwd_chunk = self.vpp_size - 1

--- a/tests/unit_tests/core/pipeline_parallel/test_pipeline_schedules.py
+++ b/tests/unit_tests/core/pipeline_parallel/test_pipeline_schedules.py
@@ -108,6 +108,53 @@ def test_1f1b_forward_backward_balance():
         assert bw == MICRO_BATCHES
 
 
+def test_1f1b_clamps_warmup_when_microbatches_are_fewer_than_pipeline_stages():
+    """A short batch must not create unmatched forward or backward nodes."""
+    table = _make("1f1b", 1, pp=4, mb=2).generate_schedule_table()
+
+    for rank_nodes in table:
+        compute_nodes = [n for n in rank_nodes if n.func_type in (FuncType.F, FuncType.BW)]
+        assert len([n for n in compute_nodes if n.func_type == FuncType.F]) == 2
+        assert len([n for n in compute_nodes if n.func_type == FuncType.BW]) == 2
+        assert all(0 <= n.mini_batch < 2 for n in compute_nodes)
+
+
+def test_interleaved_clamps_warmup_when_microbatches_are_fewer_than_pipeline_stages():
+    """Interleaved warmup must not emit more work than the batch contains."""
+    table = _make("1f1b-interleaved", 2, pp=4, mb=2).generate_schedule_table()
+
+    for rank_nodes in table:
+        compute_nodes = [n for n in rank_nodes if n.func_type in (FuncType.F, FuncType.BW)]
+        assert len([n for n in compute_nodes if n.func_type == FuncType.F]) == 4
+        assert len([n for n in compute_nodes if n.func_type == FuncType.BW]) == 4
+        assert all(0 <= n.mini_batch < 4 for n in compute_nodes)
+
+
+@pytest.mark.parametrize("algo,vpp,mb", [("1f1b", 1, 2)])
+def test_short_batch_communication_nodes_are_paired(algo, vpp, mb):
+    """Every inter-rank send must have exactly one matching receive."""
+    table = _make(algo, vpp, pp=4, mb=mb).generate_schedule_table()
+    recv_type = {FuncType.SF: FuncType.RF, FuncType.SB: FuncType.RB}
+
+    for src_rank, rank_nodes in enumerate(table):
+        for send in rank_nodes:
+            if send.func_type not in recv_type:
+                continue
+
+            dst_rank = send.args["to_pp_rank"]
+            expected_recv = recv_type[send.func_type]
+            matches = [
+                recv
+                for recv in table[dst_rank]
+                if recv.func_type == expected_recv
+                and recv.mini_batch == send.mini_batch
+                and recv.args["from_pp_rank"] == src_rank
+                and recv.args["recv_from_chunk"] == send.chunk
+                and recv.chunk == send.args["send_to_chunk"]
+            ]
+            assert len(matches) == 1, (src_rank, dst_rank, send, matches)
+
+
 def test_zero_bubble_splits_backward_into_b_and_w():
     """Zero-bubble splits backward into B (compute) and W (weight grad)."""
     table = _make("zero-bubble", 1).generate_schedule_table()


### PR DESCRIPTION
## Summary

Clamp basic and interleaved 1F1B warmup so short batches cannot generate work for nonexistent micro-batches.

## Root cause

When the number of micro-batches is smaller than the pipeline depth, warmup was calculated from pipeline depth alone. This generated invalid nodes such as:

- `RB|-1`
- `BW|-1`

The backward handler then failed because the invalid backward node had no matching forward node.

## Notes

- In the base `rocm/primus:v26.5` image, the Turbo GEMM path fails with:
  `gemm() got an unexpected keyword argument 'fuse_bgrad_accum_pattern'`.
- The same error is not reproduced in `、tasimage/primus:latest`; the latest image's installed regular GEMM API accepts `fuse_bgrad_accum_pattern`.

Fixes #1003.