### PR TITLE
[Torchtitan] Disable use_turbo_grouped_mm on MI325X (#1022)

### DIFF
--- a/examples/megatron/configs/MI325X/deepseek_v3-BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI325X/deepseek_v3-BF16-pretrain.yaml
@@ -77,6 +77,7 @@ modules:
       enable_primus_turbo: true
       use_turbo_attention: true
       use_turbo_grouped_gemm: true
+      use_turbo_grouped_mm: false # disable due to triton regression
 
       # Cross entropy flags
       cross_entropy_fusion_impl: "te"


### PR DESCRIPTION
[perf(torchtitan/deepseek-v3-16b)] Disable turbo grouped GEMM on MI325X to recover 6% throughput regression

## Problem

The Torchtitan DeepSeek-V3-16B BF16 benchmark on MI325X shows a ~6% throughput regression in 26.6 and 26.7 vs the 26.4 baseline:

- 26.4: 18,143 TPS (baseline)
- 26.6: 16,994 TPS (-6.3%)
- 26.7: 17,125 TPS (-5.6%)

## Root Cause

Profiling with the MI325X config (local_batch_size=8) confirmed the regression is localized to `_grouped_variable_k_gemm_kernel` — the Primus Turbo variable-K grouped GEMM kernel used in the MoE expert layers — which is 35.4% slower in 26.6 vs 26.4 (200ms → 272ms).

## Fix

Disabling the turbo grouped GEMM path (`use_turbo_grouped_mm: false`) falls back to the standard grouped GEMM kernel, which does not carry the BLOCK_K=32 restriction and fully recovers performance:

- 26.6 with `use_turbo_grouped_mm: false`: ~18,050 TPS (-0.5% vs 26.4 ✅)
- 26.7 with `use_turbo_grouped_mm: false`: ~18,210 TPS (+0.4% vs 26.4 ✅)

## Changes

```yaml
# examples/torchtitan/configs/MI325X/deepseek_v3_16b-BF16-pretrain.yaml
primus_turbo:
  use_turbo_grouped_mm: false   # was: true
```

## Testing

- 20-step benchmark on tus1-p3-g10 (MI325X) with 26.6 and 26.7 images
- Confirmed recovery on both releases

## Related

- Follow-up needed: re-tune `_grouped_variable_k_gemm_kernel` for BLOCK_K=32 on DSv3-16B MoE shapes so `use_turbo_grouped_mm: true` can be re-enabled

---------