### PR TITLE
fix(megatron_bridge): unblock Qwen3-32B posttrain on transformers 5.x (#1030)

### DIFF
--- a/examples/megatron_bridge/configs/MI300X/qwen3_32b_lora_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI300X/qwen3_32b_lora_posttrain.yaml
@@ -31,10 +31,10 @@ modules:
       # Training configuration
       train_iters: 200
       global_batch_size: 32
-      micro_batch_size: 1
+      micro_batch_size: 2
       seq_length: 8192
       eval_interval: 30
-      save_interval: 50
+      skip_save: true
 
       # Optimizer configuration
       finetune_lr: 1.0e-4

--- a/examples/megatron_bridge/configs/MI300X/qwen3_32b_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI300X/qwen3_32b_sft_posttrain.yaml
@@ -31,10 +31,10 @@ modules:
       # Training configuration
       train_iters: 200
       global_batch_size: 8
-      micro_batch_size: 1
+      micro_batch_size: 2
       seq_length: 8192
       eval_interval: 30
-      save_interval: 50
+      skip_save: true
 
       # Optimizer configuration
       finetune_lr: 5.0e-6

--- a/examples/megatron_bridge/configs/MI355X/qwen3_32b_lora_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/qwen3_32b_lora_posttrain.yaml
@@ -34,7 +34,7 @@ modules:
       micro_batch_size: 4
       seq_length: 8192
       eval_interval: 30
-      save_interval: 50
+      skip_save: true
 
       # Optimizer configuration
       finetune_lr: 1.0e-4

--- a/examples/megatron_bridge/configs/MI355X/qwen3_32b_sft_posttrain.yaml
+++ b/examples/megatron_bridge/configs/MI355X/qwen3_32b_sft_posttrain.yaml
@@ -34,7 +34,7 @@ modules:
       micro_batch_size: 1
       seq_length: 8192
       eval_interval: 30
-      save_interval: 50
+      skip_save: true
 
       # Optimizer configuration
       finetune_lr: 5.0e-6

--- a/primus/backends/megatron_bridge/convert_common.py
+++ b/primus/backends/megatron_bridge/convert_common.py
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Shared helpers for Megatron-Bridge checkpoint conversion hooks.
+
+Use ``run_convert_checkpoints.py`` (or ``run_bridge_convert_checkpoints()``)
+so convert-phase patches run in the **same** Python process as the bridge
+converter. Applying patches in a separate ``python -c`` invocation does not
+carry over to a subsequent ``convert_checkpoints.py`` subprocess.
+"""
+
+
+def apply_bridge_convert_patches() -> int:
+    """Register + run all ``phase="convert"`` Megatron-Bridge patches.
+
+    Must be called in the conversion hook process BEFORE importing or running
+    ``megatron.bridge`` conversion entrypoints (e.g.
+    ``convert_checkpoints.py import``).
+    """
+    import importlib
+
+    importlib.import_module("primus.backends.megatron_bridge.patches.transformers_rope_theta_patches")
+    from primus.core.patches import run_patches
+
+    return run_patches(
+        backend="megatron_bridge",
+        phase="convert",
+    )

--- a/primus/backends/megatron_bridge/patches/transformers_rope_theta_patches.py
+++ b/primus/backends/megatron_bridge/patches/transformers_rope_theta_patches.py
@@ -1,0 +1,59 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Megatron-Bridge transformers RoPE compatibility patches.
+
+transformers 5.x removed the flat ``Qwen3Config.rope_theta`` field (and the
+same for other model configs). The vendored Megatron-Bridge still reads
+``hf_config.rope_theta`` during HF->Megatron conversion and provider setup.
+
+These patches install a ``PretrainedConfig`` attribute shim so existing bridge
+code keeps working without editing ``third_party/Megatron-Bridge``.
+"""
+
+from primus.backends.megatron_bridge.utils.rope_config import (
+    install_transformers_rope_theta_shim,
+)
+from primus.core.patches import PatchContext, register_patch
+from primus.core.utils.module_utils import log_rank_0
+
+
+def _apply_rope_theta_shim(_ctx: PatchContext, phase: str) -> None:
+    if install_transformers_rope_theta_shim():
+        log_rank_0(
+            f"[Patch:megatron_bridge.transformers_rope_theta] "
+            f"Installed transformers 5.x rope_theta shim ({phase})"
+        )
+
+
+@register_patch(
+    "megatron_bridge.convert.transformers_rope_theta",
+    backend="megatron_bridge",
+    phase="convert",
+    priority=5,
+    description=(
+        "Shim PretrainedConfig.rope_theta for transformers 5.x during "
+        "Megatron-Bridge HF->Megatron checkpoint conversion."
+    ),
+)
+def patch_transformers_rope_theta_convert(ctx: PatchContext) -> None:
+    """Install the rope_theta shim for Megatron-Bridge checkpoint conversion."""
+    _apply_rope_theta_shim(ctx, "convert")
+
+
+@register_patch(
+    "megatron_bridge.train.transformers_rope_theta",
+    backend="megatron_bridge",
+    phase="before_train",
+    priority=5,
+    description=(
+        "Shim PretrainedConfig.rope_theta for transformers 5.x during " "Megatron-Bridge training startup."
+    ),
+)
+def patch_transformers_rope_theta_train(ctx: PatchContext) -> None:
+    """Install the rope_theta shim before Megatron-Bridge training starts."""
+    _apply_rope_theta_shim(ctx, "before_train")

--- a/primus/backends/megatron_bridge/run_convert_checkpoints.py
+++ b/primus/backends/megatron_bridge/run_convert_checkpoints.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Run Megatron-Bridge checkpoint conversion with Primus convert patches applied."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def run_bridge_convert_checkpoints() -> int:
+    """Apply convert patches, then run bridge ``convert_checkpoints.main()``."""
+    repo_root = _repo_root()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from primus.backends.megatron_bridge.convert_common import (
+        apply_bridge_convert_patches,
+    )
+
+    apply_bridge_convert_patches()
+
+    bridge_script = repo_root / "third_party/Megatron-Bridge/examples/conversion/convert_checkpoints.py"
+    spec = importlib.util.spec_from_file_location("mb_convert_checkpoints", bridge_script)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load Megatron-Bridge converter: {bridge_script}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["mb_convert_checkpoints"] = module
+    spec.loader.exec_module(module)
+
+    result = module.main()
+    return int(result or 0)
+
+
+def main() -> int:
+    """Entry point for the Megatron-Bridge conversion wrapper script."""
+    return run_bridge_convert_checkpoints()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/primus/backends/megatron_bridge/utils/rope_config.py
+++ b/primus/backends/megatron_bridge/utils/rope_config.py
@@ -1,0 +1,69 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Transformers RoPE config compatibility for Megatron-Bridge."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_ORIG_PRETRAINED_CONFIG_GETATTRIBUTE = None
+
+
+def resolve_rope_theta(config: Any) -> float:
+    """Return RoPE base (theta) from a HuggingFace config.
+
+    transformers 4.x exposes ``rope_theta`` on the config directly.
+    transformers 5.x moved the value into ``default_theta`` / ``rope_parameters``.
+    """
+    default_theta = getattr(config, "default_theta", None)
+    if default_theta is not None:
+        return default_theta
+
+    rope_parameters = getattr(config, "rope_parameters", None)
+    if rope_parameters is not None:
+        if isinstance(rope_parameters, dict):
+            theta = rope_parameters.get("rope_theta")
+            if theta is not None:
+                return theta
+        else:
+            theta = getattr(rope_parameters, "rope_theta", None)
+            if theta is not None:
+                return theta
+
+    raise AttributeError(
+        f"{type(config).__name__} has no rope_theta, default_theta, " f"or rope_parameters['rope_theta']"
+    )
+
+
+def install_transformers_rope_theta_shim() -> bool:
+    """Shim ``PretrainedConfig.rope_theta`` for transformers 5.x configs.
+
+    Megatron-Bridge reads ``hf_config.rope_theta`` when mapping HF configs to
+    Megatron providers. transformers 5.x removed the flat field, so bridge
+    conversion fails before training starts. This patch restores the old
+    attribute transparently for any config subclass.
+    """
+    global _ORIG_PRETRAINED_CONFIG_GETATTRIBUTE
+
+    from transformers.configuration_utils import PretrainedConfig
+
+    if getattr(PretrainedConfig, "_primus_rope_theta_shim_installed", False):
+        return False
+
+    _ORIG_PRETRAINED_CONFIG_GETATTRIBUTE = PretrainedConfig.__getattribute__
+
+    def _getattribute(self, key: str) -> Any:
+        if key == "rope_theta":
+            try:
+                return _ORIG_PRETRAINED_CONFIG_GETATTRIBUTE(self, key)
+            except AttributeError:
+                return resolve_rope_theta(self)
+        return _ORIG_PRETRAINED_CONFIG_GETATTRIBUTE(self, key)
+
+    PretrainedConfig.__getattribute__ = _getattribute
+    PretrainedConfig._primus_rope_theta_shim_installed = True
+    return True

--- a/runner/helpers/hooks/train/posttrain/megatron_bridge/01_convert_checkpoints.sh
+++ b/runner/helpers/hooks/train/posttrain/megatron_bridge/01_convert_checkpoints.sh
@@ -198,7 +198,9 @@ if [[ "$NODE_RANK" == "0" ]]; then
     # can configure them for the conversion pass.
     unset NVTE_FLASH_ATTN NVTE_FUSED_ATTN NVTE_UNFUSED_ATTN
 
-    python3 third_party/Megatron-Bridge/examples/conversion/convert_checkpoints.py import \
+    # Run conversion in one Python process so convert-phase patches (e.g.
+    # transformers 5.x rope_theta shim) stay active for the bridge import.
+    PYTHONPATH="${PRIMUS_ROOT}:${PYTHONPATH:-}" python3 "${PRIMUS_ROOT}/primus/backends/megatron_bridge/run_convert_checkpoints.py" import \
       --hf-model "${HF_PATH}" \
       --megatron-path "${MEGATRON_PATH}"
 

--- a/runner/helpers/hooks/train/posttrain/megatron_bridge/requirements-megatron-bridge.txt
+++ b/runner/helpers/hooks/train/posttrain/megatron_bridge/requirements-megatron-bridge.txt
@@ -2,7 +2,7 @@
 # Extracted from third_party/Megatron-Bridge/pyproject.toml
 
 # Transformers (pinned version for compatibility)
-transformers==4.57.6
+# transformers==4.57.6
 
 # Core dependencies from [project.dependencies]
 qwen-vl-utils

--- a/tests/unit_tests/backends/megatron_bridge/test_rope_config.py
+++ b/tests/unit_tests/backends/megatron_bridge/test_rope_config.py
@@ -1,0 +1,47 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for Megatron-Bridge transformers rope_theta compatibility."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from primus.backends.megatron_bridge.utils.rope_config import (
+    install_transformers_rope_theta_shim,
+    resolve_rope_theta,
+)
+
+
+class TestResolveRopeTheta:
+    def test_default_theta(self):
+        cfg = Mock(spec=[])
+        cfg.default_theta = 500000.0
+        assert resolve_rope_theta(cfg) == 500000.0
+
+    def test_rope_parameters_dict(self):
+        cfg = Mock(spec=[])
+        cfg.default_theta = None
+        cfg.rope_parameters = {"rope_theta": 750000.0}
+        assert resolve_rope_theta(cfg) == 750000.0
+
+    def test_missing_raises(self):
+        cfg = Mock(spec=[])
+        with pytest.raises(AttributeError, match="rope_theta"):
+            resolve_rope_theta(cfg)
+
+
+class TestTransformersRopeThetaShim:
+    def test_shim_exposes_rope_theta_for_transformers5_style_config(self):
+        pytest.importorskip("transformers")
+        from transformers.configuration_utils import PretrainedConfig
+
+        install_transformers_rope_theta_shim()
+
+        cfg = PretrainedConfig()
+        object.__setattr__(cfg, "default_theta", 1000000.0)
+
+        assert cfg.rope_theta == 1000000.0


### PR DESCRIPTION


## Summary

- Fix Megatron-Bridge Qwen3-32B posttrain failure on transformers 5.x by adding a Primus `rope_theta` compatibility shim (`default_theta` / `rope_parameters` fallback) instead of patching vendored `third_party/Megatron-Bridge`.
- Run HF→Megatron conversion in a single Python process via `run_convert_checkpoints.py` so convert-phase patches stay active (fixes the case where the shim was applied in one process but `convert_checkpoints.py` ran in another).
- Tune Qwen3-32B Megatron-Bridge posttrain example configs:
- Disable checkpoint saves (`skip_save: true`) on MI300X and MI355X SFT/LoRA recipes.
  - Increase MI300X `micro_batch_size` from 1 → 2 for SFT and LoRA.
- Stop pinning `transformers==4.57.6` in the bridge posttrain requirements file to align with the image’s transformers 5.x stack.

## Problem

On v26.6 (transformers 5.5.0), Qwen3-32B Megatron-Bridge LoRA/SFT fails during checkpoint conversion with:

```
AttributeError: 'Qwen3Config' object has no attribute 'rope_theta'
```

Megatron-Bridge still reads `hf_config.rope_theta`, which transformers 5.x removed in favor of `default_theta` / `rope_parameters`.

## Solution

| Area | Change |
|------|--------|
| Shim | `primus/backends/megatron_bridge/utils/rope_config.py` | | Patches | `convert` + `before_train` registration in `transformers_rope_theta_patches.py` |
| Conversion entrypoint | `run_convert_checkpoints.py` + hook update in `01_convert_checkpoints.sh` |
| Tests |
`tests/unit_tests/backends/megatron_bridge/test_rope_config.py` | | Configs | MI300X/MI355X `qwen3_32b_{sft,lora}_posttrain.yaml` | | Requirements | Comment out `transformers==4.57.6` in `requirements-megatron-bridge.txt` |

## Test plan

- [ ] Unit tests: `pytest tests/unit_tests/backends/megatron_bridge/test_rope_config.py`
- [ ] Pre-commit / code-lint: `pre-commit run --all-files` (or CI `code-lint` job)
- [ ] MI355X: Qwen3-32B LoRA posttrain ```bash # config:
examples/megatron_bridge/configs/MI355X/qwen3_32b_lora_posttrain.yaml
  ```
  - [ ] HF→Megatron conversion completes without `rope_theta` error
  - [ ] Training reaches step 1+
  - [ ] No checkpoints written (`skip_save: true`)
- [ ] MI355X: Qwen3-32B SFT posttrain ```bash # config:
examples/megatron_bridge/configs/MI355X/qwen3_32b_sft_posttrain.yaml
  ```
  - [ ] Conversion and training startup succeed
- [ ] MI300X: Qwen3-32B LoRA/SFT with `micro_batch_size: 2`
  - [ ] Runs without OOM at configured batch size
- [ ] Confirm patch log appears in the **same** process as conversion: ``` [Patch:megatron_bridge.transformers_rope_theta] Installed transformers 5.x rope_theta shim (convert)
  ```

## Notes for reviewers

- No changes under `third_party/Megatron-Bridge/` — compatibility is handled entirely in Primus patches.
- The single-process conversion wrapper is required; applying patches in a separate `python -c` invocation does not carry over to the converter subprocess.

---