### PR TITLE
fix(torchtitan): rename turbo grouped GEMM config

### DIFF
--- a/docs/03-configuration-reference/torchtitan-parameters.md
+++ b/docs/03-configuration-reference/torchtitan-parameters.md
@@ -304,7 +304,7 @@ modules:
 | `primus_turbo.use_turbo_async_tp` | `true` | Async tensor-parallel communication in Turbo. |
 | `primus_turbo.use_turbo_mx_linear` | `true` | MX linear layers via Turbo. |
 | `primus_turbo.use_turbo_float8_linear` | `true` | FP8 linear layers via Turbo. |
-| `primus_turbo.use_turbo_grouped_mm` | `false` | Turbo grouped GEMM for MoE (off by default). |
+| `primus_turbo.use_turbo_grouped_gemm` | `false` | Turbo grouped GEMM for MoE (off by default). |
 | `primus_turbo.use_moe_fp8` | `true` | FP8 paths for MoE experts when applicable. |
 | `primus_turbo.enable_embedding_autocast` | `true` | Autocast policy around embeddings for Turbo. |
 

--- a/docs/04-technical-guides/performance-tuning.md
+++ b/docs/04-technical-guides/performance-tuning.md
@@ -115,7 +115,7 @@ primus_turbo:
   use_turbo_attention: true
   use_turbo_async_tp: true
   use_turbo_float8_linear: true
-  use_turbo_grouped_mm: false
+  use_turbo_grouped_gemm: false
 ```
 
 ### Documentation

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: false
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
         use_classic_attention: true
 

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_16b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_16b-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: true
         use_classic_attention: false
 

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_236b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_236b-BF16-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: false
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
         use_classic_attention: true
 

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_236b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_236b-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: true
         use_classic_attention: false
 

--- a/examples/torchtitan/configs/MI300X/deepseek_v3_671b-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/deepseek_v3_671b-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
         use_turbo_float8_linear: true
         enable_attention_float8: false
         use_classic_attention: true
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
 
       # quantize:

--- a/examples/torchtitan/configs/MI300X/gpt_oss_120B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/gpt_oss_120B-BF16-pretrain.yaml
@@ -53,5 +53,5 @@ modules:
         use_turbo_float8_linear: false
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI300X/gpt_oss_120B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/gpt_oss_120B-FP8-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: true
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI300X/gpt_oss_20B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/gpt_oss_20B-BF16-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: false
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI300X/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/gpt_oss_20B-FP8-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: true
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI300X/llama4_17Bx128E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/llama4_17Bx128E-BF16-pretrain.yaml
@@ -36,4 +36,4 @@ modules:
       primus_turbo:
         enable_primus_turbo: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI300X/llama4_17Bx128E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/llama4_17Bx128E-FP8-pretrain.yaml
@@ -44,4 +44,4 @@ modules:
         enable_primus_turbo: true
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI300X/llama4_17Bx16E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/llama4_17Bx16E-BF16-pretrain.yaml
@@ -36,4 +36,4 @@ modules:
       primus_turbo:
         enable_primus_turbo: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI300X/llama4_17Bx16E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI300X/llama4_17Bx16E-FP8-pretrain.yaml
@@ -44,4 +44,4 @@ modules:
         enable_primus_turbo: true
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: false
         enable_attention_float8: false
-        use_turbo_grouped_mm: false # disable due to triton regression (Primus-Turbo PR #471)
+        use_turbo_grouped_gemm: false # disable due to triton regression (Primus-Turbo PR #471)
         use_moe_fp8: false
         use_classic_attention: true
 

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_16b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_16b-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: true
         use_classic_attention: false
 

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_236b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_236b-BF16-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: false
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
         use_classic_attention: true
 

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_236b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_236b-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: true
         use_classic_attention: false
 

--- a/examples/torchtitan/configs/MI325X/deepseek_v3_671b-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/deepseek_v3_671b-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
         use_turbo_float8_linear: true
         enable_attention_float8: false
         use_classic_attention: true
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
 
       # quantize:

--- a/examples/torchtitan/configs/MI325X/gpt_oss_120B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/gpt_oss_120B-BF16-pretrain.yaml
@@ -53,5 +53,5 @@ modules:
         use_turbo_float8_linear: false
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI325X/gpt_oss_120B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/gpt_oss_120B-FP8-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: true
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI325X/gpt_oss_20B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/gpt_oss_20B-BF16-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: false
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI325X/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/gpt_oss_20B-FP8-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: true
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI325X/llama4_17Bx128E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/llama4_17Bx128E-BF16-pretrain.yaml
@@ -36,4 +36,4 @@ modules:
       primus_turbo:
         enable_primus_turbo: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI325X/llama4_17Bx128E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/llama4_17Bx128E-FP8-pretrain.yaml
@@ -44,4 +44,4 @@ modules:
         enable_primus_turbo: true
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI325X/llama4_17Bx16E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/llama4_17Bx16E-BF16-pretrain.yaml
@@ -36,4 +36,4 @@ modules:
       primus_turbo:
         enable_primus_turbo: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI325X/llama4_17Bx16E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI325X/llama4_17Bx16E-FP8-pretrain.yaml
@@ -44,4 +44,4 @@ modules:
         enable_primus_turbo: true
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_16b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_16b-BF16-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: false
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
         use_classic_attention: true
 

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_16b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_16b-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: true
         use_classic_attention: false
 

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_236b-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_236b-BF16-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: false
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
         use_classic_attention: true
 

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_236b-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_236b-FP8-pretrain.yaml
@@ -79,7 +79,7 @@ modules:
         use_turbo_mx_linear: false
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: true
         use_classic_attention: false
 

--- a/examples/torchtitan/configs/MI355X/deepseek_v3_671b-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/deepseek_v3_671b-pretrain.yaml
@@ -80,7 +80,7 @@ modules:
         use_turbo_float8_linear: true
         enable_attention_float8: false
         use_classic_attention: true
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true
         use_moe_fp8: false
 
       # quantize:

--- a/examples/torchtitan/configs/MI355X/gpt_oss_120B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/gpt_oss_120B-BF16-pretrain.yaml
@@ -53,5 +53,5 @@ modules:
         use_turbo_float8_linear: false
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI355X/gpt_oss_120B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/gpt_oss_120B-FP8-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: true
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI355X/gpt_oss_20B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/gpt_oss_20B-BF16-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: false
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI355X/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/gpt_oss_20B-FP8-pretrain.yaml
@@ -54,5 +54,5 @@ modules:
         use_turbo_float8_linear: true
         use_turbo_mx_linear: false
         use_moe_fp8: false
-        use_turbo_grouped_mm: false
+        use_turbo_grouped_gemm: false
         use_classic_attention: false

--- a/examples/torchtitan/configs/MI355X/llama4_17Bx128E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama4_17Bx128E-BF16-pretrain.yaml
@@ -36,4 +36,4 @@ modules:
       primus_turbo:
         enable_primus_turbo: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI355X/llama4_17Bx128E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama4_17Bx128E-FP8-pretrain.yaml
@@ -44,4 +44,4 @@ modules:
         enable_primus_turbo: true
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI355X/llama4_17Bx16E-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama4_17Bx16E-BF16-pretrain.yaml
@@ -36,4 +36,4 @@ modules:
       primus_turbo:
         enable_primus_turbo: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/examples/torchtitan/configs/MI355X/llama4_17Bx16E-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama4_17Bx16E-FP8-pretrain.yaml
@@ -44,4 +44,4 @@ modules:
         enable_primus_turbo: true
         use_turbo_float8_linear: true
         enable_attention_float8: false
-        use_turbo_grouped_mm: true
+        use_turbo_grouped_gemm: true

--- a/primus/backends/torchtitan/patches/turbo/moe_grouped_mm_patches.py
+++ b/primus/backends/torchtitan/patches/turbo/moe_grouped_mm_patches.py
@@ -12,7 +12,7 @@ the generic Primus patch system so that MoE grouped_mm integration with
 Primus-Turbo can be managed declaratively.
 
 Behavior:
-    - Enabled when ``primus_turbo.use_turbo_grouped_mm`` is True in the
+    - Enabled when ``primus_turbo.use_turbo_grouped_gemm`` is True in the
       TorchTitan job config.
     - Uses ``primus_turbo.use_moe_fp8`` to control FP8 MoE behavior.
     - Monkey patches ``torchtitan.models.moe.moe._run_experts_grouped_mm`` to
@@ -34,7 +34,7 @@ _ALREADY_PATCHED_SENTINEL = "_run_experts_grouped_mm_dynamic"
     description="Use Primus-Turbo grouped_mm for TorchTitan MoE experts",
     condition=lambda ctx: (
         get_param(ctx, "primus_turbo.enable_primus_turbo", False)
-        and get_param(ctx, "primus_turbo.use_turbo_grouped_mm", False)
+        and get_param(ctx, "primus_turbo.use_turbo_grouped_gemm", False)
     ),
 )
 def patch_torchtitan_moe(ctx: PatchContext) -> None:

--- a/primus/backends/torchtitan/primus_turbo_extensions/config_extension.py
+++ b/primus/backends/torchtitan/primus_turbo_extensions/config_extension.py
@@ -23,7 +23,7 @@ class PrimusTurboConfig:
     use_turbo_async_tp: bool = False
     use_turbo_mx_linear: bool = False
     use_turbo_float8_linear: bool = False
-    use_turbo_grouped_mm: bool = False
+    use_turbo_grouped_gemm: bool = False
     use_moe_fp8: bool = True
     enable_embedding_autocast: bool = True
     use_classic_attention: bool = False

--- a/primus/configs/modules/torchtitan/pre_trainer.yaml
+++ b/primus/configs/modules/torchtitan/pre_trainer.yaml
@@ -159,6 +159,6 @@ primus_turbo:
   use_turbo_async_tp: true
   use_turbo_mx_linear: true
   use_turbo_float8_linear: true
-  use_turbo_grouped_mm: false
+  use_turbo_grouped_gemm: false
   use_moe_fp8: true
   enable_embedding_autocast: true

--- a/tests/trainer/test_torchtitan_trainer.py
+++ b/tests/trainer/test_torchtitan_trainer.py
@@ -210,7 +210,7 @@ class TestTorchTitanTrainer(PrimusUT):
         )
 
     # Llama 4 had no E2E in either backend. Distinct from the llama3 flavor above:
-    # MoE with a shared expert, and the recipe's use_turbo_grouped_mm path.
+    # MoE with a shared expert, and the recipe's use_turbo_grouped_gemm path.
     @pytest.mark.weekly
     def test_llama4_17Bx16E(self):
         run_script(

--- a/tests/unit_tests/backends/torchtitan/test_moe_grouped_mm_patch.py
+++ b/tests/unit_tests/backends/torchtitan/test_moe_grouped_mm_patch.py
@@ -28,11 +28,11 @@ from primus.core.patches.patch_registry import PatchRegistry
 PATCH_ID = "torchtitan.primus_turbo.moe_grouped_mm"
 
 
-def _ctx(enable_turbo=True, use_turbo_grouped_mm=True, use_moe_fp8=False):
+def _ctx(enable_turbo=True, use_turbo_grouped_gemm=True, use_moe_fp8=False):
     params = SimpleNamespace(
         primus_turbo=SimpleNamespace(
             enable_primus_turbo=enable_turbo,
-            use_turbo_grouped_mm=use_turbo_grouped_mm,
+            use_turbo_grouped_gemm=use_turbo_grouped_gemm,
             use_moe_fp8=use_moe_fp8,
         ),
     )


### PR DESCRIPTION
## Summary

- rename the TorchTitan user config from `primus_turbo.use_turbo_grouped_mm` to `primus_turbo.use_turbo_grouped_gemm`
- update the MoE grouped-MM patch condition to read the unified config name
- update TorchTitan defaults, examples, documentation, and related tests
- keep the TorchTitan `_run_experts_grouped_mm` implementation and compile/Dynamo workaround unchanged