### PR TITLE
Update MI355X Llama 3.1 8B and GPT-OSS 20B pretrain YAML defaults

### DIFF
--- a/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gpt_oss_20B-FP8-pretrain.yaml
@@ -47,8 +47,8 @@ modules:
 
       # hyper parameters
       train_iters: 50
-      micro_batch_size: 6
-      global_batch_size: 48
+      micro_batch_size: 10
+      global_batch_size: 80
       seq_length: ${PRIMUS_SEQ_LENGTH:4096}
       max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
       lr: 1.0e-5

--- a/examples/torchtitan/configs/MI355X/llama3.1_8B-BF16-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_8B-BF16-pretrain.yaml
@@ -29,6 +29,11 @@ modules:
         mock_data: true
         steps: 50
         gc_freq: 100
+        dataloader:
+          num_workers: 1
+          prefetch_factor: 4
+          persistent_workers: true
+          pin_memory: true
 
       activation_checkpoint:
         mode: "none"  # ["none", "selective", "full"]

--- a/examples/torchtitan/configs/MI355X/llama3.1_8B-FP8-pretrain.yaml
+++ b/examples/torchtitan/configs/MI355X/llama3.1_8B-FP8-pretrain.yaml
@@ -28,6 +28,11 @@ modules:
         mock_data: true
         steps: 50
         gc_freq: 100
+        dataloader:
+          num_workers: 1
+          prefetch_factor: 4
+          persistent_workers: true
+          pin_memory: true
 
       activation_checkpoint:
         mode: "none"  # ["none", "selective", "full"]


### PR DESCRIPTION
## Summary
- Add dataloader tuning defaults to TorchTitan Llama 3.1 8B BF16 and FP8 MI355X pretrain configs (`num_workers=1`, `prefetch_factor=4`, `persistent_workers=true`, `pin_memory=true`).
- Update GPT-OSS 20B FP8 Megatron pretrain batch sizes on MI355X (`micro_batch_size` 6→10, `global_batch_size` 48→80).

## Test plan
- [x] Ran Llama 3.1 8B BF16/FP8 with dataloader overrides on MI355X (~2% TPS improvement)
- [x] Ran GPT-OSS 20B FP8 with updated batch sizes on MI355X
- [ ] CI passes


Made with [Cursor](https://cursor.com)