### PR TITLE
fix(turbo): accumulate the weight gradient on every microbatch, not just the first

### DIFF
--- a/primus/backends/megatron/core/extensions/primus_turbo.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo.py
@@ -203,7 +203,16 @@ def _bridge_weight_grad(
                 # The gemm accumulated into main_grad already; grad_quantized_weight is
                 # the dummy it returns in that case and must not be added on top.
                 weight.grad_added_to_main_grad = True
-            elif not weight.grad_added_to_main_grad:
+            else:
+                # Unconditional: this backward runs once per microbatch, while
+                # grad_added_to_main_grad is a per-iteration flag that DDP resets in
+                # zero_grad_buffer() before the microbatch loop. The flag means "main_grad
+                # already owns this gradient, so the AccumulateGrad hook must not add
+                # param.grad on top" -- not "an add already happened". Gating the add on it
+                # lands only the first microbatch and silently drops every later one, and
+                # the dummy wgrad returned below means they are not recoverable from
+                # param.grad either. The fused path above is immune because its beta=1
+                # epilogue accumulates on every microbatch regardless of the flag.
                 if _is_gfx1250():
                     inplace_add_triton_(weight.main_grad, grad_quantized_weight)
                 else:


### PR DESCRIPTION

## The bug

`_bridge_weight_grad`'s non-fused path gates its `main_grad.add_` on
`not weight.grad_added_to_main_grad`:

```python
if fuse_wgrad_accum:
    weight.grad_added_to_main_grad = True
elif not weight.grad_added_to_main_grad:      # <-- here
    weight.main_grad.add_(grad_quantized_weight)
    weight.grad_added_to_main_grad = True
```

That flag is **per-iteration, not per-microbatch**. DDP clears it in `zero_grad_buffer()` before
the microbatch loop, and this bridge sets it on the first backward -- so with gradient accumulation
only microbatch 0's weight gradient ever reaches `main_grad`. At global batch 512 / micro 2 that is
1 gradient of 32.

The other 31 are not recoverable from `param.grad` either: the bridge returns a dummy wgrad
precisely so the framework's own accumulation stands down, which makes the gated add the only
writer.

The flag means "main_grad already owns this gradient, so `AccumulateGrad` must not add `param.grad`
on top" -- not "an add already happened".

## The change

Drop the gate; add unconditionally. The fused branch is untouched -- its beta=1 epilogue
accumulates on every microbatch regardless of the flag.

## Evidence

DeepSeek-V3 4-layer, **mxfp8**, stock MoE, EP=8, GBS 512 / micro 2, 50 iterations, deterministic
args. One node, one container, one stack, same day; the gate is the only variable.

| | lm loss @50 | grad norm (mean) | ms/iter |
|---|---|---|---|
| Gate in place (today's main) | **8.4360** | 1.2056 | 10002.2 |
| Gate removed (this PR) | **4.5671** | 5.1941 | 10296.6 |
<img width="795" height="488" alt="image" src="https://github.com/user-attachments/assets/6c91d0ef-4511-4342-8f98-3db0d5dd81ec" />


A gap of **3.8689**, against an mxfp8 noise floor of 3.5e-02 for this configuration. The two runs
separate at iteration 3 and never rejoin.

Both endpoints reproduce the 26 August bisect, which was collected on a different turbo build
(8.4357 / 8.4370 / 8.4363 with the gate; 4.5324 / 4.5633 / 4.5670 without), so the fault is
independent of turbo and of the DeepEP fence work landing in Primus-Turbo separately.

The gradient norm is the more direct signal: with 31 of 32 microbatches dropped, what reaches the
optimizer is a fraction of the batch, and the gated run averages 1.21 against 5.19.

There is also a counter-intuitive tell worth recording: dropping 31 of 32 accumulations drops most
of the nondeterminism with them, so the **broken** configuration's rep-to-rep spread is *narrower*
-- 0.0013 against 0.0346 in the August bisect, 26x tighter. Low variance reads as health; here it
is the fault.

## Cost

+2.94% per step, 10002.2 -> 10296.6 ms/iter. That is expected and correct: the fix performs 32 adds
into `main_grad` per iteration where the gate performed 1. The work was always required.
<img width="797" height="282" alt="image" src="https://github.com/user-attachments/assets/6f738797-db48-41ad-9412-d7143bc738f9" />

The measurement is one rep per arm, but the two distributions do not overlap -- the gated run tops
out at 10028.6 ms and the fixed one starts at 10280.1 ms -- so the difference is 118 standard
errors. First-iteration times (728 s gated, 133 s fixed) are autotune and are excluded from the
steady-state mean over iterations 11-50.

## Why a BF16 run cannot see this

`_fuse_wgrad_accum_pattern` returns `"megatron"` for BF16, FP16 and FP8 current-scaling. Those
recipes take the fused beta=1 epilogue above the gate, which accumulates on every microbatch
regardless of the flag, leaving the gated branch dead code. It returns `None` -- and so reaches the
gate -- only for FP8 block, MXFP8 and FP4.

This is not hypothetical. The first pass of the August bisect ran BF16, measured 4.52179 with the
gate against 4.52043 without, and concluded no commit had regressed. That difference sits inside
the BF16 noise floor of 2.6e-04. The mxfp8 floor is 3.5e-02, two orders of magnitude wider: an FP8
difference has to be judged against the FP8 floor.

## Reproducing

```bash
# the config in the repo is `fp8: hybrid` (delayed tensorwise), which takes the fused path and
# never reaches the gate -- an mxfp8 recipe is required or both arms measure the same thing
python3 -m primus.cli.main train pretrain \
    --config examples/megatron/configs/MI355X/deepseek_v3-FP8-pretrain.yaml \
    --num_layers 4 --global_batch_size 512 --micro_batch_size 2 --train_iters 50 \
    --turbo_sync_free_moe_stage 0 --use_turbo_deepep False --mock_data True
```

Judge the endpoint against 4.57, and check the grad norm: a mean near 1.2 instead of 5.2 is the
gate dropping microbatches.

## Test plan

- [x] mxfp8 A/B, gate present vs removed, one node / one container / one stack / same day -- table
      above.
- [x] Endpoints reproduce the independent 26 August bisect on a different turbo build.
- [x] Gradient-norm trace confirms the mechanism rather than just the symptom.
- [x] Step time measured on the same runs, iterations 11-50.
- [ ] FP8 block and FP4 reach the same branch by inspection of `_fuse_wgrad_accum_pattern`, but
      only MXFP8 was measured here.
- [ ] BF16 unaffected by construction (fused path); not re-measured in this round.
