### PR TITLE
ci: bump Primus-Turbo to pick up the DeepEP cheap-fence fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,13 @@ env:
   # (weekend cron, or a manual run with full_tests=true) adds the
   # @pytest.mark.weekly siblings and the slow unit tests.
   PRIMUS_CI_FULL: ${{ (github.event_name == 'schedule' || github.event.inputs.full_tests == 'true') && '1' || '0' }}
-  PRIMUS_TURBO_COMMIT: 7bedebe5c0a06ebf5b94777b1cc68ec6d7e12807 # fix(flydsl): compile-cache fixes (restore LDS-repack modifiers; drop m_total from cache key) (#478, #473)
+  # FlyDSL pad-aware grouped-fp8 down-proj for gpt-oss-20b MoE (#470) -- the first commit after
+  # #482, which is what this bump is for: DeepEP's cheap fence is no longer the default. Its
+  # "release" store was an s_waitcnt plus a RELAXED system-scope store; the s_waitcnt covers only
+  # the wave publishing the channel tail, never the other waves that wrote the payload rows, so a
+  # receiver could read the previous round out of the ring buffer -- silent gradient corruption on
+  # every DeepEP run. Costs ~2.4% per step; DISABLE_CHEAP_FENCE=0 takes the old path back.
+  PRIMUS_TURBO_COMMIT: 6d5ff979eb019fbbcd91790ac812024cca05a882
   PRIMUS_TURBO_AITER_COMMIT: 0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e # AITER v0.1.14.post1 (tag commit) — required by Primus-Turbo main aiter_utils.py
   #ROCSHMEM_COMMIT: 17ff985c026f9f97f85068647e863ab541dd5645 # Update version to 3.2.0 for 7.2.0 rocm release (#351) (#355)
   UCCL_COMMIT: 5afb4117893c58cc0c8557d9286336141a301053 # [EP]: fix fp8 error of internode_ll on amd gfx950 arch. (#710)

--- a/primus/backends/megatron/core/extensions/primus_turbo_float8_local.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_float8_local.py
@@ -62,12 +62,24 @@ from primus.backends.megatron.core.fp8_utils import (
 
 _custom_op = torch.library.custom_op
 
+# ``quantize_fp8_tensorwise`` padding alignment: 1 == no padding, the shape-preserving
+# cast this module has always assumed.
+_QUANT_PAD_ALIGN_K = 1
+_QUANT_PAD_ALIGN_N = 1
+
 
 @_custom_op("primus::quantize_fp8_tensorwise", mutates_args=(), device_types="cuda")
 def _quantize_fp8_tensorwise_op(
     x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    return torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(x, out_dtype, scale)
+    # padding_align_size=1 keeps the cast shape-preserving.  The cpp op defaults it to 128
+    # (zero-padding the last dim up to a multiple of 128 for the pad-aware grouped-GEMM
+    # path), which breaks two things here: the empty_like() fake below no longer matches
+    # the real output, and in a dgrad-style ``trans_b=False`` GEMM the padded K becomes the
+    # output's N.  Callers that want a K-aligned operand should ask for it explicitly.
+    return torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(
+        x, out_dtype, scale, _QUANT_PAD_ALIGN_K, _QUANT_PAD_ALIGN_N
+    )
 
 
 @_quantize_fp8_tensorwise_op.register_fake

--- a/tests/unit_tests/backends/megatron/diffusion/test_fp8_compile_graph_breaks.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_fp8_compile_graph_breaks.py
@@ -71,6 +71,12 @@ _OUT_DIM = 128
 _BATCH = 4
 _GRAN_VALUE = ScalingGranularity.TENSORWISE.value
 _BACKEND_VALUE = BackendType.HIPBLASLT.value
+# quantize_fp8_tensorwise padding alignment (padding_align_size,
+# pad_penultimate_align_size).  The cpp op defaults the first to 128, which zero-pads the
+# last dim for the pad-aware grouped-GEMM path; 1/1 asks for the shape-preserving cast the
+# linear path below needs -- _DIM is 64, so a padded weight would turn the dgrad GEMM's
+# N from 64 into 128.
+_NO_PAD = (1, 1)
 
 
 # ---------------------------------------------------------------------------
@@ -95,11 +101,13 @@ class _Level1FP8Linear(torch.autograd.Function):
             input_2d,
             fp8_dtype,
             None,
+            *_NO_PAD,
         )
         b_fp8, b_scale_inv = torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(
             weight,
             fp8_dtype,
             None,
+            *_NO_PAD,
         )
 
         output = gemm_fp8_impl(
@@ -141,6 +149,7 @@ class _Level1FP8Linear(torch.autograd.Function):
             grad_2d,
             ctx.fp8_dtype,
             None,
+            *_NO_PAD,
         )
         grad_input = gemm_fp8_impl(
             grad_fp8,


### PR DESCRIPTION

Two commits: the pin bump itself, and the source change the bump forces.

## 1. The pin bump

`PRIMUS_TURBO_COMMIT` moves to `6d5ff979`, which is the first commit after
[Primus-Turbo #482](https://github.com/AMD-AGI/Primus-Turbo/pull/482) — DeepEP no longer defaults
to the cheap fence.

The cheap fence's "release" store was an `s_waitcnt` plus a `__ATOMIC_RELAXED` system-scope store.
`s_waitcnt` covers only the wave that publishes the channel tail, never the other waves that wrote
the payload rows, so a receiver could read the previous round out of the ring buffer — silent
gradient corruption on every DeepEP run. Measured on MI355X, DeepSeek-V3 mxfp8: the fault moved
`lm loss` by **+1.6861** on `rocm/primus:v26.3` and by **−0.3557** on `v26.5` against an
all2all reference of 4.5206–4.5218. Same fault, opposite sign, and the low-loss form is the more
dangerous one because it does not look like a bug.

Cost is ~2.4% per step. `PRIMUS_TURBO_DEEPEP_DISABLE_CHEAP_FENCE=0` takes the old path back.

## 2. Why the test had to change

`6d5ff979` is not only #482. It also carries
[#470](https://github.com/AMD-AGI/Primus-Turbo/pull/470) (FlyDSL pad-aware grouped-fp8 down-proj),
which gave the cpp op `quantize_fp8_tensorwise` two new parameters:

```diff
- quantize_fp8_tensorwise(Tensor input, ScalarType dest_dtype, Tensor? scale_opt=None) -> Tensor[]
+ quantize_fp8_tensorwise(Tensor input, ScalarType dest_dtype, Tensor? scale_opt=None,
+                         int padding_align_size=128, int pad_penultimate_align_size=1) -> Tensor[]
```

**The new `padding_align_size` defaults to 128**, and before #470 the op did no padding at all.
So every existing three-argument caller silently changed shape — the last dim is now zero-padded
up to a multiple of 128:

```
                       pre-#470          post-#470
quantize (128, 64)  →  (128, 64)         (128, 128)
quantize (4, 100)   →  (4, 100)          (4, 128)
quantize (4, 256)   →  (4, 256)          (4, 256)      # already aligned, unchanged
```

Note that turbo's own Python API `quantize_fp8` defaults to `pad_align_last=0`, i.e. **no**
padding. Only the raw op defaults to 128; the two defaults disagree with each other.

### What that breaks

**A dgrad-shaped GEMM reads the padding as N.** `gemm_fp8_impl`'s `get_gemm_logical_shape` takes
`N = b.shape[1]` when `trans_b=False`. For a weight quantized to `(out=128, in→padded 128)`, `N`
comes back 128 instead of 64:

```
grad_input.reshape((4, 64))
RuntimeError: shape '[4, 64]' is invalid for input of size 512
```

The forward survives by luck: it uses `trans_b=True`, so `N = b.shape[0]` — the real `out_dim` —
and `K` is padded on both operands with zeros, so the numerics still come out right.

**The registered fake stops matching the real op.** In
`primus/backends/megatron/core/extensions/primus_turbo_float8_local.py`,
`_quantize_fp8_tensorwise_op` registers a fake that returns `torch.empty_like(x)`. Post-#470 that
shape is wrong for any unaligned last dim. This one does not raise — it is a silent fake/real
divergence under `torch.compile`, which is the more serious of the two.

### The change

Both call sites now state the alignment they want instead of inheriting the default:

- `primus_turbo_float8_local.py` — `_QUANT_PAD_ALIGN_K = _QUANT_PAD_ALIGN_N = 1`, passed explicitly.
  The `empty_like` fake is correct again.
- `test_fp8_compile_graph_breaks.py` — `_NO_PAD = (1, 1)` applied to the three raw-op calls in
  `_Level1FP8Linear` (input, weight, grad).

That is the whole diff: 2 files, 23 lines, most of it comments. No numerics change — for
128-aligned dims the padded and unpadded casts are byte-identical, and the tests below assert
compiled-vs-eager equality at `atol=0, rtol=0`.

### Why nothing else noticed

Real hidden dims are 128-aligned, so `padding_align_size=128` is a no-op in production and the
regression is invisible there. `test_fp8_compile_graph_breaks.py` uses `_DIM = 64` and is,
as far as this repo is concerned, the only thing that exercises the unaligned path.

Three of the eight failures in that file are `TestDelayedPhase0*` tests that reach the same
`_Level1FP8Linear`; the two `TestCompiledVsEagerEquivalence` failures come from the production
wrapper, where `_OpaqueModule` quantizes the weight through turbo's *unpadded* Python API while
`OpaqueFP8LinearTensorwiseFunction` quantizes the input through the *padded* raw op — mismatched
`K`, and hipBLASLt asserts `A.size(1) == B.size(1)`.

## Verification

`rocm/primus:v26.5`, MI355X (gfx950), turbo `6d5ff979`:

| | before | after |
|---|---|---|
| `test_fp8_compile_graph_breaks.py` | 8 failed, 20 passed | **28 passed** |
| `test_primus_turbo_float8_local.py` | 1 failed, 19 passed | **20 passed** |
| `tests/unit_tests/backends/megatron/diffusion/` (full) | — | **326 passed** |

Attribution was confirmed by swapping only the turbo build in one container: against the image's
own pre-#470 turbo (`/workspace/Primus-Turbo`, `edc8d2cc`) the unmodified test file is 28 passed.
`git log -L` on the schema line shows #470 is the only commit that ever touched it.

## Compatibility

The five-argument call form exists only from `6d5ff979` on:

| turbo | schema |
|---|---|
| `7bedebe5` (previous pin) | 3 args |
| `fb35ba7e` (#482, fence fix) | 3 args |
| `6d5ff979` (#470) | 5 args |

So the source change cannot land without the pin bump, and the pin bump cannot land without the
source change. They ship together in this PR.

## Follow-up (not in this PR)

Worth fixing upstream: the raw op's `padding_align_size` should default to 1 to match turbo's own
`quantize_fp8`, with the pad-aware grouped-fp8 path asking for 128 explicitly. A default that
changes the shape of every existing caller is the kind of thing that only gets caught when
something happens to use an unaligned dim.
