### PR TITLE
perf(megatron): avoid full logits copy in fused cross-entropy

### DIFF
--- a/primus/backends/megatron/patches/mamba_fused_ce_patches.py
+++ b/primus/backends/megatron/patches/mamba_fused_ce_patches.py
@@ -91,8 +91,14 @@ def _fused_cross_entropy_loss(self, hidden_states, labels, output_weight, runtim
             weight=output_weight,
             runtime_gather_output=runtime_gather_output,
         )
-        logits_2d = logits.permute(1, 0, 2).reshape(b * s, -1)
-        labels_1d = labels.reshape(b * s)
+        # logits is [s, b, vocab] (contiguous). Do NOT permute to [b, s, vocab] --
+        # that forces a full copy of the (huge) logits tensor in both the forward
+        # and its mirror in the backward (~170 ms/step for a 128k vocab at
+        # micro_batch 128 here; verified 963 -> 792 ms/it on GDN-pure 300M).
+        # Cross-entropy is an order-invariant mean, so flatten logits with a free
+        # view in [s, b] token order and reorder the (tiny) labels to match.
+        logits_2d = logits.reshape(s * b, -1)
+        labels_1d = labels.transpose(0, 1).reshape(s * b)
         loss = self._fused_ce(logits_2d, labels_1d)
         return loss.expand(b, s)
     else:


### PR DESCRIPTION
Reopens the change from #1023 on top of current `main`.

## Summary
The fused CE path permuted logits from `[s, b, vocab]` to `[b, s, vocab]` before flattening. That materializes a second copy of the largest tensor in the step, plus its mirror in the backward.

Cross-entropy is an order-invariant mean over tokens, so the `[s, b]` layout can be flattened with a free view and the (tiny) labels transposed instead.

## Measured
GDN-pure 300M, 8x MI355X, seq 2048, micro-batch 128, vocab 128256: **963 -> 792 ms/iter**.

## Test plan
- [x] Existing unit tests pass
- [x] Measured end-to-end on GDN-pure 300M as above

Made with [Cursor](https://cursor.com)