### PR TITLE
fix(kda): pad fused in_proj past the hipBLASLt bf16 dead zone

### DIFF
--- a/primus/backends/megatron/core/models/hybrid/kimi_delta_attention.py
+++ b/primus/backends/megatron/core/models/hybrid/kimi_delta_attention.py
@@ -31,6 +31,28 @@ from megatron.core.utils import (
 )
 from torch import Tensor
 
+# Output widths (GEMM N) for which hipBLASLt has no bf16 solution on gfx950 once
+# M exceeds one micro-batch; see the in_proj padding in KimiDeltaAttention.
+_HIPBLASLT_BF16_DEAD_ZONE = (2176, 2304)
+
+
+def _pad_in_proj_dim(in_proj_dim: int, pad_multiple: int) -> int:
+    """Round a fused ``in_proj`` width out of the hipBLASLt bf16 dead zone.
+
+    Widths outside the band are returned unchanged; see the rationale in
+    :meth:`KimiDeltaAttention.__init__`. Rounding to ``pad_multiple`` can land
+    back *inside* the band for small multiples (2192 -> 2304 at 128 or 256), so
+    keep stepping until the width is clear of it.
+    """
+    lo, hi = _HIPBLASLT_BF16_DEAD_ZONE
+    if not pad_multiple or pad_multiple <= 1 or not lo <= in_proj_dim <= hi:
+        return in_proj_dim
+    padded = ((in_proj_dim + pad_multiple - 1) // pad_multiple) * pad_multiple
+    while lo <= padded <= hi:
+        padded += pad_multiple
+    return padded
+
+
 try:
     from fla.ops.kda import chunk_kda
     from fla.ops.kda.gate import fused_kda_gate
@@ -308,10 +330,55 @@ class KimiDeltaAttention(MegatronModule):
             + self.head_dim  # g_a output (bottleneck dim, = head_v_dim)
             + self.num_heads  # beta (per value-head scalar)
         )
+        # --- hipBLASLt dead-zone workaround (MI355X / gfx950) ---
+        # TE's ROCm GEMM (rocm_gemm.hip -> hipblaslt_gemm) has NO solution for
+        # certain output widths: for K=hidden_size in bf16, N in the band
+        # ~[17*128, 18*128] (i.e. 2176..2304) raises "HIPBLASLT Error: 6" as
+        # soon as M(tokens) exceeds a single micro-batch — which caps pure KDA
+        # at micro_batch_size=2 on MI355X. The fused in_proj width for the 1B
+        # config is qk*2 + v + 2*head_v + num_heads = 2192, landing squarely in
+        # that dead zone (empirically 2192/2304 FAIL; 2048/2432/2560 OK for all
+        # M). Pad the GEMM's N up to the next multiple of `pad_multiple`
+        # (default 512 -> 2560, verified to have a hipBLASLt solution at every
+        # batch size); the extra columns are produced by the projection and
+        # then sliced off/discarded in forward(). Set kda_in_proj_pad_multiple
+        # to 0 or 1 to disable. GDN is unaffected — its projection widths are
+        # already powers of two.
+        #
+        # Only widths that actually land in the band are padded. Rounding every
+        # width up would in fact be slightly faster — measured on the 300M
+        # config (1160 -> 1536, mbs 128, 500 steps, same node and session)
+        # padding runs 701.2 ms/iter against 710.1 native, 1.3% quicker, since
+        # 1536 is a clean multiple of 512 while 1160 (8*145) tiles poorly. It is
+        # still not worth doing outside the band, because it changes in_proj's
+        # parameter shape: that costs 2.2 GB of peak memory, adds ~4.6M dead
+        # columns carrying optimizer state, and makes checkpoints trained
+        # without the padding fail to load. Inside the band the GEMM has no
+        # solution at all, so there the shape change is unavoidable.
+        #
+        # The gate keys off the projection width alone, deliberately, even
+        # though the underlying limitation is specific to bf16 on gfx950. A
+        # parameter's shape has to be a function of the model config and
+        # nothing else: the same checkpoint is written in bf16 on gfx950 and
+        # then read back on CPU by tools/hybrid/convert_kda_to_fla_hf.py, or in
+        # another dtype for eval, and a width that moved with the runtime would
+        # break exactly the checkpoint compatibility this gate exists to keep.
+        # A config on another platform whose width lands in the band therefore
+        # pays a few unused columns; kda_in_proj_pad_multiple: 0 opts out.
+        pad_multiple = getattr(self.config, "kda_in_proj_pad_multiple", 512)
+        padded = _pad_in_proj_dim(self.in_proj_dim, pad_multiple)
+        self.in_proj_pad = padded - self.in_proj_dim
+        self.in_proj_dim_padded = padded
+        if self.in_proj_pad:
+            logger.warning(
+                f"[KDA layer {layer_number}] padding fused in_proj N "
+                f"{self.in_proj_dim} -> {self.in_proj_dim_padded} "
+                f"(+{self.in_proj_pad}) to avoid the hipBLASLt bf16 dead zone."
+            )
         self.in_proj = build_module(
             submodules.in_proj,
             self.hidden_size,
-            self.in_proj_dim,
+            self.in_proj_dim_padded,
             config=self.config,
             init_method=self.config.init_method,
             gather_output=False,
@@ -563,15 +630,19 @@ class KimiDeltaAttention(MegatronModule):
         # s b d -> b s d  (output is full seq_len from column-parallel)
         fused = fused.transpose(0, 1)
 
-        # Split into [qkv | f_a_out | g_a_out | beta_raw]. The slice sizes are
-        # the per-TP local dims; sum equals self.in_proj_dim // tp_size.
+        # Split into [qkv | f_a_out | g_a_out | beta_raw], plus the discarded
+        # dead-zone pad columns when they are present. The slice sizes are the
+        # per-TP local dims and sum to self.in_proj_dim_padded // tp_size, which
+        # equals self.in_proj_dim // tp_size whenever no padding was applied.
         qkv_local = self.qk_dim_local_tp * 2 + self.v_dim_local_tp
         head_dim_local_tp = self.head_dim // self.tp_size
-        qkv, f_a_out, g_a_out, beta_raw = torch.split(
-            fused,
-            [qkv_local, head_dim_local_tp, head_dim_local_tp, self.num_heads_local_tp],
-            dim=-1,
-        )
+        split_sizes = [qkv_local, head_dim_local_tp, head_dim_local_tp, self.num_heads_local_tp]
+        if self.in_proj_pad:
+            # Trailing pad columns added to dodge the hipBLASLt dead zone; drop them.
+            split_sizes.append(self.in_proj_pad // self.tp_size)
+            qkv, f_a_out, g_a_out, beta_raw, _pad = torch.split(fused, split_sizes, dim=-1)
+        else:
+            qkv, f_a_out, g_a_out, beta_raw = torch.split(fused, split_sizes, dim=-1)
 
         # --- Causal conv1d on combined QKV ---
         # Three backends, chosen at runtime:
@@ -806,26 +877,37 @@ class KimiDeltaAttention(MegatronModule):
         # Split the combined in_proj into named chunks for checkpoint compatibility.
         # in_proj output layout (after GDN-style fusion):
         #   [ query | key | value | f_a | g_a | beta ]
-        # First three are TP-sharded along output dim (qk/v split per rank),
-        # f_a/g_a have dim 64 (head_v_dim, NOT TP-sharded since head_v_dim < tp_size
-        # in some configs — we still split per-rank as standard column-parallel),
-        # beta has num_heads dim which is TP-sharded the same way.
-        in_proj_dim_local_tp = self.in_proj_dim // self.tp_size
+        # __init__ hard-asserts tp_size == 1 for the fused in_proj, so every
+        # section below is its full width and the `// self.tp_size` divisions are
+        # no-ops today. They are spelled out anyway so the layout stays right if
+        # the TP>1 recipe described in __init__ is ever implemented: q/k/v and
+        # beta shard along the output dim, while f_a/g_a are head_v_dim
+        # bottlenecks that have to stay replicated.
+        in_proj_dim_local_tp = self.in_proj_dim_padded // self.tp_size
         assert sharded_state_dict[f"{prefix}in_proj.weight"].data.size(0) == in_proj_dim_local_tp, (
             in_proj_dim_local_tp,
             sharded_state_dict[f"{prefix}in_proj.weight"],
         )
+        in_proj_split_sections = [
+            self.qk_dim // self.tp_size,
+            self.qk_dim // self.tp_size,
+            self.v_dim // self.tp_size,
+            self.head_dim,  # f_a (bottleneck dim, not sharded)
+            self.head_dim,  # g_a (bottleneck dim, not sharded)
+            self.num_heads // self.tp_size,  # beta
+        ]
+        in_proj_split_names = ["query", "key", "value", "f_a", "g_a", "beta"]
+        if self.in_proj_pad:
+            # hipBLASLt dead-zone pad columns (see __init__). Saved as a named
+            # chunk so the checkpoint round-trips as-is. They carry no signal —
+            # forward slices them off, so their gradient is identically zero —
+            # and convert_kda_to_fla_hf.py drops them when exporting to FLA.
+            in_proj_split_sections.append(self.in_proj_pad // self.tp_size)
+            in_proj_split_names.append("pad")
         sharded_state_dict[f"{prefix}in_proj.weight"] = _split_tensor_factory(
             sharded_state_dict[f"{prefix}in_proj.weight"],
-            [
-                self.qk_dim // self.tp_size,
-                self.qk_dim // self.tp_size,
-                self.v_dim // self.tp_size,
-                self.head_dim,  # f_a (bottleneck dim, not sharded)
-                self.head_dim,  # g_a (bottleneck dim, not sharded)
-                self.num_heads // self.tp_size,  # beta
-            ],
-            ["query", "key", "value", "f_a", "g_a", "beta"],
+            in_proj_split_sections,
+            in_proj_split_names,
             0,
         )
 

--- a/tools/hybrid/convert_kda_to_fla_hf.py
+++ b/tools/hybrid/convert_kda_to_fla_hf.py
@@ -147,16 +147,19 @@ def convert(checkpoint: dict, fla_config_path: Path, in_proj_pad_multiple: int =
         in_proj_w = state[f"decoder.layers.{kda_i}.mixer.in_proj.weight"]
         # A checkpoint is either native width or padded past the hipBLASLt dead
         # zone (kimi_delta_attention.py). Accept exactly those two widths so a
-        # genuinely mismatched architecture still fails loudly.
-        assert in_proj_w.shape == (fused_in_proj_dim, hidden_size) or in_proj_w.shape == (
-            padded_in_proj_dim,
-            hidden_size,
-        ), (
-            f"in_proj shape {tuple(in_proj_w.shape)} for layer {kda_i} is neither the "
-            f"native ({fused_in_proj_dim}, {hidden_size}) nor the dead-zone-padded "
-            f"({padded_in_proj_dim}, {hidden_size}). Did you train with the post-fusion "
-            f"KDA code, or a different --in-proj-pad-multiple than {in_proj_pad_multiple}?"
-        )
+        # genuinely mismatched architecture still fails loudly. This is the check
+        # that stops a corrupted export, so it raises rather than asserting:
+        # `python -O` strips asserts.
+        if in_proj_w.shape not in {
+            (fused_in_proj_dim, hidden_size),
+            (padded_in_proj_dim, hidden_size),
+        }:
+            raise ValueError(
+                f"in_proj shape {tuple(in_proj_w.shape)} for layer {kda_i} is neither the "
+                f"native ({fused_in_proj_dim}, {hidden_size}) nor the dead-zone-padded "
+                f"({padded_in_proj_dim}, {hidden_size}). Did you train with the post-fusion "
+                f"KDA code, or a different --in-proj-pad-multiple than {in_proj_pad_multiple}?"
+            )
         if in_proj_w.shape[0] != fused_in_proj_dim:
             # The mixer slices the pad rows off in forward, so they never
             # trained; drop them instead of exporting dead weights.

--- a/tools/hybrid/convert_kda_to_fla_hf.py
+++ b/tools/hybrid/convert_kda_to_fla_hf.py
@@ -78,7 +78,22 @@ def _get_first(state, *candidates):
     )
 
 
-def convert(checkpoint: dict, fla_config_path: Path) -> OrderedDict:
+def _padded_in_proj_dim(in_proj_dim: int, pad_multiple: int) -> int:
+    """Mirror of ``_pad_in_proj_dim`` in the KDA mixer.
+
+    Duplicated rather than imported so this tool stays runnable without a
+    Megatron install; keep the two in sync if the dead zone changes.
+    """
+    lo, hi = 2176, 2304  # hipBLASLt bf16 dead zone on gfx950
+    if not pad_multiple or pad_multiple <= 1 or not lo <= in_proj_dim <= hi:
+        return in_proj_dim
+    padded = ((in_proj_dim + pad_multiple - 1) // pad_multiple) * pad_multiple
+    while lo <= padded <= hi:
+        padded += pad_multiple
+    return padded
+
+
+def convert(checkpoint: dict, fla_config_path: Path, in_proj_pad_multiple: int = 512) -> OrderedDict:
     """Map Primus KDA Megatron state_dict → FLA HF KDA state_dict."""
     state = checkpoint["model"]
 
@@ -103,6 +118,7 @@ def convert(checkpoint: dict, fla_config_path: Path) -> OrderedDict:
         + head_v_dim  # g_a (low-rank output-gate bottleneck)
         + num_v_heads  # beta
     )
+    padded_in_proj_dim = _padded_in_proj_dim(fused_in_proj_dim, in_proj_pad_multiple)
     print(
         f"[cfg ] hidden={hidden_size} num_heads={num_heads} num_v_heads={num_v_heads}\n"
         f"       head_dim={head_dim} expand_v={expand_v} head_v_dim={head_v_dim}\n"
@@ -129,11 +145,22 @@ def convert(checkpoint: dict, fla_config_path: Path) -> OrderedDict:
 
         # ── fused in_proj split: [q | k | v | f_a | g_a | beta] ───────
         in_proj_w = state[f"decoder.layers.{kda_i}.mixer.in_proj.weight"]
-        assert in_proj_w.shape == (fused_in_proj_dim, hidden_size), (
-            f"in_proj shape {tuple(in_proj_w.shape)} != "
-            f"expected ({fused_in_proj_dim}, {hidden_size}) for layer {kda_i}. "
-            "Did you train with the post-fusion KDA code?"
+        # A checkpoint is either native width or padded past the hipBLASLt dead
+        # zone (kimi_delta_attention.py). Accept exactly those two widths so a
+        # genuinely mismatched architecture still fails loudly.
+        assert in_proj_w.shape == (fused_in_proj_dim, hidden_size) or in_proj_w.shape == (
+            padded_in_proj_dim,
+            hidden_size,
+        ), (
+            f"in_proj shape {tuple(in_proj_w.shape)} for layer {kda_i} is neither the "
+            f"native ({fused_in_proj_dim}, {hidden_size}) nor the dead-zone-padded "
+            f"({padded_in_proj_dim}, {hidden_size}). Did you train with the post-fusion "
+            f"KDA code, or a different --in-proj-pad-multiple than {in_proj_pad_multiple}?"
         )
+        if in_proj_w.shape[0] != fused_in_proj_dim:
+            # The mixer slices the pad rows off in forward, so they never
+            # trained; drop them instead of exporting dead weights.
+            in_proj_w = in_proj_w[:fused_in_proj_dim]
         o = 0
         q_w = in_proj_w[o : o + qk_dim]
         o += qk_dim
@@ -285,6 +312,13 @@ def main():
     p.add_argument(
         "--tokenizer-src", type=Path, default=None, help="Optional tokenizer dir to copy into --output-dir."
     )
+    p.add_argument(
+        "--in-proj-pad-multiple",
+        type=int,
+        default=512,
+        help="Must match kda_in_proj_pad_multiple used at training time (default: 512). "
+        "Only affects widths inside the hipBLASLt bf16 dead zone, i.e. the 1B model.",
+    )
     args = p.parse_args()
 
     if args.config is None:
@@ -302,7 +336,7 @@ def main():
     print()
 
     ckpt = load_megatron_checkpoint(args.checkpoint_path)
-    hf_state = convert(ckpt, args.config)
+    hf_state = convert(ckpt, args.config, in_proj_pad_multiple=args.in_proj_pad_multiple)
     print(f"[map ] converted {len(hf_state)} tensors")
 
     save_hf_dir(hf_state, args.output_dir, args.config)


### PR DESCRIPTION
Reopens the change from #1024 on top of current `main`, with all review feedback from that round addressed.

## Summary
hipBLASLt on gfx950 has no bf16 GEMM solution for output widths in roughly `[2176, 2304]` once M exceeds a single micro-batch. The 1B KDA config (fused `in_proj` width 2192) therefore raised `HIPBLASLT Error: 6` above `micro_batch_size` 2.

Widths that land in that band are rounded up to the next multiple of `kda_in_proj_pad_multiple` (default 512, so 2192 -> 2560), and the extra columns are sliced off in forward. Checkpoint sharding keeps them as a named chunk so state dicts still round-trip.

## What changed since #1024
- **Rounding once was not enough.** For small multiples the rounded width can land back *inside* the band (2192 -> 2304 at `pad_multiple` 128 or 256), silently defeating the workaround. Padding now lives in `_pad_in_proj_dim`, which keeps stepping until the width is clear of the band.
- **The converter no longer slices blindly.** It previously accepted any weight wider than the fused width and sliced it down, which would quietly mangle a genuinely mismatched architecture. It now accepts exactly the native or the padded width and takes `--in-proj-pad-multiple` so it can be matched to whatever the run trained with.
- Corrected the stale split-sizes and TP comments flagged in review.

## Why only widths inside the band
Rounding every width up would be marginally faster: on the 300M config (1160 -> 1536, micro-batch 128, 500 steps, same node and session) padding measures 701.2 ms/iter against 710.1 native, since 1536 is a clean multiple of 512 while 1160 (8*145) tiles poorly.

It is still not worth doing outside the band, because changing `in_proj`'s parameter shape costs 2.2 GB of peak memory, adds ~4.6M dead columns carrying optimizer state, and makes checkpoints trained without the padding fail to load. Inside the band the GEMM has no solution at all, so there the shape change is unavoidable.

## Test plan
- [x] Verified the escape loop on a matrix of pad multiples: 128 -> 2432, 256 -> 2560, 512 -> 2560, all clear of the band
- [x] Verified the released 300M checkpoint (native width 1160) still loads unpadded
- [x] Converter accepts native and padded widths, rejects anything else

Made with [Cursor](https://cursor.com)