### PR TITLE
perf(mlp): add opt-in fused SwiGLU+fc2 via FLA swiglu_linear

### DIFF
--- a/primus/backends/megatron/patches/_source_patch_utils.py
+++ b/primus/backends/megatron/patches/_source_patch_utils.py
@@ -82,6 +82,42 @@ def patch_method_source(
     return new_func
 
 
+def patch_method_source_multi(
+    cls: Any,
+    method_name: str,
+    replacements: "list[tuple[str, str]]",
+) -> Callable:
+    """Apply several ``(anchor, replacement)`` rewrites to one method in one pass.
+
+    A method can only be source-patched *once*: ``inspect.getsource`` cannot read
+    a function that was already rebuilt by ``exec``, so a second
+    :func:`patch_method_source` call on the same method raises ``OSError``.
+    Batching the rewrites keeps multiple independent injections possible.
+    """
+    original = getattr(cls, method_name)
+    source = inspect.getsource(original)
+    for ori_code, new_code in replacements:
+        assert ori_code in source, (
+            f"[SourcePatch] Anchor not found in {cls.__name__}.{method_name}; "
+            f"upstream source may have changed. Anchor: {ori_code!r}"
+        )
+        source = source.replace(ori_code, new_code)
+    modified_source = textwrap.dedent(source)
+
+    wrapper_source = "class _PrimusPatchWrapper:\n" + textwrap.indent(modified_source, "    ")
+    namespace: dict = {}
+    exec(wrapper_source, original.__globals__, namespace)  # noqa: S102
+    wrapper_cls = namespace["_PrimusPatchWrapper"]
+    new_func = wrapper_cls.__dict__[original.__name__]
+    if new_func.__closure__:
+        for cell in new_func.__closure__:
+            if cell.cell_contents is wrapper_cls:
+                cell.cell_contents = cls
+    new_func.__qualname__ = f"{cls.__qualname__}.{method_name}"
+    setattr(cls, method_name, new_func)
+    return new_func
+
+
 def patch_function_source(
     module: Any,
     function_name: str,

--- a/primus/backends/megatron/patches/_source_patch_utils.py
+++ b/primus/backends/megatron/patches/_source_patch_utils.py
@@ -97,11 +97,18 @@ def patch_method_source_multi(
     original = getattr(cls, method_name)
     source = inspect.getsource(original)
     for ori_code, new_code in replacements:
-        assert ori_code in source, (
-            f"[SourcePatch] Anchor not found in {cls.__name__}.{method_name}; "
-            f"upstream source may have changed. Anchor: {ori_code!r}"
-        )
-        source = source.replace(ori_code, new_code)
+        # Require exactly one match. A missing anchor means upstream moved, and
+        # an ambiguous one would rewrite every occurrence and inject the patch
+        # somewhere it was never meant to go. Raise rather than assert so the
+        # check survives `python -O`.
+        found = source.count(ori_code)
+        if found != 1:
+            raise RuntimeError(
+                f"[SourcePatch] Anchor matched {found} times in "
+                f"{cls.__name__}.{method_name}, expected exactly 1; upstream "
+                f"source may have changed. Anchor: {ori_code!r}"
+            )
+        source = source.replace(ori_code, new_code, 1)
     modified_source = textwrap.dedent(source)
 
     wrapper_source = "class _PrimusPatchWrapper:\n" + textwrap.indent(modified_source, "    ")

--- a/primus/backends/megatron/patches/fla_runtime_patches.py
+++ b/primus/backends/megatron/patches/fla_runtime_patches.py
@@ -81,6 +81,7 @@ from primus.core.utils.module_utils import log_rank_0
 
 _FLA_RUNTIME_KNOBS: tuple = (
     ("use_fla_fused_swiglu", "PRIMUS_FLA_SWIGLU", True),
+    ("use_fla_fused_swiglu_linear", "PRIMUS_FLA_SWIGLU_LINEAR", False),
     ("use_fla_fused_rmsnorm", "PRIMUS_FLA_NORM", False),
     ("use_fla_fused_gated_norm", "PRIMUS_FLA_NORM", False),
     ("use_fla_short_conv", "PRIMUS_FLA_CONV", False),

--- a/primus/backends/megatron/patches/fla_runtime_patches.py
+++ b/primus/backends/megatron/patches/fla_runtime_patches.py
@@ -32,6 +32,10 @@ knob.
 
     # --- FLA Triton kernel toggles -------------------------------------------
     use_fla_fused_swiglu: true          # default true
+    use_fla_fused_swiglu_linear: false  # default false. Fuses swiglu *into*
+                                        #   linear_fc2, trading throughput for
+                                        #   one fewer ffn-wide saved tensor per
+                                        #   layer; see mlp_fla_swiglu_patches.
     use_fla_fused_rmsnorm: false        # default false
     use_fla_fused_gated_norm: false     # default false  (same semantic scope
                                         #   as use_fla_fused_rmsnorm but kept

--- a/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
+++ b/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
@@ -244,14 +244,23 @@ def _install_mlp_fla_swiglu_patch() -> None:
         log_rank_0(f"[Patch:{_PATCH_KEY}] MLP already patched; skipping.")
         return
 
-    patch_method_source(MLP, "__init__", _INIT_ORI, _INIT_NEW)
-    # Both forward rewrites must go in one pass: a method can only be
-    # source-patched once (inspect.getsource cannot re-read an exec'd function).
-    patch_method_source_multi(
-        MLP,
-        "forward",
-        [(_FWD_FUSED_ORI, _FWD_FUSED_NEW), (_FORWARD_ORI, _FORWARD_NEW)],
-    )
+    # Apply both rewrites or neither. If an anchor drifts on a Megatron bump the
+    # second call raises, and a half-patched MLP is worse than an unpatched one:
+    # __init__ would set the _use_fla_* flags that only the patched forward
+    # reads, and a retry cannot re-read the source of an already-exec'd method.
+    original_init, original_forward = MLP.__init__, MLP.forward
+    try:
+        patch_method_source(MLP, "__init__", _INIT_ORI, _INIT_NEW)
+        # Both forward rewrites must go in one pass: a method can only be
+        # source-patched once (inspect.getsource cannot re-read an exec'd function).
+        patch_method_source_multi(
+            MLP,
+            "forward",
+            [(_FWD_FUSED_ORI, _FWD_FUSED_NEW), (_FORWARD_ORI, _FORWARD_NEW)],
+        )
+    except Exception:
+        MLP.__init__, MLP.forward = original_init, original_forward
+        raise
 
     mark_patched(MLP, _PATCH_KEY)
     log_rank_0(

--- a/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
+++ b/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
@@ -98,7 +98,7 @@ def _plain_swiglu_reject(config) -> str:
     """Why FLA's swiglu kernel cannot stand in for this MLP's activation, if so."""
     if not config.gated_linear_unit:
         return "gated_linear_unit is off"
-    if config.activation_func is not F.silu:
+    if config.activation_func != F.silu:
         return "activation_func is not F.silu"
     if getattr(config, "use_te_activation_func", False):
         return "activation_func comes from the TE module slot (may be clamped)"

--- a/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
+++ b/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
@@ -38,13 +38,15 @@ entire measured activation gap vs FLA).
 It is a trade, not a free win, which is why it stays off by default: recomputing
 the activation costs time, and the cost grows with the micro-batch. Measured on
 MI355X, 300M, seq 2048, 30 iters, median of three A/B repeats -- loss matched to
-four decimals in every pair, and peak memory was bit-identical across repeats:
+four decimals in every pair, and peak memory was bit-identical across repeats.
+Both columns are deltas against the unfused path, so a positive iteration time
+means the fused path is *slower* and a negative memory figure means it saves:
 
-    model  mbs   speed    peak memory
-    GDN      2    ~0%      -0.3 GB
-    GDN     32   +4.4%     -5.3 GB
-    KDA      2   +2.2%     -0.6 GB
-    KDA     32   +5.1%     -5.8 GB
+    model  mbs   iteration time   peak memory
+    GDN      2       ~0%            -0.3 GB
+    GDN     32     +4.4% slower     -5.3 GB
+    KDA      2     +2.2% slower     -0.6 GB
+    KDA     32     +5.1% slower     -5.8 GB
 
 The saving tracks ~0.18 GiB per unit micro-batch, as predicted by the size of
 the tensor that is no longer stashed for the fc2 weight gradient.
@@ -165,7 +167,11 @@ def _resolve_fla_swiglu(config, is_expert: bool):
 
             swiglu_fn = swiglu
         except ImportError:
-            pass
+            # use_fla_fused_swiglu defaults to on, so a missing FLA install is a
+            # normal configuration rather than an error: leave swiglu_fn as None
+            # and let Megatron's own activation run. The opt-in fc2 path below
+            # does report its ImportError, since that one was asked for.
+            swiglu_fn = None
 
     swiglu_linear_fn = None
     if getattr(args, "use_fla_fused_swiglu_linear", False):

--- a/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
+++ b/primus/backends/megatron/patches/mlp_fla_swiglu_patches.py
@@ -11,42 +11,212 @@ MLP FLA SwiGLU Patch
 Routes ``MLP``'s gated-linear-unit activation through
 flash-linear-attention's (FLA) Triton-fused ``swiglu`` kernel (one fwd + one
 bwd kernel) instead of Megatron's naive two-kernel ``silu(x_glu) * x_linear``,
-saving ~20 ms/iter on GDN/KDA/Mamba hybrid training. Only takes effect when
-``config.gated_linear_unit`` and the activation is ``F.silu`` -- i.e. it is a
-no-op for GeLU-based MLPs, MoE, and any config where
-``use_te_activation_func`` / ``bias_activation_fusion`` are already handling
-the activation through a different (already-fused) code path.
+saving ~20 ms/iter on GDN/KDA/Mamba hybrid training.
+
+Only takes effect for plain, unclamped SwiGLU: ``config.gated_linear_unit`` with
+``F.silu``, no ``use_te_activation_func`` module slot, no
+``activation_func_clamp_value`` and no ``glu_linear_offset``. ``F.silu`` on its
+own is not a sufficient test -- Kimi K3 keeps that config value only to satisfy
+the whitelist in ``TransformerConfig.__post_init__`` while supplying the real,
+soft-clamped ``SituActivation`` through the module slot, and DeepSeek-V4 style
+configs reach the eager ``glu()`` with a clamp bound. FLA's kernels implement
+neither, so those configs fall through to Megatron's own code, as do GeLU-based
+MLPs and MoE.
 
 Toggle: ``args.use_fla_fused_swiglu`` (resolved by ``fla_runtime_patches.py``
 from ``PRIMUS_FLA_SWIGLU`` / YAML ``use_fla_fused_swiglu``, default True).
 
+Memory variant: ``args.use_fla_fused_swiglu_linear`` (default False) goes one
+step further and fuses the activation *into* ``linear_fc2`` via FLA's
+``swiglu_linear``. Megatron computes ``swiglu`` as its own op and then feeds the
+result to ``linear_fc2``, which saves that ffn-wide tensor for its weight
+gradient; ``swiglu_linear`` instead saves only the two fc1 halves and recomputes
+the activation in the backward. That removes one ffn-wide tensor per MLP layer
+(measured 0.188 GiB per unit micro-batch on GDN-300M, ffn 4096, seq 2048 -- the
+entire measured activation gap vs FLA).
+
+It is a trade, not a free win, which is why it stays off by default: recomputing
+the activation costs time, and the cost grows with the micro-batch. Measured on
+MI355X, 300M, seq 2048, 30 iters, median of three A/B repeats -- loss matched to
+four decimals in every pair, and peak memory was bit-identical across repeats:
+
+    model  mbs   speed    peak memory
+    GDN      2    ~0%      -0.3 GB
+    GDN     32   +4.4%     -5.3 GB
+    KDA      2   +2.2%     -0.6 GB
+    KDA     32   +5.1%     -5.8 GB
+
+The saving tracks ~0.18 GiB per unit micro-batch, as predicted by the size of
+the tensor that is no longer stashed for the fc2 weight gradient.
+
+Correctness note: this bypasses ``linear_fc2``'s
+``linear_with_grad_accumulation_and_async_allreduce``, so the fc2 weight
+gradient lands in ``param.grad`` instead of being fused straight into
+``param.main_grad``. That is safe -- Megatron's DDP backward post-hook folds
+``param.grad`` into ``main_grad`` whenever ``grad_added_to_main_grad`` is False
+-- but it does forgo the wgrad-accumulation fusion, so the path is gated to the
+simple case it was measured on: TP=1, PP=1, no sequence parallel, no bias, no
+per-token scaling, non-expert MLPs, no FP8 / ``delay_wgrad_compute`` /
+``activation_func_fp8_input_store``, and no ``overlap_param_gather``. Everything
+it bypasses lives in ``linear_fc2``: FP8 and delayed-wgrad execution inside
+``TERowParallelLinear``, the deferred-wgrad enqueue the zero-bubble pipeline
+schedules pop in their W phase, and the parameter all-gather hook. A PEFT
+adapter can also wrap ``linear_fc2`` *after* ``__init__``, so the forward
+rechecks that the module still exposes a plain ``.weight``.
+
 Source-string rewrite style: the injection points sit inside ``MLP.__init__``
 and the non-fused branch of ``MLP.forward``, which a plain wrapper cannot
-reach without duplicating the whole (large) method body.
+reach without duplicating the whole (large) method body. The eligibility rules
+themselves live in ``_resolve_fla_swiglu`` rather than in the injected string,
+so they can be read and exercised as ordinary Python.
 """
 
+import torch.nn.functional as F
+
 from primus.backends.megatron.patches._patch_guard import is_patched, mark_patched
-from primus.backends.megatron.patches._source_patch_utils import patch_method_source
+from primus.backends.megatron.patches._source_patch_utils import (
+    patch_method_source,
+    patch_method_source_multi,
+)
 from primus.core.patches import PatchContext, get_args, register_patch
 from primus.core.utils.module_utils import log_rank_0
 
 _PATCH_KEY = "megatron.mlp.fla_swiglu"
 
+
+# `activation_func == F.silu` alone does not mean "plain SwiGLU". Kimi K3 keeps
+# that value only to satisfy the whitelist in TransformerConfig.__post_init__
+# while routing the real, soft-clamped activation through the `activation_func`
+# module slot (`use_te_activation_func`, mlp.py:226); DeepSeek-V4 style configs
+# instead reach the eager `glu()` with a clamp bound and/or a non-zero
+# `glu_linear_offset`. FLA's kernels implement none of that, so both fused paths
+# below are restricted to the plain, unclamped, zero-offset case and everything
+# else falls through to Megatron's own code.
+def _plain_swiglu_reject(config) -> str:
+    """Why FLA's swiglu kernel cannot stand in for this MLP's activation, if so."""
+    if not config.gated_linear_unit:
+        return "gated_linear_unit is off"
+    if config.activation_func is not F.silu:
+        return "activation_func is not F.silu"
+    if getattr(config, "use_te_activation_func", False):
+        return "activation_func comes from the TE module slot (may be clamped)"
+    if getattr(config, "activation_func_clamp_value", None) is not None:
+        return "activation_func_clamp_value is set"
+    if getattr(config, "glu_linear_offset", 0):
+        return "glu_linear_offset is non-zero"
+    return ""
+
+
+def _fused_fc2_reject(config, args, is_expert: bool) -> str:
+    """Why swiglu cannot be fused into linear_fc2 here, if it cannot.
+
+    Everything this path bypasses lives in ``linear_fc2``, so each gate below
+    names the mechanism that would silently be skipped.
+    """
+    plain = _plain_swiglu_reject(config)
+    if plain:
+        return plain
+    if is_expert:
+        return "expert MLP"
+    if config.tensor_model_parallel_size != 1:
+        return "tensor_model_parallel_size > 1 (fc2 is row-parallel)"
+    if config.sequence_parallel:
+        return "sequence_parallel is on"
+    if config.add_bias_linear:
+        return "add_bias_linear is on"
+    # Zero-bubble / custom pipeline schedules expect linear_fc2's backward to
+    # enqueue a deferred wgrad (WeightGradStore.split_bw); calling FLA's
+    # autograd directly never enqueues, so the W phase pops an empty queue.
+    if config.pipeline_model_parallel_size != 1:
+        return "pipeline_model_parallel_size > 1 (deferred-wgrad schedules)"
+    # FP8 and delayed-wgrad execution live inside TERowParallelLinear.
+    if config.fp8:
+        return "fp8 is enabled"
+    if getattr(config, "delay_wgrad_compute", False):
+        return "delay_wgrad_compute is on"
+    if getattr(config, "activation_func_fp8_input_store", False):
+        return "activation_func_fp8_input_store is on"
+    # Reading linear_fc2.weight directly never triggers that module's parameter
+    # all-gather hook, so the kernel could consume a still-sharded parameter.
+    if getattr(args, "overlap_param_gather", False):
+        return "overlap_param_gather is on"
+    return ""
+
+
+_DECISIONS_LOGGED = set()
+
+
+def _resolve_fla_swiglu(config, is_expert: bool):
+    """Pick the FLA SwiGLU kernels this MLP may use.
+
+    Returns ``(swiglu_fn_or_None, swiglu_linear_fn_or_None)``. Kept a plain
+    function of the config -- rather than inlined into the injected source
+    string -- so the eligibility rules stay readable, and so a rejected opt-in
+    is reported instead of silently falling back.
+    """
+    from megatron.training import get_args
+
+    args = get_args()
+
+    swiglu_fn = None
+    if getattr(args, "use_fla_fused_swiglu", True) and not _plain_swiglu_reject(config):
+        try:
+            from fla.modules.activations import swiglu
+
+            swiglu_fn = swiglu
+        except ImportError:
+            pass
+
+    swiglu_linear_fn = None
+    if getattr(args, "use_fla_fused_swiglu_linear", False):
+        reason = _fused_fc2_reject(config, args, is_expert)
+        if not reason:
+            try:
+                from fla.modules.activations import swiglu_linear
+
+                swiglu_linear_fn = swiglu_linear
+            except ImportError:
+                reason = "flash-linear-attention is not installed"
+        if reason not in _DECISIONS_LOGGED:
+            _DECISIONS_LOGGED.add(reason)
+            log_rank_0(
+                f"[Patch:{_PATCH_KEY}] fused SwiGLU+fc2 "
+                + ("active" if not reason else f"disabled: {reason}")
+            )
+
+    return swiglu_fn, swiglu_linear_fn
+
+
 # Inserted right before linear_fc2 construction in MLP.__init__, mirroring
 # where megatron_patches/03-mlp-fla-swiglu.patch spliced in its detection.
 _INIT_ORI = "self.linear_fc2 = submodules.linear_fc2("
 _INIT_NEW = (
-    "from megatron.training import get_args as _get_args\n"
-    "        self._use_fla_swiglu = False\n"
-    "        if getattr(_get_args(), 'use_fla_fused_swiglu', True):\n"
-    "            if self.config.gated_linear_unit and self.config.activation_func == F.silu:\n"
-    "                try:\n"
-    "                    from fla.modules.activations import swiglu as _fla_swiglu\n"
-    "                    self._use_fla_swiglu = True\n"
-    "                    self._fla_swiglu_fn = _fla_swiglu\n"
-    "                except ImportError:\n"
-    "                    pass\n"
+    "from primus.backends.megatron.patches.mlp_fla_swiglu_patches import "
+    "_resolve_fla_swiglu as _fla_resolve\n"
+    "        self._fla_swiglu_fn, self._fla_swiglu_linear_fn = _fla_resolve(self.config, is_expert)\n"
+    "        self._use_fla_swiglu = self._fla_swiglu_fn is not None\n"
+    "        self._use_fla_swiglu_linear = self._fla_swiglu_linear_fn is not None\n"
     "\n        " + _INIT_ORI
+)
+
+# Inserted at the top of MLP.forward's activation section: when the fused
+# swiglu+fc2 path is active we short-circuit both the activation and linear_fc2,
+# so the ffn-wide activation output is never saved for backward.
+_FWD_FUSED_ORI = 'nvtx_range_push(suffix="activation")'
+_FWD_FUSED_NEW = (
+    "if (getattr(self, '_use_fla_swiglu_linear', False)\n"
+    "                and per_token_scale is None and bias_parallel is None\n"
+    # PEFT wraps linear_fc2 after __init__ (LoRALinear exposes the base module as
+    # `.to_wrap` and adds the adapter output in its forward), so the eligibility
+    # decision has to be rechecked here: the wrapper has no `.weight`, and reading
+    # through it would drop the adapter contribution anyway.
+    "                and hasattr(self.linear_fc2, 'weight')):\n"
+    "            x_glu, x_linear = torch.chunk(intermediate_parallel, 2, dim=-1)\n"
+    "            output = self._fla_swiglu_linear_fn(\n"
+    "                x_glu, x_linear, self.linear_fc2.weight, None\n"
+    "            )\n"
+    "            return output, None\n"
+    "        " + _FWD_FUSED_ORI
 )
 
 # Inserted in MLP.forward's non-fused-bias-activation branch, in place of the
@@ -69,12 +239,19 @@ def _install_mlp_fla_swiglu_patch() -> None:
         return
 
     patch_method_source(MLP, "__init__", _INIT_ORI, _INIT_NEW)
-    patch_method_source(MLP, "forward", _FORWARD_ORI, _FORWARD_NEW)
+    # Both forward rewrites must go in one pass: a method can only be
+    # source-patched once (inspect.getsource cannot re-read an exec'd function).
+    patch_method_source_multi(
+        MLP,
+        "forward",
+        [(_FWD_FUSED_ORI, _FWD_FUSED_NEW), (_FORWARD_ORI, _FORWARD_NEW)],
+    )
 
     mark_patched(MLP, _PATCH_KEY)
     log_rank_0(
         f"[Patch:{_PATCH_KEY}] Patched MLP.__init__/forward to use FLA's Triton "
-        "swiglu kernel when use_fla_fused_swiglu is set."
+        "swiglu kernel when use_fla_fused_swiglu is set, and to fuse swiglu into "
+        "linear_fc2 when use_fla_fused_swiglu_linear is set."
     )
 
 
@@ -88,7 +265,8 @@ def _install_mlp_fla_swiglu_patch() -> None:
     ),
     # Runs after fla_runtime_knobs (priority=-100) has resolved args.use_fla_fused_swiglu.
     priority=50,
-    condition=lambda ctx: getattr(get_args(ctx), "use_fla_fused_swiglu", False),
+    condition=lambda ctx: getattr(get_args(ctx), "use_fla_fused_swiglu", False)
+    or getattr(get_args(ctx), "use_fla_fused_swiglu_linear", False),
 )
 def patch_mlp_fla_swiglu(ctx: PatchContext) -> None:
     _install_mlp_fla_swiglu_patch()

--- a/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
+++ b/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
@@ -121,16 +121,17 @@ def test_anchors_are_unique_in_upstream_source():
 
 
 class _AnchorTwice:
-    """Anchor ``x = 1`` appears twice; rewriting both would be silent corruption."""
+    """Anchor ``total += 1`` appears twice; rewriting both would be silent corruption."""
 
     def run(self):
-        x = 1
-        x = 1
-        return x
+        total = 0
+        total += 1
+        total += 1
+        return total
 
 
 class _AnchorMissing:
-    """Anchor ``x = 1`` never appears, standing in for upstream drift."""
+    """Anchor ``total += 1`` never appears, standing in for upstream drift."""
 
     def run(self):
         return 0
@@ -142,7 +143,7 @@ def test_multi_rewrite_rejects_ambiguous_anchor(victim):
     original = victim.run
 
     with pytest.raises(RuntimeError, match="expected exactly 1"):
-        patch_method_source_multi(victim, "run", [("x = 1", "x = 2")])
+        patch_method_source_multi(victim, "run", [("total += 1", "total += 2")])
 
     assert victim.run is original, "a rejected rewrite must not mutate the class"
 

--- a/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
+++ b/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
@@ -28,6 +28,7 @@ from megatron.core.transformer.mlp import MLP
 
 import primus.backends.megatron.patches.mlp_fla_swiglu_patches as patch_mod
 from primus.backends.megatron.patches._patch_guard import is_patched
+from primus.backends.megatron.patches._source_patch_utils import patch_method_source_multi
 
 
 def _config(**overrides):
@@ -107,6 +108,41 @@ def test_install_patch_rewrites_both_methods(pristine_mlp, monkeypatch):
     assert is_patched(MLP, patch_mod._PATCH_KEY)
     assert MLP.__init__ is not original_init
     assert MLP.forward is not original_forward
+
+
+def test_anchors_are_unique_in_upstream_source():
+    """An anchor matching twice would inject the patch somewhere unintended."""
+    assert inspect.getsource(MLP.__init__).count(patch_mod._INIT_ORI) == 1
+    forward_source = inspect.getsource(MLP.forward)
+    assert forward_source.count(patch_mod._FWD_FUSED_ORI) == 1
+    assert forward_source.count(patch_mod._FORWARD_ORI) == 1
+
+
+class _AnchorTwice:
+    """Anchor ``x = 1`` appears twice; rewriting both would be silent corruption."""
+
+    def run(self):
+        x = 1
+        x = 1
+        return x
+
+
+class _AnchorMissing:
+    """Anchor ``x = 1`` never appears, standing in for upstream drift."""
+
+    def run(self):
+        return 0
+
+
+@pytest.mark.parametrize("victim", [_AnchorMissing, _AnchorTwice])
+def test_multi_rewrite_rejects_ambiguous_anchor(victim):
+    """patch_method_source_multi must demand exactly one match, not at least one."""
+    original = victim.run
+
+    with pytest.raises(RuntimeError, match="expected exactly 1"):
+        patch_method_source_multi(victim, "run", [("x = 1", "x = 2")])
+
+    assert victim.run is original, "a rejected rewrite must not mutate the class"
 
 
 def test_install_patch_rolls_back_when_forward_rewrite_fails(pristine_mlp, monkeypatch):

--- a/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
+++ b/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
@@ -109,6 +109,24 @@ def test_install_patch_rewrites_both_methods(pristine_mlp, monkeypatch):
     assert MLP.forward is not original_forward
 
 
+def test_install_patch_rolls_back_when_forward_rewrite_fails(pristine_mlp, monkeypatch):
+    """A drifted forward anchor must not leave __init__ patched on its own."""
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
+    original_init, original_forward = MLP.__init__, MLP.forward
+
+    def boom(*args, **kwargs):
+        raise ValueError("anchor drift")
+
+    monkeypatch.setattr(patch_mod, "patch_method_source_multi", boom)
+
+    with pytest.raises(ValueError, match="anchor drift"):
+        patch_mod._install_mlp_fla_swiglu_patch()
+
+    assert MLP.__init__ is original_init
+    assert MLP.forward is original_forward
+    assert not is_patched(MLP, patch_mod._PATCH_KEY)
+
+
 def test_install_patch_is_idempotent(pristine_mlp, monkeypatch):
     monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
 

--- a/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
+++ b/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
@@ -1,0 +1,210 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Unit tests for the FLA fused-SwiGLU MLP patch.
+
+Verifies:
+  1. The source anchors still match upstream ``MLP.__init__``/``MLP.forward``.
+  2. The patch rewrites both methods in one pass and is idempotent.
+  3. ``_plain_swiglu_reject`` accepts only plain, unclamped, zero-offset SwiGLU.
+  4. ``_fused_fc2_reject`` refuses every path that ``linear_fc2`` would own
+     (TP/SP/PP, bias, FP8, deferred wgrad, overlapped param gather, experts).
+  5. ``_resolve_fla_swiglu`` reports a rejected opt-in instead of silently
+     falling back to the unfused path.
+"""
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import torch.nn.functional as F
+
+pytest.importorskip("megatron")
+
+from megatron.core.transformer.mlp import MLP
+
+import primus.backends.megatron.patches.mlp_fla_swiglu_patches as patch_mod
+from primus.backends.megatron.patches._patch_guard import is_patched
+
+
+def _config(**overrides):
+    """A config the fused fc2 path accepts; override one field per test."""
+    config = SimpleNamespace(
+        gated_linear_unit=True,
+        activation_func=F.silu,
+        use_te_activation_func=False,
+        activation_func_clamp_value=None,
+        glu_linear_offset=0,
+        tensor_model_parallel_size=1,
+        sequence_parallel=False,
+        add_bias_linear=False,
+        pipeline_model_parallel_size=1,
+        fp8=None,
+        delay_wgrad_compute=False,
+        activation_func_fp8_input_store=False,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _args(**overrides):
+    args = SimpleNamespace(
+        use_fla_fused_swiglu=True,
+        use_fla_fused_swiglu_linear=False,
+        overlap_param_gather=False,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+@pytest.fixture
+def pristine_mlp():
+    """Restore ``MLP`` methods and patch-guard state after each test."""
+    original_init, original_forward = MLP.__init__, MLP.forward
+    yield
+    MLP.__init__, MLP.forward = original_init, original_forward
+    if hasattr(MLP, "_primus_applied_patch_keys"):
+        MLP._primus_applied_patch_keys.discard(patch_mod._PATCH_KEY)
+
+
+@pytest.fixture(autouse=True)
+def _reset_decision_log():
+    patch_mod._DECISIONS_LOGGED.clear()
+    yield
+    patch_mod._DECISIONS_LOGGED.clear()
+
+
+def test_init_anchor_matches_upstream():
+    source = inspect.getsource(MLP.__init__)
+    assert (
+        patch_mod._INIT_ORI in source
+    ), "Upstream MLP.__init__ changed; update mlp_fla_swiglu_patches anchor."
+
+
+def test_forward_anchors_match_upstream():
+    source = inspect.getsource(MLP.forward)
+    for anchor in (patch_mod._FWD_FUSED_ORI, patch_mod._FORWARD_ORI):
+        assert anchor in source, f"Upstream MLP.forward changed; anchor missing: {anchor!r}"
+
+
+def test_fused_forward_rechecks_lora_wrapper():
+    # PEFT swaps linear_fc2 for a wrapper after __init__, so the __init__-time
+    # decision cannot be trusted at call time.
+    assert "hasattr(self.linear_fc2, 'weight')" in patch_mod._FWD_FUSED_NEW
+
+
+def test_install_patch_rewrites_both_methods(pristine_mlp, monkeypatch):
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
+    original_init, original_forward = MLP.__init__, MLP.forward
+
+    patch_mod._install_mlp_fla_swiglu_patch()
+
+    assert is_patched(MLP, patch_mod._PATCH_KEY)
+    assert MLP.__init__ is not original_init
+    assert MLP.forward is not original_forward
+
+
+def test_install_patch_is_idempotent(pristine_mlp, monkeypatch):
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
+
+    patch_mod._install_mlp_fla_swiglu_patch()
+    first_init, first_forward = MLP.__init__, MLP.forward
+    patch_mod._install_mlp_fla_swiglu_patch()
+
+    assert MLP.__init__ is first_init
+    assert MLP.forward is first_forward
+
+
+def test_plain_swiglu_accepts_plain_config():
+    assert patch_mod._plain_swiglu_reject(_config()) == ""
+
+
+@pytest.mark.parametrize(
+    "overrides, expected",
+    [
+        ({"gated_linear_unit": False}, "gated_linear_unit is off"),
+        ({"activation_func": F.gelu}, "activation_func is not F.silu"),
+        # Kimi K3 keeps activation_func=F.silu but routes the real, clamped
+        # activation through the TE module slot.
+        ({"use_te_activation_func": True}, "TE module slot"),
+        ({"activation_func_clamp_value": 7.0}, "activation_func_clamp_value is set"),
+        ({"glu_linear_offset": 1}, "glu_linear_offset is non-zero"),
+    ],
+)
+def test_plain_swiglu_rejects(overrides, expected):
+    reason = patch_mod._plain_swiglu_reject(_config(**overrides))
+    assert expected in reason
+
+
+def test_fused_fc2_accepts_plain_config():
+    assert patch_mod._fused_fc2_reject(_config(), _args(), is_expert=False) == ""
+
+
+@pytest.mark.parametrize(
+    "config_overrides, args_overrides, is_expert, expected",
+    [
+        ({}, {}, True, "expert MLP"),
+        ({"tensor_model_parallel_size": 2}, {}, False, "tensor_model_parallel_size > 1"),
+        ({"sequence_parallel": True}, {}, False, "sequence_parallel is on"),
+        ({"add_bias_linear": True}, {}, False, "add_bias_linear is on"),
+        ({"pipeline_model_parallel_size": 2}, {}, False, "pipeline_model_parallel_size > 1"),
+        ({"fp8": "e4m3"}, {}, False, "fp8 is enabled"),
+        ({"delay_wgrad_compute": True}, {}, False, "delay_wgrad_compute is on"),
+        (
+            {"activation_func_fp8_input_store": True},
+            {},
+            False,
+            "activation_func_fp8_input_store is on",
+        ),
+        ({}, {"overlap_param_gather": True}, False, "overlap_param_gather is on"),
+        # A config the plain kernel already refuses must not reach the fc2 path.
+        ({"use_te_activation_func": True}, {}, False, "TE module slot"),
+    ],
+)
+def test_fused_fc2_rejects(config_overrides, args_overrides, is_expert, expected):
+    reason = patch_mod._fused_fc2_reject(_config(**config_overrides), _args(**args_overrides), is_expert)
+    assert expected in reason
+
+
+def test_resolve_declines_fused_fc2_when_not_opted_in(monkeypatch):
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
+    monkeypatch.setattr("megatron.training.get_args", _args, raising=False)
+
+    _, swiglu_linear_fn = patch_mod._resolve_fla_swiglu(_config(), is_expert=False)
+
+    assert swiglu_linear_fn is None
+
+
+def test_resolve_reports_rejected_opt_in(monkeypatch):
+    messages = []
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda msg, *a, **k: messages.append(msg))
+    monkeypatch.setattr(
+        "megatron.training.get_args",
+        lambda: _args(use_fla_fused_swiglu_linear=True),
+        raising=False,
+    )
+
+    _, swiglu_linear_fn = patch_mod._resolve_fla_swiglu(
+        _config(tensor_model_parallel_size=2), is_expert=False
+    )
+
+    assert swiglu_linear_fn is None
+    assert any("disabled: tensor_model_parallel_size > 1" in m for m in messages)
+
+
+def test_resolve_declines_plain_swiglu_for_clamped_activation(monkeypatch):
+    monkeypatch.setattr(patch_mod, "log_rank_0", lambda *a, **k: None)
+    monkeypatch.setattr("megatron.training.get_args", _args, raising=False)
+
+    swiglu_fn, _ = patch_mod._resolve_fla_swiglu(_config(activation_func_clamp_value=7.0), is_expert=False)
+
+    assert swiglu_fn is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
+++ b/tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py
@@ -28,7 +28,9 @@ from megatron.core.transformer.mlp import MLP
 
 import primus.backends.megatron.patches.mlp_fla_swiglu_patches as patch_mod
 from primus.backends.megatron.patches._patch_guard import is_patched
-from primus.backends.megatron.patches._source_patch_utils import patch_method_source_multi
+from primus.backends.megatron.patches._source_patch_utils import (
+    patch_method_source_multi,
+)
 
 
 def _config(**overrides):


### PR DESCRIPTION
Reopens the change from #1025 on top of current `main`, with all review feedback from that round addressed.

## Summary
Megatron computes swiglu as its own op and hands the result to `linear_fc2`, which saves that ffn-wide tensor for its weight gradient. FLA's `swiglu_linear` instead saves only the two fc1 halves and recomputes the activation in the backward, removing one ffn-wide saved tensor per MLP layer.

Off by default (`use_fla_fused_swiglu_linear` / `PRIMUS_FLA_SWIGLU_LINEAR`).

## Measured
GDN-300M (ffn 4096, seq 2048): **0.188 GiB per unit micro-batch**, i.e. 204.3 -> 181.8 GB peak at micro-batch 128, for ~3.8% more iteration time.

The memory saving is the point; the time is the price. Across the fuller A/B matrix in the module docstring the cost is ~0% at micro-batch 2 and +4.4% to +5.1% at micro-batch 32, always in the slower direction.

## What changed since #1025
- **Eligibility is now testable.** The rules moved out of the injected source string into two plain functions, `_plain_swiglu_reject` and `_fused_fc2_reject`. A rejected opt-in is logged rather than silently falling back.
- **Added the gates review asked for.** Because the fc2 path reads `linear_fc2.weight` directly, it must decline everything that module would otherwise own: FP8 and `activation_func_fp8_input_store`, `delay_wgrad_compute`, PP>1 (zero-bubble schedules expect fc2's backward to enqueue a deferred wgrad), and `overlap_param_gather` (the direct read skips the parameter all-gather hook).
- **LoRA.** PEFT wraps `linear_fc2` after `__init__`, so the forward rechecks for a real `.weight` and falls back for `LoRALinear`, whose adapter contribution would otherwise be dropped.
- **Unit tests added**, which review noted were missing.

## Why `activation_func == F.silu` is not sufficient
Kimi K3 keeps that config value only to satisfy the whitelist in `TransformerConfig.__post_init__`, while routing the real, soft-clamped `SituActivation` through the `activation_func` module slot. DeepSeek-V4 style configs reach the eager `glu()` with a clamp bound or a non-zero `glu_linear_offset`.

The new fc2 path returns before `mlp.py`'s module-slot branch, so without the extra guards it would have silently replaced a soft-clamped activation with plain SiLU. Both fused paths are now restricted to plain, unclamped, zero-offset SwiGLU.

## Note on `patch_method_source_multi`
A method can only be source-patched once, since `inspect.getsource` cannot re-read a function already rebuilt by `exec`, so both `MLP.forward` rewrites must be applied in a single pass.

## Test plan
- [x] New `tests/unit_tests/backends/megatron/test_mlp_fla_swiglu_patches.py`: 25 tests covering upstream source anchors, patch idempotence, and every rejection reason (25 passed)
- [x] A/B measured on GDN and KDA at micro-batch 2 and 32 to confirm the gates do not over-restrict the fused paths on the shipped configs

Made with [Cursor](https://cursor.com)
