### PR TITLE
fix(runner): honor PRIMUS_SKIP_PIP in the Megatron pretrain hook

### DIFF
--- a/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
+++ b/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
@@ -13,10 +13,10 @@ PRIMUS_ROOT="${PRIMUS_PATH:-${DEFAULT_PRIMUS_ROOT}}"
 # Standard pip-skip switch, matching the posttrain Megatron and MaxDiffusion
 # hooks. An image that already ships the stack has nothing to gain here, and on
 # a ROCm image it can actively lose: these requirements are the Qwen3.5
-# gated-delta-net deps, and causal-conv1d ships no wheel, so pip builds it from
-# source and the build environment resolves a fresh `torch` against the image's
-# pinned ROCm build. That conflict is unresolvable and aborts the run before
-# training starts, for packages the model under test never imports.
+# gated-delta-net deps, the version causal-conv1d~=1.5 resolves to ships no
+# wheel, and its isolated source build resolves a fresh torch against the
+# image's pinned ROCm build. That conflict is unresolvable, so the run dies
+# before training starts over packages the model under test never imports.
 if [[ -n "${PRIMUS_SKIP_PIP:-}" && "${PRIMUS_SKIP_PIP}" != "0" && "${PRIMUS_SKIP_PIP,,}" != "false" ]]; then
   echo "[00_install_requirements] PRIMUS_SKIP_PIP=${PRIMUS_SKIP_PIP} -> skipping Megatron pretrain dependency install"
   exit 0

--- a/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
+++ b/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
@@ -10,13 +10,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_PRIMUS_ROOT="$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)"
 PRIMUS_ROOT="${PRIMUS_PATH:-${DEFAULT_PRIMUS_ROOT}}"
 
-# Standard pip-skip switch, matching the posttrain Megatron and MaxDiffusion
-# hooks. An image that already ships the stack has nothing to gain here, and on
-# a ROCm image it can actively lose: these requirements are the Qwen3.5
-# gated-delta-net deps, the version causal-conv1d~=1.5 resolves to ships no
-# wheel, and its isolated source build resolves a fresh torch against the
-# image's pinned ROCm build. That conflict is unresolvable, so the run dies
-# before training starts over packages the model under test never imports.
+# Standard pip-skip switch, matching the posttrain Megatron hook's condition.
+# An image that already ships these deps has nothing to gain here, and a caller
+# whose environment cannot resolve them needs a way out that is not "edit the
+# requirements file".
+#
+# The concrete case this came from: these are the Qwen3.5 gated-delta-net deps,
+# which the model under test never imports. `causal-conv1d~=1.5` also admits
+# 1.7.0, so pip can reach past a satisfying build the image already ships and
+# try to build the newer sdist. If the caller exports a PIP_CONSTRAINT pinning
+# torch to a local version label (as a ROCm image's constraints file may), the
+# isolated build environment cannot resolve torch from any index and the run
+# dies before training starts. Skipping is the blunt fix; constraining
+# causal-conv1d to the shipped version is the narrower one.
 if [[ -n "${PRIMUS_SKIP_PIP:-}" && "${PRIMUS_SKIP_PIP}" != "0" && "${PRIMUS_SKIP_PIP,,}" != "false" ]]; then
   echo "[00_install_requirements] PRIMUS_SKIP_PIP=${PRIMUS_SKIP_PIP} -> skipping Megatron pretrain dependency install"
   exit 0

--- a/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
+++ b/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
@@ -10,6 +10,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_PRIMUS_ROOT="$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)"
 PRIMUS_ROOT="${PRIMUS_PATH:-${DEFAULT_PRIMUS_ROOT}}"
 
+# Standard pip-skip switch, matching the posttrain Megatron and MaxDiffusion
+# hooks. An image that already ships the stack has nothing to gain here, and on
+# a ROCm image it can actively lose: these requirements are the Qwen3.5
+# gated-delta-net deps, and causal-conv1d ships no wheel, so pip builds it from
+# source and the build environment resolves a fresh `torch` against the image's
+# pinned ROCm build. That conflict is unresolvable and aborts the run before
+# training starts, for packages the model under test never imports.
+if [[ -n "${PRIMUS_SKIP_PIP:-}" && "${PRIMUS_SKIP_PIP}" != "0" && "${PRIMUS_SKIP_PIP,,}" != "false" ]]; then
+  echo "[00_install_requirements] PRIMUS_SKIP_PIP=${PRIMUS_SKIP_PIP} -> skipping Megatron pretrain dependency install"
+  exit 0
+fi
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --data_path)


### PR DESCRIPTION
## Summary

The Megatron **pretrain** install hook has no `PRIMUS_SKIP_PIP` guard, unlike its posttrain Megatron and MaxDiffusion siblings, so there is no way to stop it on an image that already ships the stack. This adds the same guard, using the same three-way check (`unset` / `0` / `false` all mean "do not skip").

On a ROCm image the missing guard is fatal rather than merely wasteful. `requirements-megatron.txt` pins the Qwen3.5 gated-delta-net dependencies, and `causal-conv1d~=1.5` resolves to a version with no wheel. pip therefore builds it from source, and the isolated build environment resolves a fresh `torch` against the image's pinned ROCm build:

```
ERROR: Cannot install torch because these package versions have conflicting dependencies.
    The user requested torch
    The user requested (constraint) torch==2.12.0+rocm7.15.0a20260720
ERROR: ResolutionImpossible
```

The hook exits non-zero, `prepare_experiment.sh` fails, and the run dies before training starts — over two packages the model under test never imports. This currently breaks any Megatron pretrain launched through `primus-cli direct` on a ROCm image, which includes the MLPerf Flux launcher at `examples/mlperf/flux1/megatron/run_and_time.sh`.

## Test plan

- [x] `bash -n` clean
- [x] `PRIMUS_SKIP_PIP=1` skips and exits 0
- [x] `PRIMUS_SKIP_PIP=0` and unset both still install (guard does not change the default path)
- [x] Reproduced the original failure on `rocm/primus:v26.5` (MI355X, Flux 12B MXFP6 MLPerf recipe)
- [ ] End-to-end rerun of that recipe with the guard set — waiting on a node
