### PR TITLE
fix(flux): wait on the warmup's gradient reduce-scatter

### DIFF
--- a/primus/backends/megatron/patches/mlperf_warmup_patches.py
+++ b/primus/backends/megatron/patches/mlperf_warmup_patches.py
@@ -270,19 +270,37 @@ def _run_warmup_and_restore(
     # ---- 3b. Save LR scheduler state (NeMo never steps the scheduler during warmup) ----
     saved_lr_num_steps = opt_param_scheduler.num_steps
 
+    # ---- 3c. Install Megatron's grad-finalize callback for the warmup steps ----
+    # At the pre-data boundary `train()` has not run yet, so it has not assigned
+    # config.finalize_model_grads_func. That callback is the only caller of
+    # finish_grad_sync(), so without it a warmup backward dispatches the
+    # data-parallel reduce-scatter and nothing ever waits on it. The handle is
+    # still outstanding when the first real step dispatches its own, and
+    # Megatron asserts "Should not have multiple communication calls
+    # outstanding at once" before a single iteration completes.
+    saved_finalize = config.finalize_model_grads_func
+    if saved_finalize is None:
+        from megatron.core.distributed import finalize_model_grads
+
+        config.finalize_model_grads_func = finalize_model_grads
+        _log("Installed finalize_model_grads_func for warmup (unset at this boundary)")
+
     # ---- 4. Run warmup steps with synthetic data ----
-    for step_idx in range(warmup_steps):
-        _log(f"Warmup step {step_idx + 1}/{warmup_steps}")
-        train_step_fn(
-            forward_step_func,
-            synthetic_iter,
-            model,
-            optimizer,
-            opt_param_scheduler,
-            config,
-            forward_backward_func,
-            iteration=iteration,
-        )
+    try:
+        for step_idx in range(warmup_steps):
+            _log(f"Warmup step {step_idx + 1}/{warmup_steps}")
+            train_step_fn(
+                forward_step_func,
+                synthetic_iter,
+                model,
+                optimizer,
+                opt_param_scheduler,
+                config,
+                forward_backward_func,
+                iteration=iteration,
+            )
+    finally:
+        config.finalize_model_grads_func = saved_finalize
     _log(f"Completed {warmup_steps} warmup steps")
 
     # ---- 5. Restore optimizer ----

--- a/tests/unit_tests/backends/megatron/test_mlperf_patches.py
+++ b/tests/unit_tests/backends/megatron/test_mlperf_patches.py
@@ -153,6 +153,51 @@ def _install_fake_megatron(monkeypatch):
     return training_mod, _megatron_args
 
 
+def _install_fake_grad_finalize(monkeypatch):
+    """Point megatron.core.distributed.finalize_model_grads at a sentinel.
+
+    Call this *before* ``_install_fake_megatron``: the warmup imports the
+    callback lazily, and once ``megatron`` is a stub the real package can no
+    longer be reached to swap the attribute on.
+    """
+    import importlib
+    import sys
+
+    def finalize_model_grads(*args, **kwargs):
+        return None
+
+    try:
+        real = importlib.import_module("megatron.core.distributed")
+    except ImportError:
+        core_mod = types.ModuleType("megatron.core")
+        core_mod.__path__ = []
+        distributed_mod = types.ModuleType("megatron.core.distributed")
+        distributed_mod.finalize_model_grads = finalize_model_grads
+        core_mod.distributed = distributed_mod
+        monkeypatch.setitem(sys.modules, "megatron.core", core_mod)
+        monkeypatch.setitem(sys.modules, "megatron.core.distributed", distributed_mod)
+    else:
+        monkeypatch.setattr(real, "finalize_model_grads", finalize_model_grads)
+
+    return finalize_model_grads
+
+
+def _warmup_actors(monkeypatch):
+    """A model / optimizer / scheduler trio small enough to warm up on CPU."""
+    import torch
+
+    # The warmup brackets itself with device syncs; there is no device here.
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+
+    model = torch.nn.Linear(2, 2)
+    optimizer = SimpleNamespace(
+        param_groups=[{"betas": (0.9, 0.95), "weight_decay": 0.1, "step": 0}],
+        state={},
+        zero_grad=lambda set_to_none=True: None,
+    )
+    return [model], optimizer, SimpleNamespace(num_steps=0)
+
+
 def _install_mock_mllog(monkeypatch, events=None):
     """Install a fake mlperf_logging.mllog and return (module, events).
 
@@ -570,6 +615,84 @@ class TestMeasuredTimeBoundary:
 
         assert getattr(mt.train_step, "_primus_warmup_hook", False) is True
         assert mlperf_boundary._HOOKS == []
+
+    def test_warmup_steps_run_with_a_grad_finalize_callback(self, monkeypatch):
+        """Every warmup backward must have something that waits on its grad sync.
+
+        The boundary warmup runs before Megatron's ``train()``, which is where
+        ``config.finalize_model_grads_func`` is assigned. That callback is the
+        only caller of ``finish_grad_sync()``, so if it is missing a warmup
+        backward dispatches the data-parallel reduce-scatter and nothing ever
+        waits on it. The first real step then asserts "Should not have multiple
+        communication calls outstanding at once" and training never starts.
+        """
+        sentinel = _install_fake_grad_finalize(monkeypatch)
+        _, megatron_args = _install_fake_megatron(monkeypatch)
+        # The local-spec FP8 reset pulls in real Megatron enums, which the fake
+        # megatron above does not provide and this test is not about.
+        megatron_args.transformer_impl = "transformer_engine"
+        _silence_log_rank_0(monkeypatch)
+        model, optimizer, scheduler = _warmup_actors(monkeypatch)
+        config = SimpleNamespace(finalize_model_grads_func=None)
+
+        seen = []
+
+        def _train_step(fwd, data_iter, mdl, opt, sched, cfg, fwdbwd, iteration=None):
+            seen.append(cfg.finalize_model_grads_func)
+
+        from primus.backends.megatron.patches.mlperf_warmup_patches import (
+            _run_warmup_and_restore,
+        )
+
+        _run_warmup_and_restore(
+            warmup_steps=2,
+            train_step_fn=_train_step,
+            forward_step_func=lambda *a, **k: None,
+            synthetic_iter=iter(()),
+            model=model,
+            optimizer=optimizer,
+            opt_param_scheduler=scheduler,
+            config=config,
+            forward_backward_func=lambda *a, **k: None,
+            iteration=0,
+        )
+
+        assert seen == [sentinel, sentinel]
+        assert config.finalize_model_grads_func is None, "warmup must leave the config as it found it"
+
+    def test_warmup_keeps_a_finalize_callback_the_caller_already_set(self, monkeypatch):
+        _install_fake_grad_finalize(monkeypatch)
+        _, megatron_args = _install_fake_megatron(monkeypatch)
+        megatron_args.transformer_impl = "transformer_engine"
+        _silence_log_rank_0(monkeypatch)
+        model, optimizer, scheduler = _warmup_actors(monkeypatch)
+        preexisting = lambda *a, **k: None  # noqa: E731
+        config = SimpleNamespace(finalize_model_grads_func=preexisting)
+
+        seen = []
+
+        def _train_step(fwd, data_iter, mdl, opt, sched, cfg, fwdbwd, iteration=None):
+            seen.append(cfg.finalize_model_grads_func)
+
+        from primus.backends.megatron.patches.mlperf_warmup_patches import (
+            _run_warmup_and_restore,
+        )
+
+        _run_warmup_and_restore(
+            warmup_steps=1,
+            train_step_fn=_train_step,
+            forward_step_func=lambda *a, **k: None,
+            synthetic_iter=iter(()),
+            model=model,
+            optimizer=optimizer,
+            opt_param_scheduler=scheduler,
+            config=config,
+            forward_backward_func=lambda *a, **k: None,
+            iteration=0,
+        )
+
+        assert seen == [preexisting]
+        assert config.finalize_model_grads_func is preexisting
 
 
 # ============================================================================

--- a/tests/unit_tests/backends/megatron/test_mlperf_patches.py
+++ b/tests/unit_tests/backends/megatron/test_mlperf_patches.py
@@ -666,7 +666,10 @@ class TestMeasuredTimeBoundary:
         megatron_args.transformer_impl = "transformer_engine"
         _silence_log_rank_0(monkeypatch)
         model, optimizer, scheduler = _warmup_actors(monkeypatch)
-        preexisting = lambda *a, **k: None  # noqa: E731
+
+        def preexisting(*args, **kwargs):
+            return None
+
         config = SimpleNamespace(finalize_model_grads_func=preexisting)
 
         seen = []


### PR DESCRIPTION
## Summary

Every Flux run with `mlperf_mode: true` and `warmup_train_steps > 0` dies during the first real training step, before a single iteration completes. This makes the warmup wait on the gradient reduce-scatter it dispatches.

The MLPerf warmup runs at the pre-data boundary, which is before Megatron's `train()` executes. `train()` is where `config.finalize_model_grads_func` gets assigned, and that callback is the only caller of `finish_grad_sync()`. So with `overlap_grad_reduce: true` a warmup backward dispatches the data-parallel reduce-scatter and nothing ever waits on it. The handle is still outstanding when the first real step dispatches its own, and Megatron asserts:

```
File ".../megatron/core/distributed/param_and_grad_buffer.py", line 530, in start_grad_sync
    self.grad_reduce_handle is None
AssertionError: Should not have multiple communication calls outstanding at once
```

### The fix

Install `finalize_model_grads` for the duration of the warmup loop and restore whatever was there before, so the boundary warmup does not change what `train()` later sees. The `None` guard leaves the in-`train_step` warmup path used by development recipes untouched, since by then `train()` has already installed the callback — which is why only MLPerf mode was affected.

### Why the escape hatch does not cover this

`start_grad_sync` no-ops when a handle is outstanding *and* `is_first_batch` is still set. Warmup step 1 populates the ready counts without dispatching; the `reset()` at the head of warmup step 2 records the golden counts and clears `is_first_batch`; warmup step 2 then dispatches for real. By the first training step the flag is long gone, so the assertion fires.

## Test plan

- [x] Two unit tests in `tests/unit_tests/backends/megatron/test_mlperf_patches.py`: the warmup steps see a grad-finalize callback, and a callback the caller already set is preserved rather than replaced. Both fail without the production change.
- [x] Full `test_mlperf_patches.py` passes (46 tests) on an MI355X dev container.
- [x] Bisected on 8x MI355X with the Flux 12B MXFP6 MLPerf recipe. The FP8 MLPerf recipe fails identically, so this is not precision-specific; `mlperf_mode: false` passes; `warmup_train_steps: 0` passes.
- [x] With this change the full MLPerf recipe at `warmup_train_steps: 2` trains 20 iterations clean, and a full convergence run is in flight.
