### PR TITLE
fix(flux): start each MLPerf run with an empty result file

### DIFF
--- a/examples/mlperf/flux1/megatron/run_and_time.sh
+++ b/examples/mlperf/flux1/megatron/run_and_time.sh
@@ -51,6 +51,11 @@ export RESULTS_DIR RUN_INDEX PRIMUS_SEED MLLOG_OUTPUT_FILE
 
 mkdir -p "${RESULTS_DIR}"
 
+# The MLLOG logger opens this append-only, so a relaunch under the same
+# RUN_INDEX concatenates two runs into one file and the compliance checker
+# reports every once-per-run key twice. One file is one run.
+: > "${MLLOG_OUTPUT_FILE}"
+
 # --- Cold start -------------------------------------------------------------
 # cache_clear is a claim about the machine, so drop the caches here and report
 # what actually happened rather than what was requested. Dropping caches needs

--- a/examples/mlperf/flux1/megatron/run_and_time.sh
+++ b/examples/mlperf/flux1/megatron/run_and_time.sh
@@ -54,6 +54,7 @@ mkdir -p "${RESULTS_DIR}"
 # The MLLOG logger opens this append-only, so a relaunch under the same
 # RUN_INDEX concatenates two runs into one file and the compliance checker
 # reports every once-per-run key twice. One file is one run.
+mkdir -p "$(dirname "${MLLOG_OUTPUT_FILE}")"
 : > "${MLLOG_OUTPUT_FILE}"
 
 # --- Cold start -------------------------------------------------------------


### PR DESCRIPTION
## Summary

The MLLOG logger opens `MLLOG_OUTPUT_FILE` append-only, and `run_and_time.sh` derives that path from `RUN_INDEX` alone. Relaunching a run under the same index therefore writes both attempts into one `result_N.txt`, and the compliance checker reports every once-per-run key twice.

This turned up on a real MXFP6 Flux convergence run. A first attempt died early, the fixed relaunch converged, and the checker then reported ~20 failures — `run_start`, `init_stop`, `opt_name`, `train_samples`, `eval_samples` and all the submission metadata, each "required EXACTLY_ONE occurrence but found 2". None of them were real. Splitting the file at the second `init_start` and re-running the checker left exactly one finding, the known `mxfp6` vocabulary gap this script already documents.

The fix truncates the file where the run is set up, next to the `mkdir` that creates its directory. One file is one run.

## Test plan

- [x] `bash -n examples/mlperf/flux1/megatron/run_and_time.sh`
- [x] Re-ran `mlperf_logging.compliance_checker --ruleset 6.0.0` on the manually split log from the affected run: all duplicate-key findings cleared, only the `mxfp6` precision-vocabulary failure remains
- [ ] Next MLPerf run relaunched under the same `RUN_INDEX` produces a single-run `result_N.txt` (covered by the issue 306 ten-run campaign)
