### PR TITLE
fix(runner): honor PRIMUS_SKIP_PIP in the Megatron pretrain hook (mxfp6 line)

### DIFF
--- a/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
+++ b/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
@@ -13,10 +13,10 @@ PRIMUS_ROOT="${PRIMUS_PATH:-${DEFAULT_PRIMUS_ROOT}}"
 # Standard pip-skip switch, matching the posttrain Megatron and MaxDiffusion
 # hooks. An image that already ships the stack has nothing to gain here, and on
 # a ROCm image it can actively lose: these requirements are the Qwen3.5
-# gated-delta-net deps, and causal-conv1d ships no wheel, so pip builds it from
-# source and the build environment resolves a fresh `torch` against the image's
-# pinned ROCm build. That conflict is unresolvable and aborts the run before
-# training starts, for packages the model under test never imports.
+# gated-delta-net deps, the version causal-conv1d~=1.5 resolves to ships no
+# wheel, and its isolated source build resolves a fresh torch against the
+# image's pinned ROCm build. That conflict is unresolvable, so the run dies
+# before training starts over packages the model under test never imports.
 if [[ -n "${PRIMUS_SKIP_PIP:-}" && "${PRIMUS_SKIP_PIP}" != "0" && "${PRIMUS_SKIP_PIP,,}" != "false" ]]; then
   echo "[00_install_requirements] PRIMUS_SKIP_PIP=${PRIMUS_SKIP_PIP} -> skipping Megatron pretrain dependency install"
   exit 0

--- a/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
+++ b/runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh
@@ -10,6 +10,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEFAULT_PRIMUS_ROOT="$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)"
 PRIMUS_ROOT="${PRIMUS_PATH:-${DEFAULT_PRIMUS_ROOT}}"
 
+# Standard pip-skip switch, matching the posttrain Megatron and MaxDiffusion
+# hooks. An image that already ships the stack has nothing to gain here, and on
+# a ROCm image it can actively lose: these requirements are the Qwen3.5
+# gated-delta-net deps, and causal-conv1d ships no wheel, so pip builds it from
+# source and the build environment resolves a fresh `torch` against the image's
+# pinned ROCm build. That conflict is unresolvable and aborts the run before
+# training starts, for packages the model under test never imports.
+if [[ -n "${PRIMUS_SKIP_PIP:-}" && "${PRIMUS_SKIP_PIP}" != "0" && "${PRIMUS_SKIP_PIP,,}" != "false" ]]; then
+  echo "[00_install_requirements] PRIMUS_SKIP_PIP=${PRIMUS_SKIP_PIP} -> skipping Megatron pretrain dependency install"
+  exit 0
+fi
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --data_path)


### PR DESCRIPTION
## Summary

Forward-ports [PR 1067](https://github.com/AMD-AGI/Primus/pull/1067) onto `feat/mxfp6-fused-mlp` so the pinned MXFP6 submission line can launch from a clean checkout. Same two commits, cherry-picked unchanged.

The Megatron pretrain hook installs the Qwen3.5 gated-delta-net requirements. `causal-conv1d~=1.5` resolves to a version with no wheel, and its isolated source build resolves a fresh torch against the image's pinned ROCm build. That conflict is unresolvable, so the run dies before training starts, over packages the model under test never imports. This cost a whole allocation on 2026-08-31.

PR 1067 targets `main`, which is the fix's proper home, but `fix/flux-eval-correctness` is 20 commits behind `main` and `feat/mxfp6-fused-mlp` sits on top of it. Waiting for the fix to arrive through that chain means two rebases before the pinned line sees it. Issue 306's launcher asserts the guard is present and aborts when it is not, so until then no run on `ccd4d18a` can start. PR 1067 stays open against `main`; this merge becomes a no-op when the chain catches up.

## Test plan

- [x] `bash -n runner/helpers/hooks/train/pretrain/megatron/00_install_requirements.sh`
- [x] Guard condition is byte-identical to the posttrain Megatron hook's, so the comment's "matching the sibling hooks" claim holds
- [x] Exercised on the node for the whole of issue 306's Task 1 — the launcher runs the hook standalone as a preflight and asserts it prints the skip line
- [ ] Repin `MXFP6_PRIMUS_REF` to this merge commit on `perf/primus-lm/mxfp6-flux-artifacts`
