### PR TITLE
[Perf Optimization] Tune GDN/KDA 1B MI355X pretrain configs for high-occupancy throughput.

### DIFF
--- a/examples/megatron/configs/MI355X/gdn_1B_BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/gdn_1B_BF16-pretrain.yaml
@@ -22,7 +22,7 @@ modules:
       use_pytorch_profiler: false
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
-      log_interval: 10
+      log_interval: 1
       tensorboard_log_interval: 10
 
       # --- Optimal MI355X fusion recipe (see zebra_parity README §8) ---
@@ -45,13 +45,16 @@ modules:
       check_for_nan_in_loss_and_grad: false
       barrier_with_L1_time: false
 
-      # GBS=16 is the FLA loss-parity recipe (small global batch), which pins
-      # MBS=2 on 8 GPUs. Unlike KDA, GDN has no hipBLASLt shape limit — raise
-      # MBS+GBS together for throughput (verified MBS=32/GBS=256 -> ~77k
-      # tok/s/GPU at 39% VRAM).
+      # Throughput recipe (8 GPUs, no grad-accum: GBS = MBS * 8).
+      # MI300X maxed occupancy the same way: MBS=56 / GBS=448 at 97.1% of
+      # 192 GB (BS=512 OOM). GDN has no hipBLASLt shape limit, so batch scales
+      # freely here.
+      #
+      # Measured on MI355X (288 GB): MBS=64 / GBS=512 sits at 94% VRAM.
+      # MBS=56 / GBS=448 was 83%. Drop to MBS=2 / GBS=16 for FLA parity.
       train_iters: 50
-      micro_batch_size: 2
-      global_batch_size: 16
+      micro_batch_size: 64
+      global_batch_size: 512
 
       seq_length: 2048
       max_position_embeddings: 2048

--- a/examples/megatron/configs/MI355X/kda_1B_BF16-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/kda_1B_BF16-pretrain.yaml
@@ -22,7 +22,7 @@ modules:
       use_pytorch_profiler: false
       log_avg_skip_iterations: 2
       log_avg_reset_interval: 50
-      log_interval: 10
+      log_interval: 1
       tensorboard_log_interval: 10
 
       # --- Optimal MI355X fusion recipe (see zebra_parity README §8) ---
@@ -45,18 +45,17 @@ modules:
       check_for_nan_in_loss_and_grad: false
       barrier_with_L1_time: false
 
-      # GBS=16 here is the FLA loss-parity recipe (FLA reference used global
-      # batch 16), which pins MBS=2 on 8 GPUs. The previous "HIPBLASLT kernel
-      # limit" that ALSO blocked raising the batch is now fixed: KDA's fused
-      # in_proj width (2192) fell in a hipBLASLt bf16 dead zone on gfx950 and
-      # is padded to 2560 in kimi_delta_attention.py, so MBS/GBS can now be
-      # scaled for throughput. With the optimal fusion recipe above, verified
-      # MBS=32/GBS=256 -> ~98k tok/s/GPU inst (~1505 TFLOP/s) at 48% VRAM,
-      # 0 hipBLASLt errors. Raise both together for throughput runs; keep
-      # GBS=16 for FLA parity.
+      # Throughput recipe (8 GPUs, no grad-accum: GBS = MBS * 8).
+      # MI300X maxed occupancy the same way: MBS=56 / GBS=448 at 94.5% of
+      # 192 GB (BS=512 OOM). The gfx950 hipBLASLt bf16 dead zone on fused
+      # in_proj width 2192 is padded to 2560 in kimi_delta_attention.py, so
+      # batch can scale.
+      #
+      # Measured on MI355X (288 GB): MBS=68 / GBS=544 sits at 93% VRAM.
+      # MBS=64 / GBS=512 was 88%. Drop to MBS=2 / GBS=16 for FLA parity.
       train_iters: 50
-      micro_batch_size: 2
-      global_batch_size: 16
+      micro_batch_size: 68
+      global_batch_size: 544
 
       seq_length: 2048
       max_position_embeddings: 2048


### PR DESCRIPTION
## Changes

- **`gdn_1B_BF16-pretrain.yaml`**: `micro_batch_size` 2 → 64, `global_batch_size` 16 → 512; `log_interval` 10 → 1; updated recipe comments.
- **`kda_1B_BF16-pretrain.yaml`**: `micro_batch_size` 2 → 68, `global_batch_size` 16 → 544; `log_interval` 10 → 1; updated recipe comments. (KDA's fused in_proj width 2192 is padded to 2560 in `kimi_delta_attention.py` to avoid a gfx950 hipBLASLt bf16 dead zone, allowing batch to scale.)

## Measured results

MI355X 288 GB, seq=2048, 8 GPU, no grad-accum:

| Config | Setting | VRAM | Notes |
|--------|---------|------|-------|
| gdn_1B_BF16-pretrain | MBS=64 / GBS=512 (new) | 94% | MBS=56 / GBS=448 was 83% |
| kda_1B_BF16-pretrain | MBS=68 / GBS=544 (new) | 93% | MBS=64 / GBS=512 was 88% |

## Notes

- These are example/reference configs only; no runtime/kernel code is modified.
- The FLA loss-parity recipe (MBS=2 / GBS=16) is preserved in the comments for reproducibility.