### PR TITLE
docs(networking): add AINIC bundle version guide

### DIFF
--- a/docs/04-technical-guides/README.md
+++ b/docs/04-technical-guides/README.md
@@ -11,6 +11,7 @@ Deep technical topics for advanced users.
 - [Data preparation](data-preparation.md): tokenization, data formats, mock data
 - [Checkpoint management](checkpoint-management.md): formats, save/load, distributed checkpointing
 - [Multi-node networking](multi-node-networking.md): InfiniBand, RoCE, AINIC configuration
+- [AINIC bundle versions](ainic-bundle-versions.md): rebuilding a training image against a different AINIC bundle
 - [Profiling and observability](profiling-and-observability.md): Torch profiler, TraceLens, memory snapshots, projection, pp_vis
 - [Logging and experiment tracking](logging-and-experiment-tracking.md): TensorBoard, WandB, MLflow setup per backend
 - [Fault tolerance and elastic training](fault-tolerance-and-elastic-training.md): graceful exit, auto-resume, in-process restart, torchft

--- a/docs/04-technical-guides/ainic-bundle-versions.md
+++ b/docs/04-technical-guides/ainic-bundle-versions.md
@@ -2,25 +2,79 @@
 
 AMD published training images ship a **fixed AINIC bundle**. The bundle version is
 baked in at build time through the `AINIC_BUNDLE_VERSION` build argument, and the
-image installs the userspace half of the AINIC stack from
-`https://repo.radeon.com/amdainic/pensando/ubuntu/<bundle>/`.
+image installs the userspace half of the AINIC stack — the `libionic` library —
+from `https://repo.radeon.com/amdainic/pensando/ubuntu/<bundle>/`.
 
 Sometimes the bundle in the image is not the one your cluster needs. This guide
 shows how to rebuild a published image against an arbitrary bundle, and how to
-confirm the change landed. Both directions are supported; a downgrade is a normal
-and fully supported operation here, not a workaround.
+confirm the change landed. Upgrades and downgrades are both normal operations
+here; the correct bundle for your cluster is often an older one.
 
-> **Scope.** This guide covers **making the change** to the AINIC **hostlib**
-> inside the container, and verifying it took effect.
+> **Scope.** This guide covers **making the change** to `libionic` inside the
+> container, and verifying it took effect. **Deciding which bundle you need is
+> your responsibility** — `libionic` in the container has to be compatible with
+> the `ionic` driver on the host, and only your cluster's operators know what
+> that is. See [section 3](#3-choosing-a-bundle).
 >
-> **Deciding which bundle you need is out of scope and is your responsibility.**
-> The hostlib in the container has to be compatible with the `ionic` driver on the
-> host, and only your cluster's operators know what that is. See
-> [section 3](#3-choosing-a-bundle) for what to check before you pick a version.
->
-> This guide also does not change the host driver, and does not change how AINIC
-> is *enabled* at runtime — for that, see
+> This guide does not change the host driver, and does not change how AINIC is
+> *enabled* at runtime — for that, see
 > [Multi-node networking](./multi-node-networking.md#4-ainic-amd-ai-nic).
+
+---
+
+## Quickstart
+
+If you already know which bundle you need, this is the whole procedure. Save the
+block below as `Dockerfile` in an otherwise empty directory — the whole directory
+is sent to the Docker daemon as build context, so keeping it empty keeps the
+build fast.
+
+```dockerfile
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG AINIC_BUNDLE_VERSION
+
+RUN set -eux; \
+    rm -f /etc/apt/sources.list.d/*amdainic*; \
+    add-apt-repository -y "deb https://repo.radeon.com/amdainic/pensando/ubuntu/${AINIC_BUNDLE_VERSION} noble main"; \
+    apt update --allow-insecure-repositories; \
+    ver="$(apt-cache madison libionic1 | awk -F'|' 'NR==1{gsub(/ /,"",$2); print $2}')"; \
+    test -n "$ver"; \
+    echo "installing libionic $ver from ${AINIC_BUNDLE_VERSION}"; \
+    apt install -y --allow-unauthenticated --allow-downgrades \
+        "libionic-dev=$ver" "libionic1=$ver"; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fail the build rather than ship an image whose libionic silently did not move.
+RUN set -eux; \
+    dpkg-query -W -f='${Package} ${Version}\n' libionic1 libionic-dev; \
+    dpkg -C; \
+    test -e /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so; \
+    readlink -f /usr/lib/x86_64-linux-gnu/libionic.so.1
+```
+
+Then, from that same directory:
+
+```bash
+BASE=rocm/jax-training:maxtext-v26.6
+BUNDLE=1.117.5-a-147
+
+docker build --network host \
+  --build-arg BASE_IMAGE=$BASE \
+  --build-arg AINIC_BUNDLE_VERSION=$BUNDLE \
+  -t ${BASE##*/}-ainic-$BUNDLE .
+```
+
+Neither build argument has a default, so omitting one fails the build rather than
+silently producing an unintended image. Tagging the image after the bundle is
+worth the small effort: the bundle is otherwise invisible without running
+`dpkg-query` inside the image.
+
+**A clean build does not mean the image works on your host.** It means the
+version you asked for was installed. See [section 6](#6-verify) before trusting
+it, and [section 5](#5-how-the-rebuild-works) for why the two apparently
+boilerplate lines are load-bearing.
 
 ---
 
@@ -38,10 +92,12 @@ The driver-side packages of the bundle — `ionic-dkms`, `pds-dkms`, `nicctl`,
 This is why bundle mismatches show up as a host/container skew rather than as a
 missing package.
 
-Note that the bundle name and the hostlib version are **different numbering
-schemes**, and they are easy to confuse when discussing versions. The table below
-is ordered by bundle version, newest first; the hostlib column does not follow,
-because a higher bundle version does not imply a higher hostlib version:
+Note that the bundle name and the `libionic` version are **different numbering
+schemes**, and they are easy to confuse when discussing versions. The excerpt
+below is ordered by bundle version, newest first; the `libionic` column does not
+follow, because a higher bundle version does not imply a higher `libionic`
+version. See [section 4](#4-list-published-bundles) to list every published
+bundle.
 
 | Bundle | `libionic` version |
 |--------|--------------------|
@@ -54,7 +110,7 @@ because a higher bundle version does not imply a higher hostlib version:
 ## 2. Check what you have
 
 ```bash
-# hostlib version actually installed in the image
+# libionic version actually installed in the image
 docker run --rm <image> dpkg-query -W -f='${Package} ${Version}\n' libionic1 libionic-dev
 
 # which bundle repositories the image was built against
@@ -64,7 +120,7 @@ docker run --rm <image> grep -rh amdainic /etc/apt/sources.list.d/
 **The repository list is not a reliable indicator of the installed version.** An
 image can carry several AINIC repositories, and `apt` resolves `libionic` to the
 highest version across *all* enabled repositories. An image whose Dockerfile names
-one bundle can therefore ship the hostlib of a different one. Always trust
+one bundle can therefore ship the library of a different one. Always trust
 `dpkg-query`, not the `sources.list` entries or the build argument.
 
 On the **host**, check the other half of the pair:
@@ -77,26 +133,29 @@ ls /sys/class/infiniband/          # expect ionic_* entries
 
 ## 3. Choosing a bundle
 
-**Which bundle you need is determined by your cluster, not by this guide.** The
-hostlib in the container must be compatible with the `ionic` driver on the host,
-so the version to install is whatever your cluster's operators tell you it is.
+**Which bundle you need is determined by your cluster, not by this guide.**
+`libionic` in the container must be compatible with the `ionic` driver on the
+host, so the version to install is whatever your cluster's operators tell you it
+is. Bring them the output of the host commands in section 2, along with:
 
-Two things are worth knowing before you pick:
+```bash
+cat /sys/class/infiniband_verbs/uverbs*/abi_version
+```
 
-- **Newer is not automatically better.** Compatibility is not monotonic in the
-  bundle version, so the correct target may be older than what the image already
-  ships. That is why this guide supports downgrades as a first-class operation.
-- **The two halves must agree on the uverbs ABI.** The kernel side is readable on
-  the host:
+This is the kernel side of the uverbs ABI, the interface `libionic` has to speak.
+There is no matching number you can read out of the container to compare it
+against — a provider library declares the ABI range it supports internally, not
+as a queryable version — so this value is an input to the conversation with your
+operators, not a check you can run yourself. The authoritative test is the
+runtime one in [section 6](#6-verify).
 
-  ```bash
-  cat /sys/class/infiniband_verbs/uverbs*/abi_version
-  ```
+One thing worth knowing before you pick: **newer is not automatically better.**
+Compatibility is not monotonic in the bundle version, so the correct target may
+well be older than what the image already ships.
 
 If you install a bundle the host cannot work with, the build still succeeds and
-every package-level check in section 7 still passes — the mismatch only shows up
-as an unreachable fabric at runtime. Section 7 covers how to confirm that,
-which is why it is worth doing even when the build looks clean.
+every package-level check in section 6 still passes — the mismatch only shows up
+as an unreachable fabric at runtime.
 
 ## 4. List published bundles
 
@@ -117,63 +176,11 @@ and `db/`, with no `dists/` or `pool/`, and `apt` cannot install from them. The
 `Packages` query above returns nothing for these, which is the quickest way to
 spot one before a build fails.
 
-## 5. Rebuild the image
+## 5. How the rebuild works
 
-The block below is a **complete Dockerfile**, both `RUN` stanzas included. Save
-it as `Dockerfile` in an otherwise empty directory and run the build from there —
-the whole directory is sent to the Docker daemon as build context, so keeping it
-empty keeps the build fast.
-
-Both arguments are placeholders, supplied at build time: set `BASE_IMAGE` to the
-published image you already run, and `AINIC_BUNDLE_VERSION` to the bundle your
-host driver needs. Neither has a default, so omitting one fails the build rather
-than silently producing an unintended image.
-
-```dockerfile
-ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
-
-ARG AINIC_BUNDLE_VERSION
-
-RUN set -eux; \
-    rm -f /etc/apt/sources.list.d/*amdainic*; \
-    add-apt-repository -y "deb https://repo.radeon.com/amdainic/pensando/ubuntu/${AINIC_BUNDLE_VERSION} noble main"; \
-    apt update --allow-insecure-repositories; \
-    ver="$(apt-cache madison libionic1 | awk -F'|' 'NR==1{gsub(/ /,"",$2); print $2}')"; \
-    test -n "$ver"; \
-    echo "installing libionic $ver from ${AINIC_BUNDLE_VERSION}"; \
-    apt install -y --allow-unauthenticated --allow-downgrades \
-        "libionic-dev=$ver" "libionic1=$ver"; \
-    rm -rf /var/lib/apt/lists/*
-
-# Fail the build rather than ship an image whose hostlib silently did not move.
-RUN set -eux; \
-    dpkg-query -W -f='${Package} ${Version}\n' libionic1 libionic-dev; \
-    dpkg -C; \
-    test -e /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so; \
-    readlink -f /usr/lib/x86_64-linux-gnu/libionic.so.1
-```
-
-Then, from that same directory:
-
-```bash
-BASE=rocm/jax-training:maxtext-v26.6
-BUNDLE=1.117.5-a-147
-
-docker build --network host \
-  --build-arg BASE_IMAGE=$BASE \
-  --build-arg AINIC_BUNDLE_VERSION=$BUNDLE \
-  -t ${BASE##*/}-ainic-$BUNDLE .
-```
-
-Tagging the image after the bundle it contains is worth the small effort: the
-bundle is otherwise invisible without running `dpkg-query` inside the image.
-
-### Why the two extra steps
-
-Both of the lines that look like boilerplate are load-bearing, and **both failure
-modes are silent** — apt reports success and the build produces an image with the
-wrong hostlib:
+Both of the lines in the quickstart Dockerfile that look like boilerplate are
+load-bearing, and **both failure modes are silent** — apt reports success and the
+build produces an image with the wrong library:
 
 1. **`rm -f /etc/apt/sources.list.d/*amdainic*`** — without this, the bundle
    already configured in the base image stays enabled, apt picks the highest
@@ -191,21 +198,21 @@ refuses to nominate a downgrade as the candidate at any pin priority, so for an
 older bundle it reports the *installed* version and the pin silently becomes a
 no-op again.
 
-Because of the verification step at the end, a build that hits either of these
-now fails instead of shipping.
+Because of the verification stanza at the end of the Dockerfile, a build that hits
+either of these now fails instead of shipping.
 
-## 6. No uninstall is required
+### No uninstall is required
 
 Upgrades and downgrades both apply in place. `dpkg` unpacks the new version over
 the old one with `0 to remove`, and `dpkg -C` stays clean afterwards.
 
-This is worth stating explicitly because the hostlib filename embeds its version
+This is worth stating explicitly because the library filename embeds its version
 (`libionic.so.1.1.54.0-187`), which normally suggests old files would accumulate.
 They do not: `dpkg` removes the previous versioned object and repoints both
 `libionic.so.1` and the `libibverbs` provider symlink `libionic-rdmav34.so` at the
 new one.
 
-## 7. Verify
+## 6. Verify
 
 ```bash
 docker run --rm --privileged --network host --cap-add=IPC_LOCK \
@@ -224,8 +231,8 @@ Check that the package version and the provider symlink agree, and that
 Two traps when automating this check:
 
 - **Treat "no `ionic` devices" as a failure, not a warning.** An image whose
-  hostlib cannot attach to the fabric passes every package-level check above. If
-  the node does have AINIC hardware, an empty enumeration means the hostlib is
+  `libionic` cannot attach to the fabric passes every package-level check above.
+  If the node does have AINIC hardware, an empty enumeration means the library is
   incompatible — see section 3.
 - **Do not compare versions by parsing the `.so` filename.** The soname scheme is
   not stable across bundles, so a literal prefix match rejects images that are in
@@ -239,7 +246,7 @@ Two traps when automating this check:
 
 ### Confirm the fabric is actually used
 
-The checks above prove the *hostlib you asked for is installed*. They cannot prove
+The checks above prove the *library you asked for is installed*. They cannot prove
 it works with your host. Do not skip this step on the grounds that the build was
 clean and training runs — when the two halves are incompatible, RCCL falls back to
 TCP and the job completes normally. In one measured 2-node, 16-GPU MaxText
@@ -258,7 +265,7 @@ plausible numbers while never touching the NIC. See
 [Multi-node networking](./multi-node-networking.md#rccl-network-plugin-anp) for
 how Primus sets `NCCL_NET_PLUGIN` through `runner/helpers/hooks/03_enable_ainic.sh`.
 
-## 8. Installing from local `.deb` files
+## 7. Installing from local `.deb` files
 
 For a bundle that is not published — an internal or pre-release build — place the
 two `.deb` files next to the Dockerfile and replace the install step:
@@ -271,17 +278,17 @@ RUN dpkg -i /tmp/libionic1_*.deb /tmp/libionic-dev_*.deb && rm /tmp/*.deb
 `dpkg -i` applies the given version in either direction with no extra flags, so
 neither pitfall in section 5 applies.
 
-## 9. Troubleshooting
+## 8. Troubleshooting
 
 | Symptom | Cause |
 |---------|-------|
-| `apt install` reports `already the newest version` and nothing changes | Target bundle is older than the installed hostlib and the version was not pinned. See section 5. |
-| Built image still has the old hostlib, build reported success | Old bundle repositories left enabled in the base image. See section 5. |
+| `apt install` reports `already the newest version` and nothing changes | Target bundle is older than the installed `libionic` and the version was not pinned. See section 5. |
+| Built image still has the old `libionic`, build reported success | Old bundle repositories left enabled in the base image. See section 5. |
 | `E: Packages were downgraded and -y was used without --allow-downgrades` | Expected for a downgrade; add `--allow-downgrades`. |
 | `apt update` cannot find the repository | Bundle directory is an empty placeholder, or the name is wrong. See section 4. |
-| `ibv_devices` lists no `ionic` device | Not AINIC hardware; the host `ionic` driver is not loaded; or the hostlib is ABI-incompatible with the host driver. See sections 2 and 3. |
-| Training runs fine but throughput is far below expectation | RCCL fell back to `NET/Socket`. The job still completes and converges normally, so check the transport rather than the loss. See section 7. |
-| The requested hostlib is installed but the fabric is unreachable | The installed bundle is not compatible with the host. Bundle selection is a cluster question — confirm the required version with your operators, and note that it may be older than what the image shipped. See section 3. |
+| `ibv_devices` lists no `ionic` device | Not AINIC hardware; the host `ionic` driver is not loaded; or `libionic` is ABI-incompatible with the host driver. See sections 2 and 3. |
+| Training runs fine but throughput is far below expectation | RCCL fell back to `NET/Socket`. The job still completes and converges normally, so check the transport rather than the loss. See section 6. |
+| The requested `libionic` is installed but the fabric is unreachable | The installed bundle is not compatible with the host. Bundle selection is a cluster question — confirm the required version with your operators, and note that it may be older than what the image shipped. See section 3. |
 
 ---
 

--- a/docs/04-technical-guides/ainic-bundle-versions.md
+++ b/docs/04-technical-guides/ainic-bundle-versions.md
@@ -1,0 +1,293 @@
+# AINIC bundle versions
+
+AMD published training images ship a **fixed AINIC bundle**. The bundle version is
+baked in at build time through the `AINIC_BUNDLE_VERSION` build argument, and the
+image installs the userspace half of the AINIC stack from
+`https://repo.radeon.com/amdainic/pensando/ubuntu/<bundle>/`.
+
+Sometimes the bundle in the image is not the one your cluster needs. This guide
+shows how to rebuild a published image against an arbitrary bundle, and how to
+confirm the change landed. Both directions are supported; a downgrade is a normal
+and fully supported operation here, not a workaround.
+
+> **Scope.** This guide covers **making the change** to the AINIC **hostlib**
+> inside the container, and verifying it took effect.
+>
+> **Deciding which bundle you need is out of scope and is your responsibility.**
+> The hostlib in the container has to be compatible with the `ionic` driver on the
+> host, and only your cluster's operators know what that is. See
+> [section 3](#3-choosing-a-bundle) for what to check before you pick a version.
+>
+> This guide also does not change the host driver, and does not change how AINIC
+> is *enabled* at runtime — for that, see
+> [Multi-node networking](./multi-node-networking.md#4-ainic-amd-ai-nic).
+
+---
+
+## 1. What is actually in the image
+
+An AINIC-enabled training image contains only the **userspace** half of the pair:
+
+| Package | Role |
+|---------|------|
+| `libionic1` | User space ionic provider driver for `libibverbs` |
+| `libionic-dev` | Development headers for the ionic provider |
+
+The driver-side packages of the bundle — `ionic-dkms`, `pds-dkms`, `nicctl`,
+`ainic-monitor` — are **not** installed in the container. They belong to the host.
+This is why bundle mismatches show up as a host/container skew rather than as a
+missing package.
+
+Note that the bundle name and the hostlib version are **different numbering
+schemes**, and they are easy to confuse when discussing versions. The table below
+is ordered by bundle version, newest first; the hostlib column does not follow,
+because a higher bundle version does not imply a higher hostlib version:
+
+| Bundle | `libionic` version |
+|--------|--------------------|
+| `1.125.0-a-187` | `54.0-192-1` |
+| `1.117.5-a-147` | `54.0-197-1` |
+| `1.117.5-a-77` | `54.0-187-1` |
+| `1.117.5-a-56` | `54.0-184` |
+| `1.117.1-a-63` | `54.0-149.g3304be71` |
+
+## 2. Check what you have
+
+```bash
+# hostlib version actually installed in the image
+docker run --rm <image> dpkg-query -W -f='${Package} ${Version}\n' libionic1 libionic-dev
+
+# which bundle repositories the image was built against
+docker run --rm <image> grep -rh amdainic /etc/apt/sources.list.d/
+```
+
+**The repository list is not a reliable indicator of the installed version.** An
+image can carry several AINIC repositories, and `apt` resolves `libionic` to the
+highest version across *all* enabled repositories. An image whose Dockerfile names
+one bundle can therefore ship the hostlib of a different one. Always trust
+`dpkg-query`, not the `sources.list` entries or the build argument.
+
+On the **host**, check the other half of the pair:
+
+```bash
+lspci | grep -i pensando
+modinfo ionic | grep -E '^version|^srcversion'
+ls /sys/class/infiniband/          # expect ionic_* entries
+```
+
+## 3. Choosing a bundle
+
+**Which bundle you need is determined by your cluster, not by this guide.** The
+hostlib in the container must be compatible with the `ionic` driver on the host,
+so the version to install is whatever your cluster's operators tell you it is.
+
+Two things are worth knowing before you pick:
+
+- **Newer is not automatically better.** Compatibility is not monotonic in the
+  bundle version, so the correct target may be older than what the image already
+  ships. That is why this guide supports downgrades as a first-class operation.
+- **The two halves must agree on the uverbs ABI.** The kernel side is readable on
+  the host:
+
+  ```bash
+  cat /sys/class/infiniband_verbs/uverbs*/abi_version
+  ```
+
+If you install a bundle the host cannot work with, the build still succeeds and
+every package-level check in section 7 still passes — the mismatch only shows up
+as an unreachable fabric at runtime. Section 7 covers how to confirm that,
+which is why it is worth doing even when the build looks clean.
+
+## 4. List published bundles
+
+```bash
+curl -s https://repo.radeon.com/amdainic/pensando/ubuntu/ | grep -oE 'href="[^"]+/"'
+```
+
+To see the exact package versions a bundle ships before committing to it:
+
+```bash
+BUNDLE=1.117.5-a-147
+curl -s "https://repo.radeon.com/amdainic/pensando/ubuntu/${BUNDLE}/dists/noble/main/binary-amd64/Packages" \
+  | awk '/^Package: /{p=$2} /^Version: /{print p"="$2}'
+```
+
+Some published directories are **empty placeholders** — they contain only `conf/`
+and `db/`, with no `dists/` or `pool/`, and `apt` cannot install from them. The
+`Packages` query above returns nothing for these, which is the quickest way to
+spot one before a build fails.
+
+## 5. Rebuild the image
+
+The block below is a **complete Dockerfile**, both `RUN` stanzas included. Save
+it as `Dockerfile` in an otherwise empty directory and run the build from there —
+the whole directory is sent to the Docker daemon as build context, so keeping it
+empty keeps the build fast.
+
+Both arguments are placeholders, supplied at build time: set `BASE_IMAGE` to the
+published image you already run, and `AINIC_BUNDLE_VERSION` to the bundle your
+host driver needs. Neither has a default, so omitting one fails the build rather
+than silently producing an unintended image.
+
+```dockerfile
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG AINIC_BUNDLE_VERSION
+
+RUN set -eux; \
+    rm -f /etc/apt/sources.list.d/*amdainic*; \
+    add-apt-repository -y "deb https://repo.radeon.com/amdainic/pensando/ubuntu/${AINIC_BUNDLE_VERSION} noble main"; \
+    apt update --allow-insecure-repositories; \
+    ver="$(apt-cache madison libionic1 | awk -F'|' 'NR==1{gsub(/ /,"",$2); print $2}')"; \
+    test -n "$ver"; \
+    echo "installing libionic $ver from ${AINIC_BUNDLE_VERSION}"; \
+    apt install -y --allow-unauthenticated --allow-downgrades \
+        "libionic-dev=$ver" "libionic1=$ver"; \
+    rm -rf /var/lib/apt/lists/*
+
+# Fail the build rather than ship an image whose hostlib silently did not move.
+RUN set -eux; \
+    dpkg-query -W -f='${Package} ${Version}\n' libionic1 libionic-dev; \
+    dpkg -C; \
+    test -e /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so; \
+    readlink -f /usr/lib/x86_64-linux-gnu/libionic.so.1
+```
+
+Then, from that same directory:
+
+```bash
+BASE=rocm/jax-training:maxtext-v26.6
+BUNDLE=1.117.5-a-147
+
+docker build --network host \
+  --build-arg BASE_IMAGE=$BASE \
+  --build-arg AINIC_BUNDLE_VERSION=$BUNDLE \
+  -t ${BASE##*/}-ainic-$BUNDLE .
+```
+
+Tagging the image after the bundle it contains is worth the small effort: the
+bundle is otherwise invisible without running `dpkg-query` inside the image.
+
+### Why the two extra steps
+
+Both of the lines that look like boilerplate are load-bearing, and **both failure
+modes are silent** — apt reports success and the build produces an image with the
+wrong hostlib:
+
+1. **`rm -f /etc/apt/sources.list.d/*amdainic*`** — without this, the bundle
+   already configured in the base image stays enabled, apt picks the highest
+   version across all of them, and `AINIC_BUNDLE_VERSION` becomes advisory rather
+   than binding.
+
+2. **Pinning `libionic-dev=$ver libionic1=$ver`** — an unpinned `apt install` is a
+   no-op when the requested bundle is *older* than what the base image carries;
+   apt reports `already the newest version` and exits 0. `--allow-downgrades` only
+   *permits* a downgrade, it does not request one.
+
+The pinned version must be read with `apt-cache madison`, which reports only what
+the repository offers. `apt-cache policy ... Candidate` cannot be used here: apt
+refuses to nominate a downgrade as the candidate at any pin priority, so for an
+older bundle it reports the *installed* version and the pin silently becomes a
+no-op again.
+
+Because of the verification step at the end, a build that hits either of these
+now fails instead of shipping.
+
+## 6. No uninstall is required
+
+Upgrades and downgrades both apply in place. `dpkg` unpacks the new version over
+the old one with `0 to remove`, and `dpkg -C` stays clean afterwards.
+
+This is worth stating explicitly because the hostlib filename embeds its version
+(`libionic.so.1.1.54.0-187`), which normally suggests old files would accumulate.
+They do not: `dpkg` removes the previous versioned object and repoints both
+`libionic.so.1` and the `libibverbs` provider symlink `libionic-rdmav34.so` at the
+new one.
+
+## 7. Verify
+
+```bash
+docker run --rm --privileged --network host --cap-add=IPC_LOCK \
+  -v /dev/infiniband:/dev/infiniband <image> bash -c '
+    dpkg-query -W -f="libionic1 \${Version}\n" libionic1
+    readlink -f /usr/lib/x86_64-linux-gnu/libionic.so.1
+    readlink -f /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so
+    dpkg -C && echo "dpkg consistent"
+    ibv_devices
+  '
+```
+
+Check that the package version and the provider symlink agree, and that
+`ibv_devices` lists `ionic` devices.
+
+Two traps when automating this check:
+
+- **Treat "no `ionic` devices" as a failure, not a warning.** An image whose
+  hostlib cannot attach to the fabric passes every package-level check above. If
+  the node does have AINIC hardware, an empty enumeration means the hostlib is
+  incompatible — see section 3.
+- **Do not compare versions by parsing the `.so` filename.** The soname scheme is
+  not stable across bundles, so a literal prefix match rejects images that are in
+  fact correct. Check package ownership instead, which is what you actually want
+  to know and also catches a stale file:
+
+  ```bash
+  so=$(readlink -f /usr/lib/x86_64-linux-gnu/libionic.so.1)
+  dpkg -L libionic1 | grep -qxF "$so" && echo "owned by installed libionic1"
+  ```
+
+### Confirm the fabric is actually used
+
+The checks above prove the *hostlib you asked for is installed*. They cannot prove
+it works with your host. Do not skip this step on the grounds that the build was
+clean and training runs — when the two halves are incompatible, RCCL falls back to
+TCP and the job completes normally. In one measured 2-node, 16-GPU MaxText
+comparison the fallback cost **3.2x throughput (245.6 vs 791.7 TFLOP/s/device)**
+while completing every step and converging to an identical loss. Nothing in the
+training output distinguished the two runs.
+
+```bash
+export NCCL_NET_PLUGIN=librccl-anp.so
+export NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=INIT,NET
+```
+
+In the resulting log, confirm the ANP plugin was selected and an `ionic` device
+was chosen. A fallback to `NET/Socket` will still complete the job and report
+plausible numbers while never touching the NIC. See
+[Multi-node networking](./multi-node-networking.md#rccl-network-plugin-anp) for
+how Primus sets `NCCL_NET_PLUGIN` through `runner/helpers/hooks/03_enable_ainic.sh`.
+
+## 8. Installing from local `.deb` files
+
+For a bundle that is not published — an internal or pre-release build — place the
+two `.deb` files next to the Dockerfile and replace the install step:
+
+```dockerfile
+COPY libionic1_*.deb libionic-dev_*.deb /tmp/
+RUN dpkg -i /tmp/libionic1_*.deb /tmp/libionic-dev_*.deb && rm /tmp/*.deb
+```
+
+`dpkg -i` applies the given version in either direction with no extra flags, so
+neither pitfall in section 5 applies.
+
+## 9. Troubleshooting
+
+| Symptom | Cause |
+|---------|-------|
+| `apt install` reports `already the newest version` and nothing changes | Target bundle is older than the installed hostlib and the version was not pinned. See section 5. |
+| Built image still has the old hostlib, build reported success | Old bundle repositories left enabled in the base image. See section 5. |
+| `E: Packages were downgraded and -y was used without --allow-downgrades` | Expected for a downgrade; add `--allow-downgrades`. |
+| `apt update` cannot find the repository | Bundle directory is an empty placeholder, or the name is wrong. See section 4. |
+| `ibv_devices` lists no `ionic` device | Not AINIC hardware; the host `ionic` driver is not loaded; or the hostlib is ABI-incompatible with the host driver. See sections 2 and 3. |
+| Training runs fine but throughput is far below expectation | RCCL fell back to `NET/Socket`. The job still completes and converges normally, so check the transport rather than the loss. See section 7. |
+| The requested hostlib is installed but the fabric is unreachable | The installed bundle is not compatible with the host. Bundle selection is a cluster question — confirm the required version with your operators, and note that it may be older than what the image shipped. See section 3. |
+
+---
+
+## Related documentation
+
+- [Multi-node networking](./multi-node-networking.md): enabling AINIC, ANP plugin, and NCCL/RCCL variables
+- [Preflight diagnostics](../02-user-guide/preflight.md)
+- [Deployment](../05-operations/deployment.md)
+- [Troubleshooting](../05-operations/troubleshooting.md)

--- a/docs/04-technical-guides/multi-node-networking.md
+++ b/docs/04-technical-guides/multi-node-networking.md
@@ -75,6 +75,7 @@ GID selection (`NCCL_IB_GID_INDEX`) and traffic classes (`NCCL_IB_TC`, `NCCL_IB_
 
 - Set **`USING_AINIC=1`**. The hook `runner/helpers/hooks/03_enable_ainic.sh` runs when this is set and exports AINIC-related variables back to the caller (`env.VAR=VALUE` lines).
 - Use container images built for AINIC when required by your site. Examples in this repository use tags such as `docker.io/tasimage/primus:<version>-ainic` (see `examples/customer_package/` and `.github/workflows/ci.yaml`). Match the image to your ROCm and ANP bundle.
+- If the AINIC bundle in a published image does not match your host driver, see [AINIC bundle versions](./ainic-bundle-versions.md) for how to rebuild the image against a different bundle. Note that the bundle named in an image's build arguments is **not** always the one installed; verify with `dpkg-query -W libionic1`.
 
 ### `runner/use_ainic.yaml`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ Deep technical topics for advanced users.
 - [Data preparation](./04-technical-guides/data-preparation.md): tokenization, data formats, mock data
 - [Checkpoint management](./04-technical-guides/checkpoint-management.md): formats, save/load, distributed checkpointing
 - [Multi-node networking](./04-technical-guides/multi-node-networking.md): InfiniBand, RoCE, AINIC configuration
+- [AINIC bundle versions](./04-technical-guides/ainic-bundle-versions.md): rebuilding a training image against a different AINIC bundle
 - [Profiling and observability](./04-technical-guides/profiling-and-observability.md): Torch profiler, TraceLens, memory snapshots, projection, pp_vis
 - [Logging and experiment tracking](./04-technical-guides/logging-and-experiment-tracking.md): TensorBoard, WandB, MLflow setup per backend
 - [Fault tolerance and elastic training](./04-technical-guides/fault-tolerance-and-elastic-training.md): graceful exit, auto-resume, in-process restart, torchft

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -82,6 +82,8 @@ subtrees:
         title: Parallelism configuration
       - file: 04-technical-guides/multi-node-networking.md
         title: Multi-node networking
+      - file: 04-technical-guides/ainic-bundle-versions.md
+        title: AINIC bundle versions
       - file: 04-technical-guides/collective-operations.md
         title: Collective operations (NCCL/RCCL)
       - file: 04-technical-guides/data-preparation.md


### PR DESCRIPTION
## What

Adds `docs/04-technical-guides/ainic-bundle-versions.md`, a guide to rebuilding a published training image against a different AINIC bundle. Plus index entries (`docs/README.md`, `04-technical-guides/README.md`, `sphinx/_toc.yml.in`) and a cross-link from the multi-node networking guide.

Docs only — no code changes.

## Why

`multi-node-networking.md` §4 tells users to "match the image to your ROCm and ANP bundle" but never explains how. This fills that gap.

## Scope

Covers **making** the change and verifying it took effect. Choosing *which* bundle is explicitly out of scope — it depends on the host `ionic` driver and belongs to the cluster's operators. The guide points at the uverbs ABI check and notes that compatibility is not monotonic in the bundle version, so downgrades are supported as a first-class operation.

## Notable content

- Two silent build-time failure modes: stale AINIC repos make `AINIC_BUNDLE_VERSION` advisory rather than binding, and an unpinned `apt install` is a no-op when the target is older than what's installed. Both report success, so the Dockerfile ends with a check that fails the build instead.
- The bundle named in an image's build args is not necessarily the one installed — trust `dpkg-query`.
- No uninstall is required in either direction.

## Verification

Every command was run on an MI300X node. Builds tested against `maxtext-v26.3.2` and `maxtext-v26.6` bases in both directions. The "no uninstall required" claim was tested by fingerprinting (MD5 of every owned file, all symlink targets, package status) an in-place upgrade against a purge-then-install: byte-identical, both directions, no orphaned files, `dpkg -C` clean.