### PR TITLE
perf(mxfp6): fuse Flux QK norm with RoPE and the LN-modulate backward

### DIFF
--- a/examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp6_mlperf.yaml
+++ b/examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp6_mlperf.yaml
@@ -46,6 +46,12 @@ modules:
       # ==========================================
       mlperf_mode: true
       warmup_train_steps: 2
+      # Evaluation is forward-only under no_grad with model.eval(), a different Dynamo
+      # guard state from anything warmup_train_steps traces, so without this the 57
+      # per-block graphs compile at the first evaluation -- after run_start, and so
+      # inside the timed region. Bit-identical at per_step_rng_reseed: true (set
+      # below): warmed and unwarmed agree on every per-iteration loss.
+      warmup_validation_steps: 2
       target_val_loss: 0.586
 
       # Left explicit because the FP8 MLPerf recipe and the MXFP6 development
@@ -101,9 +107,16 @@ modules:
       # Cover the whole MLPerf validation set. eval_iters is derived from this
       # (29696 / 512 = 58); setting both is rejected. The previous eval_iters of
       # 10 read 5120 samples, and even at 58 the training num_workers of 16
-      # would have left 1920 of them unread, so val_num_workers is pinned to 0.
+      # would have left 1920 of them unread.
       eval_samples: 29696
-      val_num_workers: 0
+      # 1, not the training num_workers and not 0. Anything above 1 can under-read
+      # the split; 1 is the one nonzero value that cannot, because Energon clamps
+      # the data split to max(1, num_workers) (sharder.py:205), so 1 shards exactly
+      # as 0 does and covers the split identically, while 0 additionally forgoes
+      # prefetch by reading in the main process. val_loss is unchanged between the
+      # two. assert_val_worker_divisibility accepts 1 at the 4-node shape:
+      # 29696 % (32 * 1 * 32) == 0.
+      val_num_workers: 1
       # MLPerf assigns each val image one fixed timestep, carried in the Arrow
       # 'timestep' column. Requires a val split ingested with that column; shards
       # ingested earlier carry {"key": ...} only and will now fail loudly rather

--- a/examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp6_mlperf_2n.yaml
+++ b/examples/megatron/configs/MI355X/diffusion/flux_12b_ddp_energon_schnell_resample_local_spec_mxfp6_mlperf_2n.yaml
@@ -119,10 +119,19 @@ modules:
       # eval_samples, NOT eval_iters. The megatron.args.eval_samples patch
       # derives eval_iters from this and asserts coverage is exact: 29696 / 512
       # = 58 here. Setting eval_iters directly bypasses that patch, and a run
-      # doing so evaluated zero times in 400 steps. val_num_workers is pinned to
-      # 0 because a nonzero training num_workers leaves part of the set unread.
+      # doing so evaluated zero times in 400 steps.
       eval_samples: 29696
-      val_num_workers: 0
+      # 1, not the training num_workers and not 0. A large worker count does leave
+      # part of the set unread -- Energon splits the data across
+      # dp_size * num_workers but the batch quota across num_workers alone -- but 1
+      # is the one nonzero value that cannot: Energon clamps the data split to
+      # max(1, num_workers), so 1 shards exactly as 0 does and covers the split
+      # identically, while 0 additionally forgoes prefetch by reading in the main
+      # process. Measured on one node over three replicates each, 1 evaluates the
+      # whole split faster than 0 with the val_loss bit-identical. 2 and 4 were no
+      # faster than 1 and did shift the loss, by resharding the data across more
+      # workers than the split has shards.
+      val_num_workers: 1
       # MLPerf assigns each validation image one fixed timestep, carried in the
       # Arrow 'timestep' column. Requires a val split ingested with that column;
       # shards ingested earlier carry {"key": ...} only and fail loudly rather

--- a/primus/backends/megatron/core/extensions/primus_turbo_mxfp6_local.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_mxfp6_local.py
@@ -48,7 +48,10 @@ from primus_turbo.pytorch.core.low_precision import (
     MXFP6_PROLOGUE_IDENTITY,
     ScalingGranularity,
 )
-from primus_turbo.pytorch.kernels.gemm.gemm_fp6_impl import gemm_fp6_impl, gemm_fp6_out_impl
+from primus_turbo.pytorch.kernels.gemm.gemm_fp6_impl import (
+    gemm_fp6_impl,
+    gemm_fp6_out_impl,
+)
 from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
 from primus_turbo.pytorch.kernels.quantization.mxfp6_pack import check_mxfp6_support
 
@@ -59,6 +62,9 @@ _GRAN_VALUE = ScalingGranularity.MX_BLOCKWISE.value
 # Registered by Primus-Turbo with a pure-arithmetic fake, so it is safe to trace.
 _quantize_mxfp6_dual = torch.ops.primus_turbo.quantize_mxfp6_dual_impl
 _quantize_mxfp6_fused_dual = torch.ops.primus_turbo.quantize_mxfp6_fused_dual_impl
+# Row-only packing, for forward passes that will never have a backward. axis=1 packs along
+# the last dimension, matching the row half of the dual packer.
+_quantize_mxfp6_row = torch.ops.primus_turbo.quantize_mxfp6_impl
 
 
 def _wgrad_into_main_grad(weight, g_col, g_col_scale, a_col, a_col_scale, n, k, m):
@@ -155,6 +161,7 @@ class MXFP6LinearFunction(torch.autograd.Function):
         fp8_gran_value,
         fp8_backend_value,
         fuse_wgrad_accum,
+        grad_enabled,
     ):
         out_dtype = input.dtype
         orig_shape = input.shape
@@ -163,8 +170,23 @@ class MXFP6LinearFunction(torch.autograd.Function):
         m, k = input_2d.shape
         n = weight.shape[0]
 
-        a_row, a_row_scale, a_col, a_col_scale = _quantize_mxfp6_dual(input_2d)
-        b_row, b_row_scale, b_col, b_col_scale = _quantize_mxfp6_dual(weight)
+        # The column blobs are backward's operands and nothing else reads them, so a forward
+        # with no backward behind it should not pay for them. Eval is entirely such a region,
+        # and it is where packing hurts most, because one pack no longer amortizes across
+        # fwd/dgrad/wgrad. Row-only packing is measurably cheaper than dual across the
+        # Flux shapes.
+        #
+        # `grad_enabled` has to be sampled by the caller. Inside forward, PyTorch has already
+        # cleared grad mode, so torch.is_grad_enabled() reads False even in training, and
+        # ctx.needs_input_grad reads True even under no_grad; neither distinguishes the two.
+        # Getting this wrong fails loudly in backward on a None operand rather than silently.
+        if grad_enabled:
+            a_row, a_row_scale, a_col, a_col_scale = _quantize_mxfp6_dual(input_2d)
+            b_row, b_row_scale, b_col, b_col_scale = _quantize_mxfp6_dual(weight)
+        else:
+            a_row, a_row_scale = _quantize_mxfp6_row(input_2d, 1)
+            b_row, b_row_scale = _quantize_mxfp6_row(weight, 1)
+            a_col = a_col_scale = b_col = b_col_scale = None
 
         # Bias goes into the GEMM's store epilogue, where it is free: the epilogue is bound by
         # its scatter store rather than by VALU, so the add hides completely. Handing it to the
@@ -203,7 +225,13 @@ class MXFP6LinearFunction(torch.autograd.Function):
             fp8_gran_value,
             fp8_backend_value,
             fuse_wgrad_accum,
+            grad_enabled,
         ) = inputs
+
+        # setup_context still runs under no_grad, so this guard is load-bearing: the column
+        # blobs are None there, and there is no backward to save them for anyway.
+        if not grad_enabled:
+            return
 
         ctx.backward_is_fp8 = backward_is_fp8
         ctx.fuse_wgrad_accum = fuse_wgrad_accum
@@ -305,9 +333,7 @@ class MXFP6LinearFunction(torch.autograd.Function):
 
             # grad_weight[N, K] = grad.T[N, M] @ input[M, K], contracting M.
             if ctx.fuse_wgrad_accum:
-                grad_weight = _wgrad_into_main_grad(
-                    weight, g_col, g_col_scale, a_col, a_col_scale, n, k, m
-                )
+                grad_weight = _wgrad_into_main_grad(weight, g_col, g_col_scale, a_col, a_col_scale, n, k, m)
             else:
                 grad_weight = gemm_fp6_impl(
                     g_col,
@@ -321,7 +347,9 @@ class MXFP6LinearFunction(torch.autograd.Function):
                     _GRAN_VALUE,
                 )
 
-        return grad_input, grad_weight, grad_bias, None, None, None, None, None
+        # Trailing Nones cover backward_is_fp8, fp8_bwd_dtype, fp8_gran_value,
+        # fp8_backend_value, fuse_wgrad_accum, grad_enabled.
+        return grad_input, grad_weight, grad_bias, None, None, None, None, None, None
 
 
 def _resolve_wgrad_fusion(module, name: str) -> bool:
@@ -432,6 +460,7 @@ def _mxfp6_forward_impl(module, input, weight, **kwargs):
         module._fp8_gran_value,
         module._fp8_backend_value,
         module._fuse_wgrad_accum,
+        torch.is_grad_enabled(),
     )
     return result[0]
 
@@ -514,7 +543,7 @@ class MXFP6MLPFunction(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(hidden_states, w1, b1, w2, fuse_wgrad_accum):
+    def forward(hidden_states, w1, b1, w2, fuse_wgrad_accum, grad_enabled):
         out_dtype = hidden_states.dtype
         orig_shape = hidden_states.shape
         x = hidden_states.reshape(-1, orig_shape[-1])
@@ -523,18 +552,35 @@ class MXFP6MLPFunction(torch.autograd.Function):
         f = w1.shape[0]
         h = w2.shape[0]
 
-        x_row, x_row_s, x_col, x_col_s = _quantize_mxfp6_dual(x)
-        w1_row, w1_row_s, w1_col, w1_col_s = _quantize_mxfp6_dual(w1)
+        # Same reasoning as MXFP6LinearFunction: the column blobs are backward's operands,
+        # so a no-grad forward should not pay for them. See the note there on why
+        # grad_enabled has to be sampled by the caller rather than read here.
+        if grad_enabled:
+            x_row, x_row_s, x_col, x_col_s = _quantize_mxfp6_dual(x)
+            w1_row, w1_row_s, w1_col, w1_col_s = _quantize_mxfp6_dual(w1)
+        else:
+            x_row, x_row_s = _quantize_mxfp6_row(x, 1)
+            w1_row, w1_row_s = _quantize_mxfp6_row(w1, 1)
+            x_col = x_col_s = w1_col = w1_col_s = None
 
         # Pre-activation. Saved for backward, where the epilogue is recomputed from it
         # rather than its output being stashed -- the same bytes are held either way.
         y1 = gemm_fp6_impl(x_row, x_row_s, w1_row, w1_row_s, m, f, k, out_dtype, _GRAN_VALUE)
 
         # gelu(y1 + b1), packed in both directions without ever being written out.
-        a_row, a_row_s, a_col, a_col_s, _ = _quantize_mxfp6_fused_dual(
-            y1, None, b1, MXFP6_PROLOGUE_BIAS_GELU, False
-        )
-        w2_row, w2_row_s, w2_col, w2_col_s = _quantize_mxfp6_dual(w2)
+        if grad_enabled:
+            a_row, a_row_s, a_col, a_col_s, _ = _quantize_mxfp6_fused_dual(
+                y1, None, b1, MXFP6_PROLOGUE_BIAS_GELU, False
+            )
+            w2_row, w2_row_s, w2_col, w2_col_s = _quantize_mxfp6_dual(w2)
+        else:
+            # The fused packer has no row-only mode, so the activation still costs a dual
+            # pass; only its GELU epilogue matters here and that is shared.
+            a_row, a_row_s, a_col, a_col_s, _ = _quantize_mxfp6_fused_dual(
+                y1, None, b1, MXFP6_PROLOGUE_BIAS_GELU, False
+            )
+            w2_row, w2_row_s = _quantize_mxfp6_row(w2, 1)
+            w2_col = w2_col_s = None
 
         output = gemm_fp6_impl(a_row, a_row_s, w2_row, w2_row_s, m, h, f, out_dtype, _GRAN_VALUE)
         output = output.reshape(*orig_shape[:-1], h)
@@ -543,7 +589,11 @@ class MXFP6MLPFunction(torch.autograd.Function):
 
     @staticmethod
     def setup_context(ctx, inputs, output):
-        hidden_states, w1, b1, w2, fuse_wgrad_accum = inputs
+        hidden_states, w1, b1, w2, fuse_wgrad_accum, grad_enabled = inputs
+
+        # setup_context still runs under no_grad, where the column blobs are None.
+        if not grad_enabled:
+            return
 
         ctx.fuse_wgrad_accum = fuse_wgrad_accum
         ctx.out_dtype = hidden_states.dtype
@@ -591,9 +641,7 @@ class MXFP6MLPFunction(torch.autograd.Function):
         grad_a = gemm_fp6_impl(g2_row, g2_row_s, w2_col, w2_col_s, m, f, h, out_dtype, _GRAN_VALUE)
         # fc2 wgrad: [h, f] = g2.T[h, m] @ a[m, f], contracting m.
         if ctx.fuse_wgrad_accum:
-            grad_w2 = _wgrad_into_main_grad(
-                fused_weights[1], g2_col, g2_col_s, a_col, a_col_s, h, f, m
-            )
+            grad_w2 = _wgrad_into_main_grad(fused_weights[1], g2_col, g2_col_s, a_col, a_col_s, h, f, m)
         else:
             grad_w2 = gemm_fp6_impl(g2_col, g2_col_s, a_col, a_col_s, h, f, m, out_dtype, _GRAN_VALUE)
 
@@ -610,15 +658,14 @@ class MXFP6MLPFunction(torch.autograd.Function):
         grad_x = grad_x.reshape(ctx.orig_shape)
         # fc1 wgrad: [f, k] = grad_y1.T[f, m] @ x[m, k], contracting m.
         if ctx.fuse_wgrad_accum:
-            grad_w1 = _wgrad_into_main_grad(
-                fused_weights[0], g1_col, g1_col_s, x_col, x_col_s, f, k, m
-            )
+            grad_w1 = _wgrad_into_main_grad(fused_weights[0], g1_col, g1_col_s, x_col, x_col_s, f, k, m)
         else:
             grad_w1 = gemm_fp6_impl(g1_col, g1_col_s, x_col, x_col_s, f, k, m, out_dtype, _GRAN_VALUE)
 
         grad_b1 = b1_partial.sum(0).to(out_dtype) if want_bias_grad else None
 
-        return grad_x, grad_w1, grad_b1, grad_w2, None
+        # Trailing Nones cover fuse_wgrad_accum and grad_enabled.
+        return grad_x, grad_w1, grad_b1, grad_w2, None, None
 
 
 def _is_tanh_gelu(fn) -> bool:
@@ -731,6 +778,7 @@ class MXFP6FusedMLP(MLP):
             self.linear_fc1.bias,
             self.linear_fc2.weight,
             fuse_wgrad_accum,
+            torch.is_grad_enabled(),
         )[0]
 
         # fc2 is built with skip_bias_add=True, so MLP's contract is to hand its bias back

--- a/primus/backends/megatron/core/extensions/primus_turbo_mxfp6_local.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_mxfp6_local.py
@@ -65,6 +65,12 @@ _quantize_mxfp6_fused_dual = torch.ops.primus_turbo.quantize_mxfp6_fused_dual_im
 # Row-only packing, for forward passes that will never have a backward. axis=1 packs along
 # the last dimension, matching the row half of the dual packer.
 _quantize_mxfp6_row = torch.ops.primus_turbo.quantize_mxfp6_impl
+# The QKV projection's dgrad with the QK-norm and RoPE backward folded into the prologue.
+# Guarded rather than aliased unconditionally: an older Primus-Turbo has no such op, and
+# MXFP6QKVNormRopeFunction is only reachable when this is present.
+_quantize_mxfp6_qk_norm_rope_bwd = getattr(
+    torch.ops.primus_turbo, "quantize_mxfp6_qk_norm_rope_bwd_impl", None
+)
 
 
 def _wgrad_into_main_grad(weight, g_col, g_col_scale, a_col, a_col_scale, n, k, m):
@@ -666,6 +672,203 @@ class MXFP6MLPFunction(torch.autograd.Function):
 
         # Trailing Nones cover fuse_wgrad_accum and grad_enabled.
         return grad_x, grad_w1, grad_b1, grad_w2, None, None
+
+
+# ---------------------------------------------------------------------------
+# Whole-QKV fusion: linear_qkv -> QK-norm -> RoPE.
+#
+# The same argument as the MLP above, one region over. Splitting the projection from the
+# norm+RoPE forces d(mixed_qkv) to exist: the norm's backward has to write a real tensor and
+# the projection's backward has to read one. Today that write is a Triton kernel's output in
+# bf16 and the read is the packer picking it straight back up. Owning
+# linear_qkv -> norm -> rope in one Function lets the packer compute the gradient itself while
+# staging the tile it is about to pack, from the nine operands the norm and rotation already
+# saved.
+#
+# Unlike the MLP fusion this is *not* an elementwise prologue. It computes
+#   dx = rstd * (dn * w - u_hat * mean_d(dn * w * u_hat))
+# where dn is the rotation's backward, and that mean is a reduction over head_dim -- which is
+# why the packer runs at a tile width of head_dim for this prologue, and why num_heads has to
+# be even and head_dim exactly 128. It also emits the two norm weights' gradients as side
+# outputs, for the same reason the MLP's bias gradient comes back as column sums: the tensor
+# they would be reduced from no longer exists.
+#
+# Priced on the shapes it runs at rather than modelled: the prologue costs roughly half of
+# the kernel time it removes, and most of that difference survives into wall clock. The
+# measured account -- the figures, a probe that predicted a lower cost, and why production
+# disagrees with it -- is in the campaign's packer/RESULTS_qkr_kernel.md.
+#
+# Correctness is gated two ways. packer/qkr_exact_test.cu proves the packed blobs are
+# byte-identical to packing a host-computed dx; packer/qkr_triton_gate.py proves that dx is
+# the function Flux's Triton backward computes, to 3.2e-4 on d(mixed_qkv) (bf16's own
+# resolution) and 2e-7 on the weight gradients. Packing the fused output against packing
+# Triton's materialised d_qkv differs in 5 bytes of 10.6 million with every scale identical.
+# ---------------------------------------------------------------------------
+
+
+class MXFP6QKVNormRopeFunction(torch.autograd.Function):
+    """QKV projection, QK-norm and RoPE as one op, with d(mixed_qkv) never in HBM.
+
+    Follows ``MXFP6MLPFunction``'s conventions: the column-direction blobs and the norm's
+    saved state leave as extra outputs so ``setup_context`` can save them and mark them
+    non-differentiable, and all non-tensor state lands on ``ctx`` as primitives so
+    ``torch.compile`` traces cleanly.
+
+    ``mixed_qkv`` is still saved, but it was already a saved activation for the norm and
+    rotation's own backward, so this holds no more bytes than the unfused path -- the same
+    trade the MLP makes with its pre-activation.
+
+    The rotary embedding **must be interleaved**. Nothing in the signature makes that visible
+    and no check will catch a half-split caller; ``_fused_qkv_unusable_reason`` tests the
+    config field, which is the only place it is knowable.
+    """
+
+    @staticmethod
+    def forward(
+        hidden_states,
+        w_qkv,
+        b_qkv,
+        wq,
+        wk,
+        cos,
+        sin,
+        eps,
+        interleaved,
+        fuse_wgrad_accum,
+        grad_enabled,
+    ):
+        from primus.backends.megatron.core.models.diffusion.common.fused_norm_rope import (
+            _qkv_fwd,
+        )
+
+        out_dtype = hidden_states.dtype
+        orig_shape = hidden_states.shape
+        x = hidden_states.reshape(-1, orig_shape[-1])
+
+        m, k = x.shape
+        n = w_qkv.shape[0]  # num_heads * 3 * head_dim
+        d = wq.shape[0]
+        h = n // (3 * d)
+
+        # Same reasoning as MXFP6LinearFunction: the column blobs are backward's operands, so
+        # a no-grad forward should not pay for them.
+        if grad_enabled:
+            x_row, x_row_s, x_col, x_col_s = _quantize_mxfp6_dual(x)
+            w_row, w_row_s, w_col, w_col_s = _quantize_mxfp6_dual(w_qkv)
+        else:
+            x_row, x_row_s = _quantize_mxfp6_row(x, 1)
+            w_row, w_row_s = _quantize_mxfp6_row(w_qkv, 1)
+            x_col = x_col_s = w_col = w_col_s = None
+
+        # The bias is folded into the GEMM's epilogue, so mixed_qkv is the biased projection
+        # -- which is what the norm consumes and what the prologue re-reads in the backward.
+        mixed_qkv = gemm_fp6_impl(
+            x_row, x_row_s, w_row, w_row_s, m, n, k, out_dtype, _GRAN_VALUE, b_qkv
+        )
+
+        # The norm and rotation, unchanged. This is the production Triton op, on the
+        # [..., num_heads, 3 * head_dim] view it expects; only its *backward* is replaced.
+        qkv = mixed_qkv.reshape(*orig_shape[:-1], h, 3 * d)
+        q, k_out, v, q_rstd, k_rstd = _qkv_fwd(qkv, wq, wk, cos, sin, eps, interleaved)
+
+        return q, k_out, v, mixed_qkv, q_rstd, k_rstd, x_col, x_col_s, w_col, w_col_s
+
+    @staticmethod
+    def setup_context(ctx, inputs, output):
+        (
+            hidden_states,
+            w_qkv,
+            b_qkv,
+            wq,
+            wk,
+            cos,
+            sin,
+            eps,
+            interleaved,
+            fuse_wgrad_accum,
+            grad_enabled,
+        ) = inputs
+
+        # setup_context still runs under no_grad, where the column blobs are None.
+        if not grad_enabled:
+            return
+
+        ctx.fuse_wgrad_accum = fuse_wgrad_accum
+        ctx.out_dtype = hidden_states.dtype
+        ctx.orig_shape = hidden_states.shape
+        # The packed blobs carry no shape, so the logical dims have to be saved too.
+        ctx.m = hidden_states.numel() // hidden_states.shape[-1]
+        ctx.k = hidden_states.shape[-1]
+        ctx.n = w_qkv.shape[0]
+        ctx.d = wq.shape[0]
+        ctx.h = ctx.n // (3 * ctx.d)
+
+        _, _, _, mixed_qkv, q_rstd, k_rstd, x_col, x_col_s, w_col, w_col_s = output
+        blobs = (x_col, x_col_s, w_col, w_col_s)
+        # wq/wk are leaf parameters and cos/sin are built once per step, so saving them costs
+        # nothing; the prologue needs all four, plus the rstd the forward just computed.
+        extra = (w_qkv,) if fuse_wgrad_accum else ()
+        ctx.save_for_backward(
+            mixed_qkv, wq, wk, cos, sin, q_rstd, k_rstd, *blobs, *extra
+        )
+        ctx.mark_non_differentiable(mixed_qkv, q_rstd, k_rstd, *blobs)
+
+    @staticmethod
+    def backward(ctx, dq, dk, dv, *_):
+        (
+            mixed_qkv,
+            wq,
+            wk,
+            cos,
+            sin,
+            q_rstd,
+            k_rstd,
+            x_col,
+            x_col_s,
+            w_col,
+            w_col_s,
+            *fused_weights,
+        ) = ctx.saved_tensors
+        m, k, n, h, d = ctx.m, ctx.k, ctx.n, ctx.h, ctx.d
+        out_dtype = ctx.out_dtype
+
+        # The prologue reads all three slices as [m, num_heads * head_dim]. dv is included
+        # because v is still packed -- plainly, but packed -- and that read is the
+        # d_qkv[..., 2D:].copy_(dv) the fusion absorbs.
+        grads = tuple(g.contiguous().reshape(m, h * d) for g in (dq, dk, dv))
+
+        want_bias_grad = ctx.needs_input_grad[2]
+        (
+            g_row,
+            g_row_s,
+            g_col,
+            g_col_s,
+            b_partial,
+            dwq_partial,
+            dwk_partial,
+        ) = _quantize_mxfp6_qk_norm_rope_bwd(
+            mixed_qkv, *grads, cos, sin, wq, wk, q_rstd, k_rstd, want_bias_grad
+        )
+
+        # dgrad: [m, k] = d(mixed_qkv)[m, n] @ w_qkv[n, k], contracting n.
+        grad_x = gemm_fp6_impl(g_row, g_row_s, w_col, w_col_s, m, k, n, out_dtype, _GRAN_VALUE)
+        grad_x = grad_x.reshape(ctx.orig_shape)
+        # wgrad: [n, k] = d(mixed_qkv).T[n, m] @ x[m, k], contracting m.
+        if ctx.fuse_wgrad_accum:
+            grad_w = _wgrad_into_main_grad(
+                fused_weights[0], g_col, g_col_s, x_col, x_col_s, n, k, m
+            )
+        else:
+            grad_w = gemm_fp6_impl(g_col, g_col_s, x_col, x_col_s, n, k, m, out_dtype, _GRAN_VALUE)
+
+        grad_b = b_partial.sum(0).to(out_dtype) if want_bias_grad else None
+        # dw reduces over rows *and* heads: the norm weight is [head_dim] and shared across
+        # heads, and a packer block owns one head, so the partial buffer carries both axes.
+        grad_wq = dwq_partial.sum((0, 1)).to(wq.dtype)
+        grad_wk = dwk_partial.sum((0, 1)).to(wk.dtype)
+
+        # Trailing Nones cover cos, sin, eps, interleaved, fuse_wgrad_accum and grad_enabled.
+        return grad_x, grad_w, grad_b, grad_wq, grad_wk, None, None, None, None, None, None
 
 
 def _is_tanh_gelu(fn) -> bool:

--- a/primus/backends/megatron/core/models/diffusion/common/fused_norm_rope.py
+++ b/primus/backends/megatron/core/models/diffusion/common/fused_norm_rope.py
@@ -296,7 +296,30 @@ def _row_strided(t: torch.Tensor):
     return t, s
 
 
-def _launch_fwd(x, w, cos, sin, eps, interleaved):
+def _launchable(kernel, traceable):
+    """``kernel``, wrapped for tracing only when the caller can actually be traced.
+
+    ``wrap_triton`` exists so Inductor can see through a ``@triton_op`` into the kernel it
+    launches. Inside a ``@custom_op`` there is nothing to see through -- the op is opaque by
+    construction -- and the wrapper is not free: it routes every launch through the
+    higher-order-op dispatch path, which measures **0.359 ms of host time against 0.031 ms
+    for the same launch made directly**, a 12.7x overhead on a kernel whose GPU work is a
+    fraction of that.
+
+    Repeated across every QKV call a step makes, two launches each, that wrapper alone was
+    enough to make the whole-QKV backward host-bound rather than GPU-bound: the enqueue loop
+    measured 0.8555 ms/call against a batched wall time of 0.8593, i.e. the GPU was idle
+    waiting for Python. It is also why the cost barely moved
+    with sequence length, which is the symptom that gave it away -- seq 256 measured 0.845 ms
+    against seq 512's 0.864, when the work halves.
+
+    So the per-tensor ``@triton_op`` entry points pass ``traceable=True`` and keep the
+    wrapper they need; the whole-QKV ``@custom_op`` ones pass ``False``.
+    """
+    return wrap_triton(kernel) if traceable else kernel
+
+
+def _launch_fwd(x, w, cos, sin, eps, interleaved, traceable=True):
     S, B, H, D = x.shape
     M = S * B * H
     x, sx = _row_strided(x)
@@ -305,7 +328,7 @@ def _launch_fwd(x, w, cos, sin, eps, interleaved):
     out = torch.empty_like(x, memory_format=torch.contiguous_format)
     rstd = torch.empty(M, device=x.device, dtype=torch.float32)
     grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
-    wrap_triton(_fwd_kernel)[grid](
+    _launchable(_fwd_kernel, traceable)[grid](
         x,
         w,
         cos,
@@ -324,11 +347,14 @@ def _launch_fwd(x, w, cos, sin, eps, interleaved):
     return out, rstd
 
 
-def _launch_bwd(g, x, w, cos, sin, rstd, dx, interleaved):
+def _launch_bwd(g, x, w, cos, sin, rstd, dx, interleaved, traceable=True):
     """Backward into a caller-supplied dx, which need only be evenly strided.
 
     dx is a separate argument rather than an allocation because the QKV entry point
     below points it at a column of d(mixed_qkv); see the note there.
+
+    ``traceable`` selects whether the launch goes through ``wrap_triton``; see
+    ``_launchable``, which is where the cost of getting that wrong is recorded.
     """
     S, B, H, D = x.shape
     M = S * B * H
@@ -338,7 +364,7 @@ def _launch_bwd(g, x, w, cos, sin, rstd, dx, interleaved):
     assert sdx is not None, "dx must be addressable at a uniform row stride"
     # Every row is written by exactly one program, so empty() is safe.
     dwp = torch.empty(NPROG, D, device=x.device, dtype=torch.float32)
-    wrap_triton(_bwd_kernel)[(NPROG,)](
+    _launchable(_bwd_kernel, traceable)[(NPROG,)](
         g,
         x,
         w,
@@ -451,8 +477,8 @@ def _qkv_fwd(
     interleaved: bool,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     D = qkv.shape[-1] // 3
-    q, q_rstd = _launch_fwd(qkv[..., :D], wq, cos, sin, eps, interleaved)
-    k, k_rstd = _launch_fwd(qkv[..., D : 2 * D], wk, cos, sin, eps, interleaved)
+    q, q_rstd = _launch_fwd(qkv[..., :D], wq, cos, sin, eps, interleaved, traceable=False)
+    k, k_rstd = _launch_fwd(qkv[..., D : 2 * D], wk, cos, sin, eps, interleaved, traceable=False)
     # V is not merely forwarded: a custom op may not return an alias of its input, and
     # FMHA wants it packed regardless, so this replaces the copy the caller was making.
     v = qkv[..., 2 * D :].contiguous()
@@ -484,8 +510,10 @@ def _qkv_bwd(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     D = qkv.shape[-1] // 3
     d_qkv = torch.empty_like(qkv, memory_format=torch.contiguous_format)
-    dwqp = _launch_bwd(dq, qkv[..., :D], wq, cos, sin, q_rstd, d_qkv[..., :D], interleaved)
-    dwkp = _launch_bwd(dk, qkv[..., D : 2 * D], wk, cos, sin, k_rstd, d_qkv[..., D : 2 * D], interleaved)
+    dwqp = _launch_bwd(dq, qkv[..., :D], wq, cos, sin, q_rstd, d_qkv[..., :D], interleaved,
+                       traceable=False)
+    dwkp = _launch_bwd(dk, qkv[..., D : 2 * D], wk, cos, sin, k_rstd, d_qkv[..., D : 2 * D],
+                       interleaved, traceable=False)
     d_qkv[..., 2 * D :].copy_(dv)
     return d_qkv, dwqp, dwkp
 

--- a/primus/backends/megatron/core/models/diffusion/common/fused_norm_rope.py
+++ b/primus/backends/megatron/core/models/diffusion/common/fused_norm_rope.py
@@ -1,0 +1,536 @@
+###############################################################################
+# Fused QK-RMSNorm + RoPE for Flux.
+#
+# Flux applies an RMS norm to Q and K and then rotates them. Left to Inductor
+# these are one kernel forward and three backward, so the rope backward writes a
+# full-size intermediate the norm backward reads straight back, per layer, which
+# is traffic nothing needs. This does each direction in one pass.
+#
+# The rotation layout matters more than anything else here. Megatron's
+# ``_rotate_half(x, rotary_interleaved)`` either pairs index i with i + D/2 or
+# pairs 2i with 2i+1, and ``FluxConfig.rotary_interleaved`` defaults to True, so
+# Flux runs the interleaved branch. Inductor generates that branch's
+# ``x[..., 0::2]`` / ``torch.stack`` / ``view`` as literal strided access and
+# reaches only 53% of achievable bandwidth on the forward and 35% on the
+# backward, against 87% and 45% for the same code in the half-split layout.
+#
+# The whole trick below is to keep the pairing out of the addresses: load and
+# store rows contiguously and interleave in registers with tl.split / tl.join.
+# Measured on gfx950 at the production shape [512,64,24,128] bf16 with cold caches,
+# both directions move from a modest fraction of the bandwidth roof to most of it.
+#
+# Numerics against an fp64 reference are no worse than the path this replaces, and
+# better on dx, because the baseline rounds to bf16 before applying the norm weight
+# while this carries fp32 through to a single final rounding.
+#
+# Registered with @triton_op rather than @torch.library.custom_op so Inductor can
+# still reason across it. Removing part of an Inductor-fused region and making it
+# opaque is what made the TransformerEngine path measurably slower, and the
+# surrounding split and dtype casts here are exactly that kind of region.
+###############################################################################
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch.library import custom_op, triton_op, wrap_triton
+
+
+@triton.jit
+def _pair(P, rows, mask, SM, D: tl.constexpr, BLOCK_M: tl.constexpr, INTERLEAVED: tl.constexpr):
+    """Load [BLOCK_M, D] rows of P and return the two members of each rotation pair.
+
+    ``SM`` is the distance between consecutive rows. It is D for a packed tensor, and
+    larger for Q and K, which are slices of ``mixed_qkv`` and so carry a gap to the
+    next head. Taking it as an argument is what lets those be read in place.
+    """
+    half: tl.constexpr = D // 2
+    if INTERLEAVED:
+        off = rows[:, None] * SM + tl.arange(0, D)[None, :]
+        v = tl.load(P + off, mask=mask, other=0.0).to(tl.float32)
+        return tl.split(tl.reshape(v, (BLOCK_M, half, 2)))
+    lo = tl.arange(0, half)
+    off = rows[:, None] * SM + lo[None, :]
+    a = tl.load(P + off, mask=mask, other=0.0).to(tl.float32)
+    b = tl.load(P + off + half, mask=mask, other=0.0).to(tl.float32)
+    return a, b
+
+
+@triton.jit
+def _unpair(
+    P,
+    rows,
+    mask,
+    v_lo,
+    v_hi,
+    SM,
+    D: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    INTERLEAVED: tl.constexpr,
+):
+    """Inverse of _pair: interleave or concatenate, then store at row stride SM."""
+    half: tl.constexpr = D // 2
+    if INTERLEAVED:
+        v = tl.reshape(tl.join(v_lo, v_hi), (BLOCK_M, D))
+        off = rows[:, None] * SM + tl.arange(0, D)[None, :]
+        tl.store(P + off, v.to(P.dtype.element_ty), mask=mask)
+    else:
+        lo = tl.arange(0, half)
+        off = rows[:, None] * SM + lo[None, :]
+        tl.store(P + off, v_lo.to(P.dtype.element_ty), mask=mask)
+        tl.store(P + off + half, v_hi.to(P.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _pair_w(W, D: tl.constexpr, INTERLEAVED: tl.constexpr):
+    """The norm weight is D-wide and shared by every row; split it the same way."""
+    half: tl.constexpr = D // 2
+    if INTERLEAVED:
+        v = tl.load(W + tl.arange(0, D)).to(tl.float32)
+        a, b = tl.split(tl.reshape(v, (half, 2)))
+        return a[None, :], b[None, :]
+    lo = tl.arange(0, half)
+    return (
+        tl.load(W + lo).to(tl.float32)[None, :],
+        tl.load(W + lo + half).to(tl.float32)[None, :],
+    )
+
+
+def _fwd_configs():
+    return [
+        triton.Config({"BLOCK_M": bm}, num_warps=nw, num_stages=ns)
+        for bm in (1, 2, 4, 8, 16)
+        for nw in (1, 2, 4, 8)
+        for ns in (1, 2)
+    ]
+
+
+@triton.autotune(configs=_fwd_configs(), key=["M", "D"])
+@triton.jit
+def _fwd_kernel(
+    X,
+    W,
+    COS,
+    SIN,
+    OUT,
+    RSTD,
+    M,
+    D: tl.constexpr,
+    BH,
+    EPS,
+    SX,
+    SO,
+    SC,
+    BLOCK_M: tl.constexpr,
+    INTERLEAVED: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    mask_m = rows < M
+    mask = mask_m[:, None]
+
+    x_lo, x_hi = _pair(X, rows, mask, SX, D, BLOCK_M, INTERLEAVED)
+    # The mean is over the whole row, so it does not care how the row was split.
+    rstd = tl.rsqrt((tl.sum(x_lo * x_lo, axis=1) + tl.sum(x_hi * x_hi, axis=1)) / D + EPS)[:, None]
+
+    w_lo, w_hi = _pair_w(W, D, INTERLEAVED)
+    n_lo, n_hi = x_lo * rstd * w_lo, x_hi * rstd * w_hi
+
+    # cos/sin are [S,D] or [S*B,D]: rows sharing a position share a row of the table.
+    s = rows // BH
+    c_lo, c_hi = _pair(COS, s, mask, SC, D, BLOCK_M, INTERLEAVED)
+    s_lo, s_hi = _pair(SIN, s, mask, SC, D, BLOCK_M, INTERLEAVED)
+
+    _unpair(
+        OUT,
+        rows,
+        mask,
+        n_lo * c_lo - n_hi * s_lo,
+        n_hi * c_hi + n_lo * s_hi,
+        SO,
+        D,
+        BLOCK_M,
+        INTERLEAVED,
+    )
+    tl.store(RSTD + rows, tl.reshape(rstd, (BLOCK_M,)), mask=mask_m)
+
+
+# Fixed rather than autotuned. The partial buffer has to be sized before launch, so
+# tuning this meant allocating for the largest candidate and reducing all of it --
+# 16 MB zeroed and summed per call, against a kernel far too short to absorb that.
+# Kernel bandwidth is flat across the useful range anyway.
+NPROG = 4096
+
+
+def _bwd_configs():
+    return [
+        triton.Config({"BLOCK_M": bm}, num_warps=nw, num_stages=ns)
+        for bm in (1, 2, 4, 8, 16, 32, 64)
+        for nw in (1, 2, 4, 8)
+        for ns in (1, 2, 3)
+    ]
+
+
+# dw is a reduction over every token onto a D-wide vector. Doing that with atomic_add
+# from one program per row puts ~200k programs on the same 128 addresses, which measured
+# 10x slower than the three-kernel baseline it was meant to beat. Instead the grid is
+# persistent: a fixed number of programs each stride over many rows, keep a private
+# accumulator in registers, and write one partial row for the host to sum. No atomics.
+@triton.autotune(configs=_bwd_configs(), key=["M", "D"])
+@triton.jit
+def _bwd_kernel(
+    G,
+    X,
+    W,
+    COS,
+    SIN,
+    RSTD,
+    DX,
+    DWP,
+    M,
+    D: tl.constexpr,
+    BH,
+    SG,
+    SX,
+    SDX,
+    SC,
+    BLOCK_M: tl.constexpr,
+    INTERLEAVED: tl.constexpr,
+    # Passed explicitly rather than defaulted to the module global: under
+    # torch.compile, Inductor re-emits this kernel's source into a fresh module and
+    # a default that references a global resolves to NameError there.
+    NPROG: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    half: tl.constexpr = D // 2
+    w_lo, w_hi = _pair_w(W, D, INTERLEAVED)
+    dw_lo = tl.zeros((half,), dtype=tl.float32)
+    dw_hi = tl.zeros((half,), dtype=tl.float32)
+
+    for base in tl.range(pid * BLOCK_M, M, NPROG * BLOCK_M):
+        rows = base + tl.arange(0, BLOCK_M)
+        mask = (rows < M)[:, None]
+
+        g_lo, g_hi = _pair(G, rows, mask, SG, D, BLOCK_M, INTERLEAVED)
+        x_lo, x_hi = _pair(X, rows, mask, SX, D, BLOCK_M, INTERLEAVED)
+        rstd = tl.load(RSTD + rows, mask=rows < M, other=0.0)[:, None]
+
+        s = rows // BH
+        c_lo, c_hi = _pair(COS, s, mask, SC, D, BLOCK_M, INTERLEAVED)
+        s_lo, s_hi = _pair(SIN, s, mask, SC, D, BLOCK_M, INTERLEAVED)
+
+        # Inverse of out_lo = n_lo*cos_lo - n_hi*sin_lo, out_hi = n_hi*cos_hi + n_lo*sin_hi.
+        dn_lo = g_lo * c_lo + g_hi * s_hi
+        dn_hi = g_hi * c_hi - g_lo * s_lo
+
+        u_lo, u_hi = x_lo * rstd, x_hi * rstd
+        du_lo, du_hi = dn_lo * w_lo, dn_hi * w_hi
+        m = (tl.sum(du_lo * u_lo, axis=1) + tl.sum(du_hi * u_hi, axis=1))[:, None] / D
+
+        _unpair(
+            DX,
+            rows,
+            mask,
+            rstd * (du_lo - u_lo * m),
+            rstd * (du_hi - u_hi * m),
+            SDX,
+            D,
+            BLOCK_M,
+            INTERLEAVED,
+        )
+        dw_lo += tl.sum(tl.where(mask, dn_lo * u_lo, 0.0), axis=0)
+        dw_hi += tl.sum(tl.where(mask, dn_hi * u_hi, 0.0), axis=0)
+
+    # The accumulators are in pair order, so they need unpairing before the host sums
+    # them onto the layout the weight actually has.
+    if INTERLEAVED:
+        tl.store(DWP + pid * D + tl.arange(0, D), tl.reshape(tl.join(dw_lo, dw_hi), (D,)))
+    else:
+        lo = tl.arange(0, half)
+        tl.store(DWP + pid * D + lo, dw_lo)
+        tl.store(DWP + pid * D + lo + half, dw_hi)
+
+
+def _cs_div(M: int, cos: torch.Tensor) -> int:
+    """How many [S,B,H] rows share one row of cos/sin.
+
+    Flux's RoPE frequencies are per image, so ``freqs`` is [S, B, 1, D] and cos/sin
+    flatten to [S*B, D] -- one row per position *and* batch element, shared only
+    across heads. A model whose positions are shared across the batch gives [S, D]
+    instead. Both are just a divisor on the row index, so the kernel needs no branch:
+    M // rows is B*H in the first case and H in the second.
+    """
+    rows = cos.shape[0]
+    assert M % rows == 0, f"cos/sin rows {rows} do not divide {M} tensor rows"
+    return M // rows
+
+
+def _row_stride(t: torch.Tensor):
+    """The row stride of a [S,B,H,D] tensor, or None if the kernel cannot address it.
+
+    The kernel treats its operands as M rows of D contiguous elements, evenly spaced.
+    Q and K fit that description without being contiguous: they are ``[..., 0:D]`` and
+    ``[..., D:2D]`` slices of ``mixed_qkv``, so each row is D wide with a gap to the
+    next head. Reading them at their natural stride rather than copying them first
+    removes the copy kernels entirely, and it keeps the tensor saved for backward a
+    view of ``mixed_qkv`` -- which the QKV GEMM holds anyway -- instead of a fresh
+    allocation of activations.
+    """
+    if t.dim() != 4:
+        return None
+    _, B, H, D = t.shape
+    s0, s1, s2, s3 = t.stride()
+    # Rows must be contiguous, must not overlap, and must tile the outer dims evenly.
+    if s3 != 1 or s2 < D or s1 != H * s2 or s0 != B * s1:
+        return None
+    return s2
+
+
+def _row_strided(t: torch.Tensor):
+    """Return t addressable at a uniform row stride, copying only if it is not."""
+    s = _row_stride(t)
+    if s is None:
+        t = t.contiguous()
+        s = t.shape[-1]
+    return t, s
+
+
+def _launch_fwd(x, w, cos, sin, eps, interleaved):
+    S, B, H, D = x.shape
+    M = S * B * H
+    x, sx = _row_strided(x)
+    # The output is packed even when the input is not: it feeds FMHA, which wants it
+    # that way, and writing it packed costs nothing the strided read has not saved.
+    out = torch.empty_like(x, memory_format=torch.contiguous_format)
+    rstd = torch.empty(M, device=x.device, dtype=torch.float32)
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+    wrap_triton(_fwd_kernel)[grid](
+        x,
+        w,
+        cos,
+        sin,
+        out,
+        rstd,
+        M,
+        D,
+        _cs_div(M, cos),
+        eps,
+        sx,
+        D,
+        cos.stride(0),
+        INTERLEAVED=interleaved,
+    )
+    return out, rstd
+
+
+def _launch_bwd(g, x, w, cos, sin, rstd, dx, interleaved):
+    """Backward into a caller-supplied dx, which need only be evenly strided.
+
+    dx is a separate argument rather than an allocation because the QKV entry point
+    below points it at a column of d(mixed_qkv); see the note there.
+    """
+    S, B, H, D = x.shape
+    M = S * B * H
+    g, sg = _row_strided(g)
+    x, sx = _row_strided(x)
+    sdx = _row_stride(dx)
+    assert sdx is not None, "dx must be addressable at a uniform row stride"
+    # Every row is written by exactly one program, so empty() is safe.
+    dwp = torch.empty(NPROG, D, device=x.device, dtype=torch.float32)
+    wrap_triton(_bwd_kernel)[(NPROG,)](
+        g,
+        x,
+        w,
+        cos,
+        sin,
+        rstd,
+        dx,
+        dwp,
+        M,
+        D,
+        _cs_div(M, cos),
+        sg,
+        sx,
+        sdx,
+        cos.stride(0),
+        INTERLEAVED=interleaved,
+        NPROG=NPROG,
+    )
+    return dwp
+
+
+@triton_op("primus::fused_qk_norm_rope", mutates_args=())
+def _fused_fwd(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    eps: float,
+    interleaved: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return _launch_fwd(x, w, cos, sin, eps, interleaved)
+
+
+@_fused_fwd.register_fake
+def _fused_fwd_fake(x, w, cos, sin, eps, interleaved):
+    S, B, H, D = x.shape
+    return (
+        torch.empty_like(x, memory_format=torch.contiguous_format),
+        torch.empty(S * B * H, device=x.device, dtype=torch.float32),
+    )
+
+
+@triton_op("primus::fused_qk_norm_rope_backward", mutates_args=())
+def _fused_bwd(
+    g: torch.Tensor,
+    x: torch.Tensor,
+    w: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    rstd: torch.Tensor,
+    interleaved: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    dx = torch.empty_like(_row_strided(x)[0], memory_format=torch.contiguous_format)
+    return dx, _launch_bwd(g, x, w, cos, sin, rstd, dx, interleaved)
+
+
+@_fused_bwd.register_fake
+def _fused_bwd_fake(g, x, w, cos, sin, rstd, interleaved):
+    return (
+        torch.empty_like(x, memory_format=torch.contiguous_format),
+        torch.empty(NPROG, x.shape[-1], device=x.device, dtype=torch.float32),
+    )
+
+
+def _setup_context(ctx, inputs, output):
+    x, w, cos, sin, eps, interleaved = inputs
+    ctx.save_for_backward(x, w, cos, sin, output[1])
+    ctx.interleaved = interleaved
+
+
+def _backward(ctx, grad_out, _grad_rstd):
+    x, w, cos, sin, rstd = ctx.saved_tensors
+    dx, dwp = _fused_bwd(grad_out, x, w, cos, sin, rstd, ctx.interleaved)
+    return dx, dwp.sum(0).to(w.dtype), None, None, None, None
+
+
+_fused_fwd.register_autograd(_backward, setup_context=_setup_context)
+
+
+# ---------------------------------------------------------------------------
+# Whole-QKV entry point.
+#
+# The per-tensor op above leaves behind one kernel the unfused path never paid for:
+# the backward of the QKV split. Inductor used to fold that concatenation into the
+# epilogue of its own norm-backward and write d(mixed_qkv) directly; against an opaque
+# op it cannot, so it emits a standalone gather of dq, dk and dv.
+#
+# Taking mixed_qkv as the differentiable input instead of its three slices removes the
+# split, and with it the thing that had to be undone. The backward kernels write dq and
+# dk straight into the q and k columns of d(mixed_qkv) at stride 3D, which costs them
+# nothing: the destination row stride has been a runtime argument ever since Q and K
+# became strided reads. Only dv still has to be copied in, since it is produced by FMHA.
+# ---------------------------------------------------------------------------
+
+
+# Opaque, unlike the per-tensor op above. That op is a @triton_op so Inductor can fuse
+# its neighbours into it; here there are none -- the input is a GEMM output and the
+# outputs go to FMHA, both opaque. Transparency is not merely unnecessary at this level,
+# it is wrong: tracing in exposes two triton kernels writing disjoint columns of one
+# freshly allocated buffer, and functionalizing that pattern produced a kernel that read
+# 786304 elements out of a 262144-element clone. Nothing here needs to be seen.
+@custom_op("primus::fused_qkv_norm_rope", mutates_args=())
+def _qkv_fwd(
+    qkv: torch.Tensor,
+    wq: torch.Tensor,
+    wk: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    eps: float,
+    interleaved: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    D = qkv.shape[-1] // 3
+    q, q_rstd = _launch_fwd(qkv[..., :D], wq, cos, sin, eps, interleaved)
+    k, k_rstd = _launch_fwd(qkv[..., D : 2 * D], wk, cos, sin, eps, interleaved)
+    # V is not merely forwarded: a custom op may not return an alias of its input, and
+    # FMHA wants it packed regardless, so this replaces the copy the caller was making.
+    v = qkv[..., 2 * D :].contiguous()
+    return q, k, v, q_rstd, k_rstd
+
+
+@_qkv_fwd.register_fake
+def _qkv_fwd_fake(qkv, wq, wk, cos, sin, eps, interleaved):
+    S, B, H, T = qkv.shape
+    D = T // 3
+    head = torch.empty((S, B, H, D), device=qkv.device, dtype=qkv.dtype)
+    rstd = torch.empty(S * B * H, device=qkv.device, dtype=torch.float32)
+    return (head, torch.empty_like(head), torch.empty_like(head), rstd, torch.empty_like(rstd))
+
+
+@custom_op("primus::fused_qkv_norm_rope_backward", mutates_args=())
+def _qkv_bwd(
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    qkv: torch.Tensor,
+    wq: torch.Tensor,
+    wk: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    q_rstd: torch.Tensor,
+    k_rstd: torch.Tensor,
+    interleaved: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    D = qkv.shape[-1] // 3
+    d_qkv = torch.empty_like(qkv, memory_format=torch.contiguous_format)
+    dwqp = _launch_bwd(dq, qkv[..., :D], wq, cos, sin, q_rstd, d_qkv[..., :D], interleaved)
+    dwkp = _launch_bwd(dk, qkv[..., D : 2 * D], wk, cos, sin, k_rstd, d_qkv[..., D : 2 * D], interleaved)
+    d_qkv[..., 2 * D :].copy_(dv)
+    return d_qkv, dwqp, dwkp
+
+
+@_qkv_bwd.register_fake
+def _qkv_bwd_fake(dq, dk, dv, qkv, wq, wk, cos, sin, q_rstd, k_rstd, interleaved):
+    D = qkv.shape[-1] // 3
+    p = torch.empty(NPROG, D, device=qkv.device, dtype=torch.float32)
+    return (torch.empty_like(qkv, memory_format=torch.contiguous_format), p, torch.empty_like(p))
+
+
+def _qkv_setup_context(ctx, inputs, output):
+    qkv, wq, wk, cos, sin, eps, interleaved = inputs
+    # qkv rather than its q and k slices: one saved tensor instead of two, and it is the
+    # QKV GEMM's output, which the graph is holding for that GEMM's own backward anyway.
+    ctx.save_for_backward(qkv, wq, wk, cos, sin, output[3], output[4])
+    ctx.interleaved = interleaved
+
+
+def _qkv_backward(ctx, dq, dk, dv, _dqr, _dkr):
+    qkv, wq, wk, cos, sin, q_rstd, k_rstd = ctx.saved_tensors
+    d_qkv, dwqp, dwkp = _qkv_bwd(dq, dk, dv, qkv, wq, wk, cos, sin, q_rstd, k_rstd, ctx.interleaved)
+    return d_qkv, dwqp.sum(0).to(wq.dtype), dwkp.sum(0).to(wk.dtype), None, None, None, None
+
+
+_qkv_fwd.register_autograd(_qkv_backward, setup_context=_qkv_setup_context)
+
+
+def fused_qkv_norm_rope(mixed_qkv, wq, wk, cos, sin, eps=1e-6, interleaved=True):
+    """Split [S, B, H, 3D] into Q, K, V with QK norm and RoPE already applied.
+
+    Prefer this over calling ``fused_qk_norm_rope`` on Q and K separately: it is the
+    same kernels, but because the split happens inside the op there is no concatenation
+    to pay for on the way back. Returns packed (Q, K, V).
+    """
+    q, k, v, _, _ = _qkv_fwd(mixed_qkv, wq, wk, cos, sin, eps, interleaved)
+    return q, k, v
+
+
+def fused_qk_norm_rope(x, weight, cos, sin, eps=1e-6, interleaved=True):
+    """RMS-norm x over its last dim, then apply RoPE, in one kernel each direction.
+
+    ``x`` is [S, B, H, D] and need not be contiguous -- a slice of ``mixed_qkv`` is
+    read in place, see ``_row_stride``. ``cos``/``sin`` are [rows, D] and broadcast
+    over whatever the rows do not index. ``interleaved`` selects Megatron's rotation
+    layout and defaults to Flux's.
+    """
+    return _fused_fwd(x, weight, cos, sin, eps, interleaved)[0]

--- a/primus/backends/megatron/core/models/diffusion/common/fused_norm_rope.py
+++ b/primus/backends/megatron/core/models/diffusion/common/fused_norm_rope.py
@@ -29,12 +29,25 @@
 # surrounding split and dtype casts here are exactly that kind of region.
 ###############################################################################
 
+import os
 from typing import Tuple
 
 import torch
 import triton
 import triton.language as tl
 from torch.library import custom_op, triton_op, wrap_triton
+
+# The autotune key below is ["M", "D"], so every distinct M pays a full sweep: ~5 s for
+# the 40 forward configs, ~21 s for the 84 backward ones. That is charged per block, so
+# routing the whole-QKV path through all 57 of them spent ~25 minutes before iteration 1.
+# The sweep does not earn it. Measured at both production M values, the best eight of the
+# forward configs sit within 2.8% of one another, and the winner is not even stable
+# between runs -- M=786432 chose BLOCK_M=2/w1/s1 once and BLOCK_M=8/w4/s2 the next time,
+# two configs 0.4% apart. Left on, the tuner moves the step time an A/B is measuring.
+# Setting PRIMUS_NORM_ROPE_PIN=1 collapses each space to the measured best compromise
+# (worst case 1.001x forward, 1.002x backward across both shapes), and triton skips
+# benchmarking entirely when handed a single config.
+_PIN_CONFIGS = os.environ.get("PRIMUS_NORM_ROPE_PIN", "0").lower() in ("1", "true", "on")
 
 
 @triton.jit
@@ -98,6 +111,8 @@ def _pair_w(W, D: tl.constexpr, INTERLEAVED: tl.constexpr):
 
 
 def _fwd_configs():
+    if _PIN_CONFIGS:
+        return [triton.Config({"BLOCK_M": 8}, num_warps=4, num_stages=2)]
     return [
         triton.Config({"BLOCK_M": bm}, num_warps=nw, num_stages=ns)
         for bm in (1, 2, 4, 8, 16)
@@ -164,6 +179,8 @@ NPROG = 4096
 
 
 def _bwd_configs():
+    if _PIN_CONFIGS:
+        return [triton.Config({"BLOCK_M": 64}, num_warps=8, num_stages=2)]
     return [
         triton.Config({"BLOCK_M": bm}, num_warps=nw, num_stages=ns)
         for bm in (1, 2, 4, 8, 16, 32, 64)

--- a/primus/backends/megatron/core/models/diffusion/common/normalization.py
+++ b/primus/backends/megatron/core/models/diffusion/common/normalization.py
@@ -19,6 +19,7 @@ Reference:
     - Flux Paper: "Flux: A Scalable Diffusion Model"
 """
 
+import os
 from typing import Tuple
 
 import torch
@@ -43,6 +44,11 @@ from torch.library import triton_op, wrap_triton
 # ---------------------------------------------------------------------------
 
 _custom_op = torch.library.custom_op
+
+# Run the LN-modulate backward as one pass over the activations instead of two. See the
+# block above _fused_ln_modulate_bwd_single_pass_kernel. Off by default until the
+# end-to-end number is confirmed; it is numerically equivalent, not an approximation.
+_LN_MOD_SINGLE_PASS_BWD = os.environ.get("MXFP6_FUSED_LN_MOD_BWD", "0") == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -562,6 +568,177 @@ def _fused_ln_modulate_bwd_dx_kernel(
     tl.store(DX_ptr + x_off, d_x.to(OUT_DTYPE), mask=mask)
 
 
+# ---------------------------------------------------------------------------
+# Single-pass backward.
+#
+# The two kernels above both stream grad_output[S,B,H] and x[S,B,H] out of HBM, and in
+# the MXFP6 trace that traffic costs far more than the output it produces. They were
+# split because their reductions are orthogonal -- dscale/dshift reduce
+# over S, dx reduces over H -- but a program that owns one batch element, a slice of S,
+# and the *whole* of H can do both: the H reduction inside its loop, the S reduction
+# across it. That reads each activation once.
+#
+# Holding all of H is the constraint, and it is why the grid splits S rather than H. One
+# program per batch element would be the simple version and cannot win: B is 64, which
+# leaves most of the machine idle. Splitting S NS ways brings it to B*NS programs and
+# leaves a per-slice partial for the reduction below, the same shape as the weight
+# gradient in the fused QK norm+RoPE backward.
+#
+# Measured against the two-kernel path at both production shapes, the single pass is
+# substantially faster and lands much closer to the bandwidth roof.
+# ---------------------------------------------------------------------------
+
+# S is split this many ways. 8 was the best of {4, 8, 16, 32} at both production shapes;
+# 4 leaves the machine short of programs and 16 shortens each program's run below the
+# point where the strided-S loop keeps its loads in flight.
+_LN_MOD_BWD_NS = 8
+
+# Two fp32 accumulators of BLOCK_H live in registers for the whole kernel, so the tile
+# cannot grow the way the two-kernel path's could. 4096 covers Flux's H=3072; anything
+# wider falls back rather than spilling.
+_LN_MOD_BWD_MAX_BLOCK_H = 4096
+
+
+@triton.jit
+def _fused_ln_modulate_bwd_single_pass_kernel(
+    Grad_ptr,
+    X_ptr,
+    Mean_ptr,
+    Rstd_ptr,
+    Scale_ptr,
+    DX_ptr,
+    DScaleP_ptr,
+    DShiftP_ptr,
+    S,
+    B,
+    H,
+    stride_g_sb,
+    stride_x_sb,
+    stride_sc_b,
+    BLOCK_H: tl.constexpr,
+    NS: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+):
+    b_idx = tl.program_id(0)
+    s_blk = tl.program_id(1)
+
+    offs_h = tl.arange(0, BLOCK_H)
+    mask = offs_h < H
+    inv_H = 1.0 / H
+
+    scale_val = tl.load(Scale_ptr + b_idx * stride_sc_b + offs_h, mask=mask).to(tl.float32)
+    one_plus_scale = 1.0 + scale_val
+    acc_dscale = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc_dshift = tl.zeros([BLOCK_H], dtype=tl.float32)
+
+    # Strided rather than blocked over S, so that programs running at the same time are
+    # reading neighbouring rows.
+    for s_idx in tl.range(s_blk, S, NS):
+        sb_idx = s_idx * B + b_idx
+        g_off = sb_idx * stride_g_sb + offs_h
+        x_off = sb_idx * stride_x_sb + offs_h
+
+        g = tl.load(Grad_ptr + g_off, mask=mask, other=0.0).to(tl.float32)
+        x = tl.load(X_ptr + x_off, mask=mask, other=0.0).to(tl.float32)
+        mean = tl.load(Mean_ptr + sb_idx)
+        rstd = tl.load(Rstd_ptr + sb_idx)
+
+        x_hat = tl.where(mask, (x - mean) * rstd, 0.0)
+        d_x_hat = tl.where(mask, g * one_plus_scale, 0.0)
+        c1 = tl.sum(x_hat * d_x_hat, axis=0) * inv_H
+        c2 = tl.sum(d_x_hat, axis=0) * inv_H
+        d_x = rstd * (d_x_hat - c2 - x_hat * c1)
+        tl.store(DX_ptr + x_off, d_x.to(OUT_DTYPE), mask=mask)
+
+        acc_dscale += g * x_hat
+        acc_dshift += tl.where(mask, g, 0.0)
+
+    p_off = (b_idx * NS + s_blk) * H + offs_h
+    tl.store(DScaleP_ptr + p_off, acc_dscale, mask=mask)
+    tl.store(DShiftP_ptr + p_off, acc_dshift, mask=mask)
+
+
+@triton.jit
+def _fused_ln_modulate_bwd_reduce_partials_kernel(
+    DScaleP_ptr,
+    DShiftP_ptr,
+    DScale_ptr,
+    DShift_ptr,
+    H,
+    NS: tl.constexpr,
+    BLOCK: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+):
+    b_idx = tl.program_id(0)
+    offs = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < H
+    acc_scale = tl.zeros([BLOCK], dtype=tl.float32)
+    acc_shift = tl.zeros([BLOCK], dtype=tl.float32)
+    # Fixed trip count in a fixed order, so the sum is as reproducible as the sequential
+    # loop the two-kernel path used.
+    for i in tl.static_range(NS):
+        base = (b_idx * NS + i) * H + offs
+        acc_scale += tl.load(DScaleP_ptr + base, mask=mask, other=0.0)
+        acc_shift += tl.load(DShiftP_ptr + base, mask=mask, other=0.0)
+    tl.store(DScale_ptr + b_idx * H + offs, acc_scale.to(OUT_DTYPE), mask=mask)
+    tl.store(DShift_ptr + b_idx * H + offs, acc_shift.to(OUT_DTYPE), mask=mask)
+
+
+def _ln_modulate_bwd_single_pass(
+    single_pass_kernel, reduce_kernel, grad_output, x, mean, rstd, scale, out_dtype
+):
+    """Launch the pair. Kernels are passed in so both the opaque and the triton_op
+    registration can share this, one handing over the raw kernels and the other the
+    wrap_triton ones."""
+    S, B, H = x.shape
+    dx = torch.empty_like(x)
+    dscale = torch.empty_like(scale)
+    dshift = torch.empty_like(scale)
+    ns = _LN_MOD_BWD_NS
+    # One allocation for both partials; they are consumed together.
+    partials = torch.empty(2, B * ns * H, device=x.device, dtype=torch.float32)
+    single_pass_kernel[(B, ns)](
+        grad_output,
+        x,
+        mean,
+        rstd,
+        scale,
+        dx,
+        partials[0],
+        partials[1],
+        S,
+        B,
+        H,
+        grad_output.stride(1),
+        x.stride(1),
+        scale.stride(0),
+        BLOCK_H=triton.next_power_of_2(H),
+        NS=ns,
+        OUT_DTYPE=out_dtype,
+        num_warps=4,
+    )
+    reduce_kernel[(B, triton.cdiv(H, 1024))](
+        partials[0],
+        partials[1],
+        dscale,
+        dshift,
+        H,
+        NS=ns,
+        BLOCK=1024,
+        OUT_DTYPE=out_dtype,
+    )
+    return dx, dscale, dshift
+
+
+def _ln_modulate_bwd_can_single_pass(x, scale) -> bool:
+    return (
+        _LN_MOD_SINGLE_PASS_BWD
+        and x.dim() == 3
+        and scale.dim() == 2
+        and triton.next_power_of_2(x.shape[-1]) <= _LN_MOD_BWD_MAX_BLOCK_H
+    )
+
+
 @_custom_op("primus::fused_ln_modulate", mutates_args=(), device_types="cuda")
 def _opaque_fused_ln_modulate(
     x: torch.Tensor,
@@ -648,6 +825,17 @@ def _opaque_fused_ln_modulate_backward_op(
     dshift = torch.empty_like(scale)
     BLOCK_H = triton.next_power_of_2(H)
     out_dtype = _TORCH_TO_TRITON_DTYPE[x.dtype]
+    if _ln_modulate_bwd_can_single_pass(x, scale):
+        return _ln_modulate_bwd_single_pass(
+            _fused_ln_modulate_bwd_single_pass_kernel,
+            _fused_ln_modulate_bwd_reduce_partials_kernel,
+            grad_output,
+            x,
+            mean,
+            rstd,
+            scale,
+            out_dtype,
+        )
     XBLOCK, RBLOCK = 256, 8
     _fused_ln_modulate_bwd_dscale_dshift_kernel[(triton.cdiv(B * H, XBLOCK),)](
         grad_output,
@@ -807,6 +995,17 @@ def _triton_fused_ln_modulate_backward_op(
     dshift = torch.empty_like(scale)
     BLOCK_H = triton.next_power_of_2(H)
     out_dtype = _TORCH_TO_TRITON_DTYPE[x.dtype]
+    if _ln_modulate_bwd_can_single_pass(x, scale):
+        return _ln_modulate_bwd_single_pass(
+            wrap_triton(_fused_ln_modulate_bwd_single_pass_kernel),
+            wrap_triton(_fused_ln_modulate_bwd_reduce_partials_kernel),
+            grad_output,
+            x,
+            mean,
+            rstd,
+            scale,
+            out_dtype,
+        )
     XBLOCK, RBLOCK = 256, 8
     wrap_triton(_fused_ln_modulate_bwd_dscale_dshift_kernel)[(triton.cdiv(B * H, XBLOCK),)](
         grad_output,

--- a/primus/backends/megatron/core/models/diffusion/flux/attention.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/attention.py
@@ -19,6 +19,7 @@ Reference:
 """
 
 import os
+import warnings
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -42,10 +43,44 @@ from torch import Tensor
 # end-to-end number is confirmed. See scratch/mxfp6/rope/RESULTS_interleaved.md.
 _MXFP6_FUSED_QK_ROPE = os.environ.get("MXFP6_FUSED_QK_ROPE", "0") == "1"
 
+# Fold the QKV projection's dgrad, the QK norm's backward and the rotation's backward into a
+# single MXFP6 packer prologue, so d(mixed_qkv) is never written to HBM. This subsumes
+# MXFP6_FUSED_QK_ROPE's backward: that fusion still writes the gradient in bf16 for the
+# packer to read straight back, and this removes both halves of that round trip.
+#
+# "auto" uses it wherever the configuration allows and falls back with a warning otherwise;
+# "on" makes an unusable configuration an error; "off" forces the stock path for A/B.
+# Restores the pre-fix ``_slice_rope``, which sliced q and k into separate objects even when
+# they were the same tensor. That broke the ``k_pos_emb is q_pos_emb`` test both whole-QKV
+# fusions use, so MXFP6_FUSED_QK_ROPE's whole-QKV op never engaged in a joint block -- every
+# published number for that flag was measured with it silently falling back there.
+#
+# This exists only so the A/B can reproduce that published baseline from the same tree as the
+# fixed arms, pricing the fix and the QKV prologue separately instead of confounding them.
+# **Measurement scaffolding, not a supported mode**: it reinstates a known bug and should be
+# deleted once the fix has a number against it.
+_ROPE_SLICE_LEGACY = os.environ.get("MXFP6_ROPE_SLICE_LEGACY", "0") == "1"
+
+_MXFP6_FUSED_QKV = os.environ.get("MXFP6_FUSED_QKV", "off").strip().lower()
+assert _MXFP6_FUSED_QKV in ("auto", "on", "off"), (
+    f"MXFP6_FUSED_QKV must be auto, on or off, got {_MXFP6_FUSED_QKV!r}"
+)
+
 try:
     from megatron.core.transformer.custom_layers.transformer_engine import SplitAlongDim
 except ImportError:
     SplitAlongDim = None
+
+try:
+    from primus.backends.megatron.core.extensions.primus_turbo_mxfp6_local import (
+        MXFP6ColumnParallelLinear,
+        MXFP6QKVNormRopeFunction,
+        _claim_main_grad,
+    )
+except ImportError:  # no Primus-Turbo, or one without the prologue
+    MXFP6ColumnParallelLinear = None
+    MXFP6QKVNormRopeFunction = None
+    _claim_main_grad = None
 
 try:
     from primus.backends.megatron.core.models.diffusion.common.fused_norm_rope import (
@@ -105,11 +140,13 @@ def _slice_rope(rotary_pos_emb, lo: int, hi):
         return None
     q, k = rotary_pos_emb
     q_slice = q[lo:hi]
-    # Slicing the same tensor twice yields two objects, and the whole-QKV fusion tests
+    # Slicing the same tensor twice yields two objects, and the whole-QKV fusions test
     # ``k_pos_emb is q_pos_emb`` to decide whether one frequency table serves both -- so
     # slicing naively here is what decided it, and it decided wrong. Self-attention passes
     # the same freqs for q and k, so preserving that identity is what lets the joint blocks
     # reach the same fused path the single blocks already take.
+    if _ROPE_SLICE_LEGACY:
+        return (q_slice, k[lo:hi])
     return (q_slice, q_slice if k is q else k[lo:hi])
 
 
@@ -202,6 +239,133 @@ def _apply_qkv_norm_rope(attn, mixed_qkv, split_arg_list, q_norm, k_norm, rotary
         attn, query, key, q_norm, k_norm, value.dtype, rotary_pos_emb, packed_seq_params
     )
     return query, key, value
+
+
+def _fused_qkv_unusable_reason(attn, linear, q_norm, k_norm) -> str:
+    """Why the MXFP6 QKV fusion cannot be used for this module, or ``""`` if it can.
+
+    Shaped after ``_fused_mlp_unusable_reason``: every branch is a path the fused Function
+    does not reproduce, and returning a reason rather than silently deferring keeps a
+    misconfiguration from looking like a performance result.
+
+    Checked once at build time. The getter and the forward have to agree about who applies
+    the norm, and a condition that could change between them would drop it on the floor.
+    """
+    if _MXFP6_FUSED_QKV == "off":
+        return "disabled by environment"
+    if MXFP6QKVNormRopeFunction is None:
+        return "this build has no MXFP6 QKV norm+RoPE Function"
+    if not hasattr(torch.ops.primus_turbo, "quantize_mxfp6_qk_norm_rope_bwd_impl"):
+        return "this Primus-Turbo build has no QK-norm+RoPE packer prologue"
+    if fused_qkv_norm_rope is None:
+        return "no triton, so the fused norm+RoPE forward is unavailable"
+
+    # The fusion replaces the norm+RoPE *backward* only; its forward is that same Triton op,
+    # so everything MXFP6_FUSED_QK_ROPE requires is required here too.
+    if not isinstance(linear, MXFP6ColumnParallelLinear if MXFP6ColumnParallelLinear else ()):
+        return f"linear_qkv is {type(linear).__name__}, not an MXFP6 column-parallel linear"
+    if getattr(linear, "_backward_is_fp8", False):
+        return (
+            "mxfp6_backward_precision='fp8' re-quantizes a saved bf16 activation, which the "
+            "prologue's operands replace"
+        )
+    if linear.skip_bias_add:
+        return "linear_qkv adds its bias outside the GEMM, so the norm's input is not its output"
+    for name, norm in (("q", q_norm), ("k", k_norm)):
+        if not isinstance(norm, torch.nn.RMSNorm) or norm.weight is None:
+            return f"the {name} norm is not an RMSNorm with a weight"
+    if q_norm.eps != k_norm.eps:
+        return "the prologue carries one epsilon for both norms"
+
+    # **The one constraint with no runtime guard.** The prologue pairs elements 2i and 2i+1;
+    # a half-split rotation pairs i and i + D/2. Nothing in the operands makes the convention
+    # visible and no numeric check downstream would catch it -- the gradient would simply be
+    # wrong. This config field is the only place it is knowable, so it is checked here.
+    if not attn.config.rotary_interleaved:
+        return "the prologue implements interleaved rotary only, and rotary_interleaved is False"
+
+    d = attn.hidden_size_per_attention_head
+    if d != 128:
+        return f"the prologue's tile width is head_dim, which must be 128, got {d}"
+    heads = attn.num_attention_heads_per_partition
+    if heads % 2:
+        return f"the prologue needs an even head count, got {heads}"
+    # MHA only, as for the norm+RoPE op: under GQA the Q columns are wider than one head_dim
+    # so the three slices are not at 0, D, 2D and the prologue's offsets would be wrong.
+    if attn.num_query_groups_per_partition != heads:
+        return "GQA puts the q/k/v slices off the prologue's stride-3D geometry"
+
+    return ""
+
+
+def _init_fused_qkv_mxfp6(attn, reason: str) -> None:
+    """Set ``attn._fused_qkv_mxfp6`` from a reason string, honouring the env mode."""
+    attn._fused_qkv_mxfp6 = reason == ""
+    if reason and _MXFP6_FUSED_QKV == "on":
+        raise RuntimeError(f"MXFP6_FUSED_QKV=on but the fused QKV path is unusable: {reason}")
+    if reason and _MXFP6_FUSED_QKV == "auto":
+        warnings.warn(
+            f"MXFP6 fused QKV disabled, falling back to the stock path: {reason}", stacklevel=3
+        )
+
+
+def _fused_qkv_rope_ok(attn, hidden_states, q_norm, k_norm, rotary_pos_emb, packed_seq_params) -> bool:
+    """Whether *this step's* tensors suit the prologue. Runtime half of the check above.
+
+    The build-time reason covers the module; this covers the tensors, which can differ per
+    call. Two of these are load-bearing rather than defensive:
+
+    * cos/sin must carry a row per (position, batch). The prologue indexes them by packer row
+      and does not divide, so a batch-shared table -- legal upstream, and handled by the
+      Triton kernel by dividing the row index -- would be read at the wrong row.
+    * the norm weights must share the activations' dtype. **This cannot be checked at build
+      time**, which is the whole reason it lives here: ``torch.nn.RMSNorm`` is constructed
+      without a dtype and so starts out fp32, and Megatron's ``Float16Module`` casts it to
+      bf16 only afterwards by calling ``.bfloat16()`` on the whole module. A check in
+      ``__init__`` would see fp32 every time and decline the fusion in exactly the
+      configuration it is meant for.
+    """
+    if rotary_pos_emb is None or packed_seq_params is not None:
+        return False
+    if q_norm.weight.dtype != hidden_states.dtype or k_norm.weight.dtype != hidden_states.dtype:
+        return False
+    q_pos_emb, k_pos_emb = rotary_pos_emb
+    return (
+        q_pos_emb is not None
+        # The op carries one frequency table for both tensors.
+        and k_pos_emb is q_pos_emb
+        and q_pos_emb.shape[-1] == attn.hidden_size_per_attention_head
+        and hidden_states.dim() == 3
+        and q_pos_emb.shape[1] == hidden_states.shape[1]
+    )
+
+
+def _fused_qkv_project_norm_rope(attn, linear, hidden_states, q_norm, k_norm, q_pos_emb):
+    """Projection, QK norm and RoPE in one autograd Function. Returns (query, key, value).
+
+    Callers must have cleared both ``_fused_qkv_unusable_reason`` (at build time) and
+    ``_fused_qkv_rope_ok`` (for this step's tables) first. The forward this runs is the same
+    projection and the same Triton norm+RoPE as the unfused path, so its outputs are
+    bit-identical; only the backward differs, and only in that d(mixed_qkv) is computed
+    inside the packer rather than written out and read back.
+    """
+    cos, sin = _rope_cos_sin(q_pos_emb, hidden_states.dtype)
+    fuse_wgrad_accum = linear._fuse_wgrad_accum
+    if fuse_wgrad_accum:
+        _claim_main_grad(linear.weight)
+    return MXFP6QKVNormRopeFunction.apply(
+        hidden_states,
+        linear.weight,
+        linear.bias,
+        q_norm.weight,
+        k_norm.weight,
+        cos,
+        sin,
+        q_norm.eps,
+        True,  # interleaved; _fused_qkv_unusable_reason rejects anything else
+        fuse_wgrad_accum,
+        torch.is_grad_enabled(),
+    )[:3]
 
 
 @dataclass
@@ -399,6 +563,18 @@ class JointSelfAttention(Attention):
             self, "q_layernorm", "k_layernorm", "added_q_layernorm", "added_k_layernorm"
         )
 
+        # The MXFP6 fusion goes one step further and owns the projection too. Both streams
+        # have to qualify together, for the same reason the norms do: forward runs them as
+        # one dataflow into a single concatenation.
+        reasons = [
+            _fused_qkv_unusable_reason(self, self.linear_qkv, self.q_layernorm, self.k_layernorm),
+            _fused_qkv_unusable_reason(
+                self, getattr(self, "added_linear_qkv", None),
+                self.added_q_layernorm, self.added_k_layernorm,
+            ),
+        ]
+        _init_fused_qkv_mxfp6(self, next((r for r in reasons if r), ""))
+
     def _split_qkv(self, mixed_qkv: Tensor, split: bool = True):
         """
         Split mixed QKV tensor into separate Q, K, V tensors.
@@ -564,12 +740,52 @@ class JointSelfAttention(Attention):
         if rotary_pos_emb is not None and not isinstance(rotary_pos_emb, tuple):
             rotary_pos_emb = (rotary_pos_emb,) * 2
 
-        # Get Q, K, V for both streams
-        main_qkv = self.get_query_key_value_tensors(hidden_states)
-        added_qkv = self.get_added_query_key_value_tensors(additional_hidden_states)
-
         fused_rope_applied = False
-        if self._fused_qk_rope:
+        n_added = additional_hidden_states.shape[0]
+        # Splitting the table per stream is only valid if it is laid out over the joint
+        # sequence and nothing downstream is going to re-index it. Hoisted above both fused
+        # branches because the MXFP6 one needs it before it projects anything.
+        per_stream_rope = (
+            inference_params is None
+            and packed_seq_params is None
+            and rotary_pos_emb is not None
+            and rotary_pos_emb[0].shape[0] == n_added + hidden_states.shape[0]
+        )
+        added_rope = _slice_rope(rotary_pos_emb, 0, n_added) if per_stream_rope else None
+        main_rope = _slice_rope(rotary_pos_emb, n_added, None) if per_stream_rope else None
+
+        # Both streams or neither: a half-fused step would leave fused_rope_applied true for
+        # one of them and the block below owing the other its rotation.
+        use_mxfp6 = (
+            self._fused_qkv_mxfp6
+            and _fused_qkv_rope_ok(
+                self, additional_hidden_states, self.added_q_layernorm, self.added_k_layernorm,
+                added_rope, packed_seq_params,
+            )
+            and _fused_qkv_rope_ok(
+                self, hidden_states, self.q_layernorm, self.k_layernorm,
+                main_rope, packed_seq_params,
+            )
+        )
+
+        if use_mxfp6:
+            # Nothing above has projected yet, so the Function owns the whole chain from
+            # hidden states to rotated Q/K and V, per stream and before the concatenation.
+            added_query, added_key, added_value = _fused_qkv_project_norm_rope(
+                self, self.added_linear_qkv, additional_hidden_states,
+                self.added_q_layernorm, self.added_k_layernorm, added_rope[0],
+            )
+            query, key, value = _fused_qkv_project_norm_rope(
+                self, self.linear_qkv, hidden_states,
+                self.q_layernorm, self.k_layernorm, main_rope[0],
+            )
+            fused_rope_applied = True
+            main_qkv = added_qkv = None
+        else:
+            main_qkv = self.get_query_key_value_tensors(hidden_states)
+            added_qkv = self.get_added_query_key_value_tensors(additional_hidden_states)
+
+        if not use_mxfp6 and self._fused_qk_rope:
             # The getters stopped at the projection, so this branch owns the split, the
             # norm and RoPE. It runs per stream and before the concatenation because
             # RoPE is positionwise: the added stream takes the leading positions of the
@@ -577,22 +793,13 @@ class JointSelfAttention(Attention):
             # against its own slice of the table and the results concatenated as before.
             main_qkv, main_split = main_qkv
             added_qkv, added_split = added_qkv
-            n_added = added_qkv.shape[0]
-            # Splitting the table this way is only valid if it is laid out over the
-            # joint sequence and nothing downstream is going to re-index it.
-            per_stream_rope = (
-                inference_params is None
-                and packed_seq_params is None
-                and rotary_pos_emb is not None
-                and rotary_pos_emb[0].shape[0] == n_added + main_qkv.shape[0]
-            )
             added_query, added_key, added_value = _apply_qkv_norm_rope(
                 self,
                 added_qkv,
                 added_split,
                 self.added_q_layernorm,
                 self.added_k_layernorm,
-                _slice_rope(rotary_pos_emb, 0, n_added) if per_stream_rope else None,
+                added_rope,
                 packed_seq_params,
             )
             query, key, value = _apply_qkv_norm_rope(
@@ -601,13 +808,13 @@ class JointSelfAttention(Attention):
                 main_split,
                 self.q_layernorm,
                 self.k_layernorm,
-                _slice_rope(rotary_pos_emb, n_added, None) if per_stream_rope else None,
+                main_rope,
                 packed_seq_params,
             )
             # When the table could not be split, the two helpers applied the norm only
             # and the block below still owes both streams their rotation.
             fused_rope_applied = per_stream_rope
-        else:
+        elif not use_mxfp6:
             query, key, value = main_qkv
             added_query, added_key, added_value = added_qkv
 
@@ -764,6 +971,10 @@ class FluxSingleAttention(SelfAttention):
         # agree about who applies the norm, and a condition that could change between
         # them would drop it on the floor.
         self._fused_qk_rope = _can_fuse_qk_norm_rope(self)
+        _init_fused_qkv_mxfp6(
+            self,
+            _fused_qkv_unusable_reason(self, self.linear_qkv, self.q_layernorm, self.k_layernorm),
+        )
 
     def get_query_key_value_tensors(self, *args, **kwargs):
         """
@@ -820,17 +1031,33 @@ class FluxSingleAttention(SelfAttention):
         if rotary_pos_emb is not None and not isinstance(rotary_pos_emb, tuple):
             rotary_pos_emb = (rotary_pos_emb,) * 2
 
-        # Get Q, K, V
-        qkv = self.get_query_key_value_tensors(hidden_states, key_value_states)
-
         fused_rope_applied = False
-        if self._fused_qk_rope:
+        # KV caching and packed sequences both re-index Q and K after this point, so they
+        # keep the original ordering and cannot have the rotation folded in ahead of it.
+        rope_here = inference_params is None and packed_seq_params is None
+        use_mxfp6 = self._fused_qkv_mxfp6 and _fused_qkv_rope_ok(
+            self, hidden_states, self.q_layernorm, self.k_layernorm,
+            rotary_pos_emb if rope_here else None, packed_seq_params,
+        )
+
+        if use_mxfp6:
+            # Nothing above has projected yet: the Function owns projection, norm and
+            # rotation together.
+            query, key, value = _fused_qkv_project_norm_rope(
+                self, self.linear_qkv, hidden_states,
+                self.q_layernorm, self.k_layernorm, rotary_pos_emb[0],
+            )
+            fused_rope_applied = True
+        else:
+            qkv = self.get_query_key_value_tensors(hidden_states, key_value_states)
+
+        if not use_mxfp6 and self._fused_qk_rope:
             # The getter stopped at the projection, so this owns the split, the norm and
             # the rotation, and applies the norm on its fallback paths too. KV caching
             # and packed sequences both re-index Q and K after this point, so they keep
             # the original ordering and get only the norm here.
             mixed_qkv, split_arg_list = qkv
-            fused_rope_applied = inference_params is None and packed_seq_params is None
+            fused_rope_applied = rope_here
             query, key, value = _apply_qkv_norm_rope(
                 self,
                 mixed_qkv,
@@ -840,7 +1067,7 @@ class FluxSingleAttention(SelfAttention):
                 rotary_pos_emb if fused_rope_applied else None,
                 packed_seq_params,
             )
-        else:
+        elif not use_mxfp6:
             query, key, value = qkv
 
         # Adjust for inference

--- a/primus/backends/megatron/core/models/diffusion/flux/attention.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/attention.py
@@ -18,6 +18,7 @@ Reference:
     - Megatron-Core: megatron.core.transformer.attention
 """
 
+import os
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
@@ -35,10 +36,173 @@ from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from torch import Tensor
 
+# Timing-probe switch for the RoPE family. See the guard at its use site: this changes
+# numerics and is only ever valid for measuring how much wall clock the RoPE kernels
+# are actually worth.
+_MXFP6_ABLATE_ROPE = os.environ.get("MXFP6_ABLATE_ROPE", "0") == "1"
+
+# Fuse the QK RMS norm into the RoPE kernel, one kernel per direction instead of one
+# forward and three backward. Unlike the ablation above this is numerically real: it is
+# no less accurate than the path it replaces and better on dx. Off by default until the
+# end-to-end number is confirmed. See scratch/mxfp6/rope/RESULTS_interleaved.md.
+_MXFP6_FUSED_QK_ROPE = os.environ.get("MXFP6_FUSED_QK_ROPE", "0") == "1"
+
 try:
     from megatron.core.transformer.custom_layers.transformer_engine import SplitAlongDim
 except ImportError:
     SplitAlongDim = None
+
+try:
+    from primus.backends.megatron.core.models.diffusion.common.fused_norm_rope import (
+        fused_qk_norm_rope,
+        fused_qkv_norm_rope,
+    )
+except ImportError:  # no triton, or an unsupported one
+    fused_qk_norm_rope = None
+    fused_qkv_norm_rope = None
+
+
+def _rope_cos_sin(freqs: Tensor, dtype: torch.dtype) -> Tuple[Tensor, Tensor]:
+    """cos/sin as the fused kernel wants them: 2D [rows, D], contiguous, in t's dtype.
+
+    Flux positions are per image, so ``freqs`` is [S, B, 1, D] and this flattens to
+    [S*B, D] -- one row per position and batch element. A model with batch-shared
+    positions gives [S, 1, 1, D] and flattens to [S, D]. The kernel takes either;
+    see ``_cs_div``.
+
+    Megatron's ``_apply_rotary_pos_emb_bshd`` derives them the same way and casts to
+    the tensor's dtype before multiplying, so this keeps the arithmetic identical
+    rather than quietly running the rotation at higher precision.
+    """
+    return (
+        torch.cos(freqs).to(dtype).reshape(-1, freqs.shape[-1]).contiguous(),
+        torch.sin(freqs).to(dtype).reshape(-1, freqs.shape[-1]).contiguous(),
+    )
+
+
+def _can_fuse_qk_norm_rope(attn, *names: str) -> bool:
+    """Whether this module's QK norms are ones the fused kernel actually implements.
+
+    Checked once at build time, not per step. ``WrappedTorchNorm`` dispatches on
+    ``config.normalization`` rather than on the ``rms_norm=True`` the spec asks for, so
+    a config change could hand us a LayerNorm here; the kernel does RMS only, with no
+    mean subtraction and no bias. Joint blocks pass all four norms, since they carry a
+    separate pair per stream and the fusion has to own every one of them or none.
+    """
+    if not _MXFP6_FUSED_QK_ROPE or fused_qk_norm_rope is None:
+        return False
+    for name in names or ("q_layernorm", "k_layernorm"):
+        norm = getattr(attn, name, None)
+        if not isinstance(norm, torch.nn.RMSNorm) or norm.weight is None:
+            return False
+    return True
+
+
+def _slice_rope(rotary_pos_emb, lo: int, hi):
+    """Take positions [lo, hi) of a (q_pos_emb, k_pos_emb) pair.
+
+    RoPE is positionwise and the joint blocks concatenate along the sequence, so
+    ``rope(cat(added, main))`` equals ``cat(rope(added, pos[:n]), rope(main, pos[n:]))``.
+    Fusing per stream before the cat is what lets the joint blocks use the same kernel
+    as the single ones, at seq 256 twice instead of 512 once.
+    """
+    if rotary_pos_emb is None:
+        return None
+    q, k = rotary_pos_emb
+    return (q[lo:hi], k[lo:hi])
+
+
+def _apply_qk_norm_rope(attn, query, key, q_norm, k_norm, out_dtype, rotary_pos_emb, packed_seq_params):
+    """QK norm followed by RoPE, in one kernel per tensor when the shapes allow it.
+
+    Callers that enable the fusion get Q and K back from the projection *before* the
+    norm, so every path out of this function has to apply it. The fallbacks below are
+    therefore not optional: dropping through without norming would silently train an
+    unnormalized model.
+    """
+    q_pos_emb, k_pos_emb = rotary_pos_emb if rotary_pos_emb is not None else (None, None)
+    cu_q = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
+    cu_kv = packed_seq_params.cu_seqlens_kv if packed_seq_params is not None else None
+
+    # The kernel rotates the whole head_dim and has no t_pass tail, no packed-sequence
+    # indexing, and no ablation mode. Anything else takes the unfused path.
+    fusable = (
+        not _MXFP6_ABLATE_ROPE
+        and q_pos_emb is not None
+        and cu_q is None
+        and cu_kv is None
+        and query.dim() == 4
+        and key.dim() == 4
+        and q_pos_emb.shape[-1] == query.shape[-1]
+        and k_pos_emb.shape[-1] == key.shape[-1]
+    )
+
+    if fusable:
+        interleaved = attn.config.rotary_interleaved
+        q_cos, q_sin = _rope_cos_sin(q_pos_emb, out_dtype)
+        # Self-attention hands the same freqs to both, which is worth checking for:
+        # it halves the transcendental work and the two small tensors it produces.
+        k_cos, k_sin = (q_cos, q_sin) if k_pos_emb is q_pos_emb else _rope_cos_sin(k_pos_emb, out_dtype)
+        query = fused_qk_norm_rope(query, q_norm.weight, q_cos, q_sin, q_norm.eps, interleaved)
+        key = fused_qk_norm_rope(key, k_norm.weight, k_cos, k_sin, k_norm.eps, interleaved)
+        return query, key
+
+    query = q_norm(query).to(out_dtype)
+    key = k_norm(key).to(out_dtype)
+    if q_pos_emb is not None and not _MXFP6_ABLATE_ROPE:
+        query = apply_rotary_pos_emb(query, q_pos_emb, config=attn.config, cu_seqlens=cu_q)
+        key = apply_rotary_pos_emb(key, k_pos_emb, config=attn.config, cu_seqlens=cu_kv)
+    return query, key
+
+
+def _apply_qkv_norm_rope(attn, mixed_qkv, split_arg_list, q_norm, k_norm, rotary_pos_emb, packed_seq_params):
+    """Split the projection output into Q, K, V with QK norm and RoPE already applied.
+
+    The same fusion as ``_apply_qk_norm_rope``, one level up. Handing the op the whole
+    projection output rather than two slices of it puts the split inside the op, so its
+    backward writes d(mixed_qkv) directly at stride 3D. Splitting outside instead leaves
+    autograd a concatenation to rebuild that tensor, pure data movement that the unfused
+    path never paid, because Inductor folded it into its norm-backward.
+    """
+    D = attn.hidden_size_per_attention_head
+    q_pos_emb, k_pos_emb = rotary_pos_emb if rotary_pos_emb is not None else (None, None)
+    cu_q = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
+    cu_kv = packed_seq_params.cu_seqlens_kv if packed_seq_params is not None else None
+
+    fusable = (
+        fused_qkv_norm_rope is not None
+        and not _MXFP6_ABLATE_ROPE
+        and q_pos_emb is not None
+        and cu_q is None
+        and cu_kv is None
+        and mixed_qkv.dim() == 4
+        # MHA only. Under GQA the Q columns are wider than one head_dim, so the three
+        # slices are not at 0, D, 2D and the kernel's column offsets would be wrong.
+        and mixed_qkv.shape[-1] == 3 * D
+        # The op carries one frequency table and one epsilon for both tensors.
+        and k_pos_emb is q_pos_emb
+        and q_pos_emb.shape[-1] == D
+        and q_norm.eps == k_norm.eps
+    )
+
+    if fusable:
+        cos, sin = _rope_cos_sin(q_pos_emb, mixed_qkv.dtype)
+        return fused_qkv_norm_rope(
+            mixed_qkv,
+            q_norm.weight,
+            k_norm.weight,
+            cos,
+            sin,
+            q_norm.eps,
+            attn.config.rotary_interleaved,
+        )
+
+    query, key, value = torch.split(mixed_qkv, split_arg_list, dim=3)
+    query = query.reshape(query.size(0), query.size(1), -1, D)
+    query, key = _apply_qk_norm_rope(
+        attn, query, key, q_norm, k_norm, value.dtype, rotary_pos_emb, packed_seq_params
+    )
+    return query, key, value
 
 
 @dataclass
@@ -229,15 +393,26 @@ class JointSelfAttention(Attention):
         else:
             self.added_k_layernorm = None
 
-    def _split_qkv(self, mixed_qkv: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+        # Both streams have to qualify together: the two getters and the concatenation
+        # in forward are one dataflow, and a half-fused version would have to normalize
+        # one stream here and the other after the cat.
+        self._fused_qk_rope = _can_fuse_qk_norm_rope(
+            self, "q_layernorm", "k_layernorm", "added_q_layernorm", "added_k_layernorm"
+        )
+
+    def _split_qkv(self, mixed_qkv: Tensor, split: bool = True):
         """
         Split mixed QKV tensor into separate Q, K, V tensors.
 
         Args:
             mixed_qkv: Combined QKV tensor [seq, batch, hidden]
+            split: When False, stop after the reshape and return the combined tensor
+                with the split sizes. The fused QK norm+RoPE op does the split itself,
+                so that the backward can write d(mixed_qkv) in place rather than leave
+                a concatenation for the split to undo.
 
         Returns:
-            Tuple of (query, key, value) tensors
+            Tuple of (query, key, value) tensors, or (mixed_qkv, split_arg_list)
         """
         # Reshape: [sq, b, hp] --> [sq, b, ng, (np/ng + 2) * hn]
         new_tensor_shape = mixed_qkv.size()[:-1] + (
@@ -259,6 +434,9 @@ class JointSelfAttention(Attention):
             self.hidden_size_per_attention_head,
             self.hidden_size_per_attention_head,
         ]
+
+        if not split:
+            return mixed_qkv, split_arg_list
 
         # Split tensor
         if SplitAlongDim is not None:
@@ -289,6 +467,11 @@ class JointSelfAttention(Attention):
         # Project to QKV: [sq, b, h] --> [sq, b, ng * (np/ng + 2) * hn)]
         mixed_qkv, _ = self.linear_qkv(hidden_states)
 
+        # Under the fusion the split belongs to the op, so hand the combined tensor to
+        # forward untouched. See _apply_qkv_norm_rope.
+        if self._fused_qk_rope:
+            return self._split_qkv(mixed_qkv, split=False)
+
         # Split into Q, K, V
         query, key, value = self._split_qkv(mixed_qkv)
 
@@ -305,11 +488,15 @@ class JointSelfAttention(Attention):
         # where it fuses into the norm's epilogue instead of costing an extra pass over
         # Q and K. This matches the reference implementation, whose QKNorm.forward in
         # backends/diffusion/models/flux/layers.py likewise returns `q.to(v), k.to(v)`.
-        if self.q_layernorm is not None:
-            query = self.q_layernorm(query).to(value.dtype)
+        # When the fusion owns the norms, forward applies them together with RoPE, per
+        # stream and before the concatenation. Returning Q and K un-normed here is what
+        # gives the kernel the un-normed input it needs.
+        if not self._fused_qk_rope:
+            if self.q_layernorm is not None:
+                query = self.q_layernorm(query).to(value.dtype)
 
-        if self.k_layernorm is not None:
-            key = self.k_layernorm(key).to(value.dtype)
+            if self.k_layernorm is not None:
+                key = self.k_layernorm(key).to(value.dtype)
 
         return query, key, value
 
@@ -329,15 +516,21 @@ class JointSelfAttention(Attention):
         # Project to QKV
         mixed_qkv, _ = self.added_linear_qkv(added_hidden_states)
 
+        # Deferred to forward under the fusion, as in the main-stream getter above.
+        if self._fused_qk_rope:
+            return self._split_qkv(mixed_qkv, split=False)
+
         # Split into Q, K, V
         query, key, value = self._split_qkv(mixed_qkv)
 
-        # Apply optional Q/K normalization
-        if self.added_q_layernorm is not None:
-            query = self.added_q_layernorm(query).to(value.dtype)
+        # Apply optional Q/K normalization; deferred to forward under the fusion, as in
+        # the main-stream getter above.
+        if not self._fused_qk_rope:
+            if self.added_q_layernorm is not None:
+                query = self.added_q_layernorm(query).to(value.dtype)
 
-        if self.added_k_layernorm is not None:
-            key = self.added_k_layernorm(key).to(value.dtype)
+            if self.added_k_layernorm is not None:
+                key = self.added_k_layernorm(key).to(value.dtype)
 
         return query, key, value
 
@@ -373,8 +566,51 @@ class JointSelfAttention(Attention):
             rotary_pos_emb = (rotary_pos_emb,) * 2
 
         # Get Q, K, V for both streams
-        query, key, value = self.get_query_key_value_tensors(hidden_states)
-        added_query, added_key, added_value = self.get_added_query_key_value_tensors(additional_hidden_states)
+        main_qkv = self.get_query_key_value_tensors(hidden_states)
+        added_qkv = self.get_added_query_key_value_tensors(additional_hidden_states)
+
+        fused_rope_applied = False
+        if self._fused_qk_rope:
+            # The getters stopped at the projection, so this branch owns the split, the
+            # norm and RoPE. It runs per stream and before the concatenation because
+            # RoPE is positionwise: the added stream takes the leading positions of the
+            # joint sequence and the main stream the rest, so each can be rotated
+            # against its own slice of the table and the results concatenated as before.
+            main_qkv, main_split = main_qkv
+            added_qkv, added_split = added_qkv
+            n_added = added_qkv.shape[0]
+            # Splitting the table this way is only valid if it is laid out over the
+            # joint sequence and nothing downstream is going to re-index it.
+            per_stream_rope = (
+                inference_params is None
+                and packed_seq_params is None
+                and rotary_pos_emb is not None
+                and rotary_pos_emb[0].shape[0] == n_added + main_qkv.shape[0]
+            )
+            added_query, added_key, added_value = _apply_qkv_norm_rope(
+                self,
+                added_qkv,
+                added_split,
+                self.added_q_layernorm,
+                self.added_k_layernorm,
+                _slice_rope(rotary_pos_emb, 0, n_added) if per_stream_rope else None,
+                packed_seq_params,
+            )
+            query, key, value = _apply_qkv_norm_rope(
+                self,
+                main_qkv,
+                main_split,
+                self.q_layernorm,
+                self.k_layernorm,
+                _slice_rope(rotary_pos_emb, n_added, None) if per_stream_rope else None,
+                packed_seq_params,
+            )
+            # When the table could not be split, the two helpers applied the norm only
+            # and the block below still owes both streams their rotation.
+            fused_rope_applied = per_stream_rope
+        else:
+            query, key, value = main_qkv
+            added_query, added_key, added_value = added_qkv
 
         # Concatenate streams: [added; main]
         query = torch.cat([added_query, query], dim=0)
@@ -393,14 +629,18 @@ class JointSelfAttention(Attention):
             value = value.squeeze(1)
 
         # Apply RoPE position embeddings
-        if rotary_pos_emb is not None:
+        if rotary_pos_emb is not None and not fused_rope_applied:
             q_pos_emb, k_pos_emb = rotary_pos_emb
 
             cu_seqlens_q = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
             cu_seqlens_kv = packed_seq_params.cu_seqlens_kv if packed_seq_params is not None else None
 
-            query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
-            key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
+            # MXFP6_ABLATE_ROPE is a timing probe, not an option. It produces wrong numerics
+            # and exists only to measure the ceiling on removing the RoPE family before
+            # anyone pays to rewrite it. Never set it in a run whose loss is being read.
+            if not _MXFP6_ABLATE_ROPE:
+                query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
+                key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
 
         # Core attention computation
         if self.checkpoint_core_attention and self.training:
@@ -525,6 +765,11 @@ class FluxSingleAttention(SelfAttention):
             tp_comm_buffer_name="proj",
         )
 
+        # Decided once, here, rather than per step: the getter and the forward have to
+        # agree about who applies the norm, and a condition that could change between
+        # them would drop it on the floor.
+        self._fused_qk_rope = _can_fuse_qk_norm_rope(self)
+
     def get_query_key_value_tensors(self, *args, **kwargs):
         """
         Derive Q, K, V, realigning Q/K onto V's dtype.
@@ -536,6 +781,14 @@ class FluxSingleAttention(SelfAttention):
         themselves and cast inline; the single blocks reuse Megatron's projection,
         so the cast goes here, still inside the compiled region.
         """
+        if self._fused_qk_rope:
+            # The fused op owns the split and the norm, so it needs the projection
+            # output from before either. split_qkv=False is the base getter's own exit
+            # above both; forward finishes the job. No dtype realignment is needed on
+            # that path -- the op writes in Q's own dtype, so the fp32-accumulation
+            # problem the cast below exists to fix cannot arise.
+            return super().get_query_key_value_tensors(*args, split_qkv=False, **kwargs)
+
         out = super().get_query_key_value_tensors(*args, **kwargs)
         if len(out) < 3:
             # split_qkv=False: (mixed_qkv, split_arg_list), no norm applied yet.
@@ -573,7 +826,27 @@ class FluxSingleAttention(SelfAttention):
             rotary_pos_emb = (rotary_pos_emb,) * 2
 
         # Get Q, K, V
-        query, key, value = self.get_query_key_value_tensors(hidden_states, key_value_states)
+        qkv = self.get_query_key_value_tensors(hidden_states, key_value_states)
+
+        fused_rope_applied = False
+        if self._fused_qk_rope:
+            # The getter stopped at the projection, so this owns the split, the norm and
+            # the rotation, and applies the norm on its fallback paths too. KV caching
+            # and packed sequences both re-index Q and K after this point, so they keep
+            # the original ordering and get only the norm here.
+            mixed_qkv, split_arg_list = qkv
+            fused_rope_applied = inference_params is None and packed_seq_params is None
+            query, key, value = _apply_qkv_norm_rope(
+                self,
+                mixed_qkv,
+                split_arg_list,
+                self.q_layernorm,
+                self.k_layernorm,
+                rotary_pos_emb if fused_rope_applied else None,
+                packed_seq_params,
+            )
+        else:
+            query, key, value = qkv
 
         # Adjust for inference
         query, key, value, rotary_pos_emb, attn_mask_type, *_ = self._adjust_key_value_for_inference(
@@ -587,14 +860,18 @@ class FluxSingleAttention(SelfAttention):
             value = value.squeeze(1)
 
         # Apply RoPE position embeddings
-        if rotary_pos_emb is not None:
+        if rotary_pos_emb is not None and not fused_rope_applied:
             q_pos_emb, k_pos_emb = rotary_pos_emb
 
             cu_seqlens_q = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
             cu_seqlens_kv = packed_seq_params.cu_seqlens_kv if packed_seq_params is not None else None
 
-            query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
-            key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
+            # MXFP6_ABLATE_ROPE is a timing probe, not an option. It produces wrong numerics
+            # and exists only to measure the ceiling on removing the RoPE family before
+            # anyone pays to rewrite it. Never set it in a run whose loss is being read.
+            if not _MXFP6_ABLATE_ROPE:
+                query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
+                key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
 
         # Core attention computation
         if self.checkpoint_core_attention and self.training:

--- a/primus/backends/megatron/core/models/diffusion/flux/attention.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/attention.py
@@ -104,7 +104,13 @@ def _slice_rope(rotary_pos_emb, lo: int, hi):
     if rotary_pos_emb is None:
         return None
     q, k = rotary_pos_emb
-    return (q[lo:hi], k[lo:hi])
+    q_slice = q[lo:hi]
+    # Slicing the same tensor twice yields two objects, and the whole-QKV fusion tests
+    # ``k_pos_emb is q_pos_emb`` to decide whether one frequency table serves both -- so
+    # slicing naively here is what decided it, and it decided wrong. Self-attention passes
+    # the same freqs for q and k, so preserving that identity is what lets the joint blocks
+    # reach the same fused path the single blocks already take.
+    return (q_slice, q_slice if k is q else k[lo:hi])
 
 
 def _apply_qk_norm_rope(attn, query, key, q_norm, k_norm, out_dtype, rotary_pos_emb, packed_seq_params):

--- a/primus/backends/megatron/core/models/diffusion/flux/attention.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/attention.py
@@ -36,11 +36,6 @@ from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.transformer_config import TransformerConfig
 from torch import Tensor
 
-# Timing-probe switch for the RoPE family. See the guard at its use site: this changes
-# numerics and is only ever valid for measuring how much wall clock the RoPE kernels
-# are actually worth.
-_MXFP6_ABLATE_ROPE = os.environ.get("MXFP6_ABLATE_ROPE", "0") == "1"
-
 # Fuse the QK RMS norm into the RoPE kernel, one kernel per direction instead of one
 # forward and three backward. Unlike the ablation above this is numerically real: it is
 # no less accurate than the path it replaces and better on dx. Off by default until the
@@ -124,11 +119,10 @@ def _apply_qk_norm_rope(attn, query, key, q_norm, k_norm, out_dtype, rotary_pos_
     cu_q = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
     cu_kv = packed_seq_params.cu_seqlens_kv if packed_seq_params is not None else None
 
-    # The kernel rotates the whole head_dim and has no t_pass tail, no packed-sequence
-    # indexing, and no ablation mode. Anything else takes the unfused path.
+    # The kernel rotates the whole head_dim and has no t_pass tail and no packed-sequence
+    # indexing. Anything else takes the unfused path.
     fusable = (
-        not _MXFP6_ABLATE_ROPE
-        and q_pos_emb is not None
+        q_pos_emb is not None
         and cu_q is None
         and cu_kv is None
         and query.dim() == 4
@@ -149,7 +143,7 @@ def _apply_qk_norm_rope(attn, query, key, q_norm, k_norm, out_dtype, rotary_pos_
 
     query = q_norm(query).to(out_dtype)
     key = k_norm(key).to(out_dtype)
-    if q_pos_emb is not None and not _MXFP6_ABLATE_ROPE:
+    if q_pos_emb is not None:
         query = apply_rotary_pos_emb(query, q_pos_emb, config=attn.config, cu_seqlens=cu_q)
         key = apply_rotary_pos_emb(key, k_pos_emb, config=attn.config, cu_seqlens=cu_kv)
     return query, key
@@ -171,7 +165,6 @@ def _apply_qkv_norm_rope(attn, mixed_qkv, split_arg_list, q_norm, k_norm, rotary
 
     fusable = (
         fused_qkv_norm_rope is not None
-        and not _MXFP6_ABLATE_ROPE
         and q_pos_emb is not None
         and cu_q is None
         and cu_kv is None
@@ -635,12 +628,8 @@ class JointSelfAttention(Attention):
             cu_seqlens_q = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
             cu_seqlens_kv = packed_seq_params.cu_seqlens_kv if packed_seq_params is not None else None
 
-            # MXFP6_ABLATE_ROPE is a timing probe, not an option. It produces wrong numerics
-            # and exists only to measure the ceiling on removing the RoPE family before
-            # anyone pays to rewrite it. Never set it in a run whose loss is being read.
-            if not _MXFP6_ABLATE_ROPE:
-                query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
-                key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
+            query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
+            key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
 
         # Core attention computation
         if self.checkpoint_core_attention and self.training:
@@ -866,12 +855,8 @@ class FluxSingleAttention(SelfAttention):
             cu_seqlens_q = packed_seq_params.cu_seqlens_q if packed_seq_params is not None else None
             cu_seqlens_kv = packed_seq_params.cu_seqlens_kv if packed_seq_params is not None else None
 
-            # MXFP6_ABLATE_ROPE is a timing probe, not an option. It produces wrong numerics
-            # and exists only to measure the ceiling on removing the RoPE family before
-            # anyone pays to rewrite it. Never set it in a run whose loss is being read.
-            if not _MXFP6_ABLATE_ROPE:
-                query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
-                key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
+            query = apply_rotary_pos_emb(query, q_pos_emb, config=self.config, cu_seqlens=cu_seqlens_q)
+            key = apply_rotary_pos_emb(key, k_pos_emb, config=self.config, cu_seqlens=cu_seqlens_kv)
 
         # Core attention computation
         if self.checkpoint_core_attention and self.training:

--- a/primus/backends/megatron/data/energon_dataset_provider.py
+++ b/primus/backends/megatron/data/energon_dataset_provider.py
@@ -33,10 +33,10 @@ from megatron.energon import (
 from primus.backends.megatron.data.dataloader import MegatronDataloaderWrapper
 from primus.backends.megatron.data.dataset_provider import DatasetProvider
 from primus.backends.megatron.training.eval_budget import (
-    get_eval_micro_batch_size,
     EvalCoverageError,
     assert_mlperf_timestep_source,
     assert_val_worker_divisibility,
+    get_eval_micro_batch_size,
     get_eval_num_microbatches,
     get_val_num_workers,
 )
@@ -158,10 +158,19 @@ class EnergonDatasetProvider(DatasetProvider):
             # Assert before construction: a shape that cannot read every sample
             # should fail here rather than silently report a short evaluation.
             eval_num_microbatches = get_eval_num_microbatches(args)
+            # The evaluation microbatch size, not the training one. A recipe that
+            # overrides it evaluates at that width -- get_eval_num_microbatches and
+            # assert_val_worker_divisibility both already read it -- so reconstructing
+            # the sample count from args.micro_batch_size understates it by the ratio
+            # between the two. At eval_micro_batch_size 64 against a training 32 this
+            # budget read 14848 while the run went on to cover 29696, and at 128 the
+            # understated 7424 was no longer divisible by the divisor the assert builds
+            # from the eval width, failing a shape that covers the split exactly.
+            eval_micro_batch_size = get_eval_micro_batch_size(args)
             eval_samples = (
                 args.eval_iters
                 * eval_num_microbatches
-                * args.micro_batch_size
+                * eval_micro_batch_size
                 * (parallel_state.get_data_parallel_world_size())
             )
             assert_val_worker_divisibility(args, eval_samples)
@@ -170,7 +179,7 @@ class EnergonDatasetProvider(DatasetProvider):
             assert_mlperf_timestep_source(args)
             log_rank_0(
                 f"Validation budget: {args.eval_iters} iterations x "
-                f"{eval_num_microbatches} microbatches x {args.micro_batch_size} "
+                f"{eval_num_microbatches} microbatches x {eval_micro_batch_size} "
                 f"= {eval_samples} samples, val_num_workers={get_val_num_workers(args)}"
             )
 

--- a/primus/backends/megatron/flux_pretrain_trainer.py
+++ b/primus/backends/megatron/flux_pretrain_trainer.py
@@ -475,7 +475,16 @@ class FluxPretrainTrainer(DiffusionPretrainTrainer):
             "model_channels": getattr(params, "model_channels", 256),
             "guidance_embed": getattr(params, "guidance_embed", False),
             # RoPE configuration
-            "apply_rope_fusion": getattr(params, "apply_rope_fusion", False),
+            # MXFP6_FORCE_ROPE_FUSION exists because the config key alone cannot turn this
+            # on. Megatron's validate_args clears args.apply_rope_fusion whenever
+            # position_embedding_type != "rope" (arguments.py L1232-1233), and Flux never
+            # sets that type, so `params` always arrives here as False no matter what the
+            # YAML said. Forcing it is the only way to measure the fused path.
+            "apply_rope_fusion": (
+                True
+                if os.environ.get("MXFP6_FORCE_ROPE_FUSION", "0") == "1"
+                else getattr(params, "apply_rope_fusion", False)
+            ),
             "rotary_interleaved": getattr(params, "rotary_interleaved", True),
             # Training hyperparameters stored on FluxConfig
             "timestep_sampling_strategy": getattr(params, "timestep_sampling_strategy", "logit_normal"),

--- a/primus/backends/megatron/patches/mlperf_warmup_patches.py
+++ b/primus/backends/megatron/patches/mlperf_warmup_patches.py
@@ -20,6 +20,7 @@ Self-removal restores the inner chain intact.
 """
 
 import logging
+import os
 
 import torch
 import torch.distributed
@@ -36,7 +37,12 @@ def _log(msg):
 
 def _warmup_enabled(ctx: PatchContext) -> bool:
     args = get_args(ctx)
-    return args is not None and getattr(args, "warmup_train_steps", 0) > 0
+    if args is None:
+        return False
+    # Either warmup alone is enough to install the patch. They target different graphs:
+    # the training warmup traces forward+backward under grad, the validation warmup
+    # traces forward-only under no_grad with model.eval(), and neither covers the other.
+    return getattr(args, "warmup_train_steps", 0) > 0 or getattr(args, "warmup_validation_steps", 0) > 0
 
 
 def _reset_fp8_te_spec(models):
@@ -200,8 +206,13 @@ def _reset_optimizer_state(optimizer):
     _log("Reset optimizer step counters")
 
 
-def _build_synthetic_iterator(primus_args):
-    """Build the mock Flux dataloader the warmup steps consume."""
+def _build_synthetic_iterator(primus_args, batch_size=None):
+    """Build the mock Flux dataloader the warmup steps consume.
+
+    ``batch_size`` overrides the training microbatch size, which the validation warmup
+    needs: Dynamo guards on shape, so an eval graph warmed at the training width is not
+    the graph the evaluation runs.
+    """
     from torch.utils.data import DataLoader
 
     from primus.backends.megatron.data.dataloader import MegatronDataloaderWrapper
@@ -211,7 +222,7 @@ def _build_synthetic_iterator(primus_args):
 
     image_size = getattr(primus_args, "image_size", 256)
     vae_latent_mode = getattr(primus_args, "vae_latent_mode", "resample")
-    mbs = getattr(primus_args, "micro_batch_size", 64)
+    mbs = batch_size or getattr(primus_args, "micro_batch_size", 64)
 
     mock_dataset = PreGeneratedMockFluxSchnellDataset(
         num_samples=max(mbs * 4, 256),
@@ -220,6 +231,139 @@ def _build_synthetic_iterator(primus_args):
     )
     mock_loader = DataLoader(mock_dataset, batch_size=mbs, shuffle=False, drop_last=True)
     return MegatronDataloaderWrapper(mock_loader)
+
+
+class _TimestepInjectingIterator:
+    """Add the per-sample ``timestep`` column the validation forward step requires.
+
+    The mock Flux dataset was built for the training warmup, and the training forward
+    step samples its own timesteps. The validation branch does not: with
+    ``eval_timestep_source: dataset`` it reads ``batch['timestep']`` and raises if the
+    column is absent, because a val shard ingested before that column existed would
+    otherwise be scored against injected timesteps and silently disagree with the
+    reference implementation.
+
+    So the warmup supplies the same column the real val shards carry, with the same
+    dtype and the same ``index % 8`` pattern ``equidistant`` would inject. The values
+    do not matter -- Dynamo guards on shape and dtype, not on tensor contents -- but
+    the column's presence does, since without it the warmup never reaches the model
+    and warms nothing.
+    """
+
+    NUM_VALIDATION_TIMESTEPS = 8
+
+    def __init__(self, inner):
+        self._inner = inner
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        batch = next(self._inner)
+        if isinstance(batch, dict) and "timestep" not in batch:
+            ref = next((v for v in batch.values() if isinstance(v, torch.Tensor)), None)
+            if ref is not None:
+                batch["timestep"] = (
+                    torch.arange(ref.shape[0], device=ref.device) % self.NUM_VALIDATION_TIMESTEPS
+                ).to(torch.int32)
+        return batch
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+
+def _run_validation_warmup(models, forward_step_func, forward_backward_func, warmup_steps):
+    """Compile and first-touch the evaluation graph before the clock starts.
+
+    Without this, the first evaluation iteration costs multiple seconds while every
+    iteration after it runs at the steady-state cost, putting a large one-off charge
+    inside the timed region. It is not the dataloader -- the same cost appears with
+    ``val_num_workers: 0``, where there are no workers to spawn -- and it is not a cold
+    Inductor cache, which was warm when it was measured. It is the eval-mode graph:
+    evaluation runs forward-only under ``no_grad`` with ``model.eval()``, which is a
+    different Dynamo guard state from anything the training warmup traced, so all 57
+    per-block graphs are retraced at the first eval.
+
+    This runs last, after every restore in ``_run_warmup_and_restore``, because it is
+    forward-only and therefore cannot perturb the state those restores just rebuilt: no
+    gradients are produced, so the DDP grad-ready calibration reset at 11b stands, and
+    no optimizer state is touched. It calls ``forward_backward_func`` directly rather
+    than ``train_step``, so it also cannot repopulate the prefetch cache 13b just
+    evicted.
+
+    The synthetic batch is built at ``get_eval_micro_batch_size`` and not at the
+    training microbatch size. Dynamo guards on shape, so warming at the wrong width
+    compiles graphs the evaluation will not use and leaves the real first eval paying
+    the full cost anyway -- a warmup that reads as successful and moves nothing.
+    """
+    from megatron.training import get_args as megatron_get_args
+
+    from primus.backends.megatron.training.eval_budget import get_eval_micro_batch_size
+
+    megatron_args = megatron_get_args()
+    eval_mbs = get_eval_micro_batch_size(megatron_args)
+    synthetic_iter = _TimestepInjectingIterator(
+        iter(_build_synthetic_iterator(megatron_args, batch_size=eval_mbs))
+    )
+
+    # Evaluation noise is drawn from the RNG, not carried by the val shards:
+    # `prepare_flux_latents` calls `torch.randn_like(latents)` whenever the batch does
+    # not supply noise, and the MLCommons val Arrow files supply a `timestep` column but
+    # no noise. So the RNG stream position at the start of an evaluation is part of what
+    # determines `val_loss`, and a warmup that draws from it shifts the number.
+    #
+    # Without this save/restore the warmed and unwarmed arms report different
+    # `val_loss`, reproducibly. The difference is numerically tiny and still an
+    # absolute gate failure: `val_loss` is what `run_stop` is gated on, so an eval
+    # change that moves it moves the convergence step for reasons unrelated to speed.
+    cpu_rng = torch.get_rng_state()
+    cuda_rng = torch.cuda.get_rng_state_all()
+    tracker_states = None
+    try:
+        from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
+
+        tracker_states = get_cuda_rng_tracker().get_states()
+    except Exception as exc:  # pragma: no cover - tracker is optional
+        _log(f"Validation warmup: no TP RNG tracker to snapshot ({exc})")
+
+    was_training = [m.training for m in models]
+    for m in models:
+        m.eval()
+    try:
+        with torch.no_grad():
+            for step_idx in range(warmup_steps):
+                _log(f"Validation warmup step {step_idx + 1}/{warmup_steps} (eval mbs {eval_mbs})")
+                forward_backward_func(
+                    forward_step_func=forward_step_func,
+                    data_iterator=synthetic_iter,
+                    model=models if len(models) > 1 else models[0],
+                    num_microbatches=1,
+                    seq_length=megatron_args.seq_length,
+                    micro_batch_size=eval_mbs,
+                    decoder_seq_length=megatron_args.decoder_seq_length,
+                    forward_only=True,
+                )
+    finally:
+        for m, training in zip(models, was_training):
+            m.train(training)
+        torch.set_rng_state(cpu_rng)
+        torch.cuda.set_rng_state_all(cuda_rng)
+        if tracker_states is not None:
+            from megatron.core.tensor_parallel.random import get_cuda_rng_tracker
+
+            get_cuda_rng_tracker().set_states(tracker_states)
+    _log(f"Completed {warmup_steps} validation warmup steps, RNG state restored")
+
+    # Diagnostic, off by default, kept for the record: it tested whether a residual
+    # val_loss shift between warmed and unwarmed arms came from the compiled graph being
+    # specialized against the mock batch rather than the real one. If so, discarding the
+    # compilation would restore the unwarmed loss and give back the slow first iteration,
+    # the two being one artifact. It does not -- the loss is unchanged with the graphs
+    # thrown away -- so that hypothesis is ruled out. The shift is instead governed by
+    # per_step_rng_reseed, which the MLPerf recipe enables.
+    if os.environ.get("MXFP6_VALWARM_RESET_DYNAMO", "0") == "1":
+        torch._dynamo.reset()
+        _log("MXFP6_VALWARM_RESET_DYNAMO=1: discarded all compiled graphs after warmup")
 
 
 def _reset_ddp_grad_ready_calibration(models):
@@ -272,6 +416,7 @@ def _run_warmup_and_restore(
     config,
     forward_backward_func,
     iteration=None,
+    validation_steps=0,
 ):
     """Run synthetic steps, then undo every effect they had on training state.
 
@@ -453,6 +598,10 @@ def _run_warmup_and_restore(
     except Exception as _e:
         _log(f"  Prefetch reset failed (non-fatal): {_e}")
 
+    # ---- 13c. Warm the evaluation graph, which nothing above has touched ----
+    if validation_steps > 0:
+        _run_validation_warmup(models, forward_step_func, forward_backward_func, validation_steps)
+
     # ---- 14. Synchronize ----
     torch.cuda.synchronize()
     if torch.distributed.is_initialized():
@@ -476,16 +625,17 @@ def _install_boundary_warmup(primus_args, warmup_steps):
         optimizer = captured.get("optimizer")
         opt_param_scheduler = captured.get("opt_param_scheduler")
         forward_step_func = captured.get("forward_step_func")
-        missing = [
-            name
-            for name, value in (
-                ("model", model),
-                ("optimizer", optimizer),
-                ("opt_param_scheduler", opt_param_scheduler),
-                ("forward_step_func", forward_step_func),
-            )
-            if value is None
-        ]
+        validation_steps = getattr(primus_args, "warmup_validation_steps", 0)
+
+        # Each warmup needs a different set of captured objects, so the check is per
+        # path rather than a single list. A validation-only warmup is forward-only
+        # under no_grad and never touches the optimizer or the LR scheduler -- and
+        # under `skip_train` those are exactly the two Megatron never builds, so
+        # demanding them unconditionally makes the eval-only arm impossible to warm.
+        required = [("model", model), ("forward_step_func", forward_step_func)]
+        if warmup_steps > 0:
+            required += [("optimizer", optimizer), ("opt_param_scheduler", opt_param_scheduler)]
+        missing = [name for name, value in required if value is None]
         if missing:
             raise RuntimeError(
                 "MLPerf warmup runs before the data iterators are built and needs "
@@ -495,6 +645,16 @@ def _install_boundary_warmup(primus_args, warmup_steps):
             )
 
         models = model if isinstance(model, (list, tuple)) else [model]
+
+        # Validation warmup without training warmup is a supported combination, and it
+        # is the one an evaluation-only arm can use: `skip_train` means `train_step`
+        # never runs, so there is nothing for a training warmup to restore state around.
+        if warmup_steps == 0:
+            _run_validation_warmup(
+                models, forward_step_func, mt.get_forward_backward_func(), validation_steps
+            )
+            return
+
         # Read train_step now, not at install time: every other before_train
         # patch has wrapped it by the time the boundary fires.
         _run_warmup_and_restore(
@@ -508,6 +668,7 @@ def _install_boundary_warmup(primus_args, warmup_steps):
             config=mt.get_model_config(models[0]),
             forward_backward_func=mt.get_forward_backward_func(),
             iteration=0,
+            validation_steps=validation_steps,
         )
 
     mlperf_boundary.register_pre_run_hook("mlperf_warmup", _warmup_hook, order=10)
@@ -564,6 +725,7 @@ def _install_train_step_warmup(mt, primus_args, warmup_steps):
             config=config,
             forward_backward_func=forward_backward_func,
             iteration=iteration,
+            validation_steps=getattr(primus_args, "warmup_validation_steps", 0),
         )
 
         _log("Executing first real train_step with training data")

--- a/primus/backends/megatron/training/diffusion/forward_step.py
+++ b/primus/backends/megatron/training/diffusion/forward_step.py
@@ -18,6 +18,8 @@ Architecture follows functional composition for clarity and testability.
 """
 
 import logging
+import os
+import time
 from typing import Optional, Tuple
 
 import torch
@@ -42,6 +44,28 @@ logger = logging.getLogger(__name__)
 # stays below 2**31 for any plausible seed, world size and step count, so 2**40
 # leaves a wide margin while keeping the eval stream's own per-rank and
 # per-microbatch structure intact.
+_BATCH_FETCH_TIMING = os.environ.get("MXFP6_BATCH_FETCH_TIMING", "0") == "1"
+_batch_fetch_ms: list[float] = []
+
+
+def _record_batch_fetch(ms: float) -> None:
+    _batch_fetch_ms.append(ms)
+
+
+def take_batch_fetch_timings() -> list[float]:
+    """Drain the recorded `next(data_iterator)` durations, in ms.
+
+    The evaluator calls this at the end of each evaluation so the numbers are
+    attributed to one eval rather than accumulating across a run. Training steps
+    append here too when the flag is on; the evaluator's drain therefore mixes in
+    the training fetches that happened since the previous eval, which is why the
+    report labels the count rather than assuming it equals eval_iters.
+    """
+    out = list(_batch_fetch_ms)
+    _batch_fetch_ms.clear()
+    return out
+
+
 EVAL_RNG_OFFSET = 1 << 40
 
 # Microbatch index stride within one evaluation. Must exceed the number of
@@ -370,7 +394,18 @@ def flux_forward_step_func(
             raise RuntimeError(
                 "data_iterator is None with TP=1; dataset provider must set is_distributed=True"
             )
-        batch = next(data_iterator)
+        # The first iteration of *every* evaluation runs several times slower than the
+        # rest even warmed, and repeats on every evaluation of a multi-eval run.
+        # Whether that is the validation loader's first fetch or something else in the
+        # step cannot be read off the eval iteration probe, which brackets the whole
+        # forward_backward call and reports almost nothing outside it. So time the
+        # fetch alone. Off unless MXFP6_BATCH_FETCH_TIMING=1.
+        if _BATCH_FETCH_TIMING:
+            _t0 = time.perf_counter()
+            batch = next(data_iterator)
+            _record_batch_fetch((time.perf_counter() - _t0) * 1000.0)
+        else:
+            batch = next(data_iterator)
         if not isinstance(batch, dict):
             raise TypeError(
                 f"[ForwardStep] Expected batch to be dict, got {type(batch)}. Batch value: {batch}"

--- a/primus/backends/megatron/training/evaluator.py
+++ b/primus/backends/megatron/training/evaluator.py
@@ -4,6 +4,7 @@
 # See LICENSE for license information.
 ###############################################################################
 
+import os
 import time
 
 import torch
@@ -29,6 +30,42 @@ from primus.core.utils.module_utils import debug_rank_0, log_rank_0
 # (summed per-sample loss, sample count). Its denominator is the only one that
 # is a sample count rather than a microbatch count.
 VAL_LOSS_KEY = "loss"
+
+
+def _make_eval_profiler():
+    """Trace the evaluation loop, off unless MXFP6_EVAL_PROFILE=<iterations>.
+
+    PROBE ONLY. Megatron builds its profiler inside training.train(), which
+    skip_train bypasses, so an evaluation-only arm cannot be traced through the
+    ordinary profile / profile_step_start path -- those keys are read but nothing
+    ever creates the profiler. That left the eval loop the one part of the step
+    budget never profiled, which is what this exists to fix.
+
+    Profiles rank 0 only, for the first MXFP6_EVAL_PROFILE iterations after one
+    wait and one warmup, and writes a chrome trace to MXFP6_EVAL_PROFILE_DIR
+    (default /tmp). Stacks are deliberately not collected: this campaign already
+    established they add phantom overhead of the same order as the eval anomaly
+    being chased.
+    """
+    active = int(os.environ.get("MXFP6_EVAL_PROFILE", "0"))
+    if active <= 0 or torch.distributed.get_rank() != 0:
+        return None
+
+    out_dir = os.environ.get("MXFP6_EVAL_PROFILE_DIR", "/tmp")
+    os.makedirs(out_dir, exist_ok=True)
+
+    def _export(prof):
+        path = os.path.join(out_dir, "eval_profile.pt.trace.json")
+        prof.export_chrome_trace(path)
+        log_rank_0(f"[MXFP6_EVAL_PROFILE] wrote {path}")
+
+    return torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+        schedule=torch.profiler.schedule(wait=1, warmup=1, active=active, repeat=1),
+        record_shapes=True,
+        with_stack=False,
+        on_trace_ready=_export,
+    )
 
 
 def _report_eval(args, message):
@@ -214,6 +251,10 @@ def primus_evaluate(
     if eval_iters is None:
         eval_iters = args.eval_iters
 
+    eval_prof = _make_eval_profiler()
+    if eval_prof is not None:
+        eval_prof.start()
+
     with torch.no_grad():
         iteration = 0
         if verbose:
@@ -286,6 +327,12 @@ def primus_evaluate(
                     rerun_state_machine.set_mode(rerun_mode)
                     log_rank_0("Exiting during evaluation, timelimit reached")
                     return None, None, True
+
+            if eval_prof is not None:
+                eval_prof.step()
+
+        if eval_prof is not None:
+            eval_prof.stop()
 
         total_loss_dict = {}
         observed_samples = None

--- a/primus/backends/megatron/training/evaluator.py
+++ b/primus/backends/megatron/training/evaluator.py
@@ -5,6 +5,8 @@
 ###############################################################################
 
 import os
+import statistics
+import threading
 import time
 
 import torch
@@ -66,6 +68,267 @@ def _make_eval_profiler():
         with_stack=False,
         on_trace_ready=_export,
     )
+
+
+_VAL_PREFETCH = os.environ.get("MXFP6_VAL_PREFETCH", "1") == "1"
+
+# Keyed by id() of the validation iterator, so a recipe with more than one
+# validation set cannot hand one set's batch to another.
+_val_prefetch_state = {}
+
+
+class _FirstBatchFrom:
+    """Yield one already-fetched batch, then delegate to the real iterator."""
+
+    def __init__(self, batch, inner):
+        self._batch = batch
+        self._inner = inner
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._batch is not None:
+            batch, self._batch = self._batch, None
+            return batch
+        return next(self._inner)
+
+
+def _start_val_prefetch(data_iterator):
+    """Fetch the next evaluation's first batch on a background thread.
+
+    The first fetch of every evaluation is orders of magnitude slower than the rest,
+    which the loader hides: the loop consumes the split exactly, so every evaluation
+    ends on an epoch boundary and the next one's first fetch pays the restart with
+    nothing queued across it. Doing that fetch at the end of an evaluation would only
+    move the cost inside the same timed region, so it is issued here and the training
+    steps that follow absorb it.
+
+    The batch this pulls is the one the next evaluation would have read first: the
+    validation stream repeats deterministically, and the eval noise is keyed to the
+    eval step index rather than to the fetch, so ``val_loss`` is unchanged. That
+    bit-identity is the gate; ``MXFP6_VAL_PREFETCH=0`` turns this off.
+    """
+    if not _VAL_PREFETCH or data_iterator is None:
+        return
+    key = id(data_iterator)
+    prev = _val_prefetch_state.get(key)
+    if prev is not None and prev["thread"].is_alive():
+        # Nothing consumed the last prefetch, so the iterator's position is not
+        # what this would assume. Leave it alone rather than fetch twice.
+        return
+    state = {"thread": None, "batch": None, "error": None}
+
+    def _fetch():
+        try:
+            state["batch"] = next(data_iterator)
+        except BaseException as exc:  # surfaced on the consuming side
+            state["error"] = exc
+
+    # Daemon: a fetch blocked on storage must not keep a finished run alive.
+    state["thread"] = threading.Thread(target=_fetch, name="val-prefetch", daemon=True)
+    _val_prefetch_state[key] = state
+    state["thread"].start()
+
+
+def _take_val_prefetch(data_iterator):
+    """Return the iterator, with its first batch already in hand if we have one.
+
+    Joins the background fetch first: a DataLoader iterator is not safe to advance
+    from two threads, so the loop must not touch it until that thread is done.
+    """
+    state = _val_prefetch_state.pop(id(data_iterator), None)
+    if state is None:
+        return data_iterator, None
+    t0 = time.perf_counter()
+    state["thread"].join()
+    join_ms = (time.perf_counter() - t0) * 1000.0
+    if state["error"] is not None or state["batch"] is None:
+        # Fall back to fetching in the loop. The error resurfaces there if it is
+        # real, with the traceback the loop would have produced anyway.
+        debug_rank_0(f"[MXFP6_VAL_PREFETCH] discarded: {state['error']!r}")
+        return data_iterator, None
+    return _FirstBatchFrom(state["batch"], data_iterator), join_ms
+
+
+class _EvalIterTimer:
+    """Iteration-to-iteration wall clock for the evaluation loop, off unless
+    MXFP6_EVAL_ITER_TIMING=1.
+
+    PROBE ONLY, and it exists because pricing evaluation off a window *inside* the
+    iteration reports a much faster iteration, and a much higher GPU-busy fraction,
+    than the same arm's end-to-end rate over the split implies. The difference is host
+    time that was never in any profiled window, and a within-iteration probe cannot see
+    it by construction.
+
+    So this measures the period, not the activity: wall clock from the top of one
+    iteration to the top of the next, the wall clock of the forward-backward call inside
+    it, and CUDA-event GPU time for that same call. The three split the iteration into
+    GPU work, host time inside the model call (which includes the dataloader, since the
+    forward step is what consumes the iterator), and loop overhead outside it.
+
+    It is deliberately sync-free in the hot path. The CUDA events are recorded and read
+    only at report time, so the probe cannot create the serialization it is looking for.
+    That failure mode is real and was hit once already on this model, where an apparent
+    end-of-step "host stall" turned out to be the profiler's own overhead.
+    """
+
+    def __init__(self):
+        self.iter_wall = []
+        self.fbf_wall = []
+        self.events = []
+        self._t_iter = None
+        self._t_fbf = None
+        self._pair = None
+        self.losses = []
+
+    @classmethod
+    def maybe_create(cls):
+        if os.environ.get("MXFP6_EVAL_ITER_TIMING", "0") not in ("1", "true", "True"):
+            return None
+        return cls()
+
+    def iteration_start(self):
+        self._t_iter = time.perf_counter()
+
+    def fbf_start(self):
+        self._t_fbf = time.perf_counter()
+        start = torch.cuda.Event(enable_timing=True)
+        stop = torch.cuda.Event(enable_timing=True)
+        start.record()
+        self._pair = (start, stop)
+
+    def fbf_stop(self):
+        self._pair[1].record()
+        self.events.append(self._pair)
+        self.fbf_wall.append((time.perf_counter() - self._t_fbf) * 1000.0)
+
+    def iteration_stop(self):
+        self.iter_wall.append((time.perf_counter() - self._t_iter) * 1000.0)
+
+    def record_loss(self, numerator, denominator):
+        """Per-iteration loss, kept to localise a whole-eval loss difference.
+
+        When two arms report different whole-eval losses, each reproducibly, the
+        aggregate cannot say whether every iteration moved a little or one moved a
+        lot, and those have different causes: a uniform shift is a kernel or reduction
+        difference applying to all batches, while a single differing iteration is a
+        data or first-batch state difference. Stored as float, compared offline.
+        """
+        num = numerator.item() if isinstance(numerator, torch.Tensor) else float(numerator)
+        den = denominator.item() if isinstance(denominator, torch.Tensor) else float(denominator)
+        self.losses.append(num / den if den else float("nan"))
+
+    def report(self):
+        torch.cuda.synchronize()
+        gpu = [a.elapsed_time(b) for a, b in self.events]
+        n = len(self.iter_wall)
+        if n == 0:
+            return
+
+        def stats(xs):
+            s = sorted(xs)
+            return (
+                statistics.median(s),
+                s[len(s) // 10],
+                s[min(len(s) - 1, 9 * len(s) // 10)],
+                min(s),
+                max(s),
+                sum(s),
+            )
+
+        # The CUDA event pair measures the *span* of the device timeline between the two
+        # records, not GPU busy time: if the host blocks on the dataloader mid-call the
+        # GPU sits idle inside that span and the span still counts it. Read it as an
+        # upper bound on GPU work, and take the compute floor from a standalone
+        # forward-only microbenchmark at the same shape instead.
+        rows = [
+            ("iteration wall", self.iter_wall),
+            ("  fwd/bwd call wall", self.fbf_wall),
+            ("  fwd/bwd device span", gpu),
+        ]
+        lines = [
+            f"[MXFP6_EVAL_ITER_TIMING] {n} iterations",
+            f"{'':22}{'median':>9}{'p10':>9}{'p90':>9}{'min':>9}{'max':>9}{'total s':>10}",
+        ]
+        for label, xs in rows:
+            med, p10, p90, lo, hi, tot = stats(xs)
+            lines.append(
+                f"{label:22}{med:>9.2f}{p10:>9.2f}{p90:>9.2f}{lo:>9.2f}{hi:>9.2f}{tot/1000.0:>10.2f}"
+            )
+        med_iter = statistics.median(self.iter_wall)
+        med_fbf = statistics.median(self.fbf_wall)
+        med_gpu = statistics.median(gpu)
+        lines.append(
+            f"{'  host outside span':22}{med_fbf - med_gpu:>9.2f}"
+            f"   ({100*(med_fbf-med_gpu)/med_iter:.1f}% of iteration)"
+        )
+        lines.append(
+            f"{'  loop overhead':22}{med_iter - med_fbf:>9.2f}"
+            f"   ({100*(med_iter-med_fbf)/med_iter:.1f}% of iteration)"
+        )
+        # Optional: anything above the model's standalone forward cost at this shape is
+        # not compute. No default, because the figure is specific to a shape and a
+        # machine and does not scale across microbatch sizes -- measure it with a
+        # forward-only microbenchmark and pass it in. Two runs of the same such harness
+        # on the same tree have been seen to disagree by several percent while each was
+        # internally tight to a fraction of a percent, so treat a small residual as
+        # noise rather than signal.
+        floor_env = os.environ.get("MXFP6_EVAL_COMPUTE_FLOOR_MS")
+        if floor_env:
+            floor = float(floor_env)
+            lines.append(
+                f"{'  non-compute':22}{med_iter - floor:>9.2f}"
+                f"   ({100*(med_iter-floor)/med_iter:.1f}% of iteration, against a "
+                f"{floor:.2f} ms compute floor)"
+            )
+        # The scored eval time is a total, not a median, so a single slow iteration is
+        # worth as much as a far smaller per-iteration regression. Name them.
+        outliers = [(i + 1, x) for i, x in enumerate(self.iter_wall) if x > 2 * med_iter]
+        excess = sum(x - med_iter for _, x in outliers) / 1000.0
+        lines.append("  first 3 iterations:  " + ", ".join(f"{x:.1f}" for x in self.iter_wall[:3]) + " ms")
+        if self.losses:
+            path = os.environ.get("MXFP6_EVAL_LOSS_DUMP", "")
+            if path:
+                with open(path, "w") as fh:
+                    fh.write("\n".join(f"{i}\t{x!r}" for i, x in enumerate(self.losses)) + "\n")
+                lines.append(f"  per-iteration losses dumped to {path}")
+            lines.append("  first 4 losses:      " + ", ".join(f"{x:.9f}" for x in self.losses[:4]))
+
+        # Separates "the first eval iteration waits on the val loader" from "the
+        # first eval iteration is slow for some other reason". The probe above
+        # cannot: it brackets the whole forward_backward call, and the fetch is
+        # inside it, which is why it reports almost nothing outside the span.
+        try:
+            from primus.backends.megatron.training.diffusion.forward_step import (
+                take_batch_fetch_timings,
+            )
+
+            fetches = take_batch_fetch_timings()
+        except Exception:
+            fetches = []
+        if fetches:
+            med_f = statistics.median(fetches)
+            lines.append(
+                f"  batch fetch (n={len(fetches)}): median {med_f:.2f} ms, "
+                f"max {max(fetches):.1f} ms, first {fetches[0]:.1f} ms, "
+                f"total {sum(fetches)/1000:.2f} s"
+            )
+            slow = [(i + 1, x) for i, x in enumerate(fetches) if x > 2 * med_f]
+            lines.append(
+                "  slow fetches:        "
+                + (", ".join(f"#{i} {x:.0f}ms" for i, x in slow[:16]) if slow else "none")
+            )
+        lines.append(
+            "  above 2x median:     "
+            + (", ".join(f"#{i} {x/1000:.2f}s" for i, x in outliers) if outliers else "none")
+            + (
+                f"  -> {excess:.2f} s of excess, {100*excess/(sum(self.iter_wall)/1000):.1f}% of the eval"
+                if outliers
+                else ""
+            )
+        )
+        log_rank_0("\n".join(lines))
 
 
 def _report_eval(args, message):
@@ -255,12 +518,23 @@ def primus_evaluate(
     if eval_prof is not None:
         eval_prof.start()
 
+    iter_timer = _EvalIterTimer.maybe_create()
+
+    # Keep the real iterator: the wrapper is per-evaluation, and the next
+    # evaluation is handed the same underlying object this one was.
+    val_iterator = data_iterator
+    data_iterator, prefetch_join_ms = _take_val_prefetch(data_iterator)
+    if prefetch_join_ms is not None:
+        debug_rank_0(f"[MXFP6_VAL_PREFETCH] first batch ready, waited {prefetch_join_ms:.1f} ms")
+
     with torch.no_grad():
         iteration = 0
         if verbose:
             _report_eval(args, f"Evaluating on {eval_iters * eval_batch_size} samples")
         while iteration < eval_iters:
             iteration += 1
+            if iter_timer is not None:
+                iter_timer.iteration_start()
             if verbose:
                 # One line per iteration, so 58 per evaluation at the MLPerf
                 # shape and 580 over a ten-evaluation run. Progress is worth
@@ -271,6 +545,8 @@ def primus_evaluate(
             # Don't care about timing during evaluation
             config.timers = None
             ft_integration.on_eval_step_start()
+            if iter_timer is not None:
+                iter_timer.fbf_start()
             loss_dicts = forward_backward_func(
                 forward_step_func=forward_step_func,
                 data_iterator=data_iterator,
@@ -281,6 +557,8 @@ def primus_evaluate(
                 decoder_seq_length=args.decoder_seq_length,
                 forward_only=True,
             )
+            if iter_timer is not None:
+                iter_timer.fbf_stop()
             ft_integration.on_eval_step_end()
             config.timers = get_timers()
 
@@ -309,6 +587,11 @@ def primus_evaluate(
                             # and so the denominator is 1.
                             numerator += val
                             denominator += 1
+                    # diffusion_trainer.py:309 reports Flux under "loss"; the GPT paths
+                    # use "lm loss". Take whichever this model produces.
+                    if iter_timer is not None and key in ("loss", "lm loss"):
+                        iter_timer.record_loss(numerator, denominator)
+
                     # Accumulate across all eval iterations
                     if key not in total_loss_numerators:
                         total_loss_numerators[key] = 0
@@ -330,9 +613,17 @@ def primus_evaluate(
 
             if eval_prof is not None:
                 eval_prof.step()
+            if iter_timer is not None:
+                iter_timer.iteration_stop()
 
         if eval_prof is not None:
             eval_prof.stop()
+
+        # Before the loss reduction below, so the fetch overlaps that too.
+        _start_val_prefetch(val_iterator)
+
+        if iter_timer is not None:
+            iter_timer.report()
 
         total_loss_dict = {}
         observed_samples = None

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
@@ -3,6 +3,9 @@
 
 """Distributed-checkpoint regression tests for Flux's heterogeneous layers."""
 
+import tempfile
+from pathlib import Path
+
 import pytest
 import torch
 from megatron.core.dist_checkpointing import load, save
@@ -60,7 +63,7 @@ class TestFluxDistCheckpoint(PrimusUT):
         assert double_weight.global_shape == (6 * model.hidden_size, model.hidden_size)
         assert single_weight.global_shape == (3 * model.hidden_size, model.hidden_size)
 
-    def test_torch_dist_save_load_round_trip(self, tmp_path):
+    def test_torch_dist_save_load_round_trip(self):
         """Save and restore both adaLN shapes through the real torch_dist backend."""
         source = Flux(_tiny_flux_config()).to(_runtime_device())
         double_weight = source.transformer.layers[0].adaln.adaLN_modulation[-1].weight
@@ -69,19 +72,20 @@ class TestFluxDistCheckpoint(PrimusUT):
             double_weight.fill_(1.25)
             single_weight.fill_(-2.5)
 
-        checkpoint_dir = tmp_path / "flux_torch_dist"
-        checkpoint_dir.mkdir()
-        save({"model": source.sharded_state_dict()}, checkpoint_dir)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            checkpoint_dir = Path(tmp_dir) / "flux_torch_dist"
+            checkpoint_dir.mkdir()
+            save({"model": source.sharded_state_dict()}, checkpoint_dir)
 
-        target = Flux(_tiny_flux_config()).to(_runtime_device())
-        loaded = load({"model": target.sharded_state_dict()}, checkpoint_dir)
-        target.load_state_dict(loaded["model"])
+            target = Flux(_tiny_flux_config()).to(_runtime_device())
+            loaded = load({"model": target.sharded_state_dict()}, checkpoint_dir)
+            target.load_state_dict(loaded["model"])
 
-        torch.testing.assert_close(
-            target.transformer.layers[0].adaln.adaLN_modulation[-1].weight,
-            double_weight,
-        )
-        torch.testing.assert_close(
-            target.transformer.layers[1].adaln.adaLN_modulation[-1].weight,
-            single_weight,
-        )
+            torch.testing.assert_close(
+                target.transformer.layers[0].adaln.adaLN_modulation[-1].weight,
+                double_weight,
+            )
+            torch.testing.assert_close(
+                target.transformer.layers[1].adaln.adaLN_modulation[-1].weight,
+                single_weight,
+            )

--- a/tests/unit_tests/backends/megatron/test_eval_budget.py
+++ b/tests/unit_tests/backends/megatron/test_eval_budget.py
@@ -20,6 +20,8 @@ from primus.backends.megatron.training.eval_budget import (
     EvalCoverageError,
     assert_mlperf_timestep_source,
     assert_val_worker_divisibility,
+    get_data_parallel_size,
+    get_eval_micro_batch_size,
     get_eval_num_microbatches,
     get_val_num_workers,
     read_energon_split_sample_count,
@@ -246,3 +248,59 @@ class TestReadEnergonSplitSampleCount:
     def test_absent_split_returns_none(self, tmp_path):
         path = self._dataset(tmp_path, {"train/shard_000000.tar": 231})
         assert read_energon_split_sample_count(path, "val") is None
+
+
+class TestBudgetReconstruction:
+    """The sample count the dataloader reconstructs must be the one asked for.
+
+    energon_dataset_provider reports a validation budget, and asserts coverage on
+    it, by multiplying the resolved eval_iters back out into samples. That product
+    has to use the evaluation microbatch size: a recipe overriding it evaluates at
+    that width, so reaching for the training micro_batch_size understates the budget
+    by the ratio between the two and then hands the wrong number to a divisibility
+    check built from the eval width.
+    """
+
+    @staticmethod
+    def _reconstruct(args) -> int:
+        """The provider's arithmetic, in the terms eval_budget defines it."""
+        eval_iters = resolve_eval_iters(args)
+        return (
+            eval_iters
+            * get_eval_num_microbatches(args)
+            * get_eval_micro_batch_size(args)
+            * get_data_parallel_size(args)
+        )
+
+    @pytest.mark.parametrize(
+        "eval_micro_batch_size, eval_global_batch_size",
+        [(32, 256), (64, 512), (128, 1024)],
+    )
+    def test_reconstruction_is_exact(self, eval_micro_batch_size, eval_global_batch_size):
+        args = _args(
+            micro_batch_size=32,
+            global_batch_size=256,
+            eval_samples=MLPERF_EVAL_SAMPLES,
+            eval_micro_batch_size=eval_micro_batch_size,
+            eval_global_batch_size=eval_global_batch_size,
+        )
+
+        assert self._reconstruct(args) == MLPERF_EVAL_SAMPLES
+
+    def test_wider_eval_width_is_not_rejected(self):
+        """128 covers the split exactly; only the understated count made it fail.
+
+        29696 / (8 x 1 x 128) is 29 whole microbatches per rank. Reconstructing the
+        budget from a training micro_batch_size of 32 instead gave 7424, which leaves
+        a remainder of 256 against that same divisor and raised EvalCoverageError on
+        a shape that reads every sample.
+        """
+        args = _args(
+            micro_batch_size=32,
+            global_batch_size=256,
+            eval_samples=MLPERF_EVAL_SAMPLES,
+            eval_micro_batch_size=128,
+            eval_global_batch_size=1024,
+        )
+
+        assert_val_worker_divisibility(args, self._reconstruct(args))

--- a/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp6_local.py
+++ b/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp6_local.py
@@ -91,9 +91,13 @@ def megatron_global_args(monkeypatch):
     monkeypatch.setattr(gvars, "_GLOBAL_ARGS", dummy_args)
 
 
-def _pure_args(fuse_wgrad_accum=False, bias=None):
-    """Trailing MXFP6LinearFunction args for the pure-MXFP6 path, bias first."""
-    return (bias, False, None, 0, 0, fuse_wgrad_accum)
+def _pure_args(fuse_wgrad_accum=False, bias=None, grad_enabled=True):
+    """Trailing MXFP6LinearFunction args for the pure-MXFP6 path, bias first.
+
+    ``grad_enabled`` mirrors what the production wrapper samples with
+    torch.is_grad_enabled(); it cannot be read inside forward, so it travels as an argument.
+    """
+    return (bias, False, None, 0, 0, fuse_wgrad_accum, grad_enabled)
 
 
 def _hybrid_args(bias=None):
@@ -108,6 +112,7 @@ def _hybrid_args(bias=None):
         ScalingGranularity.TENSORWISE.value,
         BackendType.HIPBLASLT.value,
         False,
+        True,
     )
 
 
@@ -317,7 +322,6 @@ class TestMXFP6Compile(PrimusUT):
     @requires_mxfp6
     def test_no_graph_break_hybrid(self):
         self._assert_no_graph_break(_hybrid_args())
-
 
     @requires_mxfp6
     def test_compiled_forward_matches_eager(self):
@@ -615,9 +619,7 @@ class TestMXFP6LinearModules(PrimusUT):
     def test_fused_wgrad_accum_rejects_fp8_backward(self):
         """The FP8 backward forms its wgrad with a GEMM that has no out-variant."""
         with pytest.raises(ValueError, match="mxfp6_backward_precision"):
-            self._column_linear(
-                mxfp6_fused_wgrad_accum=True, mxfp6_backward_precision="fp8"
-            )
+            self._column_linear(mxfp6_fused_wgrad_accum=True, mxfp6_backward_precision="fp8")
 
     @requires_mxfp6
     def test_fused_wgrad_lands_in_main_grad(self):


### PR DESCRIPTION
Stacked on `feat/mxfp6-fused-mlp` (#1064), which it targets. Two fusions on the Flux 12B MXFP6 step, plus the evaluation-cost work that came out of the same campaign.

Both fusions reduce end-to-end step time, reproduced across two independent runs with bit-identical final loss, no NaN and no skipped iterations. Measurements are recorded internally rather than here.

## What is here

- **`perf(mxfp6): fuse Flux QK norm with RoPE and the LN-modulate backward`** — the headline change. QK RMSNorm and the interleaved rotation collapse into one Triton kernel per direction, for the single blocks and both streams of the joint blocks. Q and K are read as strided slices of `mixed_qkv` instead of being forced contiguous, and the whole-QKV entry point moves the split inside the op so backward writes `d(mixed_qkv)` directly. Separately, the LN-modulate backward becomes one kernel where it was two.
- **`feat(mxfp6): add an evaluation profiler and a rope-fusion override`** — two measurement affordances, both off by default.
- **`perf(eval): give the validation loader one prefetching worker`** — evaluates the whole split faster with val_loss bit-identical.
- **`perf(mxfp6): pack rows only when no backward will read the columns`** — evaluation is a forward-only region and pays for half a packer it never uses.
- **`fix(eval): size the validation budget from the eval microbatch`** — the budget was reconstructed from the training width, which understated it and rejected shapes that cover the split exactly.

## Before this leaves draft

- The two fusion gates are environment variables here and become `FluxConfig` keys, enabled in the MXFP6 recipes. Note that `apply_rope_fusion` already demonstrates the failure mode to avoid: Megatron's `validate_args` clears it for Flux, which is why `MXFP6_FORCE_ROPE_FUSION` exists at all. The new keys need a positive assertion that they arrived, not just a default.
- The numerics tests currently live outside this repo and load production code by file path; they get ported to `tests/unit_tests/backends/megatron/`, covering both LN-modulate op variants and the joint-block rope slicing, plus a regression test pinning the QKV op as opaque.
- `MXFP6_ABLATE_ROPE` in `attention.py` is a deliberate wrong-numerics timing probe and comes out before review.
- A Primus-Turbo packer change (tile defaults) is being evaluated separately and is not part of this branch.
