### PR TITLE
fix(te): requantize_data raises UnboundLocalError on the captured `inp`

### DIFF
--- a/primus/backends/transformer_engine/transformer_engine_torch/gemm.py
+++ b/primus/backends/transformer_engine/transformer_engine_torch/gemm.py
@@ -102,9 +102,9 @@ if is_te_min_version("2.0"):
                 quantizer.columnwise_usage,
             )
             quantizer.set_usage(rowwise=rowwise, columnwise=columnwise)
-            inp = quantizer(inp.dequantize())
+            requantized = quantizer(inp.dequantize())
             quantizer.set_usage(rowwise=init_rowwise_usage, columnwise=init_columnwise_usage)
-            return inp
+            return requantized
 
         if isinstance(inp, Float8TensorBase):
             scale_inv = inp._scale_inv


### PR DESCRIPTION
`get_fp8_meta.requantize_data` in `primus/backends/transformer_engine/transformer_engine_torch/gemm.py` raises `UnboundLocalError` on its first statement and can never complete.

```python
def get_fp8_meta(inp: torch.Tensor, need_transpose: bool = False):
    ...
    def requantize_data(quantizer, rowwise=None, columnwise=None):
        quantizer = inp._quantizer          # <- reads `inp`  (line 95)
        ...
        inp = quantizer(inp.dequantize())   # <- assigns `inp` (line 105)
        ...
        return inp
```

`inp` is a closure variable from `get_fp8_meta`, but the assignment on line 105 — with no `nonlocal inp` — makes `inp` **local to `requantize_data` for the whole function body**. Line 95 therefore reads it before it is bound:

```
UnboundLocalError: cannot access local variable 'inp' where it is not associated with a value
```

`requantize_data` has four call sites, all of them the "the quantizer must re-materialise the data" fallbacks:

| line | branch |
|---|---|
| 123 | `Float8TensorBase`, rowwise (`_data` and `_transpose` both unavailable) |
| 139 | `Float8TensorBase`, columnwise |
| 152 | `MXFP8TensorBase`, rowwise |
| 163 | `MXFP8TensorBase`, columnwise |

So any FP8/MXFP8 tensor reaching `get_fp8_meta` without pre-materialised data for the requested orientation crashes instead of being requantised.

### Reproduction

`get_fp8_meta` lifted verbatim out of the file with `ast.get_source_segment` and exec'd against stubs for `torch` / the TE tensor classes / `ptex` (script attached below the fold in spirit — it does no hand-transcription of the function):

```
=== BEFORE (current main) ===
  UnboundLocalError: cannot access local variable 'inp' where it is not associated with a value

=== AFTER (patched) ===
  columnwise site gemm.py:139 -> (('view', None, 'fp8e4m3'), 'SCALE_INV')  (quantizer invoked 1x)
  rowwise site   gemm.py:123 -> (('view', None, 'fp8e4m3'), 'SCALE_INV')  (quantizer invoked 1x)
```

### Fix

Give the requantised tensor its own name so the closure keeps reading the enclosing `inp`:

```python
requantized = quantizer(inp.dequantize())
quantizer.set_usage(rowwise=init_rowwise_usage, columnwise=init_columnwise_usage)
return requantized
```

This is what the upstream TransformerEngine code the helper was adapted from does — `transformer_engine/pytorch/distributed.py` runs the same `set_usage` / quantize / restore-usage sequence, but at function scope where `inp` is a parameter and rebinding it is harmless. Moving it into a nested function is what turned the rebind into a closure capture bug.

The parameter shadowing on line 95 (`quantizer = inp._quantizer` immediately discards the argument) is left alone — both Float8 call sites already pass `inp._quantizer`, so it is inert, and changing it would be a behavioural change rather than a fix.

`+2 / −2`. `black --check --line-length=110 --target-version=py38` clean with the pinned `black 24.8.0` from `.pre-commit-config.yaml`; no imports touched, so `isort` and `autoflake` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
