### PR TITLE
fix(backend): raise FileNotFoundError instead of assert False in setup_backend_path (survives python -O)

### DIFF
--- a/primus/core/backend/backend_adapter.py
+++ b/primus/core/backend/backend_adapter.py
@@ -70,7 +70,7 @@ class BackendAdapter(ABC):
                         # Logger may not be initialized yet; sys.path is already updated.
                         pass
                 return norm_path
-            assert False, error_msg
+            raise FileNotFoundError(error_msg)
 
         # 1) CLI argument: if provided, it must exist. No fallback.
         if backend_path:
@@ -105,7 +105,7 @@ class BackendAdapter(ABC):
         for candidate in candidates:
             if os.path.exists(candidate):
                 return _use_path(str(candidate), "")
-        assert False, (
+        raise FileNotFoundError(
             f"No valid backend path for '{self.framework}'.\n"
             f"Tried: {[str(c) for c in candidates]}\n"
             f"Hint: run `primus-cli deps sync`, install backend to third_party/{dir_name}, "

--- a/tests/unit_tests/core/backend/test_backend_adapter.py
+++ b/tests/unit_tests/core/backend/test_backend_adapter.py
@@ -127,3 +127,20 @@ def test_adapter_setup_backend_path_with_env_var(tmp_path, monkeypatch):
         assert str(backend_dir) in __import__("sys").path
     finally:
         __import__("sys").path[:] = original_sys_path
+
+
+def test_adapter_setup_backend_path_rejects_missing_explicit_path(tmp_path):
+    adapter = DummyBackendAdapter(framework="test_backend")
+    missing_path = tmp_path / "missing_backend"
+
+    with pytest.raises(FileNotFoundError, match="Requested path"):
+        adapter.setup_backend_path(backend_path=str(missing_path))
+
+
+def test_adapter_setup_backend_path_rejects_missing_env_path(tmp_path, monkeypatch):
+    adapter = DummyBackendAdapter(framework="test_backend")
+    missing_path = tmp_path / "missing_backend"
+    monkeypatch.setenv("BACKEND_PATH", str(missing_path))
+
+    with pytest.raises(FileNotFoundError, match="BACKEND_PATH does not exist"):
+        adapter.setup_backend_path()


### PR DESCRIPTION
### Summary
`BackendAdapter.setup_backend_path()` signalled a missing/invalid backend path with `assert False, msg`. Python strips all `assert` statements under `-O` / `PYTHONOPTIMIZE`, so on an optimized interpreter the guard disappears and the method **silently returns `None`** instead of raising — callers then fail later with an opaque `NoneType`/path error far from the real cause. This replaces both sites with `raise FileNotFoundError(msg)` so validation always fires.

Fixes #1109

### Change
`primus/core/backend/backend_adapter.py` — two sites in `setup_backend_path()`:
- `_use_path()` inner helper (~L112)
- default `third_party` candidate loop (~L147)

```diff
-            assert False, error_msg
+            raise FileNotFoundError(error_msg)
```
```diff
-        assert False, (
+        raise FileNotFoundError(
             f"No valid backend path for '{self.framework}'.\n"
             ...
         )
```

`tests/unit_tests/core/backend/test_backend_adapter.py` — regression tests for a missing explicit path and a missing `BACKEND_PATH`.

### Before / After (on `rocm/primus:v26.6`)
| Interpreter | Before | After |
|---|---|---|
| `python`    | raises `AssertionError` | raises `FileNotFoundError` |
| `python -O` | **returns `None`** (guard stripped) | raises `FileNotFoundError` |

### Testing
- `pytest tests/unit_tests/core/backend/test_backend_adapter.py` — all pass, both with and without `-O`.
- Full e2e on `rocm/primus:v26.6`, 8× MI350X (gfx950): unit suite green, and a `train pretrain` smoke completed cleanly (exit 0). No behaviour change on the success path.

### Environment
- Image: `rocm/primus:v26.6`
- ROCm 7.15, torch 2.12.0+rocm7.15.0
- 8× AMD Instinct MI350X (gfx950), single node
- Primus: `main`