### PR TITLE
docs: bump current release tags from v26.5 to v26.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ For the full and up-to-date model matrix, see [Supported Models](./docs/06-devel
 
 ## 🆕 What's New
 
+- **[2026/09/07]** Primus **v26.6** training images: `rocm/primus:v26.6` and `rocm/jax-training:maxtext-v26.6` (JAX 0.11.0, Transformer Engine 2.17)
 - **[2026/07/29]** ⚡ **MegaMoE** - FlyDSL-based fused MoE layer that folds expert all-to-all into the grouped GEMMs, plus FP4 grouped GEMM support ([MegaMoE guide](./docs/04-technical-guides/mega-moe.md))
 - **[2026/07/29]** Hybrid linear-attention models: Gated Delta Net (GDN) and Kimi Delta Attention (KDA) on Megatron-LM ([Hybrid models](./docs/04-technical-guides/hybrid-models/README.md))
 - **[2026/07/22]** Backend upgrades: TorchTitan v0.2.2 (PyTorch 2.12) with GPT-OSS, and MaxText v26.5
@@ -111,9 +112,9 @@ primus-cli deps sync --dir ~/.cache/Primus/third_party
 
     ```bash
     # For Megatron-LM and TorchTitan backends
-    docker pull rocm/primus:v26.5
+    docker pull rocm/primus:v26.6
     # For MaxText backend
-    docker pull rocm/jax-training:maxtext-v26.5
+    docker pull rocm/jax-training:maxtext-v26.6
     ```
 
 2. **Clone the repository**
@@ -122,7 +123,7 @@ primus-cli deps sync --dir ~/.cache/Primus/third_party
     git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
     cd Primus
     # checkout the branch for the specific release
-    git checkout release/v26.5
+    git checkout release/v26.6
     git submodule update --init --recursive
     ```
 
@@ -133,7 +134,7 @@ primus-cli deps sync --dir ~/.cache/Primus/third_party
     # NOTE: If your config downloads weights/tokenizer from Hugging Face Hub,
     #       you typically need to pass HF_TOKEN into the container.
     # Run in the Primus repository root directory
-    ./primus-cli container --image rocm/primus:v26.5 \
+    ./primus-cli container --image rocm/primus:v26.6 \
       --env HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
       -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
     ```
@@ -151,7 +152,7 @@ For more detailed usage instructions, see the [CLI User Guide](./docs/02-user-gu
     python -m venv primus-env
     source primus-env/bin/activate
     # Install Primus
-    pip install "primus==26.5.0" --no-deps --extra-index-url https://amd-agi.github.io/Primus/simple/
+    pip install "primus==26.6.0" --no-deps --extra-index-url https://amd-agi.github.io/Primus/simple/
 
     ```
 
@@ -162,7 +163,7 @@ For more detailed usage instructions, see the [CLI User Guide](./docs/02-user-gu
 2. **Run training in container using pip-installed Primus**
 
     ```bash
-    primus-cli container --image rocm/primus:v26.5 \
+    primus-cli container --image rocm/primus:v26.6 \
     --env HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
     --volume /path/to/your/data:/data  -- --log_file /data/run.log \
     -- train pretrain --config /data/your/config.yaml

--- a/docs/01-getting-started/installation.md
+++ b/docs/01-getting-started/installation.md
@@ -51,9 +51,9 @@ Check the AMD-published training Docker images here:
 
 ```bash
 # For Megatron-LM and TorchTitan backends
-docker pull rocm/primus:v26.5
+docker pull rocm/primus:v26.6
 # For MaxText backend
-docker pull rocm/jax-training:maxtext-v26.5
+docker pull rocm/jax-training:maxtext-v26.6
 ```
 
 ### 2. Clone the repository
@@ -64,7 +64,7 @@ Submodules are required for third-party backends and tools:
 git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
 cd Primus
 # checkout the branch for the specific release
-git checkout release/v26.5
+git checkout release/v26.6
 git submodule update --init --recursive
 ```
 
@@ -73,7 +73,7 @@ git submodule update --init --recursive
 From the repository root:
 
 ```bash
-./primus-cli container --image rocm/primus:v26.5 -- \
+./primus-cli container --image rocm/primus:v26.6 -- \
   benchmark gemm --M 4096 --N 4096 --K 4096
 ```
 
@@ -183,7 +183,7 @@ The image used for the job is resolved according to the following priority order
 1. **`DOCKER_IMAGE` environment variable**—overrides everything else. This is the simplest way to switch images and it propagates to all nodes:
 
 ```bash
-export DOCKER_IMAGE=rocm/primus:v26.5
+export DOCKER_IMAGE=rocm/primus:v26.6
 ./primus-cli slurm srun -N 2 \
   -- train pretrain --config <your-config>.yaml
 ```
@@ -192,10 +192,10 @@ export DOCKER_IMAGE=rocm/primus:v26.5
 
 ```bash
 ./primus-cli slurm srun -N 2 \
-  -- --image rocm/primus:v26.5 train pretrain --config <your-config>.yaml
+  -- --image rocm/primus:v26.6 train pretrain --config <your-config>.yaml
 ```
 
-3. **Config file default**—`container.options.image` in `runner/.primus.yaml` (or your `~/.primus.yaml`), which is set to `rocm/primus:v26.5` by default.
+3. **Config file default**—`container.options.image` in `runner/.primus.yaml` (or your `~/.primus.yaml`), which is set to `rocm/primus:v26.6` by default.
 
 ### Distributed environment variables
 
@@ -250,7 +250,7 @@ With Kubernetes, inject these as container environment variables (deriving `NODE
 | Step                 | Check                                                                                                   |
 | -------------------- | ------------------------------------------------------------------------------------------------------- |
 | **ROCm**             | `rocm-smi` shows expected GPUs and no driver errors.                                                    |
-| **Container engine** | `docker run --rm ... rocm/primus:v26.5` (or your site’s GPU test) succeeds.                             |
+| **Container engine** | `docker run --rm ... rocm/primus:v26.6` (or your site’s GPU test) succeeds.                             |
 | **GEMM benchmark**   | `./primus-cli` **container** or **direct** benchmark completes (see sections above).                    |
 | **Preflight**        | Run preflight diagnostics: `./primus-cli direct -- preflight` (single node) or `./primus-cli slurm srun -N <N> -- preflight` (cluster).         |
 

--- a/docs/01-getting-started/overview.md
+++ b/docs/01-getting-started/overview.md
@@ -73,7 +73,7 @@ Backend choice is specified in the configuration YAML and resolved through Primu
 |------|----------------|
 | **GPUs** | AMD Instinct™ **MI300X**, **MI325X**, **MI355X** |
 | **Platform** | **ROCm** (version **≥ 7.0** recommended) |
-| **Container image (reference)** | `docker.io/rocm/primus:v26.5` |
+| **Container image (reference)** | `docker.io/rocm/primus:v26.6` |
 
 Exact kernel and driver packages should match AMD’s documentation for your GPU SKU and ROCm release.
 

--- a/docs/01-getting-started/quickstart.md
+++ b/docs/01-getting-started/quickstart.md
@@ -28,9 +28,9 @@ Check the AMD published training Docker images:
 
 ```bash
 # For Megatron-LM and TorchTitan backends
-docker pull rocm/primus:v26.5
+docker pull rocm/primus:v26.6
 # For MaxText backend
-docker pull rocm/jax-training:maxtext-v26.5
+docker pull rocm/jax-training:maxtext-v26.6
 ```
 
 ### Step 2: Clone the repository
@@ -39,7 +39,7 @@ docker pull rocm/jax-training:maxtext-v26.5
 git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
 cd Primus
 # checkout the branch for the specific release
-git checkout release/v26.5
+git checkout release/v26.6
 git submodule update --init --recursive
 ```
 
@@ -48,7 +48,7 @@ git submodule update --init --recursive
 Run the training from the repository root. If your configuration downloads weights or tokenizers from Hugging Face Hub, pass `HF_TOKEN` into the container:
 
 ```bash
-./primus-cli container --image rocm/primus:v26.5 \
+./primus-cli container --image rocm/primus:v26.6 \
   --env HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
   -- train pretrain \
   --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
@@ -65,7 +65,7 @@ Install Primus in a virtual environment:
 ```bash
 python -m venv primus-env
 source primus-env/bin/activate
-pip install "primus==26.5.0" --no-deps --extra-index-url https://amd-agi.github.io/Primus/simple/
+pip install "primus==26.6.0" --no-deps --extra-index-url https://amd-agi.github.io/Primus/simple/
 ```
 
 > **Note:** This installs only the Primus CLI into your virtual environment (under `site-packages`), without other dependencies. Third-party submodules are downloaded on the first run of the container, and the complete training software stack is provided in the AMD-published Docker images. You can launch `primus-cli` from any directory.
@@ -73,7 +73,7 @@ pip install "primus==26.5.0" --no-deps --extra-index-url https://amd-agi.github.
 ### Step 2: Run training in a container using the pip-installed Primus
 
 ```bash
-primus-cli container --image rocm/primus:v26.5 \
+primus-cli container --image rocm/primus:v26.6 \
   --env HF_TOKEN="hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
   --volume /path/to/your/data:/data -- --log_file /data/run.log \
   -- train pretrain --config /data/your/config.yaml
@@ -103,7 +103,7 @@ Use one configuration file: `examples/megatron/configs/MI300X/llama2_7B-BF16-pre
 
 | Mode | Example command |
 |------|------------------|
-| **Container** | `./primus-cli container --image rocm/primus:v26.5 -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml` |
+| **Container** | `./primus-cli container --image rocm/primus:v26.6 -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml` |
 | **Direct** | `./primus-cli direct -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml` |
 | **Slurm** | `./primus-cli slurm srun -N <nodes> ... -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml` |
 
@@ -118,14 +118,14 @@ For container and Slurm runs, Primus resolves which Docker image to use in the f
 1. **`DOCKER_IMAGE` environment variable**—if set, it overrides every other source (including `--image`):
 
 ```bash
-export DOCKER_IMAGE=rocm/primus:v26.5
+export DOCKER_IMAGE=rocm/primus:v26.6
 ./primus-cli container -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
 ```
 
 2. **`--image` command-line argument**—the usual per-run override, passed as a container mode argument (before `--`):
 
 ```bash
-./primus-cli container --image rocm/primus:v26.5 -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
+./primus-cli container --image rocm/primus:v26.6 -- train pretrain --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
 ```
 
 3. **`image` field in a config file** (`container.options.image`)—used when neither of the above is set:
@@ -133,7 +133,7 @@ export DOCKER_IMAGE=rocm/primus:v26.5
 ```yaml
 container:
   options:
-    image: "rocm/primus:v26.5"
+    image: "rocm/primus:v26.6"
 ```
 
 Primus loads a **single** config file—the first that exists among `--config <file>`, then `~/.primus.yaml`, then the shipped `runner/.primus.yaml` (these files are **not** merged). Because `runner/.primus.yaml` ships with a default image, a bare `./primus-cli container -- ...` works out of the box.
@@ -154,7 +154,7 @@ primus-cli [global-options] <mode> [mode-args] -- <command> [command-args...]
 Example:
 
 ```text
-primus-cli  container  --image rocm/primus:v26.5  --  train pretrain --config path/to/experiment.yaml
+primus-cli  container  --image rocm/primus:v26.6  --  train pretrain --config path/to/experiment.yaml
             ^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             mode        mode args                     command + args
 ```

--- a/docs/02-user-guide/cli-reference.md
+++ b/docs/02-user-guide/cli-reference.md
@@ -101,7 +101,7 @@ primus-cli container [options] -- <command>
 
 | Option | Description |
 | --- | --- |
-| `--image NAME` | Image tag (default from config: `rocm/primus:v26.5`). |
+| `--image NAME` | Image tag (default from config: `rocm/primus:v26.6`). |
 | `--volume HOST[:CONTAINER]` | Bind mount (repeatable). |
 | `--env KEY=VALUE` | Pass into the **inner** `primus-cli direct` as `--env` (repeatable). |
 | `--device PATH` | Extra device nodes (repeatable; defaults include GPU/RDMA devices). |

--- a/docs/02-user-guide/end-to-end-training-recipes.md
+++ b/docs/02-user-guide/end-to-end-training-recipes.md
@@ -68,7 +68,7 @@ export NVTE_CK_IS_V3_ATOMIC_FP32=1
 
 ### Choosing the Docker image
 
-For **container** and **Slurm** modes (direct mode runs in whatever environment you launched it from), the default image is `rocm/primus:v26.5`, set in `runner/.primus.yaml`. JAX MaxText has its own separate image family, `rocm/jax-training:maxtext-…`, which is **not** the default — pass it explicitly in container and Slurm modes.
+For **container** and **Slurm** modes (direct mode runs in whatever environment you launched it from), the default image is `rocm/primus:v26.6`, set in `runner/.primus.yaml`. JAX MaxText has its own separate image family, `rocm/jax-training:maxtext-…`, which is **not** the default — pass it explicitly in container and Slurm modes.
 
 The image is picked in priority order: `DOCKER_IMAGE` environment variable > `--image` CLI argument > config file. See [Selecting the container image](../01-getting-started/quickstart.md#selecting-the-container-image) for a full explanation, and [Configuration system](configuration-system.md) for configuration loading.
 
@@ -85,19 +85,19 @@ Clone the branch matching your image, on the host. Every command on this page ru
 ```bash
 git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
 cd Primus
-git checkout release/v26.5
+git checkout release/v26.6
 git submodule update --init --recursive
 ```
 
-Container mode mounts this checkout into the container, so this is the code that runs — you do not need the `/workspace/Primus` copy baked into the image, which lags the release branch. See [Release notes → Primus source for v26.5](../01-getting-started/release-notes.md#primus-source-for-v265).
+Container mode mounts this checkout into the container, so this is the code that runs — you do not need the `/workspace/Primus` copy baked into the image, which lags the release branch. See [Release notes → Primus source for v26.6](../01-getting-started/release-notes.md#primus-source-for-v266).
 
 ### Pull the image (optional)
 
 `primus-cli container` pulls the image on first use, so this is only needed if you want to warm the cache:
 
 ```bash
-docker pull rocm/primus:v26.5                  # Megatron-LM, TorchTitan, Megatron Bridge
-docker pull rocm/jax-training:maxtext-v26.5    # JAX MaxText
+docker pull rocm/primus:v26.6                  # Megatron-LM, TorchTitan, Megatron Bridge
+docker pull rocm/jax-training:maxtext-v26.6    # JAX MaxText
 ```
 
 <details>
@@ -113,7 +113,7 @@ docker run -it \
     --security-opt seccomp=unconfined --privileged \
     -v $PWD:$PWD -w $PWD --shm-size 128G \
     --name primus_training_env \
-    rocm/primus:v26.5
+    rocm/primus:v26.6
 ```
 
 Re-enter it later with `docker start primus_training_env && docker exec -it primus_training_env bash`. Inside, use `primus-cli direct`. Remember to re-export `HF_TOKEN` and any architecture or `NCCL_*` variables, since a manual `docker run` does not forward them.
@@ -240,13 +240,13 @@ Available models include Llama 3.1 (8B/70B/405B), Llama 4 (17Bx16E/17Bx128E), De
 
 MaxText uses a different Docker image than the PyTorch backends and it is **not** the default in `runner/.primus.yaml`, so pass it explicitly with `--image` in container and Slurm modes.
 
-> On MI355X, export `RCCL_WARP_SPEED_AUTO=0` before launching or training can produce NaN losses. It is a no-op on MI300X. See [Important notes](jax-maxtext-training.md#important-notes-for-v265).
+> On MI355X, export `RCCL_WARP_SPEED_AUTO=0` before launching or training can produce NaN losses. It is a no-op on MI300X. See [Important notes](jax-maxtext-training.md#important-notes-for-v266).
 
 Pretrain Llama 3 8B on **MI355X**, from your Primus checkout on the host:
 
 ```bash
 export RCCL_WARP_SPEED_AUTO=0
-./runner/primus-cli container --image rocm/jax-training:maxtext-v26.5 \
+./runner/primus-cli container --image rocm/jax-training:maxtext-v26.6 \
   -- train pretrain \
   --config examples/maxtext/configs/MI355X/llama3_8B-pretrain.yaml
 ```

--- a/docs/02-user-guide/megatron-lm-training.md
+++ b/docs/02-user-guide/megatron-lm-training.md
@@ -6,21 +6,21 @@ Training performance validation of the Primus Docker image with the Megatron bac
 
 The Primus framework with the Megatron backend is designed to enable efficient training of large-scale language models on AMD GPUs. By leveraging AMD Instinct™ MI300X/MI350X accelerators, the Primus Megatron framework delivers enhanced scalability, performance, and resource utilization for AI workloads. It is purpose-built to support models like Llama 2, Llama 3/3.1, DeepSeek V2/V3, and Mixtral MoE, enabling developers to train next-generation AI models with greater efficiency. See the GitHub repository at [AMD-AGI/Primus](https://github.com/AMD-AGI/Primus).
 
-The ROCm PyTorch training Docker image `rocm/primus:v26.5`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for pre-training a model on the AMD Instinct™ MI300X, MI325X, MI350X, and MI355X accelerators.
+The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for pre-training a model on the AMD Instinct™ MI300X, MI325X, MI350X, and MI355X accelerators.
 
-For the full software stack of this image (ROCm, PyTorch, Transformer Engine, Flash Attention, hipBLASLt, Triton, RCCL, and the rest), see [Release notes → `rocm/primus:v26.5`](../01-getting-started/release-notes.md#rocmprimusv265). The release notes are the single source of truth for image contents, and also cover the previous [`rocm/primus:v26.4`](../01-getting-started/release-notes.md#rocmprimusv264).
+For the full software stack of this image (ROCm, PyTorch, Transformer Engine, Flash Attention, hipBLASLt, Triton, RCCL, and the rest), see [Release notes → `rocm/primus:v26.6`](../01-getting-started/release-notes.md#rocmprimusv266). The release notes are the single source of truth for image contents, and also cover the previous [`rocm/primus:v26.5`](../01-getting-started/release-notes.md#rocmprimusv265).
 
 Training is launched with `primus-cli`, the unified Primus CLI that covers direct, container, and Slurm execution from the same YAML configuration. See the [CLI reference](./cli-reference.md).
 
 ---
 
-## Important notes for v26.5
+## Important notes for v26.6
 
 Read this section before starting a training run. It collects the settings this release requires, the architecture-specific tuning, and the known issues. The contents change from release to release, so re-read it when you move to a new image tag.
 
 ### Required settings
 
-**Use the `release/v26.5` branch.** It is the Primus branch matching the `rocm/primus:v26.5` image. The `/workspace/Primus` checkout baked into the image is built from commit `b511d1b6` and the branch has moved on since — see [Release notes → Primus source for v26.5](../01-getting-started/release-notes.md#primus-source-for-v265). [Environment setup](#1-environment-setup) has the clone command.
+**Use the `release/v26.6` branch.** It is the Primus branch matching the `rocm/primus:v26.6` image. Prefer this checkout over the `/workspace/Primus` copy baked into the image — see [Release notes → Primus source for v26.6](../01-getting-started/release-notes.md#primus-source-for-v266). [Environment setup](#1-environment-setup) has the clone command.
 
 ### Architecture-specific settings
 
@@ -63,7 +63,7 @@ In `direct` mode inside a container, a plain `export PYTORCH_CUDA_ALLOC_CONF=exp
 
 ### Known issues
 
-No Megatron-LM backend issues are currently tracked for v26.5.
+No Megatron-LM backend issues are currently tracked for v26.6.
 
 ### Registry change
 
@@ -142,11 +142,11 @@ Use the following instructions to set up the environment, configure the script t
 ```bash
 git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
 cd Primus
-git checkout release/v26.5
+git checkout release/v26.6
 git submodule update --init --recursive
 ```
 
-That is all the setup required. The training commands below use `primus-cli container`, which starts `rocm/primus:v26.5` for you, mounts this checkout into it at the same path, and runs the training inside. You do not need to `docker run` or `docker exec` by hand, and the `/workspace/Primus` copy baked into the image is not used — see [Release notes → Primus source for v26.5](../01-getting-started/release-notes.md#primus-source-for-v265).
+That is all the setup required. The training commands below use `primus-cli container`, which starts `rocm/primus:v26.6` for you, mounts this checkout into it at the same path, and runs the training inside. You do not need to `docker run` or `docker exec` by hand, and the `/workspace/Primus` copy baked into the image is not used — see [Release notes → Primus source for v26.6](../01-getting-started/release-notes.md#primus-source-for-v266).
 
 Container mode also forwards environment variables you export on the host, including `HF_TOKEN`, the gfx942 tuning variables, and the `NCCL_*` networking variables. The forwarded list is `container.options.env` in `runner/.primus.yaml`.
 
@@ -158,12 +158,12 @@ Container mode also forwards environment variables you export on the host, inclu
 If you want an interactive shell — for debugging, or to run `primus-cli direct` yourself — start the container manually and bind your Primus checkout:
 
 ```bash
-docker pull rocm/primus:v26.5
+docker pull rocm/primus:v26.6
 docker run -it --device /dev/dri --device /dev/kfd --device /dev/infiniband \
     --network host --ipc host --group-add video --cap-add SYS_PTRACE \
     --security-opt seccomp=unconfined --privileged \
     -v $PWD:$PWD -w $PWD --shm-size 128G \
-    --name primus_training_env rocm/primus:v26.5
+    --name primus_training_env rocm/primus:v26.6
 ```
 
 Re-enter it later with `docker start primus_training_env && docker exec -it primus_training_env bash`. Inside the container, replace `primus-cli container` with `primus-cli direct` in every command below. Remember to re-export `HF_TOKEN` and any architecture or `NCCL_*` variables, since a manual `docker run` does not forward them.
@@ -207,7 +207,7 @@ export HF_TOKEN=<your_hftoken>
 
 ### 3.1 Single-node training
 
-To run model training on a single node, run the commands below from your `release/v26.5` Primus checkout on the host (recommended). When using `./runner/primus-cli container`, no additional `pip install` step is required.
+To run model training on a single node, run the commands below from your `release/v26.6` Primus checkout on the host (recommended). When using `./runner/primus-cli container`, no additional `pip install` step is required.
 
 #### MI300X performance configs
 
@@ -585,10 +585,10 @@ To run training on multiple nodes, you can use `primus-cli` (recommended) or the
 
 > **Verify NCCL / network env first.** The `primus-cli` launcher script sets sensible `NCCL_*` defaults via `base_env.sh`, but auto-detection can pick the wrong device on multi-NIC nodes. Always confirm `NCCL_IB_HCA`, `NCCL_IB_GID_INDEX`, `NCCL_SOCKET_IFNAME`, and `GLOO_SOCKET_IFNAME` (set to the same value as `NCCL_SOCKET_IFNAME`) are correct for your fabric. If necessary, you can `export` these environment variables before running.
 
-From your `release/v26.5` checkout (see [Environment setup](#1-environment-setup)), export the cluster settings:
+From your `release/v26.6` checkout (see [Environment setup](#1-environment-setup)), export the cluster settings:
 
 ```bash
-export DOCKER_IMAGE=rocm/primus:v26.5
+export DOCKER_IMAGE=rocm/primus:v26.6
 export HF_TOKEN=<your_HF_token>
 export NCCL_IB_HCA=<your_NCCL_IB_HCA> # specify which RDMA interfaces to use for communication
 export NCCL_SOCKET_IFNAME=<your_NCCL_SOCKET_IFNAME> # your network interface
@@ -598,7 +598,7 @@ export NCCL_IB_GID_INDEX=3 # Set InfiniBand GID index for NCCL communication. De
 # On MI300X/MI325X also export the gfx942 tuning variables; see "Architecture-specific settings"
 ```
 
-> **Note:** `release/v26.5` is the branch matching the `rocm/primus:v26.5` image. If you are reproducing published v26.4 numbers instead, use `git checkout 236cfa9` with `rocm/primus:v26.4` — see [Release notes → Primus source for v26.4](../01-getting-started/release-notes.md#primus-source-for-v264).
+> **Note:** `release/v26.6` is the branch matching the `rocm/primus:v26.6` image. If you are reproducing published v26.4 numbers instead, use `git checkout 236cfa9` with `rocm/primus:v26.4` — see [Release notes → Primus source for v26.4](../01-getting-started/release-notes.md#primus-source-for-v264).
 
 For clusters using AMD AINIC, set the following environment variables:
 

--- a/docs/02-user-guide/posttraining.md
+++ b/docs/02-user-guide/posttraining.md
@@ -48,7 +48,7 @@ From a clone of the Primus repository, the same entrypoint is often invoked as `
 ### Container mode
 
 ```bash
-./runner/primus-cli container --image rocm/primus:v26.5 -- \
+./runner/primus-cli container --image rocm/primus:v26.6 -- \
   train posttrain \
   --config ./examples/megatron_bridge/configs/MI355X/qwen3_32b_sft_posttrain.yaml
 ```

--- a/docs/02-user-guide/pretraining.md
+++ b/docs/02-user-guide/pretraining.md
@@ -33,7 +33,7 @@ From the root of the clone of the [Primus repository](https://github.com/AMD-AGI
   --config examples/megatron/configs/MI300X/llama2_7B-BF16-pretrain.yaml
 ```
 
-This uses the default image from `runner/.primus.yaml` (`rocm/primus:v26.5` unless overridden). The project tree is mounted into the container automatically by `runner/primus-cli-container.sh`.
+This uses the default image from `runner/.primus.yaml` (`rocm/primus:v26.6` unless overridden). The project tree is mounted into the container automatically by `runner/primus-cli-container.sh`.
 
 ### Example configurations under `examples/megatron/configs/MI300X/`
 

--- a/docs/02-user-guide/torchtitan-training.md
+++ b/docs/02-user-guide/torchtitan-training.md
@@ -6,21 +6,21 @@ Training performance validation with the AMD PyTorch Docker image on AMD Instinc
 
 PyTorch is an open-source machine learning framework that is widely used for model training, with GPU-optimized components for transformer-based models.
 
-The ROCm PyTorch training Docker image `rocm/primus:v26.5`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for fine-tuning and pre-training a model on the AMD Instinct™ MI300X and MI325X accelerators.
+The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for fine-tuning and pre-training a model on the AMD Instinct™ MI300X and MI325X accelerators.
 
-For the full software stack of this image (ROCm, PyTorch, Transformer Engine, Flash Attention, hipBLASLt, Triton, RCCL, and the rest), see [Release notes → `rocm/primus:v26.5`](../01-getting-started/release-notes.md#rocmprimusv265). The release notes are the single source of truth for image contents, and also cover the previous [`rocm/primus:v26.4`](../01-getting-started/release-notes.md#rocmprimusv264).
+For the full software stack of this image (ROCm, PyTorch, Transformer Engine, Flash Attention, hipBLASLt, Triton, RCCL, and the rest), see [Release notes → `rocm/primus:v26.6`](../01-getting-started/release-notes.md#rocmprimusv266). The release notes are the single source of truth for image contents, and also cover the previous [`rocm/primus:v26.5`](../01-getting-started/release-notes.md#rocmprimusv265).
 
 Training is launched with `primus-cli`, the unified Primus CLI that covers direct, container, and Slurm execution from the same YAML configuration. See the [CLI reference](./cli-reference.md).
 
 ---
 
-## Important notes for v26.5
+## Important notes for v26.6
 
 Read this section before starting a training run. It collects the settings this release requires, the architecture-specific tuning, and the known issues. The contents change from release to release, so re-read it when you move to a new image tag.
 
 ### Required settings
 
-**Use the `release/v26.5` branch.** It is the Primus branch matching the `rocm/primus:v26.5` image. The `/workspace/Primus` checkout baked into the image is built from commit `b511d1b6` and the branch has moved on since — see [Release notes → Primus source for v26.5](../01-getting-started/release-notes.md#primus-source-for-v265). [Environment setup](#get-the-primus-source) has the clone command.
+**Use the `release/v26.6` branch.** It is the Primus branch matching the `rocm/primus:v26.6` image. Prefer this checkout over the `/workspace/Primus` copy baked into the image — see [Release notes → Primus source for v26.6](../01-getting-started/release-notes.md#primus-source-for-v266). [Environment setup](#get-the-primus-source) has the clone command.
 
 ### Architecture-specific settings
 
@@ -33,7 +33,7 @@ export NVTE_CK_IS_V3_ATOMIC_FP32=1
 
 ### Known issues
 
-No TorchTitan backend issues are currently tracked for v26.5.
+No TorchTitan backend issues are currently tracked for v26.6.
 
 ### Registry change
 
@@ -102,11 +102,11 @@ Clone the branch matching the image. Do this on the host — every command in th
 ```bash
 git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
 cd Primus
-git checkout release/v26.5
+git checkout release/v26.6
 git submodule update --init --recursive
 ```
 
-That is all the setup required. The training commands below use `primus-cli container`, which starts `rocm/primus:v26.5` for you, mounts this checkout into it at the same path, and runs the training inside. You do not need to `docker run` or `docker exec` by hand, and the `/workspace/Primus` copy baked into the image is not used — see [Release notes → Primus source for v26.5](../01-getting-started/release-notes.md#primus-source-for-v265).
+That is all the setup required. The training commands below use `primus-cli container`, which starts `rocm/primus:v26.6` for you, mounts this checkout into it at the same path, and runs the training inside. You do not need to `docker run` or `docker exec` by hand, and the `/workspace/Primus` copy baked into the image is not used — see [Release notes → Primus source for v26.6](../01-getting-started/release-notes.md#primus-source-for-v266).
 
 Container mode also forwards environment variables you export on the host, including `HF_TOKEN`, the gfx942 tuning variables, and the `NCCL_*` networking variables. The forwarded list is `container.options.env` in `runner/.primus.yaml`.
 
@@ -118,11 +118,11 @@ Container mode also forwards environment variables you export on the host, inclu
 If you want an interactive shell — for debugging, or to run `primus-cli direct` yourself — start the container manually and bind your Primus checkout:
 
 ```bash
-docker pull rocm/primus:v26.5
+docker pull rocm/primus:v26.6
 docker run -it --device /dev/dri --device /dev/kfd --network host --ipc host \
     --group-add video --cap-add SYS_PTRACE --security-opt seccomp=unconfined --privileged \
     -v $PWD:$PWD -w $PWD -v $HOME/.ssh:/root/.ssh \
-    --shm-size 64G --name training_env rocm/primus:v26.5
+    --shm-size 64G --name training_env rocm/primus:v26.6
 ```
 
 Re-enter it later with `docker start training_env && docker exec -it training_env bash`. Inside the container, replace `primus-cli container` with `primus-cli direct` in every command below. Remember to re-export `HF_TOKEN` and any architecture or `NCCL_*` variables, since a manual `docker run` does not forward them.
@@ -146,7 +146,7 @@ export HF_TOKEN=$your_personal_hf_token
 
 For detailed usage of `primus-cli`, see the [CLI reference](./cli-reference.md).
 
-Run these from your `release/v26.5` checkout **on the host**. Container mode starts the image and runs the training inside it for you. If you already have a shell inside the container, swap `container` for `direct`.
+Run these from your `release/v26.6` checkout **on the host**. Container mode starts the image and runs the training inside it for you. If you already have a shell inside the container, swap `container` for `direct`.
 
 ### Benchmarking examples
 

--- a/docs/05-operations/deployment.md
+++ b/docs/05-operations/deployment.md
@@ -14,7 +14,7 @@ Primus supports three deployment modes:
 | **Direct** | Runs on the current host (or inside an existing container) | Local debugging, single-node, clusters with ROCm on nodes |
 | **Slurm** | Wraps `srun`/`sbatch` and launches per-node entry scripts | Multi-node clusters with Slurm |
 
-**Container image:** `docker.io/rocm/primus:v26.5` (default in `runner/.primus.yaml`). For clusters using **AINIC**, use `runner/use_ainic.yaml` and tune the image and NCCL-related variables (for example `USING_AINIC`, `NCCL_IB_GID_INDEX`) to match your fabric.
+**Container image:** `docker.io/rocm/primus:v26.6` (default in `runner/.primus.yaml`). For clusters using **AINIC**, use `runner/use_ainic.yaml` and tune the image and NCCL-related variables (for example `USING_AINIC`, `NCCL_IB_GID_INDEX`) to match your fabric.
 
 **Prerequisites (baseline):**
 
@@ -29,10 +29,10 @@ Primus supports three deployment modes:
 ### 2.1 Pull the image
 
 ```bash
-docker pull docker.io/rocm/primus:v26.5
+docker pull docker.io/rocm/primus:v26.6
 ```
 
-The default `container.options.image` in `runner/.primus.yaml` is `rocm/primus:v26.5` (equivalent to `docker.io/rocm/primus:v26.5` when the registry is omitted).
+The default `container.options.image` in `runner/.primus.yaml` is `rocm/primus:v26.6` (equivalent to `docker.io/rocm/primus:v26.6` when the registry is omitted).
 
 ### 2.2 Required device mounts
 
@@ -107,7 +107,7 @@ Use `--clean` before launch to remove existing containers (`primus-cli-container
 ./primus-cli slurm srun -N <nodes> -p <partition> -- train pretrain --config <yaml>
 ```
 
-The Slurm entry script invokes the container launcher on each allocated node. Set the image through `runner/.primus.yaml`, a custom launcher config file, or site policy; the default is `rocm/primus:v26.5`.
+The Slurm entry script invokes the container launcher on each allocated node. Set the image through `runner/.primus.yaml`, a custom launcher config file, or site policy; the default is `rocm/primus:v26.6`.
 
 ### 3.2 `sbatch` (batch jobs)
 
@@ -157,7 +157,7 @@ The shipped `primus-cli-slurm-entry.sh` invokes **`primus-cli-container.sh`** wi
 
 ## 4. Kubernetes deployment
 
-Kubernetes integration is **not** shipped as a Helm chart or operator in this repository. The repo includes **`examples/run_k8s_pretrain.sh`**, a client script that talks to a Kubernetes **API** to create and manage training workloads (image default `docker.io/rocm/primus:v26.5`).
+Kubernetes integration is **not** shipped as a Helm chart or operator in this repository. The repo includes **`examples/run_k8s_pretrain.sh`**, a client script that talks to a Kubernetes **API** to create and manage training workloads (image default `docker.io/rocm/primus:v26.6`).
 
 Use that script as a reference for your platform; adapt networking, storage, and scheduling to your cluster policies.
 

--- a/examples/run_k8s_pretrain.sh
+++ b/examples/run_k8s_pretrain.sh
@@ -15,7 +15,7 @@ GPU="8"
 EXP_PATH=""
 DATA_PATH=""
 BACKEND="megatron"
-IMAGE="docker.io/rocm/primus:v26.5"
+IMAGE="docker.io/rocm/primus:v26.6"
 HF_TOKEN="${HF_TOKEN:-}"
 WORKSPACE="primus-safe-pretrain"
 NODELIST=""
@@ -38,7 +38,7 @@ Options for create:
     --backend <name>            Training backend, e.g. megatron | torchtitan(default: megatron)
     --exp <exp_path>            Path to EXP config (optional)
     --data_path <data_path>     Data path (optional)
-    --image <docker_image>      Docker image to use (default: docker.io/rocm/primus:v26.5)
+    --image <docker_image>      Docker image to use (default: docker.io/rocm/primus:v26.6)
     --hf_token <token>          HuggingFace token (default: from env HF_TOKEN)
     --workspace <workspace>     Workspace name (default: safe-cluster-dev)
     --nodelist <node1,node2>    Comma-separated list of node names to run on (optional)

--- a/primus/__init__.py
+++ b/primus/__init__.py
@@ -1,4 +1,4 @@
 from .core.launcher.initialize import init
 from .core.utils.global_vars import get_primus_config
 
-__version__ = "26.5"
+__version__ = "26.6"

--- a/runner/.primus.yaml
+++ b/runner/.primus.yaml
@@ -26,7 +26,7 @@ container:
   # All keys directly map to CLI arguments (--key value)
   options:
     # Container image
-    image: "rocm/primus:v26.5"
+    image: "rocm/primus:v26.6"
 
     # Single-value options
     ipc: "host"

--- a/runner/README.md
+++ b/runner/README.md
@@ -162,7 +162,7 @@ This is the most common pattern when you need a fixed software stack.
 bash runner/primus-cli slurm \
   -N 4 \
   --nodelist "node[01-04]" \
--- --image "rocm/primus:v26.5" \
+-- --image "rocm/primus:v26.6" \
 -- --env NCCL_DEBUG=INFO \
 -- train pretrain --config examples/megatron/configs/MI300X/llama3.1_8B-BF16-pretrain.yaml
 ```

--- a/runner/use_ainic.yaml
+++ b/runner/use_ainic.yaml
@@ -26,7 +26,7 @@ container:
   # All keys directly map to CLI arguments (--key value)
   options:
     # Container image
-    image: "rocm/jax-training:maxtext-v26.5"
+    image: "rocm/jax-training:maxtext-v26.6"
 
     # Single-value options
     ipc: "host"


### PR DESCRIPTION
Point README, user-facing docs, package version, and launcher defaults at the v26.6 images and release/v26.6 branch.