### PR TITLE
fix(megatron): checkpoint heterogeneous Flux layers independently

### DIFF
--- a/primus/backends/megatron/core/extensions/primus_turbo_mxfp6_local.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_mxfp6_local.py
@@ -47,7 +47,10 @@ from primus_turbo.pytorch.core.low_precision import (
     MXFP6_PROLOGUE_BIAS_GELU_BACKWARD,
     ScalingGranularity,
 )
-from primus_turbo.pytorch.kernels.gemm.gemm_fp6_impl import gemm_fp6_impl, gemm_fp6_out_impl
+from primus_turbo.pytorch.kernels.gemm.gemm_fp6_impl import (
+    gemm_fp6_impl,
+    gemm_fp6_out_impl,
+)
 from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
 from primus_turbo.pytorch.kernels.quantization.mxfp6_pack import check_mxfp6_support
 
@@ -276,9 +279,7 @@ class MXFP6LinearFunction(torch.autograd.Function):
 
             # grad_weight[N, K] = grad.T[N, M] @ input[M, K], contracting M.
             if ctx.fuse_wgrad_accum:
-                grad_weight = _wgrad_into_main_grad(
-                    weight, g_col, g_col_scale, a_col, a_col_scale, n, k, m
-                )
+                grad_weight = _wgrad_into_main_grad(weight, g_col, g_col_scale, a_col, a_col_scale, n, k, m)
             else:
                 grad_weight = gemm_fp6_impl(
                     g_col,
@@ -563,9 +564,7 @@ class MXFP6MLPFunction(torch.autograd.Function):
         grad_a = gemm_fp6_impl(g2_row, g2_row_s, w2_col, w2_col_s, m, f, h, out_dtype, _GRAN_VALUE)
         # fc2 wgrad: [h, f] = g2.T[h, m] @ a[m, f], contracting m.
         if ctx.fuse_wgrad_accum:
-            grad_w2 = _wgrad_into_main_grad(
-                fused_weights[1], g2_col, g2_col_s, a_col, a_col_s, h, f, m
-            )
+            grad_w2 = _wgrad_into_main_grad(fused_weights[1], g2_col, g2_col_s, a_col, a_col_s, h, f, m)
         else:
             grad_w2 = gemm_fp6_impl(g2_col, g2_col_s, a_col, a_col_s, h, f, m, out_dtype, _GRAN_VALUE)
 
@@ -582,9 +581,7 @@ class MXFP6MLPFunction(torch.autograd.Function):
         grad_x = grad_x.reshape(ctx.orig_shape)
         # fc1 wgrad: [f, k] = grad_y1.T[f, m] @ x[m, k], contracting m.
         if ctx.fuse_wgrad_accum:
-            grad_w1 = _wgrad_into_main_grad(
-                fused_weights[0], g1_col, g1_col_s, x_col, x_col_s, f, k, m
-            )
+            grad_w1 = _wgrad_into_main_grad(fused_weights[0], g1_col, g1_col_s, x_col, x_col_s, f, k, m)
         else:
             grad_w1 = gemm_fp6_impl(g1_col, g1_col_s, x_col, x_col_s, f, k, m, out_dtype, _GRAN_VALUE)
 

--- a/primus/backends/megatron/core/models/diffusion/flux/config.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/config.py
@@ -78,6 +78,8 @@ class FluxConfig(BaseDiffusionConfig):
         apply_rope_fusion: Whether to apply RoPE fusion optimization (default: False)
         add_qkv_bias: Whether to add bias to QKV projections (default: True)
         single_block_bias: Whether to add bias to single block linear layers (default: True)
+        hetereogenous_dist_checkpoint: Keep joint and single blocks in distinct
+            per-layer distributed-checkpoint namespaces (required, always True)
         activation_func: Activation function (default: openai_gelu_no_jit)
         use_te_rng_tracker: Whether to use Transformer Engine RNG tracker (default: False)
     """
@@ -91,6 +93,10 @@ class FluxConfig(BaseDiffusionConfig):
     # Architecture: Number of layers
     num_joint_layers: int = 19  # Default: Flux 12B
     num_single_layers: int = 38  # Default: Flux 12B
+    # Megatron preserves this misspelling in its public TransformerConfig API.
+    # Flux's joint and single blocks have different parameter sets and shapes,
+    # so they cannot share the homogeneous layer-stacked checkpoint namespace.
+    hetereogenous_dist_checkpoint: bool = True
 
     # Architecture: Dimensions (Flux standard: 3072)
     hidden_size: int = 3072
@@ -222,6 +228,12 @@ class FluxConfig(BaseDiffusionConfig):
         self.num_layers = self.num_joint_layers + self.num_single_layers
 
         super().__post_init__()  # BaseDiffusionConfig (mapping) -> TransformerConfig (validation)
+
+        if not self.hetereogenous_dist_checkpoint:
+            raise ValueError(
+                "Flux requires hetereogenous_dist_checkpoint=True because its joint "
+                "and single transformer blocks have different checkpoint schemas"
+            )
 
         # Xavier uniform for Megatron parallel linear layers (common Flux reference default).
         self.init_method = nn.init.xavier_uniform_

--- a/primus/backends/megatron/core/models/diffusion/flux/model.py
+++ b/primus/backends/megatron/core/models/diffusion/flux/model.py
@@ -604,8 +604,8 @@ class Flux(DiffusionModule):
         indexed sharded keys (``transformer.layers.<i>.*``) are required here:
         the homogeneous layer-stacked path would leave unclaimed slots for the
         params absent in single blocks and raise a CheckpointingException at
-        save time. TransformerBlock.sharded_state_dict provides this
-        automatically, so no config toggle is needed.
+        save time. ``FluxConfig.hetereogenous_dist_checkpoint`` enables
+        TransformerBlock's supported per-layer checkpoint namespace.
 
         Args:
             prefix: Prefix for state dict keys (e.g., 'module.')
@@ -617,8 +617,8 @@ class Flux(DiffusionModule):
         """
         sharded_state_dict = {}
 
-        # Delegate transformer layers to TransformerBlock
-        # Handles heterogeneous layers automatically
+        # Delegate transformer layers to TransformerBlock. FluxConfig requires
+        # its heterogeneous per-layer checkpoint namespace.
         sharded_state_dict.update(
             self.transformer.sharded_state_dict(f"{prefix}transformer.", sharded_offsets, metadata)
         )

--- a/primus/backends/megatron/data/energon_dataset_provider.py
+++ b/primus/backends/megatron/data/energon_dataset_provider.py
@@ -33,10 +33,10 @@ from megatron.energon import (
 from primus.backends.megatron.data.dataloader import MegatronDataloaderWrapper
 from primus.backends.megatron.data.dataset_provider import DatasetProvider
 from primus.backends.megatron.training.eval_budget import (
-    get_eval_micro_batch_size,
     EvalCoverageError,
     assert_mlperf_timestep_source,
     assert_val_worker_divisibility,
+    get_eval_micro_batch_size,
     get_eval_num_microbatches,
     get_val_num_workers,
 )

--- a/primus/backends/megatron/patches/args/eval_samples_patches.py
+++ b/primus/backends/megatron/patches/args/eval_samples_patches.py
@@ -17,8 +17,8 @@ corrected ``eval_iters``.
 """
 
 from primus.backends.megatron.training.eval_budget import (
-    get_eval_global_batch_size,
     assert_val_worker_divisibility,
+    get_eval_global_batch_size,
     get_val_num_workers,
     read_energon_split_sample_count,
     resolve_eval_iters,

--- a/primus/backends/megatron/patches/dataloader_patch.py
+++ b/primus/backends/megatron/patches/dataloader_patch.py
@@ -112,8 +112,7 @@ def _install_dataloader_monkeypatch(mp_context) -> None:
                 requested = kwargs["multiprocessing_context"]
                 kwargs["multiprocessing_context"] = mp_context
                 log_rank_0(
-                    f"Overriding DataLoader multiprocessing_context={requested!r} "
-                    f"with '{mp_context}'."
+                    f"Overriding DataLoader multiprocessing_context={requested!r} " f"with '{mp_context}'."
                 )
         return original_init(self, *args, **kwargs)
 

--- a/primus/backends/megatron/patches/mlperf_warmup_patches.py
+++ b/primus/backends/megatron/patches/mlperf_warmup_patches.py
@@ -240,9 +240,7 @@ def _reset_ddp_grad_ready_calibration(models):
     """
     drained = groups_reset = 0
     for m in models:
-        groups = list(getattr(m, "bucket_groups", [])) + list(
-            getattr(m, "expert_parallel_bucket_groups", [])
-        )
+        groups = list(getattr(m, "bucket_groups", [])) + list(getattr(m, "expert_parallel_bucket_groups", []))
         for group in groups:
             if not hasattr(group, "is_first_batch"):
                 continue

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_config.py
@@ -9,10 +9,6 @@ Tests FluxConfig and BaseDiffusionConfig validation, preset configurations.
 
 import pytest
 
-from tests.utils import skip_if_no_cuda
-
-skip_if_no_cuda()
-
 from primus.backends.megatron.core.models.diffusion.common import BaseDiffusionConfig
 from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
 from tests.utils import PrimusUT
@@ -39,6 +35,19 @@ class TestBaseDiffusionConfig(PrimusUT):
 
 class TestFluxConfig(PrimusUT):
     """Tests for FluxConfig class."""
+
+    def test_distributed_checkpoint_is_non_homogeneous(self):
+        """Flux must use per-layer checkpoint keys for its two block families."""
+        config = FluxConfig.flux_535m()
+        self.assertTrue(config.hetereogenous_dist_checkpoint)
+
+    def test_homogeneous_distributed_checkpoint_is_rejected(self):
+        """A homogeneous layer stack cannot represent Flux's parameter schemas."""
+        with self.assertRaisesRegex(
+            ValueError,
+            "Flux requires hetereogenous_dist_checkpoint=True",
+        ):
+            FluxConfig.flux_535m(hetereogenous_dist_checkpoint=False)
 
     def test_validation_positive_joint_layers(self):
         """Test validation fails for non-positive num_joint_layers."""

--- a/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_flux_dist_checkpoint.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Distributed-checkpoint regression tests for Flux's heterogeneous layers."""
+
+import pytest
+import torch
+from megatron.core.dist_checkpointing import load, save
+
+from primus.backends.megatron.core.models.diffusion.flux.config import FluxConfig
+from primus.backends.megatron.core.models.diffusion.flux.model import Flux
+from tests.utils import PrimusUT
+
+
+def _tiny_flux_config() -> FluxConfig:
+    """Build the smallest useful joint+single Flux model for checkpoint tests."""
+    return FluxConfig(
+        num_joint_layers=1,
+        num_single_layers=1,
+        hidden_size=16,
+        num_attention_heads=2,
+        ffn_hidden_size=64,
+        in_channels=4,
+        context_dim=16,
+        vec_in_dim=16,
+        model_channels=16,
+        axes_dim=(2, 2, 4),
+        transformer_impl="local",
+        params_dtype=torch.float32,
+    )
+
+
+def _runtime_device() -> torch.device:
+    """Use CUDA when available, otherwise run on CPU for CI coverage."""
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+class TestFluxDistCheckpoint(PrimusUT):
+    """Verify that joint and single blocks have independent checkpoint schemas."""
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        """Initialize single-rank model parallelism."""
+
+    def test_adaln_uses_distinct_per_layer_sharded_keys(self):
+        """The 6-chunk and 3-chunk adaLN weights must not share a global key."""
+        model = Flux(_tiny_flux_config()).to(_runtime_device())
+        sharded_state_dict = model.sharded_state_dict()
+
+        double_local_key = "transformer.layers.0.adaln.adaLN_modulation.1.weight"
+        single_local_key = "transformer.layers.1.adaln.adaLN_modulation.1.weight"
+        double_weight = sharded_state_dict[double_local_key]
+        single_weight = sharded_state_dict[single_local_key]
+
+        assert double_weight.key == double_local_key
+        assert single_weight.key == single_local_key
+        assert double_weight.key != single_weight.key
+        assert double_weight.prepend_axis_num == 0
+        assert single_weight.prepend_axis_num == 0
+        assert double_weight.global_shape == (6 * model.hidden_size, model.hidden_size)
+        assert single_weight.global_shape == (3 * model.hidden_size, model.hidden_size)
+
+    def test_torch_dist_save_load_round_trip(self, tmp_path):
+        """Save and restore both adaLN shapes through the real torch_dist backend."""
+        source = Flux(_tiny_flux_config()).to(_runtime_device())
+        double_weight = source.transformer.layers[0].adaln.adaLN_modulation[-1].weight
+        single_weight = source.transformer.layers[1].adaln.adaLN_modulation[-1].weight
+        with torch.no_grad():
+            double_weight.fill_(1.25)
+            single_weight.fill_(-2.5)
+
+        checkpoint_dir = tmp_path / "flux_torch_dist"
+        checkpoint_dir.mkdir()
+        save({"model": source.sharded_state_dict()}, checkpoint_dir)
+
+        target = Flux(_tiny_flux_config()).to(_runtime_device())
+        loaded = load({"model": target.sharded_state_dict()}, checkpoint_dir)
+        target.load_state_dict(loaded["model"])
+
+        torch.testing.assert_close(
+            target.transformer.layers[0].adaln.adaLN_modulation[-1].weight,
+            double_weight,
+        )
+        torch.testing.assert_close(
+            target.transformer.layers[1].adaln.adaLN_modulation[-1].weight,
+            single_weight,
+        )

--- a/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp6_local.py
+++ b/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp6_local.py
@@ -317,7 +317,6 @@ class TestMXFP6Compile(PrimusUT):
     def test_no_graph_break_hybrid(self):
         self._assert_no_graph_break(_hybrid_args())
 
-
     @requires_mxfp6
     def test_compiled_forward_matches_eager(self):
         from primus.backends.megatron.core.extensions.primus_turbo_mxfp6_local import (
@@ -517,9 +516,7 @@ class TestMXFP6LinearModules(PrimusUT):
     def test_fused_wgrad_accum_rejects_fp8_backward(self):
         """The FP8 backward forms its wgrad with a GEMM that has no out-variant."""
         with pytest.raises(ValueError, match="mxfp6_backward_precision"):
-            self._column_linear(
-                mxfp6_fused_wgrad_accum=True, mxfp6_backward_precision="fp8"
-            )
+            self._column_linear(mxfp6_fused_wgrad_accum=True, mxfp6_backward_precision="fp8")
 
     @requires_mxfp6
     def test_fused_wgrad_lands_in_main_grad(self):


### PR DESCRIPTION
## Summary

Flux combines joint and single transformer blocks whose AdaLN tensors have incompatible shapes. The MXFP6 branch currently uses Megatron's homogeneous layer-stacked checkpoint namespace, so its first distributed checkpoint save aborts before writing any files.

- Require `FluxConfig.hetereogenous_dist_checkpoint=True`, which gives each Flux layer its own checkpoint key.
- Reject the invalid homogeneous layout instead of deferring failure until a long run reaches its first save.
- Add coverage for distinct joint/single AdaLN keys and a real `torch_dist` save/load round trip.
- Format files on the consolidated MXFP6 branch that were blocking the repository-wide lint check.

## Test plan

- [x] `py_compile` passes for all changed checkpoint files.
- [x] `isort --check-only` and `black --check` pass across all Primus-owned Python files.
- [x] The same checkpoint fix was previously reviewed and merged on another Flux branch.
- [x] A full Flux 12B prefix save and resumed continuation previously validated that merged fix.
- [ ] Required CI checks pass on this MXFP6 branch.
- [ ] Run a minimal save/load/resume smoke from the merged branch before restarting the long prefix.
