### PR TITLE
examples(megatron): add Qwen3-30B-A3B and Qwen2.5-72B MXFP4 pretrain recipes for MI355X

### DIFF
--- a/examples/megatron/configs/MI355X/qwen2.5_72B-MXFP4-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen2.5_72B-MXFP4-pretrain.yaml
@@ -1,0 +1,96 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen2.5_72B-pretrain-mxfp4}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen2.5_72B.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Qwen2.5_72B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      train_iters: 50
+      # MXFP4 forbids activation recompute, so activations stay resident and
+      # cap mbs at 1 on a single 288 GB node even with Megatron-FSDP.
+      # Real-data pretrain: launch with PYTORCH_HIP_ALLOC_CONF=expandable_segments:True (avoids iter-2 HBM-fragmentation OOM).
+      micro_batch_size: 1
+      global_batch_size: 32
+
+      seq_length: ${PRIMUS_SEQ_LENGTH:2048}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:131072}
+
+      lr: 1.0e-4
+      min_lr: 1.0e-5
+      lr_warmup_iters: 2
+      lr_decay_iters: 320000
+      lr_decay_style: cosine
+      weight_decay: 1.0e-1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+
+      # parallel -- TP/PP are env-overridable for multi-node / TP scaling.
+      # Defaults 1/1 match the FP8 sibling's single-node DP+FSDP layout (that sibling
+      # hardcodes 1/1/1); EP stays 1 since this dense model has no experts.
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: 1
+      sequence_parallel: 1
+      overlap_grad_reduce: true
+
+      overlap_param_gather: false
+      gradient_accumulation_fusion: false
+      # torch FSDP2 breaks MXFP4 (loses column-wise FP4 weight data); shard with
+      # Megatron-FSDP (ZeRO-3) instead.
+      use_torch_fsdp2: false
+      use_megatron_fsdp: true
+      data_parallel_sharding_strategy: optim_grads_params
+      use_distributed_optimizer: true
+      ckpt_format: fsdp_dtensor
+
+      # data
+      mock_data: true
+      train_data_path: null
+      valid_data_path: null
+      test_data_path: null
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+
+      # recompute: omitted -- incompatible with MXFP4 (see micro_batch_size note).
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_gemm: false
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable mxfp4 training (BF16 grad reduction, matching llama3.1_8B-MXFP4)
+      fp4: e2m1
+      fp4_recipe: mxfp4
+      accumulate_allreduce_grads_in_fp32: false
+      grad_reduce_in_bf16: true
+      attention_softmax_in_fp32: false

--- a/examples/megatron/configs/MI355X/qwen3_30B_A3B-MXFP4-pretrain.yaml
+++ b/examples/megatron/configs/MI355X/qwen3_30B_A3B-MXFP4-pretrain.yaml
@@ -1,0 +1,106 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_30B_A3B-pretrain-mxfp4}
+workspace: ${PRIMUS_WORKSPACE:./output}
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+
+    # model to run
+    model: ${PRIMUS_MODEL:qwen3_30B_A3B}.yaml
+    overrides:
+      # log
+      wandb_project: "Primus_Qwen3_30B_A3B_Pretrain"
+      stderr_sink_level: DEBUG
+
+      # debug
+      moe_router_force_load_balancing: true
+      log_avg_skip_iterations: 2
+      log_avg_reset_interval: 50
+
+      # hyper parameters
+      train_iters: 50
+      micro_batch_size: 8
+      global_batch_size: 512
+      seq_length: ${PRIMUS_SEQ_LENGTH:4096}
+      max_position_embeddings: ${PRIMUS_MAX_POSITION_EMBEDDINGS:4096}
+      lr: 1.0e-5
+      min_lr: 0.0
+      lr_warmup_iters: 2
+      lr_decay_iters: null
+      lr_decay_style: cosine
+      weight_decay: 0.1
+      adam_beta1: 0.9
+      adam_beta2: 0.95
+      eod_mask_loss: true
+      init_method_std: 0.008
+      norm_epsilon: 1.0e-6
+
+      # recompute: omitted -- MXFP4 is incompatible with activation recompute
+      # (recomputed backward misses column-wise FP4 data), as in llama3.1_8B-MXFP4.
+
+      # parallel
+      tensor_model_parallel_size: ${PRIMUS_TP:1}
+      pipeline_model_parallel_size: ${PRIMUS_PP:1}
+      expert_model_parallel_size: ${PRIMUS_EP:8}
+      overlap_grad_reduce: true
+      overlap_param_gather: true
+
+      # data
+      mock_data: true
+      train_data_path: ${PRIMUS_TOKENIZED_DATA_PATH:null}
+      valid_data_path: null
+      test_data_path: null
+
+      # optimizer
+      use_precision_aware_optimizer: true
+      main_grads_dtype: bf16
+      exp_avg_dtype: bf16
+      exp_avg_sq_dtype: bf16
+
+      # rope fusion
+      enable_experimental: true
+      apply_rope_fusion: true
+
+      # ckpt
+      finetune: false
+      auto_continue_train: false
+      load: null
+      no_load_optim: null
+      no_load_rng: null
+      save: null
+      save_interval: 20000
+      no_save_optim: null
+      no_save_rng: null
+      disable_last_saving: true
+      ckpt_format: torch
+      eval_iters: 0
+
+      # Turbo
+      enable_primus_turbo: true
+      use_turbo_attention: false
+      use_turbo_grouped_gemm: false
+      use_turbo_rms_norm: false # bug
+
+      # deepep
+      use_turbo_deepep: true
+      moe_shared_expert_overlap: false
+      moe_router_dtype: fp32
+      turbo_deepep_num_cu: 80
+      turbo_deepep_use_comm_stream: false
+      turbo_sync_free_moe_stage: 1
+
+      # Cross entropy flags
+      cross_entropy_fusion_impl: "te"
+      cross_entropy_loss_fusion: true
+
+      # enable mxfp4 training (BF16 grad reduction, matching llama3.1_8B-MXFP4)
+      fp4: e2m1
+      fp4_recipe: mxfp4
+      accumulate_allreduce_grads_in_fp32: false
+      grad_reduce_in_bf16: true
+      attention_softmax_in_fp32: false
+      moe_use_legacy_grouped_gemm: true
+      gradient_accumulation_fusion: true


### PR DESCRIPTION
### Summary
`examples/megatron/configs/MI355X` ships an MXFP4 pretrain recipe only for
Llama-3.1 8B (`llama3.1_8B-MXFP4-pretrain.yaml`). The Qwen family has BF16/FP8
pretrain recipes but no MXFP4 variant. This adds MXFP4 (`fp4_recipe: mxfp4`)
pretrain recipes for two Qwen models, mirroring their FP8 siblings and the
shipped Llama-3.1 MXFP4 recipe.

### Change
Two new files under `examples/megatron/configs/MI355X/`:

**`qwen3_30B_A3B-MXFP4-pretrain.yaml`** (MoE)
- EP8, `micro_batch_size: 8`, `global_batch_size: 512`, `seq_length: 4096`.
- Inherits the FP8 sibling's MoE-Turbo stack (DeepEP `num_cu=80`,
  `turbo_sync_free_moe_stage: 1`, rope fusion, precision-aware optimizer,
  legacy grouped GEMM, grad-accum fusion), with FP8 swapped for MXFP4.

**`qwen2.5_72B-MXFP4-pretrain.yaml`** (dense)
- Megatron-FSDP / ZeRO-3 (`data_parallel_sharding_strategy: optim_grads_params`),
  `micro_batch_size: 1`, `global_batch_size: 32`, `seq_length: 2048`.
- Uses Megatron-FSDP rather than torch FSDP2: torch FSDP2's all-gather drops the
  column-wise FP4 weight data and breaks MXFP4.
- TP/PP are env-overridable (`${PRIMUS_TP:1}` / `${PRIMUS_PP:1}`) for
  multi-node / TP scaling; defaults match the FP8 sibling's single-node DP+FSDP
  layout (EP stays 1 — dense model).

**MXFP4 recipe (both), matching `llama3.1_8B-MXFP4-pretrain.yaml`:**
- `fp4: e2m1`, `fp4_recipe: mxfp4`
- BF16 gradient reduction: `accumulate_allreduce_grads_in_fp32: false`,
  `grad_reduce_in_bf16: true`, `attention_softmax_in_fp32: false`
- No activation recompute — MXFP4 is incompatible with recompute (the
  recomputed backward misses the column-wise FP4 data).

### Testing
Validated on `rocm/primus:v26.6`, 8× MI350X (gfx950), single node, mock + real
data (FineWeb-Edu), 10 iters, 0 NaN:

| Config | Throughput | lm loss (real data) | HBM |
| --- | --- | --- | --- |
| `qwen3_30B_A3B-MXFP4` | ~534 TFLOP/s/GPU | 11.998 → 11.948 | ~81% |
| `qwen2.5_72B-MXFP4` | ~543 TFLOP/s/GPU | 12.20 → 11.82 | ~99% |

Config values were tuned by measurement (15 variants across two sweeps: batch
scaling, DeepEP `num_cu`, router dtype, turbo attention/grouped-GEMM,
precision-aware optimizer, selective recompute); the committed values are the
measured optimum for single-node MXFP4.

Note: the 72B is memory-tight at mbs1; for real-data pretraining launch with
`PYTORCH_HIP_ALLOC_CONF=expandable_segments:True` to avoid a first-optimizer-step
HBM-fragmentation OOM (documented inline in the config).