### PR TITLE
update baremetal install v26.6 and update docs to v26.6

### DIFF
--- a/docs/01-getting-started/bare-metal-installation-jax.md
+++ b/docs/01-getting-started/bare-metal-installation-jax.md
@@ -15,7 +15,7 @@ training.
 > **Looking for the PyTorch/Megatron/TorchTitan stack instead?** See
 > [bare-metal-installation.md](bare-metal-installation.md). This document is the
 > JAX **MaxText** counterpart. It is leaner than the PyTorch stack — no Flash
-> Attention / aiter / Primus-Turbo / FBGEMM / rocSHMEM builds — but v26.5 still
+> Attention / aiter / Primus-Turbo / FBGEMM / rocSHMEM builds — but v26.6 still
 > compiles **TensorFlow (CPU) and RCCL from source** (and TransformerEngine from
 > source on hosts with glibc < 2.38), so it is not build-free.
 
@@ -50,7 +50,7 @@ training.
 If you just want the environment built for you, use the helper scripts in
 [tools/installation-jax/](https://github.com/AMD-AGI/Primus/tree/main/tools/installation-jax).
 They automate everything in Section 3 (Python venv) of this guide — venv
-creation, the ROCm release tarball, MaxText and its dependencies, TensorFlow
+creation, the ROCm pip SDK, MaxText and its dependencies, TensorFlow
 (built from source), JAX + ROCm PJRT/plugin, TransformerEngine, RCCL (built from
 source), and Primus itself — and provide a single `env.sh` to activate the
 environment before each job. Read the rest of this document if you want to
@@ -125,13 +125,13 @@ Stages are idempotent and re-runnable, so if a step fails you can fix the cause
 and re-run just that stage. On failure the script stops immediately and prints
 which stage failed.
 
-Default stages (v26.5):
+Default stages (v26.6):
 
 ```
 venv → rocm → maxtext → tf_source → jax → te → primus → jaxreqs → rccl → manifest
 ```
 
-This mirrors the v26.5 image, which **builds TensorFlow (2.21 CPU) and RCCL from
+This mirrors the v26.6 image, which **builds TensorFlow (2.21 CPU) and RCCL from
 source** (`tf_source`, `rccl`). Those are heavy: the TF bazel build alone is
 ~30–60 min. Lighter/alternative stages:
 
@@ -151,23 +151,36 @@ bash setup.sh venv rocm maxtext tf_cpu_fix jax te primus jaxreqs rccl manifest
 
 ### Use the environment for a training job
 
+Do this in a **fresh shell**. `env.sh` honours any `VENV_DIR`, `WORKSPACE_DIR`
+and `MAXTEXT_PATH` already exported, so a shell that previously sourced the
+PyTorch `tools/installation/env.sh` (or a different `PRIMUS_JAX_BASE`) keeps
+those stale paths and the run fails later with
+`Backend path not found for 'maxtext'`.
+
 ```bash
 # Use the SAME PRIMUS_JAX_BASE you built with
 export PRIMUS_JAX_BASE=/path/to/big/disk/primus-jax-env
 source tools/installation-jax/env.sh    # activates the venv + sets ROCm/NVTE/XLA vars
 
+# Sanity check: both must point inside $PRIMUS_JAX_BASE
+echo "$VIRTUAL_ENV" "$MAXTEXT_PATH"
 python -c "import jax; print('devices:', jax.devices())"
 
 # Primus is checked out under $WORKSPACE_DIR
 cd "$WORKSPACE_DIR/Primus"
 ./primus-cli direct -- train pretrain \
-  --config examples/maxtext/configs/MI300X/llama2_7B-pretrain.yaml
+  --config examples/maxtext/configs/MI300X/llama2_7B-bf16-pretrain.yaml
 ```
+
+Running from your own Primus checkout instead of `$WORKSPACE_DIR/Primus` works
+too, as long as the JAX venv is active. In that case also set
+`export PRIMUS_USER=$USER` if `output/amd/root/` in that checkout is left over
+from container runs — it is root-owned and the logger cannot write into it.
 
 > Pick the config directory that matches your GPU: `examples/maxtext/configs/MI300X/`
 > for **gfx942** (MI300X/MI325X) and `examples/maxtext/configs/MI355X/` for
 > **gfx950** (MI350X/MI355X), e.g.
-> `--config examples/maxtext/configs/MI355X/llama2_7B-pretrain.yaml`.
+> `--config examples/maxtext/configs/MI355X/llama2_7B-bf16-pretrain.yaml`.
 
 ### What the scripts do NOT do
 
@@ -189,23 +202,24 @@ for the full rationale.
 
 ---
 
-## 0. The key idea: ROCm comes from a tarball, not from a system install
+## 0. The key idea: ROCm comes from pip, not from a system install
 
-This build **does not require a system-wide ROCm installation**. In v26.5 ROCm
-is delivered as a **release tarball** (AMD "TheRock" multi-arch dist) that is
-extracted into a user-writable directory (`$ROCM_DIR`, default
-`$PRIMUS_JAX_BASE/rocm`) — no `/opt/rocm`, no root:
+This build **does not require a system-wide ROCm installation**. In v26.6 ROCm
+is delivered as **TheRock pip wheels** (`rocm-sdk-devel` 7.14.0 from
+`repo.amd.com/rocm/whl-multi-arch`) that land inside the virtual environment —
+no `/opt/rocm`, no root:
 
-- The tarball (`repo.amd.com/rocm/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0.tar.gz`)
-  provides the full ROCm toolchain (HIP, hipBLASLt, compilers, headers,
-  libraries). `ROCM_PATH` points at the extraction dir.
-- `jax` + `jaxlib` (upstream) plus the ROCm `jax_rocm7_pjrt` and
-  `jax_rocm7_plugin` wheels (from `repo.amd.com/rocm/whl-multi-arch/`) provide
-  GPU-accelerated JAX built against that ROCm.
+- `rocm`, `rocm-sdk-core`, `rocm-sdk-devel`, `rocm-sdk-libraries` and the
+  per-arch `rocm-sdk-device-gfx*` packages provide the ROCm toolchain (HIP,
+  hipBLASLt, compilers, headers, libraries) **inside the venv**. `ROCM_PATH`
+  points at `_rocm_sdk_devel`.
+- `jax` + `jaxlib` 0.11.0 plus `jax_rocm7_pjrt` / `jax_rocm7_plugin`
+  `0.11.0.post1` from **PyPI** provide GPU-accelerated JAX.
 
-> The pinned **release tarball** is stable and avoids any pip version-skew that
-> could break hipBLASLt GEMMs. RCCL is then rebuilt from source (see Section 3.11)
-> and dropped into this ROCm tree.
+> RCCL is then rebuilt from source (see Section 3.11) and dropped into this
+> ROCm tree (replacing the `librccl*` symlinks from `rocm-sdk-libraries`).
+> At runtime `LD_LIBRARY_PATH` is left empty so TE 2.17 + JAX resolve ROCm via
+> RPATH — matching the image's gfx950 CK-JIT fix.
 
 This means almost the entire stack can be installed **without root** into a
 venv. The only host-level requirements from the system administrator are:
@@ -226,7 +240,7 @@ The complete environment is composed of the following layers:
 | ----------------------- | ----------------------------------------------------------------- | ------------------------- | ------------------------- |
 | Kernel / hardware       | AMD GPU driver (amdgpu KMD), GPU device access                    | OS / admin                | Yes (one-time, by admin)  |
 | OS libraries            | Build toolchain + runtime libs (`g++`, `git`, `numactl`, RDMA, …) | `apt`                     | Yes (one-time)            |
-| ROCm user-space         | TheRock ROCm dist (HIP, hipBLASLt, compilers, libs)              | **release tarball** ($ROCM_DIR) | No (user dir)       |
+| ROCm user-space         | TheRock `rocm-sdk-*` (HIP, hipBLASLt, compilers, libs)           | pip wheels (venv)         | No (venv)           |
 | Deep learning framework | JAX (`jax`, `jaxlib`) + ROCm `jax_rocm7_pjrt` / `jax_rocm7_plugin`| pip (upstream + repo.amd.com) | No (venv)             |
 | Accelerated kernels     | TransformerEngine (JAX) — prebuilt ROCm wheel (or from source)   | pip (staging index) / build | No (venv)               |
 | Training framework      | MaxText (ROCm fork) + its Python deps                             | git + pip (`uv`)          | No (venv)                 |
@@ -238,23 +252,22 @@ The complete environment is composed of the following layers:
 
 ### 1.1 Version requirements (pins and host prerequisites)
 
-These are the exact versions the v26.5 reference `Dockerfile` pins. The install
+These are the exact versions the v26.6 reference `Dockerfile` pins. The install
 scripts use the same pins; change one and you may have to change the others.
 
 | Component                         | Pinned version / source                                                 | Notes |
 | --------------------------------- | ----------------------------------------------------------------------- | ----- |
-| ROCm (TheRock dist tarball)       | `therock-dist-linux-multiarch-7.14.0.tar.gz`                            | Multi-arch (gfx942 + gfx950). Extracted into `$ROCM_DIR`. |
-| JAX / jaxlib                      | `0.10.0`                                                                | Upstream PyPI. |
-| ROCm PJRT / plugin                | `jax_rocm7_pjrt` / `jax_rocm7_plugin` `0.10.0+rocm7.14.0`               | From `repo.amd.com/rocm/whl-multi-arch/`. |
-| TransformerEngine (JAX)           | `transformer_engine_rocm_jax 2.15.0.dev0+rocm7.15.0a20260707.72d01a0`  | Prebuilt wheel **needs glibc ≥ 2.38**; else build from source (`te_source`). |
-| TensorFlow (CPU, from source)     | ROCm `tensorflow-upstream` branch `upstream-v2.21.0`                    | Built with bazelisk `v1.25.0`. Needs host `clang-18`/`lld-18`. |
+| ROCm (TheRock pip wheels)         | `rocm-sdk-*==7.14.0`                                                    | From `repo.amd.com/rocm/whl-multi-arch`. |
+| JAX / jaxlib                      | `0.11.0`                                                                | Upstream PyPI. |
+| ROCm PJRT / plugin                | `jax_rocm7_pjrt` / `jax_rocm7_plugin` `0.11.0.post1`                     | From PyPI. |
+| TransformerEngine (JAX)           | `transformer_engine_rocm_jax 2.17.0+rocm7.14.0.50a84ad`                | Prebuilt wheel **needs glibc ≥ 2.38**; else build from source (`te_source`). |
+| TensorFlow (CPU, from source)     | ROCm `tensorflow-upstream` branch `upstream-v2.21.0`                    | Built with bazelisk `v1.29.0`. Needs host `clang-18`/`lld-18`. |
 | RCCL (from source)                | `rocm-systems` @ `9e5e4084a4b8e1e86551b0eb054725c62354a926`            | Installed into `$ROCM_PATH/lib`. Needs host `clang-18`/`lld-18`. |
-| MaxText (ROCm fork)               | `release/v26.5`                                                         | 2-value `initialize()`/`run()` API; Primus `main` supports it (fix #912). |
+| MaxText (ROCm fork)               | `release/v26.6`                                                         | ROCm MaxText fork matching the image. |
 | Primus                            | `main`                                                                  | Includes the MaxText `initialize()`/`run()` compatibility shim. |
 | scipy                             | `1.16`                                                                  | |
-| amdsmi                            | `7.0.2`                                                                 | pip, after the ROCm tarball. |
-| Build front-end                   | `cmake 3.31.6`, `ninja 1.11.1.3`, `wheel 0.45.1`, `packaging 25.0`, `setuptools 69.5.1` | Plus `uv` (used by MaxText's dep install). |
-| TE deps                           | `pybind11 3.0.4`, `importlib-metadata 8.7.1`, `pydantic 2.13.4`, `flax 0.12.2` | |
+| Build front-end                   | `cmake 3.31.6`, `ninja 1.11.1.3`, `wheel 0.46.2`, `packaging 25.0`, `setuptools 80.10.2`, `msgpack 1.2.1` | Plus `uv` (used by MaxText's dep install). |
+| TE deps                           | `pybind11 3.0.4`, `importlib-metadata 8.7.1`, `pydantic 2.13.4`, `flax 0.12.8` | |
 
 **Host prerequisites** (independent of the pins above):
 
@@ -264,7 +277,7 @@ scripts use the same pins; change one and you may have to change the others.
 | **glibc**              | **≥ 2.38** for the prebuilt TE wheel           | Ubuntu 24.04 = glibc 2.38+. On **Ubuntu 22.04 (glibc 2.35)** the prebuilt TE wheel won't load — the `te` stage auto-falls-back to a from-source build. Check with `ldd --version`. `glibc` cannot be side-loaded via `LD_LIBRARY_PATH`. |
 | **libstdc++ (GCC)**    | `GLIBCXX_3.4.32` (GCC 13/14) for prebuilt TE   | Can be side-loaded via `LD_LIBRARY_PATH` if glibc itself is new enough. |
 | **C/C++ toolchain**    | `g++` with C++17; `clang-18`/`lld-18` for the TF/RCCL source builds | Source builds (`tf_source`, `rccl`, `te_source`) need LLVM 18. |
-| **GPU arch**           | AMD Instinct **gfx942** (MI300/MI325) or **gfx950** (MI350/MI355) | The pinned ROCm tarball + JAX wheels target these. Other archs (e.g. gfx90a/MI250) need matching wheels not pinned here. |
+| **GPU arch**           | AMD Instinct **gfx942** (MI300/MI325) or **gfx950** (MI350/MI355) | The pinned ROCm wheels + JAX plugin target these. Other archs (e.g. gfx90a/MI250) need matching wheels not pinned here. |
 | **GPU driver (KMD)**   | amdgpu / ROCm kernel driver loaded             | `/dev/kfd` + `/dev/dri` present; user in `video`/`render` groups. |
 
 > **Validated:** the scripts' default flow (with `te_source` substituted for the
@@ -313,7 +326,7 @@ sudo apt install -y \
     wget unzip zip
 ```
 
-> **Source builds (v26.5): LLVM 18 toolchain.** The `tf_source` (TensorFlow 2.21
+> **Source builds (v26.6): LLVM 18 toolchain.** The `tf_source` (TensorFlow 2.21
 > bazel) and `rccl` source builds want a host `clang-18`/`lld-18`. The reference
 > image adds the LLVM apt repo and installs them:
 >
@@ -421,9 +434,10 @@ pip uninstall -y wheel
 pip install \
     cmake==3.31.6 \
     ninja==1.11.1.3 \
-    wheel==0.45.1 \
+    wheel==0.46.2 \
     packaging==25.0 \
-    setuptools==69.5.1 \
+    setuptools==80.10.2 \
+    msgpack==1.2.1 \
     uv
 ```
 
@@ -439,36 +453,38 @@ export ROCPROFILER_QUEUE_INTERPOSITION=0
 export DEBUG_HIP_DYNAMIC_QUEUES=0
 ```
 
-### 3.4 Install ROCm from the TheRock release tarball
+### 3.4 Install ROCm from TheRock pip wheels
 
-This step replaces a system ROCm install. v26.5 uses a **release tarball**
-(not pip wheels) extracted into a user-writable dir — no `/opt/rocm`, no root.
+This step replaces a system ROCm install. v26.6 uses **pip `rocm-sdk-*` wheels**
+(7.14.0) — no `/opt/rocm`, no root.
 
 ```bash
-# Extract into a user-writable location (the automated env.sh uses
-# $PRIMUS_JAX_BASE/rocm). ROCM_PATH will point here.
-export ROCM_DIR=~/primus-jax-env/rocm
-mkdir -p "$ROCM_DIR"
-wget -O /tmp/therock-dist.tar.gz \
-    https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0.tar.gz
-tar -xzf /tmp/therock-dist.tar.gz -C "$ROCM_DIR"
+THE_ROCK_VERSION=7.14.0
+python -m pip install \
+    --index-url https://repo.amd.com/rocm/whl-multi-arch --pre \
+    rocm==${THE_ROCK_VERSION} \
+    rocm-bootstrap \
+    rocm-sdk-core==${THE_ROCK_VERSION} \
+    rocm-sdk-devel==${THE_ROCK_VERSION} \
+    rocm-sdk-libraries==${THE_ROCK_VERSION} \
+    rocm-sdk-device-gfx942==${THE_ROCK_VERSION} \
+    rocm-sdk-device-gfx950==${THE_ROCK_VERSION}
 
-# amdsmi (installed via pip in the reference image)
-pip install amdsmi==7.0.2
+rocm-sdk init
 ```
 
-> The tarball is multi-arch (gfx942 + gfx950), so there is no per-arch package to
-> pick, and there is **no pip version-skew to worry about** — a pinned tarball
-> cannot drift out of sync and break hipBLASLt GEMMs.
+> Install only the `rocm-sdk-device-gfx*` package matching your GPU for a smaller
+> install. The automated scripts detect the arch and do that.
 
 ### 3.5 Export ROCm paths
 
-Point the rest of the build/runtime at the extracted ROCm. **These must be set
-every time you use the environment** — Section 5 shows how to make them
-persistent (the automated `env.sh` does all of this for you).
+Point the rest of the build at the in-venv ROCm. **`ROCM_PATH` / HIP vars must be
+set for source builds**; at **runtime** leave `LD_LIBRARY_PATH` empty (TE 2.17 +
+JAX RPATH fix). Section 5 shows how to make them persistent (the automated
+`env.sh` does all of this for you).
 
 ```bash
-export ROCM_PATH=$ROCM_DIR
+export ROCM_PATH=$(python -c 'import _rocm_sdk_devel, os; print(os.path.dirname(_rocm_sdk_devel.__file__))')
 export ROCM_HOME=$ROCM_PATH
 export HIP_PLATFORM=amd
 export HIP_PATH=$ROCM_PATH
@@ -476,12 +492,12 @@ export HIP_CLANG_PATH=$ROCM_PATH/llvm/bin
 export HIP_INCLUDE_PATH=$ROCM_PATH/include
 export HIP_LIB_PATH=$ROCM_PATH/lib
 export HIP_DEVICE_LIB_PATH=$ROCM_PATH/lib/llvm/amdgcn/bitcode
-# The reference Dockerfile puts $ROCM_PATH/lib on PATH too; mirror that.
-export PATH="$ROCM_PATH/lib:$ROCM_PATH/bin:$HIP_CLANG_PATH:$PATH"
-export LD_LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib/rocm_sysdeps/lib:$ROCM_PATH/lib64:$ROCM_PATH/llvm/lib"
-export LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib64"
+export PATH="$ROCM_PATH/bin:$HIP_CLANG_PATH:$PATH"
+export LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64"
 export CPATH=$HIP_INCLUDE_PATH
 export PKG_CONFIG_PATH="$ROCM_PATH/lib/pkgconfig"
+# Runtime (match the image): do not prepend ROCM_PATH to LD_LIBRARY_PATH.
+export LD_LIBRARY_PATH=""
 ```
 
 Quick check before continuing:
@@ -492,7 +508,7 @@ hipcc --version
 
 ### 3.6 Install MaxText, then JAX + the ROCm PJRT/plugin
 
-> **Order matters (v26.5).** The subsections below are numbered for reference,
+> **Order matters (v26.6).** The subsections below are numbered for reference,
 > but the correct install order is: **MaxText deps (§3.8) → TensorFlow from
 > source (§3.9) → ROCm JAX/PJRT/plugin (§3.6, right here) → TransformerEngine
 > (§3.7) → Primus (§3.10) → RCCL from source (§3.11)**. MaxText's `setup.sh`
@@ -503,34 +519,31 @@ hipcc --version
 MaxText install is in Section 3.8 (deps) below; the JAX packages are:
 
 ```bash
-JAX_VERSION=0.10.0
-JAX_PJRT_VERSION=0.10.0+rocm7.14.0       # https://repo.amd.com/rocm/whl-multi-arch/jax-rocm7-pjrt/
-JAX_PLUGIN_VERSION=0.10.0+rocm7.14.0     # https://repo.amd.com/rocm/whl-multi-arch/jax-rocm7-plugin/
+JAX_VERSION=0.11.0
+JAX_ROCM_VERSION=0.11.0.post1
 
-pip install jax==${JAX_VERSION} jaxlib==${JAX_VERSION} scipy==1.16
-pip install \
-    --index-url https://repo.amd.com/rocm/whl-multi-arch/ \
-    --pre jax_rocm7_pjrt==${JAX_PJRT_VERSION} \
-    --pre jax_rocm7_plugin==${JAX_PLUGIN_VERSION}
+pip install jax==${JAX_VERSION} jaxlib==${JAX_VERSION} scipy==1.16 \
+    jax_rocm7_pjrt==${JAX_ROCM_VERSION} \
+    jax_rocm7_plugin==${JAX_ROCM_VERSION}
 ```
 
 ### 3.7 Install TransformerEngine (JAX) from the prebuilt ROCm wheel
 
 TransformerEngine is installed as a prebuilt ROCm JAX wheel. Check
-[the staging index](https://rocm.frameworks-nightlies.amd.com/whl-staging/device-all/transformer-engine-rocm-jax/)
+[the staging index](https://rocm.frameworks-devreleases.amd.com/whl-multi-arch-staging/)
 for the current pin.
 
 ```bash
-TE_VERSION=2.15.0.dev0+rocm7.15.0a20260707.72d01a0
+TE_VERSION=2.17.0+rocm7.14.0.50a84ad
 
 pip install \
     pybind11==3.0.4 \
     importlib-metadata==8.7.1 \
     pydantic==2.13.4 \
-    flax==0.12.2
+    flax==0.12.8
 
 pip install \
-    --index-url https://rocm.frameworks-nightlies.amd.com/whl-staging/device-all/ \
+    --index-url https://rocm.frameworks-devreleases.amd.com/whl-multi-arch-staging/ \
     --pre \
     --no-build-isolation \
     transformer_engine_rocm_jax==${TE_VERSION}
@@ -552,10 +565,10 @@ pip install \
 > ```bash
 > pip uninstall -y transformer_engine transformer_engine_rocm_jax
 > export USE_ROCM=1 NVTE_FRAMEWORK=jax NVTE_USE_ROCM=1
-> export NVTE_ROCM_ARCH="${PYTORCH_ROCM_ARCH}" CMAKE_BUILD_PARALLEL_LEVEL=${MAX_JOBS}
+> export NVTE_ROCM_ARCH="gfx942;gfx950" CMAKE_BUILD_PARALLEL_LEVEL=${MAX_JOBS}
 > git clone --recursive https://github.com/ROCm/TransformerEngine.git
 > cd TransformerEngine
-> git checkout 635d7c085c39a6d9bfe4881c7d3efab7a46d7129   # last known-good ROCm JAX TE source commit
+> git checkout 50a84ad   # commit the TE_VERSION local label refers to
 > git submodule update --init --recursive
 > python3 setup.py bdist_wheel && pip install dist/*.whl
 > cd ..
@@ -572,17 +585,14 @@ image runs MaxText's `src/dependencies/scripts/setup.sh`; on bare metal we run
 the **Python portion** of that script directly (the `apt`/`gcsfuse` steps are the
 one-time root action from Section 2, and the venv already exists).
 
-> **MaxText `release/v26.5` and the Primus API.** MaxText v26.5 uses a
-> **2-value** `initialize()`/`run()` API (`config, recorder`). Primus `main`
-> handles it: `MaxTextPretrainTrainer` forwards `initialize()`'s tuple verbatim
-> to `run()` (fix #912), so v26.5 trains out of the box. Override `MAXTEXT_BRANCH`
-> only if you deliberately need to pin a different MaxText release.
+> **MaxText `release/v26.6`.** Override `MAXTEXT_BRANCH` only if you deliberately
+> need to pin a different MaxText release.
 
 ```bash
 cd ~/primus-jax-env   # or your $WORKSPACE_DIR
 git clone https://github.com/ROCm/maxtext.git
 cd maxtext
-git checkout release/v26.5   # matches the v26.5 image; Primus main supports its 2-value API
+git checkout release/v26.6   # matches the v26.6 image
 
 # MaxText installs its deps with uv. The default (tpu) requirements set contains
 # the framework-agnostic Python deps WITHOUT any CUDA packages, which is what the
@@ -602,7 +612,7 @@ cd ..
 
 ### 3.9 Build TensorFlow (CPU) from source
 
-v26.5 rebuilds TensorFlow 2.21 (CPU) from ROCm's fork. The stock PyPI TF wheel
+v26.6 rebuilds TensorFlow 2.21 (CPU) from ROCm's fork. The stock PyPI TF wheel
 bundles an LLVM whose symbols collide with ROCm's `libLLVM` in Grain "spawn"
 workers → **SIGSEGV on `import tensorflow` after `import jax`**. A CPU build has
 correct symbol visibility and no bundled NCCL (so it also preserves the XLA→RCCL
@@ -662,7 +672,7 @@ the clone and just run the `git submodule update`, `pip uninstall`, and
 
 ### 3.11 Build RCCL from source (into the ROCm tree)
 
-v26.5 rebuilds RCCL from `rocm-systems` and drops the libraries into the ROCm
+v26.6 rebuilds RCCL from `rocm-systems` and drops the libraries into the ROCm
 tree so JAX/XLA collectives use it. Requires the ROCm toolchain (`hipcc`) from
 Section 3.4.
 
@@ -672,7 +682,8 @@ cd rocm-systems
 git checkout 9e5e4084a4b8e1e86551b0eb054725c62354a926
 cd projects/rccl
 ./install.sh -l --prefix build/ --amdgpu_targets="${PYTORCH_ROCM_ARCH}"
-cp -r build/release/librccl* "$ROCM_PATH/lib/"
+        && rm -f "$ROCM_PATH"/lib/librccl* \
+        && cp -r build/release/librccl* "$ROCM_PATH/lib/"
 cd ../../..
 ```
 
@@ -765,8 +776,8 @@ export HSA_NO_SCRATCH_RECLAIM=1
 export ROCPROFILER_QUEUE_INTERPOSITION=0
 export DEBUG_HIP_DYNAMIC_QUEUES=0
 
-# v26.5: ROCm lives in the extracted tarball dir (Section 3.4), NOT a pip wheel.
-export ROCM_PATH=$HOME/primus-jax-env/rocm
+# v26.6: ROCm lives in the pip SDK (Section 3.4).
+export ROCM_PATH=$(python -c 'import _rocm_sdk_devel, os; print(os.path.dirname(_rocm_sdk_devel.__file__))')
 export ROCM_HOME=$ROCM_PATH
 export HIP_PLATFORM=amd
 export HIP_PATH=$ROCM_PATH
@@ -774,8 +785,9 @@ export HIP_CLANG_PATH=$ROCM_PATH/llvm/bin
 export HIP_INCLUDE_PATH=$ROCM_PATH/include
 export HIP_LIB_PATH=$ROCM_PATH/lib
 export HIP_DEVICE_LIB_PATH=$ROCM_PATH/lib/llvm/amdgcn/bitcode
-export PATH="$ROCM_PATH/lib:$ROCM_PATH/bin:$HIP_CLANG_PATH:$HOME/primus-jax-env/openmpi/bin:$PATH"
-export LD_LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib/rocm_sysdeps/lib:$ROCM_PATH/lib64:$ROCM_PATH/llvm/lib:$HOME/primus-jax-env/openmpi/lib"
+export PATH="$ROCM_PATH/bin:$HIP_CLANG_PATH:$HOME/primus-jax-env/openmpi/bin:$PATH"
+# v26.6 blanks LD_LIBRARY_PATH so TE 2.17 + JAX use RPATH. OpenMPI still needs its lib.
+export LD_LIBRARY_PATH="$HOME/primus-jax-env/openmpi/lib"
 export LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib64"
 export CPATH=$HIP_INCLUDE_PATH
 export PKG_CONFIG_PATH="$ROCM_PATH/lib/pkgconfig"
@@ -803,10 +815,10 @@ export NCCL_DEBUG=VERSION
 # host, /usr/local/lib/librccl-net.so is on the default loader path and is
 # ABI-incompatible with the from-source RCCL (undefined symbol
 # ncclNetPlugin_v11/_v10 -> falls back to v9 -> segfault at clique init). The
-# v26.5 image ships no librccl-net.so, so this matches it.
+# v26.6 image ships no librccl-net.so, so this matches it.
 export NCCL_NET_PLUGIN=none
 
-# XLA / JAX runtime settings (v26.5 uses .9)
+# XLA / JAX runtime settings (v26.6 uses .9)
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.9
 export XLA_FLAGS="--xla_gpu_memory_limit_slop_factor=95 --xla_gpu_reduce_scatter_combine_threshold_bytes=8589934592 --xla_gpu_enable_latency_hiding_scheduler=True --xla_gpu_all_gather_combine_threshold_bytes=8589934592 --xla_gpu_enable_triton_gemm=False --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=0 --xla_gpu_enable_all_gather_combine_by_dim=FALSE --xla_gpu_enable_command_buffer=''"
 # ---- end Primus JAX host environment ----
@@ -839,8 +851,8 @@ python -c "import jax, jaxlib, flax, transformer_engine.jax; print('JAX/flax/TE 
 # matches your GPU: MI300X/ for gfx942 (MI300X/MI325X), MI355X/ for gfx950 (MI350X/MI355X).
 cd ~/primus-jax-env/Primus   # or your Primus checkout
 ./primus-cli direct -- train pretrain \
-  --config examples/maxtext/configs/MI300X/llama2_7B-pretrain.yaml
-  # gfx950: --config examples/maxtext/configs/MI355X/llama2_7B-pretrain.yaml
+  --config examples/maxtext/configs/MI300X/llama2_7B-bf16-pretrain.yaml
+  # gfx950: --config examples/maxtext/configs/MI355X/llama2_7B-bf16-pretrain.yaml
 ```
 
 `jax.default_backend()` should report `gpu` (ROCm), and `jax.devices()` should
@@ -860,7 +872,7 @@ running on bare metal with everything installed in your environment.
   and `render` groups (`sudo usermod -aG video,render $USER`, then re-login).
 - **Hugging Face access**: for gated models/tokenizers, export your token
   (`export HF_TOKEN=hf_xxx` and/or `huggingface-cli login`).
-- **Install order is load-bearing (v26.5)**: MaxText → TensorFlow (from source)
+- **Install order is load-bearing (v26.6)**: MaxText → TensorFlow (from source)
   → ROCm JAX/PJRT/plugin → TransformerEngine → RCCL (from source). MaxText's
   `setup.sh` pulls in a stock `jax`/`tensorflow`, so the ROCm JAX must be
   installed *after* MaxText (to override it) and *before* TE (or `jaxlib` gets
@@ -870,7 +882,7 @@ running on bare metal with everything installed in your environment.
   `/etc/security/limits.conf` (admin help). Verify NICs with `ibv_devinfo` /
   `ibstat`. JAX uses the distributed coordinator (`JAX_COORDINATOR_IP` /
   `JAX_COORDINATOR_PORT`), which Primus sets from `MASTER_ADDR` / `MASTER_PORT`.
-- **Version drift**: the ROCm release tarball, the JAX/PJRT/plugin versions, the
+- **Version drift**: the ROCm SDK wheels, the JAX/PJRT/plugin versions, the
   TransformerEngine wheel, the TensorFlow/RCCL source revisions, and the MaxText
   branch are all pinned to one release (see the table in Section 1.1). If you
   change one, you may need to update the others. The Docker image is the
@@ -890,7 +902,7 @@ multi-node components:
 
 | Component                                              | Needed for                          |
 | ------------------------------------------------------ | ----------------------------------- |
-| ROCm (tarball), JAX + PJRT/plugin, TransformerEngine (JAX) | Core MaxText training (install these) |
+| ROCm (pip SDK), JAX + PJRT/plugin, TransformerEngine (JAX) | Core MaxText training (install these) |
 | MaxText + its deps, TensorFlow (from source), RCCL (from source) | Core MaxText training (install these) |
 | Primus + `third_party/maxtext`                         | Running MaxText via Primus          |
 | gcsfuse                                                | Reading data from GCS buckets only  |

--- a/docs/01-getting-started/bare-metal-installation.md
+++ b/docs/01-getting-started/bare-metal-installation.md
@@ -3,7 +3,7 @@
 This guide explains how to build the **full Primus training software stack directly on a host machine**, without using the AMD published training Docker image. It is intended for users who, for policy or operational reasons, cannot run containers and need to reproduce the same environment on bare metal.
 
 It is derived from the official training Dockerfile — currently
-[`Dockerfile.primus-v26.5`](https://github.com/AMD-AGI/Primus/blob/main/.github/workflows/docker-release/Dockerfile.primus-v26.5) — and installs the same components and versions. Wherever possible, everything is installed **inside a Python virtual environment and without `sudo`**. The only steps that require root are a small set of OS-level system libraries (installed with `apt`), and a couple of optional networking packages used for multi-node training.
+[`Dockerfile.primus-v26.6`](https://github.com/AMD-AGI/Primus/blob/main/.github/workflows/docker-release/Dockerfile.primus-v26.6) — and installs the same components and versions. Wherever possible, everything is installed **inside a Python virtual environment and without `sudo`**. The only steps that require root are a small set of OS-level system libraries (installed with `apt`), and a couple of optional networking packages used for multi-node training.
 
 > **Important**: This is a long, build-heavy process. A full from-source build (Flash Attention, aiter, Primus-Turbo, and on older hosts TransformerEngine) can take **several hours** and needs a machine with many CPU cores, plenty of RAM, and tens of GB of free disk. The Docker image remains the recommended and best-supported path. Use this guide only when containers are not an option.
 
@@ -110,7 +110,7 @@ Use `primus-cli direct` (not `container`), since you are running on bare metal w
 - **System (`apt`) packages** ([Section 3](#3-system-packages-need-root-one-time)): skipped — they need root.
 - **Multi-node networking** ([Section 5](#5-multi-node-communication-stack-ucx-and-openmpi)): UCX, OpenMPI and AMD AINIC are not built. Single-node training works without them.
 - **FBGEMM / Flux / DLRM benchmarks**: not built (`torchrec` is an optional stage; FBGEMM additionally needs apt `libtbb-dev`).
-- **MLPerf `primus_mllog`**: v26.5 installs it from `training_results_v6.0`; it is not part of the core training path and is not installed.
+- **MLPerf `primus_mllog`**: the image installs `mlperf-common`; it is not part of the core training path and is not installed.
 
 ### 1.6 Where the scripts deliberately differ from the Dockerfile
 
@@ -250,8 +250,8 @@ export HSA_NO_SCRATCH_RECLAIM=1
 pip install --upgrade pip
 pip install \
     pybind11 typeguard \
-    wheel==0.45.1 cmake==3.31.6 ninja==1.11.1.3 \
-    packaging==25.0 setuptools==75.1.0
+    wheel==0.46.2 cmake==3.31.6 ninja==1.11.1.3 \
+    packaging==25.0 setuptools==80.10.2
 ```
 
 ### 4.3 Install ROCm + PyTorch from the TheRock multi-arch wheels
@@ -265,17 +265,21 @@ pip install \
 
 # One coherent nightly. The Dockerfile pins only `torch` and lets the companions
 # float, which no longer resolves; pin them all to the same date.
-NIGHTLY="rocm7.15.0a20260720"
+NIGHTLY="rocm7.15.0a20260727"
 
 python -m pip uninstall -y torch
 python -m pip install \
     --index-url https://rocm.nightlies.amd.com/whl-multi-arch --pre \
+    rocm==7.15.0a20260727 \
+    rocm-bootstrap \
+    rocm-sdk-core==7.15.0a20260727 \
+    rocm-sdk-devel==7.15.0a20260727 \
+    rocm-sdk-libraries==7.15.0a20260727 \
     torch==2.12.0+${NIGHTLY} \
     amd-torch-device-gfx942==2.12.0+${NIGHTLY} \
     amd-torch-device-gfx950==2.12.0+${NIGHTLY} \
-    rocm-sdk-devel==7.15.0a20260720 \
-    rocm-sdk-device-gfx942==7.15.0a20260720 \
-    rocm-sdk-device-gfx950==7.15.0a20260720 \
+    rocm-sdk-device-gfx942==7.15.0a20260727 \
+    rocm-sdk-device-gfx950==7.15.0a20260727 \
     torchaudio==2.11.0+${NIGHTLY} \
     torchvision==0.27.0+${NIGHTLY} \
     amd-torchvision-device-gfx942==0.27.0+${NIGHTLY} \
@@ -329,22 +333,22 @@ mkdir -p ~/primus-build && cd ~/primus-build
 
 | Component | Repository | Pin | Install command | Notes |
 |---|---|---|---|---|
-| Flash Attention | `ROCm/flash-attention` | `6387433156558135a998d5568a9d74c1778666d8` | `python setup.py install` | clone `--recursive` |
+| Flash Attention | PyPI `flash-attn` | `2.8.1` | `pip install --no-build-isolation flash-attn==2.8.1` | v26.6 dropped the ROCm git fork |
 | grouped_gemm | `caaatch22/grouped_gemm` | branch `rocm` | `pip install --no-build-isolation .` | MoE models |
 | causal-conv1d | `Dao-AILab/causal-conv1d` | `e940ead2fd962c56854455017541384909ca669f` | `pip install --no-build-isolation .` | needs `CAUSAL_CONV1D_FORCE_BUILD=TRUE`, `HIP_ARCHITECTURES=gfx942,gfx950` |
 | mamba | `AndreasKaratzas/mamba` | branch `enable-primus-hybrid-models` | `pip install --no-build-isolation .` | see note below |
 | aiter | `ROCm/aiter` | `0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e` | `PREBUILD_KERNELS=3 pip install --no-cache-dir --use-pep517 .` | clone `--recursive`; `pip uninstall aiter amd-aiter` first |
-| Primus-Turbo | `AMD-AGI/Primus-Turbo` | `edc8d2ccb0be4888e80ee7c6e765fd3956026a32` | `pip install -r requirements.txt` then `pip install --no-build-isolation . -v` | needs `HCC_AMDGPU_TARGET="gfx942,gfx950"`; see note below |
+| Primus-Turbo | `AMD-AGI/Primus-Turbo` | `a6a16cdce46bd2235a248b41f501fb363c215b9b` | `pip install -r requirements.txt` then `pip install --no-build-isolation . -v` | needs `HCC_AMDGPU_TARGET="gfx942,gfx950"`; see note below |
 | torchtune | `pytorch/torchtune` | `b4c98ac2a37f0397d64c22579aed415ce7264db6` | `pip install .` | patch first: `sed -i 's/use_grouped_mm = True/use_grouped_mm = False/g' torchtune/modules/moe/utils.py` |
 | torchao | `pytorch/ao` | `e9c7bead90b840b280f97374308255957108ce47` | `pip install --no-build-isolation .` | two patches: `pad_inner_dim` → `True` in `torchao/float8/config.py`, and `if defined(HIPBLASLT_VEC_EXT)` → `if false` in `torchao/csrc/rocm/swizzle/swizzle.cpp` |
 
-**mamba.** Install with `pip`, **not** `python setup.py install`: the legacy `easy_install` path ignores pip-installed packages and re-fetches the latest of every unpinned dependency as `.egg`s, which clobbers the pins. Pin `apache-tvm-ffi==0.1.11` beforehand, and `nvidia-cutlass-dsl==4.5.3` — newer CUTLASS DSL releases removed a symbol that `mamba_ssm`'s `quack-kernels` dependency imports, breaking `import mamba_ssm`. `mamba_ssm` pulls in `tilelang`, which v26.5 uninstalls again once everything is built.
+**mamba.** Install with `pip`, **not** `python setup.py install`: the legacy `easy_install` path ignores pip-installed packages and re-fetches the latest of every unpinned dependency as `.egg`s, which clobbers the pins. Pin `apache-tvm-ffi==0.1.11` beforehand, and `nvidia-cutlass-dsl==4.5.3` — newer CUTLASS DSL releases removed a symbol that `mamba_ssm`'s `quack-kernels` dependency imports, breaking `import mamba_ssm`. `mamba_ssm` pulls in `tilelang`, which v26.6 uninstalls again once everything is built.
 
 **Primus-Turbo.** Its `setup.py` hard-pins upstream `triton==3.7.0`, which conflicts with the ROCm `triton` that `torch` requires; installing it replaces the ROCm build and then segfaults on import, because ROCm's HIP runtime already loads its own LLVM. Install with `--no-deps` and supply `scipy` and `flydsl==0.2.4` yourself. Primus-Turbo also probes for rocSHMEM and mistakes the pip ROCm SDK for one; set `ROCSHMEM_HOME` to a non-existent path to make the probe fail cleanly and disable internode DeepEP.
 
 ### 4.6 TransformerEngine
 
-v26.5 changed this: TE is no longer built from source but installed from the ROCm staging index.
+v26.6 installs TE from the ROCm multi-arch staging index (TE 2.17).
 
 ```bash
 # Runtime tuning flags (see Section 6 for the full set)
@@ -353,12 +357,12 @@ export NVTE_USE_CAST_TRANSPOSE_TRITON=1
 # TE's own dependencies must be present first: the staging index serves only the
 # transformer-engine packages, so pip cannot fetch anything else while it is selected.
 pip install pybind11==3.0.4 importlib-metadata==8.7.1 onnxscript==0.7.0 \
-            pydantic==2.13.4 nvdlfw_inspect==0.2.2 einops onnx
+            pydantic==2.13.4 nvdlfw_inspect==0.2.2 einops==0.9.0.dev0 onnx
 
 pip install \
-    --index-url https://rocm.frameworks-nightlies.amd.com/whl-staging/device-all/ \
+    --index-url https://rocm.frameworks-nightlies.amd.com/whl-multi-arch-staging/ \
     --pre --no-build-isolation \
-    transformer_engine_rocm_torch==2.15.0.dev0+rocm7.15.0a20260716.a07e607
+    transformer_engine_rocm_torch==2.17.0+rocm7.15.0a20260727.e028a6c
 ```
 
 > **Those wheels need glibc ≥ 2.38.** They are built on Ubuntu 24.04, and `libtransformer_engine.so` requires `GLIBC_2.38` plus `GLIBCXX_3.4.32`. Ubuntu 22.04 has glibc 2.35, and glibc cannot be side-loaded via `LD_LIBRARY_PATH`, so on 22.04 the wheels install fine but fail at import with `version 'GLIBC_2.38' not found`.
@@ -368,7 +372,7 @@ pip install \
 > ```bash
 > git clone --recursive https://github.com/ROCm/TransformerEngine.git
 > cd TransformerEngine
-> git checkout a07e607f14a5330807ffdafeeb6224f2d7dffacc
+> git checkout e028a6c
 > git submodule update --init --recursive
 > pip install psutil
 > MAX_JOBS=${MAX_JOBS} NVTE_FRAMEWORK=pytorch NVTE_USE_ROCM=1 \
@@ -378,7 +382,7 @@ pip install \
 >
 > `setup.sh` picks between the two automatically from the host's glibc; override with `PRIMUS_TE_MODE=wheel|source`.
 
-Either way, apply the same fix v26.5 applies inside the image: concurrent CK JIT compiles race to publish the same `.so`, and without this the loser aborts the run.
+Either way, apply the same fix the image applies: concurrent CK JIT compiles race to publish the same `.so`, and without this the loser aborts the run.
 
 ```bash
 CK_JIT=$(python -c 'import os, sysconfig; print(os.path.join(sysconfig.get_paths()["purelib"], "transformer_engine/lib/ck_jit/ck_jit_compile.sh"))')
@@ -389,17 +393,19 @@ sed -i 's|    mv -n "$_TMP_SO" "$OUTPUT"$|    mv -n "$_TMP_SO" "$OUTPUT" 2>/dev/
 
 ```bash
 pip install \
-    datasets==3.6.0 av==16.0.1 transformers==4.55.0 optree==0.18.0 sympy \
+    datasets==3.6.0 av==16.0.1 transformers==5.5.0 optree==0.18.0 sympy \
     accelerate==1.9.0 trl==0.21.0 tensorboard==2.20.0 peft scipy einops \
     flask-restful nltk pytest pytest-cov pytest_mock pytest-csv \
     pytest-random-order sentencepiece wrapt \
-    zarr==2.18.7 numcodecs==0.12.1 xarray wandb tensorstore==0.1.45 \
+    zarr==2.18.7 numcodecs==0.12.1 xarray wandb==0.28.2 tensorstore==0.1.45 \
     pybind11 tiktoken pynvml "huggingface_hub[cli]"
 
 python3 -m nltk.downloader punkt_tab
 
 # AWS SDK (used by some data pipelines)
 pip install boto3==1.35.42 botocore==1.35.99
+pip install cryptography==50.0.0
+pip install --no-deps mlflow==3.15.1
 ```
 
 ### 4.8 Install Primus and its submodules
@@ -409,10 +415,11 @@ cd ~/primus-build
 # Required to resolve a post-v26.2 attention backend issue
 export NVTE_FLASH_ATTN=0
 export NVTE_FUSED_ATTN=1
+export PRIMUS_FLA_MLA_ATTN=1
 
 git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
 cd Primus
-git checkout b511d1b66b0068715308ea9bfe8ba147ea1a3860   # release/v26.5
+git checkout 2aa05ead3401708cf1a1e2958c1def18d7aecf92   # release/v26.6
 git submodule update --init --recursive
 pip install -r requirements.txt
 
@@ -435,7 +442,7 @@ pip install tensordict iopath torchmetrics==1.0.3 \
     --extra-index-url https://rocm.nightlies.amd.com/whl-multi-arch
 
 # FBGEMM (GPU) — needs apt libtbb-dev
-export BUILD_ROCM_VERSION='7.14'
+export BUILD_ROCM_VERSION='7.15'
 
 git clone https://github.com/pytorch/FBGEMM.git
 cd FBGEMM
@@ -443,7 +450,7 @@ git checkout 80bd3c077dc41b55cd16ed4dcad15cf7c1c1d76a
 cd fbgemm_gpu
 git clean -dfx && git submodule sync && git submodule update --init --recursive
 pip install -r requirements.txt
-pip install setuptools==75.1.0
+pip install setuptools==80.10.2
 python setup.py install \
     --build-variant=rocm \
     --build-target=default \
@@ -534,6 +541,7 @@ export PKG_CONFIG_PATH="$ROCM_PATH/lib/pkgconfig"
 # TransformerEngine: attention backend selection used by Primus
 export NVTE_FLASH_ATTN=0
 export NVTE_FUSED_ATTN=1
+export PRIMUS_FLA_MLA_ATTN=1
 
 # TransformerEngine: CK performance knobs
 export NVTE_USE_CAST_TRANSPOSE_TRITON=1

--- a/docs/01-getting-started/release-notes.md
+++ b/docs/01-getting-started/release-notes.md
@@ -11,11 +11,139 @@ The two families share a version number but are **not** built in lockstep — th
 
 **This page is the single source of truth for image contents.** Other pages link here instead of repeating version tables, so there is exactly one place to update per release. If you add a page that names an image tag, link to the relevant section below rather than restating the stack.
 
-Every version below was read out of the published image itself. For v26.4 and v26.5 the values were additionally cross-checked against the release Dockerfiles in [`.github/workflows/docker-release/`](https://github.com/AMD-AGI/Primus/tree/main/.github/workflows/docker-release); earlier releases predate those files and are image-derived only. See [Verifying the stack in an image](#verifying-the-stack-in-an-image) to reproduce any table.
+Every version below was read out of the published image itself. For v26.4 through v26.6 the values were additionally cross-checked against the release Dockerfiles in [`.github/workflows/docker-release/`](https://github.com/AMD-AGI/Primus/tree/main/.github/workflows/docker-release); earlier releases predate those files and are image-derived only. See [Verifying the stack in an image](#verifying-the-stack-in-an-image) to reproduce any table.
 
 ---
 
-## v26.5 (current)
+## v26.6 (current)
+
+### `rocm/primus:v26.6`
+
+Megatron-LM, TorchTitan, and Megatron Bridge backends.
+
+| | |
+| --- | --- |
+| Image ID | `4fcb3f210dc6` |
+| Built | 2026-08-25 |
+| Size | 54.0 GB |
+| Manifest | `f756f2279d8ab57b6549bcbd50d249755b69a407` |
+| Dockerfile | [`Dockerfile.primus-v26.6`](https://github.com/AMD-AGI/Primus/blob/main/.github/workflows/docker-release/Dockerfile.primus-v26.6) |
+
+| Software component | Version |
+| ------------------ | ------- |
+| ROCm | 7.15.0 (`rocm-sdk` 7.15.0a20260727) |
+| Python | 3.12.3 |
+| PyTorch | 2.12.0+rocm7.15.0a20260727 |
+| Transformer Engine | 2.17.0+rocm7.15.0a20260727.e028a6c |
+| Flash Attention | 2.8.1 |
+| hipBLASLt | 1.4.1-bbb68174 |
+| Triton | 3.8.0+git4cff872c.rocm7.15.0a20260727 |
+| RCCL | 2.30.4 |
+| torchvision | 0.27.0+rocm7.15.0a20260727 |
+| torchaudio | 2.11.0+rocm7.15.0a20260728 |
+| APEX | 1.15.0a0+rocm10.1.0a20260822 |
+| AITER | 0.1.14.post1 |
+| Primus-Turbo | 0.4.1.dev26 |
+| torchao | 0.15.0+gite9c7bead9 |
+| FBGEMM | 2026.8.25 |
+| mamba-ssm / causal-conv1d / grouped_gemm | 2.3.1 / 1.5.0.post8 / 1.1.4 |
+| transformers / datasets | 5.5.0 / 3.6.0 |
+| NumPy | 2.5.2 |
+
+### `rocm/jax-training:maxtext-v26.6`
+
+MaxText (JAX) backend. The published tag is the MaxDiffusion-combined image (`/workspace/maxdiffusion` at `68e06965`); MaxText remains at `/workspace/maxtext`.
+
+| | |
+| --- | --- |
+| Image ID | `a71d8dbb045e` |
+| Built | 2026-08-28 |
+| Size | 42.6 GB |
+| Manifest | `31a3a21d0a37cbd0b5de0342535f65d557ff77ba` |
+| Dockerfile | [`Dockerfile.jax-v26.6`](https://github.com/AMD-AGI/Primus/blob/main/.github/workflows/docker-release/Dockerfile.jax-v26.6) |
+
+| Software component | Version |
+| ------------------ | ------- |
+| ROCm | 7.14.0 |
+| Python | 3.12.3 |
+| JAX / jaxlib | 0.11.0 |
+| jax-rocm7-pjrt / jax-rocm7-plugin | 0.11.0.post1 |
+| Transformer Engine | 2.17.0+rocm7.14.0.50a84ad |
+| hipBLASLt | 1.4.1-cd957402 |
+| RCCL | 2.30.4 (built from rocm-systems `9e5e4084`) |
+| Flax | 0.12.8 |
+| TensorFlow | 2.21.0 (CPU-only, rebuilt from the ROCm fork) |
+| Optax / Orbax / Grain / tensorstore | 0.2.8 / 0.12.4 / 0.2.18 / 0.1.85 |
+| MaxText | `b47d74bf` (`release/v26.6`) |
+| transformers / datasets | 4.57.3 / 4.8.5 |
+| NumPy | 2.5.2 |
+
+> **Note:** `transformers` is 4.57.3 because the published image includes the MaxDiffusion stage, which pins transformers back to 4.x (Flax CLIP / T5). That is a step down from v26.5 (`5.9.0`). Transformer Engine is tagged `rocm7.14.0` and matches the image ROCm, unlike v26.5 where the TE wheel was a `rocm7.15` build on ROCm 7.14.0.
+
+### Primus source for v26.6
+
+Use the **`release/v26.6`** branch for both images:
+
+```bash
+git clone --recurse-submodules https://github.com/AMD-AGI/Primus.git
+cd Primus
+git checkout release/v26.6
+git submodule update --init --recursive
+```
+
+| | |
+| --- | --- |
+| Branch tip | `2aa05ead` (2026-08-25) |
+| Megatron-LM | `d3528a21` |
+| TorchTitan | `73a0e697` |
+| Megatron Bridge | `9577b128` |
+| MaxText | `b47d74bf` |
+| Emerging-Optimizers | `93d9eb3a` |
+| HummingbirdXT | `ed7b7bd0` |
+
+> **Prefer a `release/v26.6` checkout over the Primus copy baked into the images.**
+>
+> - `rocm/primus:v26.6` was built from `2aa05ead` (2026-08-25), which is the current `release/v26.6` tip, so the in-image `/workspace/Primus` currently matches. Cloning the branch still keeps you current if later commits land on it.
+> - `rocm/jax-training:maxtext-v26.6` was built from `main` at `4d2f7a74` (2026-08-28), because its Dockerfile pins `PRIMUS_BRANCH=main` rather than a commit. Unlike v26.5, its bundled `third_party/maxtext` **does** match `/workspace/maxtext` (`b47d74bf`). Use `release/v26.6` for MaxText training so you get the Primus recipes validated against this image rather than whatever `main` was on the build day.
+
+### Changes since v26.5
+
+`rocm/primus`:
+
+| Component | v26.5 | v26.6 |
+| --------- | ----- | ----- |
+| ROCm nightly | 7.15.0a20260720 | 7.15.0a20260727 |
+| PyTorch | 2.12.0+rocm7.15.0a20260720 | 2.12.0+rocm7.15.0a20260727 |
+| Transformer Engine | 2.15.0.dev0+rocm7.15.0a20260716.a07e607 | 2.17.0+rocm7.15.0a20260727.e028a6c |
+| Flash Attention | 2.8.3 | 2.8.1 |
+| Triton | 3.7.1+git0263a6a6 | 3.8.0+git4cff872c |
+| hipBLASLt | 1.4.1-1aa46415 | 1.4.1-bbb68174 |
+| Primus-Turbo | 0.3.2.dev48 | 0.4.1.dev26 |
+| APEX | 1.14.0a0+rocm7.15.0a20260721 | 1.15.0a0+rocm10.1.0a20260822 |
+| transformers | 4.55.0 | 5.5.0 |
+| FBGEMM | 2026.7.22 | 2026.8.25 |
+| NumPy | 2.5.1 | 2.5.2 |
+| Image size | 54.7 GB | 54.0 GB |
+
+`rocm/jax-training:maxtext`:
+
+| Component | v26.5 | v26.6 |
+| --------- | ----- | ----- |
+| JAX / jaxlib | 0.10.0 | 0.11.0 |
+| jax-rocm7-pjrt / jax-rocm7-plugin | 0.10.0+rocm7.14.0 | 0.11.0.post1 |
+| Transformer Engine | 2.15.0.dev0+rocm7.15.0a20260707.72d01a0 | 2.17.0+rocm7.14.0.50a84ad |
+| Flax | 0.12.2 | 0.12.8 |
+| Orbax / Grain / tensorstore | 0.11.39 / 0.2.16 / 0.1.82 | 0.12.4 / 0.2.18 / 0.1.85 |
+| MaxText | `a7c6c7e5` | `b47d74bf` |
+| transformers | 5.9.0 | 4.57.3 |
+| NumPy | 2.0.2 | 2.5.2 |
+| Image size | 45.7 GB | 42.6 GB |
+
+> **JAX 0.11.0 still requires Shardy.** Set `shardy=True` during the training run on v26.6. See the [Shardy migration guide](https://docs.jax.dev/en/latest/shardy_jax_migration.html).
+
+---
+
+## v26.5
 
 ### `rocm/primus:v26.5`
 
@@ -248,16 +376,16 @@ Images from v26.3 onward ship a manifest at `/workspace/.manifest/` recording ex
 | `dpkg-list.txt` | full `dpkg -l` |
 | `env.txt` | every environment variable baked into the image |
 | `training_docker_version` | the build's commit tag |
-| `Dockerfile` | the Dockerfile the image was built from |
+| `Dockerfile` | the Dockerfile the image was built from (`docker-build-recipe.txt` in `rocm/jax-training:maxtext-v26.6`) |
 
 ```bash
-docker run --rm --entrypoint bash rocm/primus:v26.5 -c 'cat /workspace/.manifest/requirements.txt'
+docker run --rm --entrypoint bash rocm/primus:v26.6 -c 'cat /workspace/.manifest/requirements.txt'
 ```
 
 Native library versions are not pip packages; read them from the ROCm headers:
 
 ```bash
-docker run --rm --entrypoint bash rocm/primus:v26.5 -c '
+docker run --rm --entrypoint bash rocm/primus:v26.6 -c '
   grep -E "HIPBLASLT_VERSION_(MAJOR|MINOR|PATCH|TWEAK)" $(find $ROCM_PATH /opt/rocm -name hipblaslt-version.h 2>/dev/null | head -1)
   grep -E "define NCCL_(MAJOR|MINOR|PATCH)"              $(find $ROCM_PATH /opt/rocm -name rccl.h            2>/dev/null | head -1)'
 ```

--- a/docs/02-user-guide/megatron-lm-training.md
+++ b/docs/02-user-guide/megatron-lm-training.md
@@ -6,7 +6,7 @@ Training performance validation of the Primus Docker image with the Megatron bac
 
 The Primus framework with the Megatron backend is designed to enable efficient training of large-scale language models on AMD GPUs. By leveraging AMD Instinct™ MI300X/MI350X accelerators, the Primus Megatron framework delivers enhanced scalability, performance, and resource utilization for AI workloads. It is purpose-built to support models like Llama 2, Llama 3/3.1, DeepSeek V2/V3, and Mixtral MoE, enabling developers to train next-generation AI models with greater efficiency. See the GitHub repository at [AMD-AGI/Primus](https://github.com/AMD-AGI/Primus).
 
-The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for pre-training a model on the AMD Instinct™ MI300X, MI325X, MI350X, and MI355X accelerators.
+The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [Docker hub](https://hub.docker.com/r/rocm/primus/tags), provides a prebuilt, optimized environment for pre-training a model on the AMD Instinct™ MI300X, MI325X, MI350X, and MI355X accelerators.
 
 For the full software stack of this image (ROCm, PyTorch, Transformer Engine, Flash Attention, hipBLASLt, Triton, RCCL, and the rest), see [Release notes → `rocm/primus:v26.6`](../01-getting-started/release-notes.md#rocmprimusv266). The release notes are the single source of truth for image contents, and also cover the previous [`rocm/primus:v26.5`](../01-getting-started/release-notes.md#rocmprimusv265).
 

--- a/docs/02-user-guide/torchtitan-training.md
+++ b/docs/02-user-guide/torchtitan-training.md
@@ -6,7 +6,7 @@ Training performance validation with the AMD PyTorch Docker image on AMD Instinc
 
 PyTorch is an open-source machine learning framework that is widely used for model training, with GPU-optimized components for transformer-based models.
 
-The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for fine-tuning and pre-training a model on the AMD Instinct™ MI300X, MI325X, MI350X, and MI355X accelerators.
+The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [Docker hub](https://hub.docker.com/r/rocm/primus/tags), provides a prebuilt, optimized environment for fine-tuning and pre-training a model on the AMD Instinct™ MI300X, MI325X, MI350X, and MI355X accelerators.
 
 For the full software stack of this image (ROCm, PyTorch, Transformer Engine, Flash Attention, hipBLASLt, Triton, RCCL, and the rest), see [Release notes → `rocm/primus:v26.6`](../01-getting-started/release-notes.md#rocmprimusv266). The release notes are the single source of truth for image contents, and also cover the previous [`rocm/primus:v26.5`](../01-getting-started/release-notes.md#rocmprimusv265).
 

--- a/docs/02-user-guide/torchtitan-training.md
+++ b/docs/02-user-guide/torchtitan-training.md
@@ -6,7 +6,7 @@ Training performance validation with the AMD PyTorch Docker image on AMD Instinc
 
 PyTorch is an open-source machine learning framework that is widely used for model training, with GPU-optimized components for transformer-based models.
 
-The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for fine-tuning and pre-training a model on the AMD Instinct™ MI300X and MI325X accelerators.
+The ROCm PyTorch training Docker image `rocm/primus:v26.6`, available through [AMD Infinity Hub](https://www.amd.com/en/developer/resources/infinity-hub.html), provides a prebuilt, optimized environment for fine-tuning and pre-training a model on the AMD Instinct™ MI300X, MI325X, MI350X, and MI355X accelerators.
 
 For the full software stack of this image (ROCm, PyTorch, Transformer Engine, Flash Attention, hipBLASLt, Triton, RCCL, and the rest), see [Release notes → `rocm/primus:v26.6`](../01-getting-started/release-notes.md#rocmprimusv266). The release notes are the single source of truth for image contents, and also cover the previous [`rocm/primus:v26.5`](../01-getting-started/release-notes.md#rocmprimusv265).
 
@@ -43,14 +43,15 @@ The `rocm/pytorch-training` Docker Hub registry is deprecated. Use `rocm/primus`
 
 ## Models
 
-Examples of the following models are pre-optimized for performance on the AMD Instinct MI300X and MI325X accelerators.
+Examples of the following models are pre-optimized for performance on the AMD Instinct MI300X, MI325X, MI350X, and MI355X accelerators. YAML recipes live under `examples/torchtitan/configs/<ARCH>/`, where `<ARCH>` is `MI300X`, `MI325X`, or `MI355X` (use `MI300X`/`MI325X` for gfx942 and `MI355X` for gfx950).
 
 ### Pre-training
 
 | Model | Variants |
 | ------------- | ------------- |
 | **Llama 3.1** | 8B, 70B, 405B |
-| **DeepSeek V3** | 16B |
+| **DeepSeek V3** | 16B, 236B, 671B |
+| **Qwen3** | 0.6B, 1.7B, 4B, 8B, 14B, 32B |
 
 > **Note:** Some models, such as Llama 3, require an external license agreement through a third party (for example, Meta).
 
@@ -82,14 +83,9 @@ This container should not be expected to provide generalized performance across 
 
 Use the following instructions to set up the environment, configure the script to train models, and reproduce the benchmark results on the MI300X, MI325X, MI350X, and MI355X accelerators with the Docker image.
 
-The instructions reproduce the benchmark results on an MI300X accelerator with a prebuilt PyTorch Docker image. For best performance on MI325X, MI350X, and MI355X, adjust configurations (for example, batch sizes) accordingly.
+The instructions reproduce the benchmark results on an MI300X accelerator with `rocm/primus:v26.6`. For best performance on MI325X, MI350X, and MI355X, use the matching `<ARCH>` config directory (and adjust batch sizes if you change hardware).
 
-There are two ways to run training, listed in the order we recommend:
-
-| Method | Use it when |
-| ------ | ----------- |
-| [**`primus-cli`**](#running-training-with-primus-cli-recommended) **(recommended)** | Any new work. One CLI covers direct, container, and Slurm launches, and the same YAML configurations work across every Primus backend. |
-| [MAD-integrated benchmarking](#mad-integrated-benchmarking) *(legacy)* | You are reproducing published AMD numbers through the ROCm MAD dashboarding pipeline. |
+Launch training with [`primus-cli`](#running-training-with-primus-cli). One CLI covers direct, container, and Slurm launches, and the same YAML configurations work across every Primus backend.
 
 ---
 
@@ -142,7 +138,7 @@ export HF_TOKEN=$your_personal_hf_token
 
 ---
 
-## Running training with primus-cli (recommended)
+## Running training with primus-cli
 
 For detailed usage of `primus-cli`, see the [CLI reference](./cli-reference.md).
 
@@ -199,6 +195,8 @@ On MI300X/MI325X, export the gfx942 tuning variables from [Architecture-specific
   --config examples/torchtitan/configs/MI300X/llama3.1_8B-FP8-pretrain.yaml
 ```
 
+Other models and precisions follow the same pattern: `examples/torchtitan/configs/MI300X/<model>-<precision>-pretrain.yaml`. On MI325X, swap `MI300X` for `MI325X`.
+
 #### MI35X performance configs
 
 - **Llama3.1-70B BF16:**
@@ -246,6 +244,8 @@ On MI300X/MI325X, export the gfx942 tuning variables from [Architecture-specific
   --config examples/torchtitan/configs/MI355X/llama3.1_8B-FP8-pretrain.yaml
 ```
 
+Other models and precisions follow `examples/torchtitan/configs/MI355X/<model>-<precision>-pretrain.yaml`.
+
 ### Multi-node training
 
 Multi-node training with TorchTitan is similar to Megatron-LM. See [Megatron-LM multi-node training](./megatron-lm-training.md#32-multi-node-training) for how to set the environment variables.
@@ -280,47 +280,6 @@ Launch the training using the legacy script:
 
 ```bash
 NNODES=8 EXP=examples/torchtitan/configs/MI355X/llama3.1_405B-FP8-pretrain.yaml bash examples/run_slurm_pretrain.sh --training.local_batch_size 3 --training.global_batch_size 192 --training.mock_data True
-```
-
----
-
-## MAD-integrated benchmarking
-
-> **Legacy path.** MAD-integrated benchmarking is retained for reproducing published AMD numbers through the ROCm MAD dashboarding pipeline. For new work use [`primus-cli`](#running-training-with-primus-cli-recommended) instead.
-
-Clone the ROCm Model Automation and Dashboarding (MAD) repository to a local directory and install the required packages on the host machine.
-
-```sh
-git clone https://github.com/ROCm/MAD
-cd MAD
-pip install -r requirements.txt
-```
-
-Use this command to run a performance benchmark test of the Llama 3.1 8B model through Primus on one GPU with the `float16` data type on the host machine.
-
-```sh
-export MAD_SECRETS_HFTOKEN="your personal Hugging Face token to access gated models"
-python3 tools/run_models.py --tags primus_pyt_train_llama-3.1-8b --keep-model-dir --live-output --timeout 28800
-```
-
-ROCm MAD launches a Docker container with the name `container_ci-primus_pyt_train_llama-3.1-8b`. The latency and throughput reports of the model are collected in the following path:
-
-```sh
-~/MAD/perf.csv
-```
-
-### Available models
-
-| model_name |
-| --------------------------------- |
-| `primus_pyt_train_llama-3.1-8b` |
-| `primus_pyt_train_llama-3.1-70b` |
-| `primus_pyt_train_deepseek-v3-16b` |
-
-To start the pretraining benchmark, use the following command:
-
-```bash
-./pytorch_benchmark_report.sh -t $training_mode -m $model_repo -p $datatype
 ```
 
 ---

--- a/tools/installation-jax/README.md
+++ b/tools/installation-jax/README.md
@@ -1,8 +1,9 @@
-# Primus JAX / MaxText environment in a venv (no docker, no sudo) — v26.5
+# Primus JAX / MaxText environment in a venv (no docker, no sudo) — v26.6
 
-Reproduces the Primus **v26.5 JAX training Dockerfile** in a Python virtual
-environment. Same package pins as the Dockerfile, adapted for a bare-metal host
-with no root and no containers.
+Reproduces the Primus **v26.6 JAX training Dockerfile**
+([`Dockerfile.jax-v26.6`](../../.github/workflows/docker-release/Dockerfile.jax-v26.6))
+in a Python virtual environment. Same package pins as the Dockerfile, adapted for
+a bare-metal host with no root and no containers.
 
 This is the JAX/MaxText counterpart to `tools/installation/` (the PyTorch /
 Megatron / TorchTitan stack). Use this one if you want to run the **JAX MaxText**
@@ -12,15 +13,15 @@ training backend of Primus.
 
 | Constraint | Dockerfile | Here |
 |---|---|---|
-| ROCm | release **tarball** → `/opt/rocm` | same tarball → **`$ROCM_DIR`** (`$PRIMUS_JAX_BASE/rocm`, user-writable, **no sudo**) |
+| ROCm | pip `rocm-sdk-*` 7.14.0 → `/opt/venv/.../_rocm_sdk_devel` | same wheels → in-venv `_rocm_sdk_devel` (**no sudo**) |
 | GPU arch | gfx942 + gfx950 | **auto-detected** from the host (`rocminfo`/KFD sysfs) for source builds/TE |
 | Build dir | container FS | venv on **`$PRIMUS_JAX_BASE`** (persistent); transient sources on local `/tmp` |
 | System deps | `apt install ...` | **skipped** (no sudo); documented in the guide's Section 2 |
 | MaxText setup | `setup.sh` (runs `apt`, prompts for a venv) | Python steps only (apt is a one-time root action; venv already made) |
+| `LD_LIBRARY_PATH` | blanked at the end of the image | blanked at runtime (`PRIMUS_JAX_KEEP_ROCM_LD=1` for RCCL/TE source builds) |
 
-The key reason no sudo is required: the ROCm tarball is extracted into a
-user-writable dir (`$ROCM_DIR`) instead of `/opt/rocm`, so we don't depend on
-system ROCm or apt for the ROCm toolchain itself.
+The key reason no sudo is required: the `rocm-sdk-devel` pip wheel ships a full
+ROCm toolchain inside the venv, so we don't depend on system ROCm or apt.
 
 > **Python 3.12+ required (3.12 preferred).** MaxText requires Python ≥ 3.12 (the
 > PyTorch recipe works on 3.10; this one does not). 3.12 is preferred because the
@@ -51,7 +52,7 @@ system ROCm or apt for the ROCm toolchain itself.
 ```bash
 cd tools/installation-jax
 # PRIMUS_JAX_BASE is REQUIRED (no default). Point it at a directory you can write
-# to with tens of GB free — the venv, ROCm tarball, and checkouts all live here:
+# to with tens of GB free — the venv, ROCm SDK, and checkouts all live here:
 export PRIMUS_JAX_BASE=/some/big/disk/primus-jax-env
 bash setup.sh                 # all default stages
 ```
@@ -76,31 +77,32 @@ python -c "import jax; print(jax.devices())"
 # Primus is checked out at $WORKSPACE_DIR/Primus; MaxText at $MAXTEXT_DIR.
 cd "$WORKSPACE_DIR/Primus"
 ./primus-cli direct -- train pretrain \
-  --config examples/maxtext/configs/MI300X/llama2_7B-pretrain.yaml
+  --config examples/maxtext/configs/MI300X/llama2_7B-bf16-pretrain.yaml
 ```
 
 `env.sh` exports `MAXTEXT_PATH=$MAXTEXT_DIR`, so Primus runs the same MaxText
 checkout we installed the dependencies for.
 
-## Stages (default order, v26.5)
+## Stages (default order, v26.6)
 
 `venv` → `rocm` → `maxtext` → `tf_source` → `jax` → `te` → `primus`
 → `jaxreqs` → `rccl` → `manifest`
 
 - **venv** — create the venv (Python ≥ 3.12) and bootstrap `cmake`/`ninja`/`uv`.
-- **rocm** — download + extract the TheRock ROCm release tarball into `$ROCM_DIR`
-  (+ `amdsmi`).
-- **maxtext** — clone ROCm/MaxText (`release/v26.5`) and install its deps (the
+- **rocm** — pip-install TheRock `rocm-sdk-*` 7.14.0 (core/devel/libraries +
+  per-arch device wheels) and run `rocm-sdk init`.
+- **maxtext** — clone ROCm/MaxText (`release/v26.6`) and install its deps (the
   Python part of MaxText's `setup.sh`) + the editable MaxText package.
 - **tf_source** — build **tensorflow-cpu 2.21 from source** (bazel, ~30–60 min);
   fixes the ROCm-vs-TF LLVM symbol clash (SIGSEGV) and drops bundled NCCL.
-- **jax** — `jax`/`jaxlib` 0.10.0 + the ROCm `jax_rocm7_pjrt` / `jax_rocm7_plugin`
-  (installed after MaxText to override its stock jax).
-- **te** — prebuilt `transformer_engine_rocm_jax` wheel (+ `flax`, `pydantic`, ...);
-  auto-falls-back to a from-source build (`te_source`) on glibc < 2.38 hosts.
+- **jax** — `jax`/`jaxlib` 0.11.0 + `jax_rocm7_pjrt` / `jax_rocm7_plugin`
+  `0.11.0.post1` from PyPI (installed after MaxText to override its stock jax).
+- **te** — prebuilt `transformer_engine_rocm_jax==2.17.0+rocm7.14.0.50a84ad`
+  (+ `flax==0.12.8`, `pydantic`, ...); auto-falls-back to a from-source build
+  (`te_source`) on glibc < 2.38 hosts.
 - **primus** — clone Primus, init the `third_party/maxtext` submodule, drop the
   stale `dataclasses` backports.
-- **jaxreqs** — install Primus' `requirements-jax.txt` (loguru, wandb, ...).
+- **jaxreqs** — install Primus' `requirements-jax.txt` and the v26.6 CVE-fix pins.
 - **rccl** — build **RCCL from source** and install it into `$ROCM_PATH/lib`.
 - **manifest** — dump `pip list` / `env` for reproducibility.
 
@@ -122,11 +124,8 @@ Optional / alternative stages:
 bash setup.sh venv rocm maxtext tf_cpu_fix jax te primus jaxreqs rccl manifest
 ```
 
-> **MaxText v26.5 and Primus.** MaxText v26.5 uses a **2-value**
-> `initialize()`/`run()` API. Primus `main` handles it — `MaxTextPretrainTrainer`
-> forwards `initialize()`'s tuple verbatim to `run()` (fix #912) — so this
-> recipe's pinned `release/v26.5` trains out of the box. Override
-> `MAXTEXT_BRANCH` only if you deliberately need a different MaxText release.
+> **MaxText v26.6 and Primus.** Override `MAXTEXT_BRANCH` only if you deliberately
+> need a different MaxText release.
 
 ## What is SKIPPED (needs sudo / apt — not reproducible here)
 
@@ -141,13 +140,17 @@ bash setup.sh venv rocm maxtext tf_cpu_fix jax te primus jaxreqs rccl manifest
 
 ## Notes / gotchas vs. the Dockerfile
 
-- **Stage order matters (v26.5):** `maxtext` → `tf_source` → `jax` → `te`. MaxText's
+- **Stage order matters (v26.6):** `maxtext` → `tf_source` → `jax` → `te`. MaxText's
   `setup.sh` pulls in a stock `jax`/`tensorflow`; TF is then rebuilt from source and
   the ROCm JAX/plugin is installed after (overriding MaxText's), and TE must come
   after JAX or `jaxlib` gets clobbered. The stage order enforces this.
 - **TensorFlow + RCCL are built from source** in the default flow (matching the
-  v26.5 image). These are the two long builds; use `tf_cpu_fix` if you want to skip
+  v26.6 image). These are the two long builds; use `tf_cpu_fix` if you want to skip
   the TF bazel build.
+- **Runtime `LD_LIBRARY_PATH` is empty**, matching the image's TE 2.17 + JAX
+  segfault fix. RCCL/TE source builds set `PRIMUS_JAX_KEEP_ROCM_LD=1`.
+- **TE from source always compiles gfx942+gfx950.** TE 2.17's HipKittens GEMM
+  fails to link if CMake only sees gfx942.
 - **No FlashAttention/aiter/torch stack.** The JAX MaxText path does not build the
   PyTorch kernel libraries; attention fusion comes from `transformer_engine_rocm_jax`
   + XLA.

--- a/tools/installation-jax/env.sh
+++ b/tools/installation-jax/env.sh
@@ -138,14 +138,17 @@ fi
 # keeps the OLD paths. The failure then shows up much later as a confusing
 # "Backend path not found for 'maxtext'" or as pip installing into the wrong
 # venv, so say something now. Start from a fresh shell to clear these.
-for _v in VENV_DIR WORKSPACE_DIR MAXTEXT_PATH; do
-    eval "_val=\${$_v}"
-    case "$_val" in
+_primus_warn_outside_base() {
+    local name="$1" val="$2"
+    case "$val" in
         "$PRIMUS_JAX_BASE"/*) ;;
-        *) echo "[env] WARNING: $_v=$_val is outside PRIMUS_JAX_BASE=$PRIMUS_JAX_BASE" >&2 ;;
+        *) echo "[env] WARNING: $name=$val is outside PRIMUS_JAX_BASE=$PRIMUS_JAX_BASE" >&2 ;;
     esac
-done
-unset _v _val
+}
+_primus_warn_outside_base VENV_DIR "$VENV_DIR"
+_primus_warn_outside_base WORKSPACE_DIR "$WORKSPACE_DIR"
+_primus_warn_outside_base MAXTEXT_PATH "$MAXTEXT_PATH"
+unset -f _primus_warn_outside_base
 if [ "${VIRTUAL_ENV:-}" != "$VENV_DIR" ]; then
     echo "[env] WARNING: venv not active: expected $VENV_DIR, got ${VIRTUAL_ENV:-<none>}" >&2
     echo "[env]          (before the 'venv' stage of setup.sh this is expected)" >&2

--- a/tools/installation-jax/env.sh
+++ b/tools/installation-jax/env.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# env.sh — Primus JAX/MaxText venv environment (v26.5).
+# env.sh — Primus JAX/MaxText venv environment (v26.6).
 # Source this both during the build (setup.sh does it) and every time you
 # want to USE the environment:   source env.sh
 #
-# This mirrors the v26.5 JAX training Dockerfile, adapted for a no-docker /
-# no-sudo bare-metal install. In v26.5 ROCm is delivered as a RELEASE TARBALL
-# (TheRock dist) extracted to a user-writable dir ($ROCM_DIR) — NOT the pip
-# `rocm-sdk-devel` wheels used by the v26.4 recipe. No system ROCm is required.
+# This mirrors the v26.6 JAX training Dockerfile, adapted for a no-docker /
+# no-sudo bare-metal install. In v26.6 ROCm is delivered as pip TheRock wheels
+# (`rocm-sdk-devel` 7.14.0), same as the image — not the v26.5 release tarball.
+# No system ROCm is required.
 #
 # NOTE: PRIMUS_JAX_BASE is REQUIRED (no default) — export it to a big-disk dir
 #       before sourcing this file. MaxText requires Python >= 3.12; see
@@ -14,7 +14,7 @@
 
 # ---- Install location (persistent) + transient build sources ----
 # PRIMUS_JAX_BASE is REQUIRED (there is intentionally no default): it is where
-# the venv, the extracted ROCm tarball, and the kept checkouts live. Point it at
+# Everything lives under PRIMUS_JAX_BASE (venv, kept checkouts). Point it at
 # a directory you can write to with tens of GB free, then (re-)source this file:
 #     export PRIMUS_JAX_BASE=/big/disk/primus-jax-env
 if [ -z "${PRIMUS_JAX_BASE:-}" ]; then
@@ -32,9 +32,6 @@ export WORKSPACE_DIR="${WORKSPACE_DIR:-$PRIMUS_JAX_BASE/workspace}"  # kept chec
 # Transient build sources: put on fast LOCAL /tmp (NFS is slow for compile I/O;
 # these dirs are deleted after each build anyway).
 export SRC_DIR="${SRC_DIR:-/tmp/primus-jax-build}"
-# ROCm release tarball (TheRock dist) is extracted here. This replaces the
-# Dockerfile's /opt/rocm and keeps the whole install no-sudo / user-writable.
-export ROCM_DIR="${ROCM_DIR:-$PRIMUS_JAX_BASE/rocm}"
 
 # MaxText clone (deps + editable install live here). Primus resolves the
 # MaxText backend from MAXTEXT_PATH (else its own third_party/maxtext), so we
@@ -74,7 +71,7 @@ export MAX_JOBS="${MAX_JOBS:-128}"
 #     export PYTORCH_ROCM_ARCH="gfx942;gfx950"
 # Otherwise it is auto-detected from the GPUs on this host. Detection needs no
 # sudo and no system ROCm: it uses `rocminfo` when available (e.g. after the
-# ROCm tarball is extracted) and otherwise falls back to the kernel KFD sysfs
+# pip ROCm SDK is installed) and otherwise falls back to the kernel KFD sysfs
 # topology, so it works even on a fresh machine before any install.
 
 # Decode a KFD gfx_target_version integer (e.g. 90402) into a gfx name (gfx942).
@@ -135,7 +132,31 @@ if [ -f "$VENV_DIR/bin/activate" ]; then
     source "$VENV_DIR/bin/activate"
 fi
 
-# NOTE: the two HSA_* vars below are NOT in the v26.5 Dockerfile — they are a
+# Every VENV_DIR/WORKSPACE_DIR/MAXTEXT_* export above honours a pre-existing
+# value, so sourcing this file in a shell that already has another Primus env
+# (e.g. tools/installation/env.sh, or a different PRIMUS_JAX_BASE) silently
+# keeps the OLD paths. The failure then shows up much later as a confusing
+# "Backend path not found for 'maxtext'" or as pip installing into the wrong
+# venv, so say something now. Start from a fresh shell to clear these.
+for _v in VENV_DIR WORKSPACE_DIR MAXTEXT_PATH; do
+    eval "_val=\${$_v}"
+    case "$_val" in
+        "$PRIMUS_JAX_BASE"/*) ;;
+        *) echo "[env] WARNING: $_v=$_val is outside PRIMUS_JAX_BASE=$PRIMUS_JAX_BASE" >&2 ;;
+    esac
+done
+unset _v _val
+if [ "${VIRTUAL_ENV:-}" != "$VENV_DIR" ]; then
+    echo "[env] WARNING: venv not active: expected $VENV_DIR, got ${VIRTUAL_ENV:-<none>}" >&2
+    echo "[env]          (before the 'venv' stage of setup.sh this is expected)" >&2
+fi
+if [ ! -d "$MAXTEXT_PATH" ]; then
+    echo "[env] WARNING: MAXTEXT_PATH does not exist: $MAXTEXT_PATH" >&2
+    echo "[env]          Primus will fail with \"Backend path not found for 'maxtext'\"." >&2
+    echo "[env]          (before the 'maxtext' stage of setup.sh this is expected)" >&2
+fi
+
+# NOTE: the two HSA_* vars below are NOT in the v26.6 Dockerfile — they are a
 # carryover workaround for HSA_STATUS_ERROR_OUT_OF_RESOURCES. Harmless, but
 # remove them if you want an exact match to the image.
 export HSA_ENABLE_SCRATCH_ASYNC_RECLAIM=0
@@ -145,25 +166,42 @@ export HSA_NO_SCRATCH_RECLAIM=1
 export ROCPROFILER_QUEUE_INTERPOSITION=0
 export DEBUG_HIP_DYNAMIC_QUEUES=0
 
-# ---- ROCm path: from the extracted TheRock release tarball (v26.5) ----
-# setup.sh's `rocm` stage downloads therock-dist-*.tar.gz and extracts it into
-# $ROCM_DIR. Once present, wire the HIP/ROCm env at it (mirrors the Dockerfile's
-# /opt/rocm layout, whose LD path is lib + lib/rocm_sysdeps/lib).
-if [ -d "$ROCM_DIR/lib" ] || [ -x "$ROCM_DIR/bin/hipcc" ]; then
-    export ROCM_PATH="$ROCM_DIR"
-    export ROCM_HOME="$ROCM_DIR"   # Primus uses ROCM_HOME; set both
+# ---- ROCm path: from the pip-installed _rocm_sdk_devel package (v26.6) ----
+# Computed dynamically so it works for any Python minor version.
+if command -v python >/dev/null 2>&1; then
+    _ROCM_SDK="$(python - <<'PY' 2>/dev/null
+try:
+    import _rocm_sdk_devel, os
+    print(os.path.dirname(_rocm_sdk_devel.__file__))
+except Exception:
+    pass
+PY
+)"
+fi
+
+if [ -n "${_ROCM_SDK:-}" ]; then
+    export ROCM_PATH="$_ROCM_SDK"
+    export ROCM_HOME="$_ROCM_SDK"   # Primus uses ROCM_HOME; set both
     export HIP_PLATFORM=amd
     export HIP_PATH="$ROCM_PATH"
     export HIP_CLANG_PATH="$ROCM_PATH/llvm/bin"
     export HIP_INCLUDE_PATH="$ROCM_PATH/include"
     export HIP_LIB_PATH="$ROCM_PATH/lib"
     export HIP_DEVICE_LIB_PATH="$ROCM_PATH/lib/llvm/amdgcn/bitcode"
-    # PATH: the Dockerfile puts /opt/rocm/lib on PATH too; mirror that.
-    export PATH="$ROCM_PATH/lib:$ROCM_PATH/bin:$HIP_CLANG_PATH:$PATH"
-    export LD_LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib/rocm_sysdeps/lib:$ROCM_PATH/lib64:$ROCM_PATH/llvm/lib:${LD_LIBRARY_PATH:-}"
-    export LIBRARY_PATH="$ROCM_PATH/lib:$ROCM_PATH/lib64"
+    export PATH="$ROCM_PATH/bin:$HIP_CLANG_PATH:$PATH"
+    export LIBRARY_PATH="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64"
     export CPATH="$HIP_INCLUDE_PATH"
     export PKG_CONFIG_PATH="$ROCM_PATH/lib/pkgconfig"
+    # v26.6 blanks LD_LIBRARY_PATH at runtime so TE 2.17 + JAX resolve ROCm via
+    # RPATH instead of loading a mismatched HIP copy from rocm-sdk-devel
+    # (CK-JIT fmha_bwd segfault on gfx950). Source builds that need the devel
+    # tree can export PRIMUS_JAX_KEEP_ROCM_LD=1.
+    _ROCM_LD="$HIP_LIB_PATH:$ROCM_PATH/lib:$ROCM_PATH/lib64:$ROCM_PATH/llvm/lib:$ROCM_PATH/lib/host-math/lib:$ROCM_PATH/lib/rocm_sysdeps/lib"
+    if [ "${PRIMUS_JAX_KEEP_ROCM_LD:-0}" = "1" ]; then
+        export LD_LIBRARY_PATH="${_ROCM_LD}:${LD_LIBRARY_PATH:-}"
+    else
+        export LD_LIBRARY_PATH=""
+    fi
 fi
 
 # ---- TransformerEngine (ROCm) runtime settings for JAX ----
@@ -193,7 +231,7 @@ export NCCL_DEBUG=VERSION
 # NCCL_NET_PLUGIN=none makes RCCL ignore that host plugin, matching the image.
 export NCCL_NET_PLUGIN=none
 
-# NOT in the v26.5 Dockerfile: avoids a NaN-loss issue when training on gfx950
+# NOT in the v26.6 Dockerfile: avoids a NaN-loss issue when training on gfx950
 # (no-op on gfx942). Keep it if you train on MI350/MI355; drop for exact parity.
 export RCCL_WARP_SPEED_AUTO=0
 

--- a/tools/installation-jax/setup.sh
+++ b/tools/installation-jax/setup.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-# setup.sh — Reproduce the Primus JAX/MaxText training environment (v26.5) in a
-# Python venv (no sudo, no docker). Mirrors the v26.5 JAX training Dockerfile,
+# setup.sh — Reproduce the Primus JAX/MaxText training environment (v26.6) in a
+# Python venv (no sudo, no docker). Mirrors the v26.6 JAX training Dockerfile,
 # adapted for bare metal:
-#   * ROCm from a RELEASE TARBALL (TheRock dist) extracted to $ROCM_DIR, under
-#     $PRIMUS_JAX_BASE (no sudo, no /opt/rocm) — replaces the v26.4 pip wheels
+#   * ROCm from pip TheRock wheels (`rocm-sdk-*` 7.14.0 on repo.amd.com), same
+#     delivery as the v26.6 image (v26.5 used a release tarball)
 #   * builds/checkouts on a big disk (home quota is usually tiny)
 #   * GPU arch auto-detected (gfx942 and/or gfx950); apt/sudo steps skipped
 #   * MaxText's own setup.sh apt/interactive steps skipped (system packages are
 #     a one-time root action, documented in the guide's Section 2)
 #   * TensorFlow (2.21 CPU) and RCCL are built from source in the default flow
-#     (matching the v26.5 image)
+#     (matching the v26.6 image)
+#   * JAX 0.11.0 + jax_rocm7_{pjrt,plugin} 0.11.0.post1 from PyPI
 #
 # Usage:
 #   bash setup.sh                # run all default stages in order
@@ -29,30 +30,23 @@ die()  { echo -e "\033[1;31m[setup][ERROR] $*\033[0m" >&2; exit 1; }
 # shellcheck disable=SC1091
 reload_env() { source "$SCRIPT_DIR/env.sh"; }
 
-# ---- pinned versions / commits (from the v26.5 JAX Dockerfile) ----
-# ROCm: TheRock RELEASE TARBALL (not pip wheels). Extracted into $ROCM_DIR.
-# See: https://repo.amd.com/rocm/tarball-multi-arch/
-THEROCK_TARBALL="${THEROCK_TARBALL:-https://repo.amd.com/rocm/tarball-multi-arch/therock-dist-linux-multiarch-7.14.0.tar.gz}"
+# ---- pinned versions / commits (from Dockerfile.jax-v26.6) ----
+# ROCm: TheRock pip wheels (not the v26.5 release tarball).
+# See: https://repo.amd.com/rocm/whl-multi-arch/
+ROCM_INDEX="https://repo.amd.com/rocm/whl-multi-arch"
+THE_ROCK_VERSION="7.14.0"
 
-# JAX + ROCm PJRT/plugin
-# See: https://repo.amd.com/rocm/whl-multi-arch/jax-rocm7-pjrt/
-#      https://repo.amd.com/rocm/whl-multi-arch/jax-rocm7-plugin/
-JAX_VERSION="0.10.0"
-JAX_PJRT_VERSION="0.10.0+rocm7.14.0"
-JAX_PLUGIN_VERSION="0.10.0+rocm7.14.0"
-JAX_INDEX="https://repo.amd.com/rocm/whl-multi-arch/"
+# JAX + ROCm PJRT/plugin — v26.6 publishes these on PyPI (cp312 plugin).
+JAX_VERSION="0.11.0"
+JAX_ROCM_VERSION="0.11.0.post1"
 
 # TransformerEngine (prebuilt ROCm JAX wheel)
-# See: https://rocm.frameworks-nightlies.amd.com/whl-staging/device-all/transformer-engine-rocm-jax/
-TE_VERSION="2.15.0.dev0+rocm7.15.0a20260707.72d01a0"
-TE_INDEX="https://rocm.frameworks-nightlies.amd.com/whl-staging/device-all/"
-# From-source TransformerEngine (used by the `te_source` stage). Needed on hosts
-# whose glibc is older than the prebuilt wheel requires (< 2.38, e.g. Ubuntu
-# 22.04): building against the host toolchain links TE to the local glibc so it
-# actually loads. (Commit is the last known-good ROCm TE JAX source build; bump
-# to match the prebuilt wheel above when a matching source tag is published.)
+# See: https://rocm.frameworks-devreleases.amd.com/whl-multi-arch-staging/transformer-engine-rocm-jax/
+TE_VERSION="2.17.0+rocm7.14.0.50a84ad"
+TE_INDEX="https://rocm.frameworks-devreleases.amd.com/whl-multi-arch-staging/"
+# From-source TransformerEngine (used by the `te_source` stage / glibc < 2.38).
 TE_REPO="https://github.com/ROCm/TransformerEngine.git"
-TE_SOURCE_COMMIT="${TE_SOURCE_COMMIT:-635d7c085c39a6d9bfe4881c7d3efab7a46d7129}"
+TE_SOURCE_COMMIT="${TE_SOURCE_COMMIT:-50a84ad}"
 
 # TensorFlow (CPU) built from source — replaces the stock PyPI wheel, whose
 # bundled LLVM collides with ROCm's libLLVM in Grain workers (SIGSEGV on
@@ -60,20 +54,15 @@ TE_SOURCE_COMMIT="${TE_SOURCE_COMMIT:-635d7c085c39a6d9bfe4881c7d3efab7a46d7129}"
 # NCCL, preserving the XLA->RCCL collective fix.
 TF_REPO="https://github.com/ROCm/tensorflow-upstream.git"
 TF_BRANCH="upstream-v2.21.0"
-BAZELISK_VERSION="v1.25.0"
+BAZELISK_VERSION="v1.29.0"
 
 # RCCL built from source (rocm-systems), installed into the ROCm tree.
 RCCL_REPO="https://github.com/ROCm/rocm-systems.git"
 RCCL_COMMIT="9e5e4084a4b8e1e86551b0eb054725c62354a926"
 
 # MaxText (ROCm fork)
-# v26.5 switched MaxText's initialize()/run() to a 2-value API (config, recorder);
-# v26.4 and earlier returned 3 values (adds diagnostic_config). Primus main
-# supports BOTH: MaxTextPretrainTrainer forwards initialize()'s tuple verbatim to
-# run() (fix #912), so v26.5 trains out of the box with Primus main. Override
-# MAXTEXT_BRANCH only if you deliberately need a different MaxText release.
 MAXTEXT_REPO="https://github.com/ROCm/maxtext.git"
-MAXTEXT_BRANCH="${MAXTEXT_BRANCH:-release/v26.5}"
+MAXTEXT_BRANCH="${MAXTEXT_BRANCH:-release/v26.6}"
 # Which MaxText requirements set to install. The reference Docker image runs
 # MaxText's setup.sh with defaults (DEVICE=tpu), which — on ROCm — pulls the
 # framework-agnostic deps WITHOUT any CUDA packages. Override to `cuda12` only
@@ -141,48 +130,52 @@ stage_venv() {
     $PIP install \
         cmake==3.31.6 \
         ninja==1.11.1.3 \
-        wheel==0.45.1 \
+        wheel==0.46.2 \
         packaging==25.0 \
-        setuptools==69.5.1 \
+        setuptools==80.10.2 \
+        msgpack==1.2.1 \
         uv
     rm -rf /root/.cache 2>/dev/null || true
 }
 
 stage_rocm() {
     reload_env
-    # v26.5: ROCm comes from a TheRock RELEASE TARBALL extracted into $ROCM_DIR
-    # (user-writable, no sudo, no /opt/rocm). This also sidesteps the pip
-    # rocm-sdk-* version-skew that broke hipBLASLt GEMMs in the v26.4 recipe.
-    log "Installing ROCm from tarball into $ROCM_DIR"
-    mkdir -p "$ROCM_DIR" "$SRC_DIR"
-    if [ -x "$ROCM_DIR/bin/hipcc" ] || [ -d "$ROCM_DIR/lib" ]; then
-        log "ROCm already present at $ROCM_DIR (skipping download; rm -rf it to force)"
-    else
-        local tb="$SRC_DIR/therock-dist.tar.gz"
-        log "Downloading $THEROCK_TARBALL"
-        wget -O "$tb" "$THEROCK_TARBALL" || die "ROCm tarball download failed"
-        log "Extracting to $ROCM_DIR"
-        tar -xf "$tb" -C "$ROCM_DIR" || die "ROCm tarball extract failed"
-        rm -f "$tb"
-    fi
+    # v26.6: ROCm comes from TheRock pip wheels (same as the JAX image), not a
+    # tarball. Device wheels match the host arch detected in env.sh.
+    log "Installing ROCm SDK ${THE_ROCK_VERSION} from $ROCM_INDEX (arch: $PYTORCH_ROCM_ARCH)"
+    local _arch arch_args=()
+    local _arches; IFS=';' read -ra _arches <<< "$PYTORCH_ROCM_ARCH"
+    for _arch in "${_arches[@]}"; do
+        _arch="${_arch// /}"; [ -z "$_arch" ] && continue
+        arch_args+=( "rocm-sdk-device-${_arch}==${THE_ROCK_VERSION}" )
+    done
+    [ ${#arch_args[@]} -gt 0 ] || die "no GPU arch resolved; export PYTORCH_ROCM_ARCH (e.g. gfx942;gfx950)"
+
+    $PIP install \
+        --index-url "$ROCM_INDEX" \
+        --pre \
+        "rocm==${THE_ROCK_VERSION}" \
+        rocm-bootstrap \
+        "rocm-sdk-core==${THE_ROCK_VERSION}" \
+        "rocm-sdk-devel==${THE_ROCK_VERSION}" \
+        "rocm-sdk-libraries==${THE_ROCK_VERSION}" \
+        "${arch_args[@]}"
+    log "Running rocm-sdk init"
+    rocm-sdk init
     reload_env
-    [ -n "${ROCM_PATH:-}" ] || die "ROCM_PATH not resolved after extraction (check $ROCM_DIR layout: expected $ROCM_DIR/bin, $ROCM_DIR/lib)"
+    [ -n "${ROCM_PATH:-}" ] || die "ROCM_PATH not resolved after rocm-sdk init"
     log "ROCM_PATH=$ROCM_PATH"
-    # amdsmi (the Dockerfile installs it via pip after the ROCm tarball)
-    $PIP install amdsmi==7.0.2 || log "WARNING: amdsmi install failed (non-fatal)"
     ( "$ROCM_PATH/bin/hipcc" --version || hipcc --version ) 2>/dev/null || log "hipcc not found yet; re-source env.sh"
 }
 
 stage_jax() {
     reload_env
-    log "Installing JAX ${JAX_VERSION} + ROCm PJRT/plugin (v26.5)"
+    log "Installing JAX ${JAX_VERSION} + ROCm PJRT/plugin ${JAX_ROCM_VERSION} from PyPI (v26.6)"
     # Note: JAX and related libraries need to be installed BEFORE TE and AFTER
     # MaxText (whose setup.sh pulls in a stock jax/tensorflow we override here).
-    $PIP install "jax==${JAX_VERSION}" "jaxlib==${JAX_VERSION}" scipy==1.16
-    $PIP install \
-        --index-url "$JAX_INDEX" \
-        --pre "jax_rocm7_pjrt==${JAX_PJRT_VERSION}" \
-        --pre "jax_rocm7_plugin==${JAX_PLUGIN_VERSION}"
+    $PIP install "jax==${JAX_VERSION}" "jaxlib==${JAX_VERSION}" scipy==1.16 \
+        "jax_rocm7_pjrt==${JAX_ROCM_VERSION}" \
+        "jax_rocm7_plugin==${JAX_ROCM_VERSION}"
     python -c "import jax; print('jax', jax.__version__); print('devices:', jax.devices())" || \
         log "WARNING: jax.devices() failed (expected if no GPU is visible on this build host)"
 }
@@ -203,7 +196,7 @@ stage_te() {
         pybind11==3.0.4 \
         importlib-metadata==8.7.1 \
         pydantic==2.13.4 \
-        flax==0.12.2
+        flax==0.12.8
     $PIP install \
         --index-url "$TE_INDEX" \
         --pre \
@@ -222,16 +215,30 @@ stage_te() {
         die "TransformerEngine failed to import (see error above). See docs Section 3.7."
     fi
     log "TransformerEngine import OK"
+    python - <<'PY' || true
+import glob, os, sysconfig
+for base in {sysconfig.get_paths()[k] for k in ("purelib", "platlib")}:
+    p = os.path.join(base, "flaxlib_src")
+    if os.path.isdir(p):
+        import shutil; shutil.rmtree(p)
+        print("removed", p)
+PY
 }
 
 stage_te_source() {
+    reload_env
+    export PRIMUS_JAX_KEEP_ROCM_LD=1
     reload_env
     # Build TransformerEngine (JAX) from source, linking against the HOST glibc.
     # Use this instead of `te` on hosts whose glibc is older than the prebuilt
     # wheel needs (< 2.38, e.g. Ubuntu 22.04). NOTE: this is a heavy build (CK
     # fused-attention kernels for your arch) — expect ~30-60 min.
     log "Building TransformerEngine (JAX) from source @ $TE_SOURCE_COMMIT"
-    $PIP install pybind11==3.0.4 importlib-metadata==8.7.1 pydantic==2.13.4 flax==0.12.2
+    # TE 2.17 HipKittens grouped MXFP8 GEMM is compiled only when both gfx942
+    # and gfx950 appear in CMAKE_HIP_ARCHITECTURES. A gfx942-only configure
+    # still defines USE_HIPKITTENS_GEMM and then fails to find
+    # kittens_grouped_mxfp8_gemm (CDNA4). The v26.6 image builds both archs.
+    $PIP install pybind11==3.0.4 importlib-metadata==8.7.1 pydantic==2.13.4 flax==0.12.8
     # Remove ALL prebuilt/stale TE variants so TE's install sanity-check sees a
     # single, self-consistent from-source package.
     $PIP uninstall -y transformer_engine transformer-engine transformer_engine_rocm7 \
@@ -241,7 +248,8 @@ stage_te_source() {
         && git checkout "$TE_SOURCE_COMMIT" \
         && git submodule update --init --recursive \
         && USE_ROCM=1 NVTE_FRAMEWORK=jax NVTE_USE_ROCM=1 \
-           HIP_PATH="$ROCM_PATH" NVTE_ROCM_ARCH="$PYTORCH_ROCM_ARCH" \
+           HIP_PATH="$ROCM_PATH" \
+           NVTE_ROCM_ARCH="gfx942;gfx950" \
            CMAKE_BUILD_PARALLEL_LEVEL="$MAX_JOBS" \
            PYTHONPATH="$SRC_DIR/TransformerEngine/3rdparty/hipify_torch:${PYTHONPATH:-}" \
            python3 setup.py bdist_wheel \
@@ -250,6 +258,8 @@ stage_te_source() {
     python -c "import transformer_engine.jax" || die "TransformerEngine (source) import failed"
     log "TransformerEngine (source) import OK"
     rm -rf "$SRC_DIR/TransformerEngine"
+    unset PRIMUS_JAX_KEEP_ROCM_LD
+    reload_env
 }
 
 stage_maxtext() {
@@ -337,9 +347,13 @@ stage_tf_source() {
 
 stage_rccl() {
     reload_env
-    # v26.5: build RCCL from source (rocm-systems) and drop the libraries into the
-    # ROCm tree so JAX/XLA's collectives use it. Requires the ROCm toolchain
-    # (hipcc) from the extracted tarball -> run AFTER the `rocm` stage.
+    export PRIMUS_JAX_KEEP_ROCM_LD=1
+    reload_env
+    # v26.6: build RCCL from source (rocm-systems) and drop the libraries into
+    # the pip ROCm tree so JAX/XLA's collectives use it. Requires hipcc from
+    # rocm-sdk-devel -> run AFTER the `rocm` stage. Existing librccl* entries
+    # are symlinks from rocm-sdk-libraries; rm them first (a bare cp onto a
+    # symlink hits ELOOP).
     [ -n "${ROCM_PATH:-}" ] || die "ROCM_PATH not set; run the 'rocm' stage first"
     log "Building RCCL from source @ $RCCL_COMMIT -> $ROCM_PATH/lib"
     fresh_clone "$RCCL_REPO" rocm-systems
@@ -347,8 +361,11 @@ stage_rccl() {
         && git checkout "$RCCL_COMMIT" \
         && cd projects/rccl \
         && ./install.sh -l --prefix build/ --amdgpu_targets="$PYTORCH_ROCM_ARCH" \
+        && rm -f "$ROCM_PATH"/lib/librccl* \
         && cp -r build/release/librccl* "$ROCM_PATH/lib/" ) || die "RCCL build failed"
     rm -rf "$SRC_DIR/rocm-systems"
+    unset PRIMUS_JAX_KEEP_ROCM_LD
+    reload_env
 }
 
 stage_primus() {
@@ -377,6 +394,27 @@ stage_jaxreqs() {
     else
         log "Primus requirements-jax.txt not found (skipping); run 'primus' stage first"
     fi
+    # maxtext/Primus pull these in transitively at older, CVE-affected versions.
+    log "Force-upgrading CVE-fix pins from the v26.6 image"
+    $PIP install --upgrade \
+        pillow==12.3.0 \
+        starlette==1.3.1 \
+        pyasn1==0.6.4 \
+        cryptography==50.0.0 \
+        httplib2==0.32.0 \
+        black==26.3.1 \
+        msgpack==1.2.1 \
+        setuptools==80.10.2 \
+        flax==0.12.8 \
+        keras==3.15.0
+    python - <<'PY' || true
+import os, shutil, sysconfig
+for base in {sysconfig.get_paths()[k] for k in ("purelib", "platlib")}:
+    p = os.path.join(base, "flaxlib_src")
+    if os.path.isdir(p):
+        shutil.rmtree(p)
+        print("removed", p)
+PY
 }
 
 stage_manifest() {
@@ -384,12 +422,14 @@ stage_manifest() {
     log "Writing manifest to $WORKSPACE_DIR/.manifest"
     mkdir -p "$WORKSPACE_DIR/.manifest"
     env > "$WORKSPACE_DIR/.manifest/env.txt"
+    echo "Dockerfile.jax-v26.6" > "$WORKSPACE_DIR/.manifest/derived_from"
     $PIP list > "$WORKSPACE_DIR/.manifest/requirements.txt"
     cp "$SCRIPT_DIR/env.sh" "$WORKSPACE_DIR/.manifest/env.sh"
 }
 
-# v26.5 order mirrors the Dockerfile: ROCm tarball -> MaxText -> TF-from-source
-# -> JAX (overrides what MaxText pulled) -> TE -> Primus -> RCCL-from-source.
+# v26.6 order: pip ROCm -> MaxText -> TF-from-source -> JAX (overrides MaxText)
+# -> TE -> Primus -> RCCL-from-source. JAX/TE stay after MaxText so its setup.sh
+# cannot clobber the ROCm plugin / TE 2.17 wheels.
 DEFAULT_STAGES=(venv rocm maxtext tf_source jax te primus jaxreqs rccl manifest)
 
 run_stage() { local s="$1"; local fn="stage_$s"; declare -F "$fn" >/dev/null || die "unknown stage: $s"; "$fn"; }

--- a/tools/installation/README.md
+++ b/tools/installation/README.md
@@ -1,8 +1,8 @@
 # Primus environment in a venv (no docker, no sudo)
 
-Reproduces the Primus **v26.5** training image in a Python virtual environment on
+Reproduces the Primus **v26.6** training image in a Python virtual environment on
 a bare-metal host. Derived from
-[`.github/workflows/docker-release/Dockerfile.primus-v26.5`](../../.github/workflows/docker-release/Dockerfile.primus-v26.5),
+[`.github/workflows/docker-release/Dockerfile.primus-v26.6`](../../.github/workflows/docker-release/Dockerfile.primus-v26.6),
 using the same package pins and commits, adapted for the constraints of a machine
 where we have no root.
 
@@ -14,8 +14,8 @@ failure it avoids — worth reading before "correcting" any of them back.
 ## Python 3.12 is required
 
 This is a hard requirement from upstream packaging, not a preference. The pinned
-torch nightly `2.12.0+rocm7.15.0a20260720` ships a **cp312 Linux wheel only** —
-that nightly date published no cp310 Linux build — and the v26.5
+torch nightly `2.12.0+rocm7.15.0a20260727` ships a **cp312 Linux wheel only** —
+that nightly date published no cp310 Linux build — and the v26.6
 TransformerEngine wheels are cp312-only as well.
 
 Ubuntu 22.04 hosts only have `python3.10`, so `setup.sh` provisions a standalone
@@ -35,15 +35,15 @@ python3 -m pip install --user uv     # ~/.local/bin, one of the paths setup.sh s
 If you cannot install it at all, supply your own interpreter instead and it is never
 used: `PRIMUS_PYTHON=/path/to/python3.12 bash setup.sh`.
 
-> **Migrating from the v26.4-based scripts:** a Python 3.10 venv cannot be
+> **Migrating from an older venv:** a Python 3.10 venv cannot be
 > upgraded in place. `setup.sh` detects the mismatch and stops with instructions;
 > remove the old venv and rebuild:
 > `rm -rf "$PRIMUS_BASE/venv" && bash setup.sh`
 
 ## TransformerEngine: wheel on glibc ≥ 2.38, otherwise built from source
 
-v26.5 installs TransformerEngine from the ROCm staging index instead of building
-it. Those wheels are produced on Ubuntu 24.04, and `libtransformer_engine.so`
+v26.6 installs TransformerEngine from the ROCm multi-arch staging index instead of
+building it. Those wheels are produced on Ubuntu 24.04, and `libtransformer_engine.so`
 requires **glibc ≥ 2.38** plus `GLIBCXX_3.4.32`. Ubuntu 22.04 has glibc 2.35, and
 unlike libstdc++, glibc cannot be side-loaded through `LD_LIBRARY_PATH` — so on a
 22.04 host the v26.5 wheels install fine but fail at import with:
@@ -56,8 +56,8 @@ OSError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
 
 | Host glibc | Path | What happens |
 |---|---|---|
-| ≥ 2.38 (e.g. Ubuntu 24.04) | wheel | exactly what v26.5 does |
-| < 2.38 (e.g. Ubuntu 22.04) | source | clones `ROCm/TransformerEngine` and builds commit `a07e607f14a…`, the same commit the `TE_VERSION` label refers to |
+| ≥ 2.38 (e.g. Ubuntu 24.04) | wheel | exactly what v26.6 does |
+| < 2.38 (e.g. Ubuntu 22.04) | source | clones `ROCm/TransformerEngine` and builds commit `e028a6c…`, the same commit the `TE_VERSION` label refers to |
 
 Either way you get the same TE version; the source build just links against the
 host toolchain. It takes considerably longer than the wheel install. Override the
@@ -74,7 +74,7 @@ than letting the problem surface later during training.
 | GPU arch | gfx942 + gfx950 | **auto-detected** from the host (`rocminfo`/KFD sysfs); builds only what's present → faster builds |
 | Build dir | container FS | venv under **`$PRIMUS_BASE`** (persistent, you choose it); build sources on local `/tmp` |
 | System deps | `apt install ...` | **skipped** (no sudo); pip provides what's needed |
-| torchaudio / torchvision / apex | floating (`torchvision==0.27`) | pinned to the exact `a20260720` nightly builds — see below |
+| torchaudio / torchvision / apex | floating (`torchvision==0.27`) | pinned to the exact `a20260727` nightly builds — see below |
 
 The key reason no sudo is required: the `rocm-sdk-devel` pip wheel ships a full
 ROCm toolchain inside the venv, so we don't depend on system ROCm or apt.
@@ -86,7 +86,7 @@ resolves torchvision as `==0.27`. That set no longer resolves at all: newer
 `rocm10.x` nightlies now publish matching version numbers, so a floating
 torchvision selects a build for a different ROCm line, conflicts with the pinned
 torch, and pip dies after a long backtracking storm. `setup.sh` pins each
-companion wheel to the version the `a20260720` nightly published, i.e. exactly
+companion wheel to the version the `a20260727` nightly published, i.e. exactly
 what the Dockerfile picked up on the day it was built.
 
 ## Run it
@@ -102,10 +102,10 @@ export PRIMUS_BASE="$HOME/envs/primus-env"   # required, pick your own location
 bash setup.sh                                # all default stages
 ```
 
-The build compiles aiter, Primus-Turbo, flash-attention and TransformerEngine
-from source, so budget hours rather than minutes — on glibc < 2.38 that means all
-of TE, not just its torch glue layer. Running it detached avoids losing it to a
-dropped connection:
+The build compiles aiter, Primus-Turbo and (on older glibc) TransformerEngine
+from source, so budget hours rather than minutes. `flash-attn` is a pip package
+in v26.6 (`flash-attn==2.8.1`) rather than the ROCm git fork. Running it detached
+avoids losing it to a dropped connection:
 
 ```bash
 nohup bash setup.sh > ~/primus-setup.log 2>&1 &
@@ -149,46 +149,29 @@ Optional: `torchrec` (DLRM/recommendation stack).
 
 The order matters for `te`: see the note on the staging index below.
 
-## What changed from the v26.4-based scripts
+## What changed from the v26.5-based scripts
 
-- **TransformerEngine now comes from the ROCm staging index where it can.**
-  `stage_te` installs `transformer_engine_rocm_torch==2.15.0.dev0+rocm7.15.0a20260716.a07e607`
-  from `rocm.frameworks-nightlies.amd.com/whl-staging/device-all/`, which pulls a
-  prebuilt core library and compiles only the thin torch glue layer. On hosts
+- **TransformerEngine 2.17 from the multi-arch staging index.** `stage_te`
+  installs `transformer_engine_rocm_torch==2.17.0+rocm7.15.0a20260727.e028a6c`
+  from `rocm.frameworks-nightlies.amd.com/whl-multi-arch-staging/`. On hosts
   whose glibc is too old for those wheels it builds the same commit from source
   instead — see the section above.
-- **`stage_te` must run after `stage_flash_attn`.** That staging index serves
-  *only* the transformer-engine packages, so while `--index-url` points at it pip
-  cannot reach PyPI for anything else. Every TE dependency has to be installed
-  beforehand. The Dockerfile gets `einops` transitively from flash-attention and
-  `onnx` from `onnxscript`; `stage_te` installs both explicitly rather than
-  relying on another package's transitive deps.
-- **`ck_jit_compile.sh` is patched** the same way v26.5 patches it inside the
-  image: concurrent CK JIT compiles race to publish the same `.so`, and without
-  the patch the loser aborts the run. The script locates the file through
-  `sysconfig` (rather than a hardcoded `/opt/venv/lib/python3.12` path) and the
-  patch is idempotent.
-- **New `cleanup` stage** uninstalls `tilelang`, mirroring v26.5. `mamba-ssm`
-  pulls it in as a hard dependency and v26.5 removes it again once everything is
-  built.
-- **`apache-tvm-ffi` now follows the Dockerfile pin (0.1.11).** The old scripts
-  held it at 0.1.6 to dodge a `tilelang` import failure; with `tilelang`
-  uninstalled at the end, that workaround is obsolete.
-- **`GPU_ARCHS` is `native` at runtime.** v26.5 sets `ENV GPU_ARCHS=native` after
-  the last build stage so aiter's JIT compiles for the GPU actually in the box.
-  `env.sh` therefore defaults it to `native`, and `setup.sh` overrides it to the
-  full arch list for the individual stages that cross-compile.
-- **Build-only NVTE vars dropped from the runtime environment.** `NVTE_USE_ROCM`,
-  `NVTE_FRAMEWORK`, `NVTE_ROCM_ARCH` and `NVTE_USE_HIPBLASLT` configure the
-  from-source TE build and are gone from v26.5, so `env.sh` no longer exports
-  them; `stage_te_source` still sets them inline for the duration of its build.
-  The runtime performance knobs (`NVTE_CK_*`,
-  `NVTE_USE_CAST_TRANSPOSE_TRITON`, `NVTE_FLASH_ATTN=0`, `NVTE_FUSED_ATTN=1`)
-  stay.
-- **Updated pins:** torch `2.12.0+rocm7.15.0a20260720`, Primus
-  `b511d1b66b0068715308ea9bfe8ba147ea1a3860` (`release/v26.5`), Primus-Turbo
-  `edc8d2ccb0be4888e80ee7c6e765fd3956026a32`. flash-attention, torchtune,
-  torchao, grouped_gemm, causal-conv1d, mamba and aiter are unchanged in v26.5.
+- **Flash Attention is `pip install flash-attn==2.8.1`**, not the
+  `ROCm/flash-attention` git fork used through v26.5.
+- **Full TheRock ROCm wheel set** (`rocm`, `rocm-bootstrap`, `rocm-sdk-core`,
+  `rocm-sdk-devel`, `rocm-sdk-libraries`, plus per-arch device wheels), matching
+  the image. `stage_torch` also applies the `libamd_comgr.so.3` symlink
+  workaround (AIMA-248).
+- **`PRIMUS_FLA_MLA_ATTN=1`** is exported at runtime (MLA `core_attention` uses
+  `flash_attn_func` directly).
+- **mamba** applies the v26.6 `uninitialized_copy.cuh` CUDA-namespace patches
+  and installs `nvidia-cuda-nvdisasm==13.3.73`.
+- **Updated pins:** torch `2.12.0+rocm7.15.0a20260727`, TE 2.17, transformers
+  `5.5.0`, wandb `0.28.2`, Primus `2aa05ead…` (`release/v26.6`), Primus-Turbo
+  `a6a16cdc…`. CVE pins: `cryptography==50.0.0`, `mlflow==3.15.1` (`--no-deps`).
+- **`ck_jit_compile.sh` is still patched** the same way the image patches it.
+- **`GPU_ARCHS` remains `native` at runtime.** `setup.sh` still overrides it to
+  the full arch list for stages that cross-compile.
 
 ## What is SKIPPED (needs sudo / apt — not reproducible here)
 
@@ -203,7 +186,7 @@ The order matters for `te`: see the note on the staging index below.
   install (it has rocshmem headers and device bitcode, but no host
   `librocshmem.a`) and the link then fails. Intranode DeepEP is unaffected.
   Export a real `ROCSHMEM_HOME` to opt back in.
-- **MLPerf `primus_mllog`**: v26.5 installs it from `training_results_v6.0`. Not
+- **MLPerf `primus_mllog` / `mlperf-common`**: the image installs it; it is not
   part of the core training path, so it is not installed here.
 - **DLRM / FBGEMM / Flux**: not part of the default Primus training path.
   `torchrec` is provided as an optional stage; FBGEMM additionally needs apt
@@ -232,7 +215,7 @@ scripts:
   LLVM's static initialisers — taking down `torch._dynamo`, `aiter`, `torchao` and
   `mamba_ssm` with it. `stage_turbo` therefore installs Primus-Turbo without deps
   and supplies its real runtime requirements (`scipy`, `flydsl`) explicitly. This
-  is a deliberate, tested deviation from v26.5.
+  is a deliberate, tested deviation from the image.
 - **mamba built with pip, not `python setup.py install`.** The legacy
   `easy_install` path ignores pip-installed packages and re-fetches the *latest*
   of every unpinned dep as `.egg`s — it clobbered `transformers` (→5.x), removed
@@ -267,8 +250,8 @@ scripts:
   after which aiter prints `ROCm/HIP JIT runtime not available … CK and HIP ops
   are disabled. Triton ops remain available.` and quietly runs Triton-only. 0.2.4
   is the newest release that satisfies Turbo and keeps aiter whole, and is what
-  the Dockerfile itself resolved to, since 0.3.0 was published after v26.5 was
-  built. `stage_turbo` asserts the symbol is importable afterwards. This is about
+  the Dockerfile itself resolved to historically. `stage_turbo` asserts the
+  symbol is importable afterwards. This is about
   capability parity with the image, not speed: on llama3.1_8B BF16 an A/B of 0.2.4
   against 0.3.0 measured 535.9 vs 534.5 TFLOP/s/GPU, i.e. no difference. Other
   workloads that lean on aiter's CK/HIP kernels are the ones that would notice.
@@ -278,8 +261,8 @@ scripts:
   that quack 0.3.1 imports, so the unpinned resolution ends in
   `AttributeError: module 'cutlass.cute.core' has no attribute 'ThrCopy'`. 4.5.3 is
   the newest release quack 0.3.1 still works with, and pip cannot choose it
-  unaided because 4.5.3 was published *after* 4.6.0 yet sorts lower. v26.5 does
-  not pin this, so the released image is affected by the same break.
+  unaided because 4.5.3 was published *after* 4.6.0 yet sorts lower. The image
+  does not pin this either.
 - **`patchelf` from pip**, since the apt one is unavailable.
 - **`libz3.so` from pip** (`z3-solver`, added to `LD_LIBRARY_PATH` by `env.sh`).
   With `tilelang` now uninstalled this is only a safety net, kept so that

--- a/tools/installation/env.sh
+++ b/tools/installation/env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # env.sh — Primus venv environment (Python 3.12, ROCm via pip rocm-sdk-devel)
-# Derived from .github/workflows/docker-release/Dockerfile.primus-v26.5
+# Derived from .github/workflows/docker-release/Dockerfile.primus-v26.6
 #
 # Source this both during the build (setup.sh does it) and every time you
 # want to USE the environment:   source env.sh
@@ -44,7 +44,7 @@ export MAX_JOBS="${MAX_JOBS:-128}"
 
 # ---- Python version ----
 # 3.12 is REQUIRED, not a preference. The pinned torch nightly
-# (2.12.0+rocm7.15.0a20260720) published a cp312 Linux wheel and nothing else,
+# (2.12.0+rocm7.15.0a20260727) published a cp312 Linux wheel and nothing else,
 # so this holds even where TransformerEngine is built from source. In wheel mode
 # TE reinforces it: its prebuilt core library `transformer_engine_rocm7` is also
 # cp312-only, with no sdist and no other cp3xx build. See README.md.
@@ -109,7 +109,7 @@ export HCC_AMDGPU_TARGET="${HCC_AMDGPU_TARGET:-$_ARCH_CSV}"
 export HIP_ARCHITECTURES="${HIP_ARCHITECTURES:-$_ARCH_CSV}"
 
 # GPU_ARCHS is deliberately `native` here, matching the `ENV GPU_ARCHS=native`
-# that v26.5 sets after the last build stage: aiter's JIT has to compile for the
+# that v26.6 sets after the last build stage: aiter's JIT has to compile for the
 # GPU it actually runs on. setup.sh overrides it to the full arch list for the
 # individual build stages that cross-compile.
 export GPU_ARCHS="${GPU_ARCHS:-native}"
@@ -171,10 +171,10 @@ if [ -n "${_ROCM_SDK:-}" ]; then
 fi
 
 # ---- TransformerEngine tuning ----
-# Only the runtime performance knobs v26.5 keeps. The NVTE_USE_ROCM /
-# NVTE_FRAMEWORK / NVTE_ROCM_ARCH / NVTE_USE_HIPBLASLT vars that v26.4 exported
-# are build-time switches, which is why v26.5 dropped them and why they are not
-# exported here; stage_te_source sets them inline for the duration of its build.
+# Only the runtime performance knobs v26.6 keeps. The NVTE_USE_ROCM /
+# NVTE_FRAMEWORK / NVTE_ROCM_ARCH / NVTE_USE_HIPBLASLT vars that earlier images
+# exported are build-time switches, which is why they are not exported here;
+# stage_te_source sets them inline for the duration of its build.
 export NVTE_USE_CAST_TRANSPOSE_TRITON="${NVTE_USE_CAST_TRANSPOSE_TRITON:-1}"
 export NVTE_CK_USES_FWD_V3="${NVTE_CK_USES_FWD_V3:-1}"
 export NVTE_CK_USES_BWD_V3="${NVTE_CK_USES_BWD_V3:-1}"
@@ -197,12 +197,13 @@ export NVTE_CK_IS_V3_ATOMIC_FP32="${NVTE_CK_IS_V3_ATOMIC_FP32:-$_PRIMUS_CK_ATOMI
 # Required post-v26.2 to resolve Primus attention backend issues
 export NVTE_FLASH_ATTN=0
 export NVTE_FUSED_ATTN=1
+export PRIMUS_FLA_MLA_ATTN="${PRIMUS_FLA_MLA_ATTN:-1}"
 
 # ---- causal-conv1d / mamba ----
 export CAUSAL_CONV1D_FORCE_BUILD=TRUE
 export MAMBA_FORCE_BUILD=TRUE
 
-# libz3.so safety net. v26.5 uninstalls tilelang (the mamba_ssm dep that needs
+# libz3.so safety net. v26.6 uninstalls tilelang (the mamba_ssm dep that needs
 # z3) at the end of the build, so this is normally unused; it stays because the
 # Dockerfile still ships apt libz3-dev and re-installing tilelang by hand should
 # not leave a broken environment behind. pip `z3-solver` supplies the library.

--- a/tools/installation/setup.sh
+++ b/tools/installation/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # setup.sh — Reproduce the Primus training environment in a Python venv
 # (no sudo, no docker). Mirrors the pins of
-#   .github/workflows/docker-release/Dockerfile.primus-v26.5
+#   .github/workflows/docker-release/Dockerfile.primus-v26.6
 # adapted for:
 #   * Python 3.12, auto-provisioned with `uv` (the pinned torch nightly is
 #     cp312-only on Linux; see README.md)
@@ -31,7 +31,7 @@ OPTIONAL_STAGES=(torchrec)
 
 usage() {
     cat <<EOF
-setup.sh — build the Primus v26.5 training environment in a venv.
+setup.sh — build the Primus v26.6 training environment in a venv.
 
 PRIMUS_BASE must be exported first; it has no default because the right location
 is site-specific. Point it at a writable dir on a disk with tens of GB free:
@@ -64,33 +64,30 @@ die()  { echo -e "\033[1;31m[setup][ERROR] $*\033[0m" >&2; exit 1; }
 # shellcheck disable=SC1091
 reload_env() { source "$SCRIPT_DIR/env.sh"; }
 
-# ---- pinned versions / commits (from Dockerfile.primus-v26.5) ----
+# ---- pinned versions / commits (from Dockerfile.primus-v26.6) ----
 TORCH_INDEX="https://rocm.nightlies.amd.com/whl-multi-arch"
 # The Dockerfile pins only `torch` and lets torchaudio/apex float and
 # torchvision resolve as `==0.27`. That no longer resolves: newer rocm10.x
 # nightlies now publish matching version numbers, so a floating torchvision
 # drags in a build for a different ROCm line and the resolve dies on a
-# backtracking storm. These are the versions the a20260720 nightly published,
+# backtracking storm. These are the versions the a20260727 nightly published,
 # i.e. the exact set the Dockerfile picked up when it was built.
-PYTORCH_VERSION="2.12.0+rocm7.15.0a20260720"
-ROCM_SDK_VERSION="7.15.0a20260720"
-TORCHAUDIO_VERSION="2.11.0+rocm7.15.0a20260720"
-TORCHVISION_VERSION="0.27.0+rocm7.15.0a20260720"
-APEX_VERSION="1.12.0+rocm7.15.0a20260720"
-
-FA_REPO="https://github.com/ROCm/flash-attention.git"
-FA_BRANCH="6387433156558135a998d5568a9d74c1778666d8"
-# v26.5 stopped building TransformerEngine from source and installs it from the
-# ROCm staging index instead. Those wheels are built on Ubuntu 24.04 though, and
-# libtransformer_engine.so needs glibc >= 2.38, so they cannot load on a 22.04
-# host. stage_te falls back to building the same TE commit from source; see
-# PRIMUS_TE_MODE and the README.
-TE_INDEX="https://rocm.frameworks-nightlies.amd.com/whl-staging/device-all/"
-TE_VERSION="2.15.0.dev0+rocm7.15.0a20260716.a07e607"
+PYTORCH_VERSION="2.12.0+rocm7.15.0a20260727"
+ROCM_SDK_VERSION="7.15.0a20260727"
+TORCHAUDIO_VERSION="2.11.0+rocm7.15.0a20260727"
+TORCHVISION_VERSION="0.27.0+rocm7.15.0a20260727"
+APEX_VERSION="1.12.0+rocm7.15.0a20260727"
+FLASH_ATTN_VERSION="2.8.1"
+# v26.6 installs TransformerEngine from the ROCm multi-arch staging index.
+# Those wheels are built on Ubuntu 24.04 though, and libtransformer_engine.so
+# needs glibc >= 2.38, so they cannot load on a 22.04 host. stage_te falls back
+# to building the same TE commit from source; see PRIMUS_TE_MODE and the README.
+TE_INDEX="https://rocm.frameworks-nightlies.amd.com/whl-multi-arch-staging/"
+TE_VERSION="2.17.0+rocm7.15.0a20260727.e028a6c"
 TE_WHEEL_MIN_GLIBC="2.38"
 TE_REPO="https://github.com/ROCm/TransformerEngine.git"
-# The commit the TE_VERSION local label refers to (…a20260716.a07e607).
-TE_COMMIT="a07e607f14a5330807ffdafeeb6224f2d7dffacc"
+# The commit the TE_VERSION local label refers to (…a20260727.e028a6c).
+TE_COMMIT="e028a6c"
 TORCHTUNE_REPO="https://github.com/pytorch/torchtune.git"
 TORCHTUNE_BRANCH="b4c98ac2a37f0397d64c22579aed415ce7264db6"
 TORCHAO_REPO="https://github.com/pytorch/ao.git"
@@ -103,21 +100,21 @@ MAMBA_REPO="https://github.com/AndreasKaratzas/mamba.git"
 MAMBA_BRANCH="enable-primus-hybrid-models"
 TVM_FFI_VERSION="0.1.11"
 PRIMUS_REPO="https://github.com/AMD-AGI/Primus.git"
-# Latest commit on `release/v26.5` branch. Committed on 2026-07-22.
-PRIMUS_BRANCH="b511d1b66b0068715308ea9bfe8ba147ea1a3860"
+# Latest commit on `release/v26.6` branch. Committed on 2026-08-25.
+PRIMUS_BRANCH="2aa05ead3401708cf1a1e2958c1def18d7aecf92"
 AITER_REPO="https://github.com/ROCm/aiter.git"
 AITER_COMMIT="0f3c58e6edb6754940bcf9fd5f09ccb6f389f52e"
 TURBO_REPO="https://github.com/AMD-AGI/Primus-Turbo.git"
-# Latest commit on `main` branch. Committed on 2026-07-20.
-TURBO_COMMIT="edc8d2ccb0be4888e80ee7c6e765fd3956026a32"
+# Latest commit on `main` branch. Committed on 2026-08-21.
+TURBO_COMMIT="a6a16cdce46bd2235a248b41f501fb363c215b9b"
 # aiter pins `flydsl==0.1.7` and Primus-Turbo wants `flydsl>=0.2.0`, so one of
 # them is always unsatisfied; Turbo installs last and wins. aiter only needs
 # `flydsl.expr.vector` at runtime, which survived until 0.3.0 removed it -- and
 # with it aiter's whole CK/HIP JIT path ("CK and HIP ops are disabled. Triton ops
 # remain available."). 0.2.4 is the newest release that satisfies Turbo and still
-# keeps aiter whole; it is also what the Dockerfile resolved to, since 0.3.0 was
-# published after v26.5 was built.
+# keeps aiter whole.
 FLYDSL_VERSION="0.2.4"
+NVDISASM_VERSION="13.3.73"
 
 PIP="python -m pip"
 
@@ -229,7 +226,7 @@ stage_venv() {
         local have
         have="$("$VENV_DIR/bin/python" -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null || echo unknown)"
         [ "$have" = "$PRIMUS_PYTHON_VERSION" ] || die \
-"existing venv at $VENV_DIR is Python $have, but v26.5 requires $PRIMUS_PYTHON_VERSION.
+"existing venv at $VENV_DIR is Python $have, but v26.6 requires $PRIMUS_PYTHON_VERSION.
   The pinned torch nightly ships a cp312 Linux wheel only, so an older venv
   cannot be upgraded in place. Remove it and re-run:
       rm -rf '$VENV_DIR' && bash setup.sh"
@@ -242,11 +239,11 @@ stage_venv() {
     $PIP install \
         pybind11 \
         typeguard \
-        wheel==0.45.1 \
+        wheel==0.46.2 \
         cmake==3.31.6 \
         ninja==1.11.1.3 \
         packaging==25.0 \
-        setuptools==75.1.0 \
+        setuptools==80.10.2 \
         patchelf
 }
 
@@ -284,8 +281,12 @@ stage_torch() {
     $PIP install \
         --index-url "$TORCH_INDEX" \
         --pre \
-        "torch==${PYTORCH_VERSION}" \
+        "rocm==${ROCM_SDK_VERSION}" \
+        rocm-bootstrap \
+        "rocm-sdk-core==${ROCM_SDK_VERSION}" \
         "rocm-sdk-devel==${ROCM_SDK_VERSION}" \
+        "rocm-sdk-libraries==${ROCM_SDK_VERSION}" \
+        "torch==${PYTORCH_VERSION}" \
         "torchaudio==${TORCHAUDIO_VERSION}" \
         "torchvision==${TORCHVISION_VERSION}" \
         "apex==${APEX_VERSION}" \
@@ -293,6 +294,8 @@ stage_torch() {
 
     log "Running rocm-sdk init"
     rocm-sdk init
+    relink_comgr
+    patch_rocprofv3
     reload_env
     [ -n "${ROCM_PATH:-}" ] || die "ROCM_PATH not resolved after rocm-sdk init"
     log "ROCM_PATH=$ROCM_PATH"
@@ -300,16 +303,52 @@ stage_torch() {
     python -c "import torch; print('torch', torch.__version__, 'cuda avail', torch.cuda.is_available())"
 }
 
+# rocm-sdk-core and rocm-sdk-devel both ship libamd_comgr.so.3 as separate
+# inodes, causing duplicate LLVM static constructor registration (SIGABRT).
+# Same workaround as Dockerfile.primus-v26.6 (AIMA-248).
+relink_comgr() {
+    python - <<'PY' || true
+import os, pathlib
+try:
+    import _rocm_sdk_core, _rocm_sdk_devel
+except Exception as e:
+    print("comgr relink skipped:", e)
+    raise SystemExit(0)
+src = pathlib.Path(_rocm_sdk_devel.__file__).parent / "lib" / "libamd_comgr.so.3"
+dst = pathlib.Path(_rocm_sdk_core.__file__).parent / "lib" / "libamd_comgr.so.3"
+if src.exists() and dst.parent.exists():
+    if dst.is_symlink() or dst.exists():
+        dst.unlink()
+    os.symlink(src, dst)
+    print(f"linked {dst} -> {src}")
+PY
+}
+
+patch_rocprofv3() {
+    local f
+    f="$(python - <<'PY'
+import os
+try:
+    import _rocm_sdk_devel
+    p = os.path.join(os.path.dirname(_rocm_sdk_devel.__file__), "bin", "rocprofv3")
+    print(p if os.path.exists(p) else "")
+except Exception:
+    pass
+PY
+)"
+    [ -n "$f" ] || return 0
+    sed -i 's/update_env("ROCPROFILER_LIBRARY_CTOR", True)/update_env("ROCPROFILER_LIBRARY_CTOR", False)/' "$f" || true
+}
+
 stage_flash_attn() {
     reload_env
-    log "Building flash-attention @ $FA_BRANCH"
-    fresh_clone "$FA_REPO" flash-attention --recursive
-    # GPU_ARCHS defaults to `native` for runtime; cross-compile the full set here.
-    ( cd "$SRC_DIR/flash-attention" \
-        && git checkout "$FA_BRANCH" \
-        && git submodule update --init --recursive \
-        && GPU_ARCHS="$PYTORCH_ROCM_ARCH" python setup.py install ) || die "flash-attention build failed"
-    rm -rf "$SRC_DIR/flash-attention"
+    # v26.6 switched from the ROCm/flash-attention git fork to the pip package.
+    log "Installing flash-attn==${FLASH_ATTN_VERSION} (--no-build-isolation)"
+    MAX_JOBS="$MAX_JOBS" GPU_ARCHS="$PYTORCH_ROCM_ARCH" pipi \
+        --no-build-isolation "flash-attn==${FLASH_ATTN_VERSION}" \
+        || die "flash-attn install failed"
+    python -c "import flash_attn; print('flash_attn', flash_attn.__version__)" \
+        || die "flash_attn installed but cannot be imported"
 }
 
 # Concurrent CK JIT compiles race to publish the same .so; without this the
@@ -374,7 +413,7 @@ install_te_deps() {
         onnxscript==0.7.0 \
         pydantic==2.13.4 \
         nvdlfw_inspect==0.2.2 \
-        einops \
+        einops==0.9.0.dev0 \
         onnx
 }
 
@@ -393,7 +432,7 @@ stage_te_wheel() {
 }
 
 stage_te_source() {
-    log "Building TransformerEngine from source @ $TE_COMMIT (glibc $(host_glibc) < $TE_WHEEL_MIN_GLIBC, so the v26.5 wheels cannot load)"
+    log "Building TransformerEngine from source @ $TE_COMMIT (glibc $(host_glibc) < $TE_WHEEL_MIN_GLIBC, so the v26.6 wheels cannot load)"
     # Drop any previously wheel-installed TE, otherwise the unusable prebuilt
     # core library stays behind and keeps winning the import.
     $PIP uninstall -y transformer_engine_rocm_torch transformer_engine_rocm7 \
@@ -460,7 +499,7 @@ stage_pydeps() {
     pipi \
         datasets==3.6.0 \
         av==16.0.1 \
-        transformers==4.55.0 \
+        transformers==5.5.0 \
         optree==0.18.0 \
         sympy \
         accelerate==1.9.0 \
@@ -468,7 +507,7 @@ stage_pydeps() {
         tensorboard==2.20.0 \
         peft \
         scipy \
-        einops \
+        einops==0.9.0.dev0 \
         flask-restful \
         nltk \
         pytest \
@@ -481,7 +520,7 @@ stage_pydeps() {
         zarr==2.18.7 \
         numcodecs==0.12.1 \
         xarray \
-        wandb \
+        wandb==0.28.2 \
         tensorstore==0.1.45 \
         pybind11 \
         tiktoken \
@@ -548,6 +587,11 @@ stage_mamba() {
     # packages). pip respects already-installed versions.
     ( cd "$SRC_DIR/mamba" \
         && pipi "apache-tvm-ffi==${TVM_FFI_VERSION}" \
+           "nvidia-cuda-nvdisasm==${NVDISASM_VERSION}" \
+        && sed -i '/^\s*namespace std\s*=\s*::std\s*;/d' csrc/selective_scan/uninitialized_copy.cuh \
+        && sed -i '/namespace cuda {/,/^    }/{/namespace cuda {/d;/namespace std = ::std;/d;/^    }$/d;}' \
+               csrc/selective_scan/uninitialized_copy.cuh \
+        && sed -i 's/::cuda::std::/::std::/g' csrc/selective_scan/uninitialized_copy.cuh \
         && pipi --no-build-isolation . ) || die "mamba build failed"
     rm -rf "$SRC_DIR/mamba"
     # Ahead of the check below, which then doubles as proof mamba survives it.
@@ -666,8 +710,11 @@ stage_turbo() {
 
 stage_boto() {
     reload_env
-    log "Installing boto3/botocore"
+    log "Installing boto3/botocore and CVE-fix pins from the v26.6 image"
     pipi boto3==1.35.42 botocore==1.35.99
+    pipi cryptography==50.0.0 diffusers==0.38.0 "jaraco.context==6.1.0" pyarrow==23.0.1
+    # mlflow caps cryptography<50; --no-deps keeps the 50.0.0 pin above.
+    $PIP install --no-deps mlflow==3.15.1
 }
 
 stage_cleanup() {
@@ -685,7 +732,7 @@ stage_manifest() {
     env > "$WORKSPACE_DIR/.manifest/env.txt"
     $PIP list > "$WORKSPACE_DIR/.manifest/requirements.txt"
     python --version > "$WORKSPACE_DIR/.manifest/python_version"
-    echo "Dockerfile.primus-v26.5" > "$WORKSPACE_DIR/.manifest/derived_from"
+    echo "Dockerfile.primus-v26.6" > "$WORKSPACE_DIR/.manifest/derived_from"
     cp "$SCRIPT_DIR/env.sh" "$WORKSPACE_DIR/.manifest/env.sh"
     [ -f "$PRIMUS_PIP_CONSTRAINTS" ] && cp "$PRIMUS_PIP_CONSTRAINTS" "$WORKSPACE_DIR/.manifest/"
     log "Environment ready. torch: $(python -c 'import torch; print(torch.__version__)' 2>/dev/null || echo '??')"


### PR DESCRIPTION
## Summary
- Align `tools/installation` and `tools/installation-jax` with the v26.6 Dockerfiles (`rocm/primus:v26.6`, `rocm/jax-training:maxtext-v26.6`): TheRock pip ROCm, Torch 2.12 / JAX 0.11, TE 2.17, and JAX runtime `LD_LIBRARY_PATH=""`.
- Document the published v26.6 image stacks in the release notes (image-derived, cross-checked against the Dockerfiles).
- Drop the deprecated MAD path from the TorchTitan training guide and launch only through `primus-cli`.
