### PR TITLE
skills/spur-cluster-status: report QoS node caps vs live usage

### DIFF
--- a/skills/spur-cluster-status/SKILL.md
+++ b/skills/spur-cluster-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spur-cluster-status
-description: Inspect the current Spur (AMD SLURM-compatible) cluster node-allocation state and produce a Markdown report covering the caller's account/QoS permissions, partitions and per-state node counts, per-QoS and per-account node usage, reservations, queue pressure, GPU capacity, and the caller's own jobs. Use when the user asks about Spur/SLURM cluster status, node allocation, which QoS/account/partition holds how many nodes, how many idle nodes are available, or wants a cluster snapshot report.
+description: Inspect the current Spur (AMD SLURM-compatible) cluster node-allocation state and produce a Markdown report covering the caller's account/QoS permissions, partitions and per-state node counts, per-QoS node caps vs live usage, per-QoS and per-account node usage, reservations, queue pressure, GPU capacity, and the caller's own jobs. Use when the user asks about Spur/SLURM cluster status, node allocation, which QoS/account/partition holds how many nodes, what a QoS's node limit is or how close it is to that limit, why jobs are stuck pending, how many idle nodes are available, or wants a cluster snapshot report.
 ---
 
 # Spur Cluster Status Report
@@ -42,8 +42,18 @@ python3 .claude/skills/spur-cluster-status/scripts/spur_status.py \
 After the tables, add a short analysis when relevant, e.g.:
 - Whether enough idle nodes exist for the user's target job size.
 - Whether the user's jobs are on shared (`mix`) nodes (GPU-contention risk) vs `--exclusive`.
-- Whether a low-priority QoS (e.g. `amd-burst-qos`, Prio=1) is being used for a job that
-  should use the account's normal QoS.
+- Whether a low-priority QoS (e.g. `amd-burst-qos`, Prio=100, PreemptMode=cancel) is being
+  used for a job that should use the account's normal QoS — burst jobs can be cancelled to
+  make room for higher-priority QoS.
+- **Why a job is stuck**: separate pending jobs held by `QOSGrpNodeLimit` (the QoS is at its
+  cap — more hardware will not help, the cap has to be raised) from `Dependency` (waiting on
+  another job), `Resources` (genuinely waiting on free nodes), and `JobHoldMaxRequeue` (the
+  job exhausted its requeue budget and is held until `scontrol release <jobid>`).
+- **Cap vs capacity**: caps are heavily oversubscribed (currently ~2.2x usable nodes), and
+  `amd-burst-qos` is capped above the whole cluster, so it is effectively unconstrained
+  while small-cap QoS starve. If a team keeps hitting `QOSGrpNodeLimit` on its own QoS but
+  burst is well below its cap, that team is being pushed onto preemptible burst capacity —
+  worth calling out.
 
 ## Report contents
 
@@ -51,28 +61,71 @@ The collector emits these sections (see `scripts/spur_status.py`). The report is
 written in **English**:
 
 1. **Account / QoS (you)** — the caller's account(s), default account, default QoS, the
-   permission-model note, and the global QoS list with priority/preempt.
+   permission-model note, and the global QoS list with priority/preempt/node cap/per-user
+   job caps.
 2. **Partitions & Node States** — per-partition total + per-state node counts, overall
    state breakdown, utilization %, GPU capacity, idle nodelist, and drain/down nodes.
-3. **Node Usage by QoS** — for running jobs, per QoS: #jobs, distinct nodes, node-job
+3. **QoS Node Limits vs Usage** — sorted by QoS name: running jobs, distinct nodes in
+   use, the `GrpTRES=node=` cap, used %, pending jobs/nodes, how many pending jobs are
+   held by `QOSGrpNodeLimit`, and `MaxSubmitPU`. Followed by the sum of all caps vs
+   usable nodes (oversubscription factor), which QoS sit at their cap, which are capped
+   at 0, and total demand held by the caps.
+4. **Node Usage by QoS** — for running jobs, per QoS: #jobs, distinct nodes, node-job
    slots, GPUs, plus pending jobs and pending node demand.
-4. **Node Usage by Account** — same breakdown grouped by account.
-5. **Reservations** — name, node count, users, end time.
-6. **Queue Pressure** — running vs pending job counts and pending node demand.
-7. **My Jobs** — the caller's running/pending jobs.
-8. **Jobs by User (all users)** — one row per user: total jobs (running/pending),
+5. **Node Usage by Account** — same breakdown grouped by account.
+6. **Reservations** — name, node count, users, end time.
+7. **Queue Pressure** — running vs pending job counts and pending node demand.
+8. **My Jobs** — the caller's running/pending jobs.
+9. **Jobs by User (all users)** — one row per user: total jobs (running/pending),
    distinct nodes held, number of accounts + which, which QoS, and which partitions.
-9. **Appendix: Common Commands** — the command reference used to build the report.
+10. **Appendix: Common Commands** — the command reference used to build the report.
 
 ## Spur quirks (important)
 
 These are baked into the collector; keep them in mind if you extend it:
 
-- `-o` format strings render **space-separated** regardless of literal delimiters — parse by whitespace column, not by a custom separator.
+- `-o` format strings render **space-separated** regardless of literal delimiters — parse by whitespace column, not by a custom separator. `squeue` also **drops empty fields**, which shifts later columns (see `parse_jobs`).
 - `spur accounts show user|account <name>` ignores the positional filter and lists everything — filter with `grep`/`awk`.
-- `sacctmgr` policy queries are blocked ("Please ask your administrator"); use `spur accounts show qos` for the QoS list.
+- The `sacctmgr` **binary is not on PATH**, but `spur accounts` *is* the same tool (its `--help` even prints `Usage: sacctmgr`), so policy queries do work through that entry point.
 - There is **no** `scontrol show hostnames`; expand compressed nodelists locally (the script does this).
-- The association table is empty and **QoS is not enforced per account** — only the **account** is enforced at submit time. QoS selects scheduling priority, not permission.
+- **QoS membership is not enforced per account** — only the **account** is enforced at submit time, so any QoS from the global list is accepted. But per-QoS **capacity is enforced**: each QoS has a `GrpTRES=node=` cap, and jobs over it sit in `PENDING` with reason `QOSGrpNodeLimit`.
+- `scontrol show assoc_mgr` output has **two blocks**: `QOS Records` then `Association Records`. Both contain `GrpTRES=` lines, so any parser must stop at `Association Records` or it will attribute per-account rows to the last QoS seen.
+- In a TRES string, `node=N` means **unlimited** while `node=0` is a real cap of zero — do not collapse them (`amd-mlperf-training-qos` is currently capped at 0).
+- The `(IN_USE)` figure in `assoc_mgr` is a **distinct** node count. Summing each job's `NumNodes` gives a larger number when two jobs of the same QoS share a node.
+
+## Answering ad-hoc questions without the full report
+
+For one-off questions, these are the underlying commands (all read-only):
+
+```bash
+# Per-QoS node cap + nodes currently in use, as `node=LIMIT(IN_USE)`
+scontrol show assoc_mgr | awk '
+  /^Association Records/ { exit }               # stop before the per-account block
+  /^QOS=/ { q=$1; sub("QOS=","",q); next }
+  /GrpTRES=/ { match($0, /node=[0-9N]+\([0-9]+\)/)
+               if (RSTART) print q, substr($0, RSTART, RLENGTH) }' | column -t
+
+# Caps only, in a clean parsable table (also has Priority / MaxJobsPU / MaxSubmitPU)
+spur accounts show qos -P
+
+# Who is running under a given QoS
+squeue -t RUNNING -o "%i %u %a %q %T %D %N" | grep amd-burst-qos
+
+# Which pending jobs are blocked by a QoS cap rather than by free hardware
+squeue -h -t PENDING -o "%i %u %q %D %R" | grep QOSGrpNodeLimit
+
+# True distinct node count for a QoS (deduplicates shared nodes)
+squeue -h -t RUNNING -o "%q|%N" | awk -F'|' '$1=="amd-burst-qos"{print $2}' \
+  | tr ',' '\n' | tr -d '[]' | sort -u | wc -l
+```
+
+Note that historical QoS data is **not** available: this cluster's `sacct` returns an
+empty QoS column, so anything beyond the currently-resident queue has to come from the
+cluster admins. Per-job GPU/CPU detail also needs `scontrol show job <id>` (`ReqTRES`,
+`ReqGPUs`, `Exclusive`) — `scontrol` here takes **one** job ID at a time, so loop with
+`xargs -P` for many jobs. When totalling resources, an `Exclusive=1` job holds the whole
+node (236 CPUs / 8 GPUs) regardless of what it requested, while `Exclusive=0` jobs only
+hold their requested share.
 
 ## Extending
 

--- a/skills/spur-cluster-status/scripts/spur_status.py
+++ b/skills/spur-cluster-status/scripts/spur_status.py
@@ -4,7 +4,8 @@
 Targets the AMD "Spur" scheduler (SLURM-compatible CLI: sinfo/squeue/scontrol/
 spur accounts). Read-only. Handles Spur quirks: `-o` delimiters are rendered as
 spaces, positional filters are ignored, there is no `scontrol show hostnames`,
-and QoS is not enforced per account (only the account is).
+and QoS membership is not enforced per account (only the account is) even though
+per-QoS node caps *are* enforced.
 
 Usage:
     python3 spur_status.py [--user USER]
@@ -23,6 +24,10 @@ from datetime import datetime
 BUSY_STATES = {"alloc", "mix"}
 FREE_STATES = {"idle"}
 DOWN_STATES = {"down", "drain", "drained", "fail", "failing", "unknown"}
+
+# Spur renders a TRES node entry as `node=LIMIT` or `node=LIMIT(IN_USE)`,
+# where a LIMIT of `N` means unlimited.
+NODE_TRES_RE = re.compile(r"node=([0-9]+|N)(?:\((\d+)\))?")
 
 
 def run(cmd):
@@ -105,22 +110,97 @@ def parse_user_accounts(user):
     return sorted(set(accounts)), default_acct, def_qos
 
 
+def parse_node_tres(tres):
+    """Extract (limit, in_use) from the `node=` entry of a TRES string.
+
+    Returns (None, None) when there is no node entry, and a limit of None when
+    the limit is `N` (unlimited). in_use is None unless the source rendered it.
+    """
+    if not tres:
+        return None, None
+    m = NODE_TRES_RE.search(tres)
+    if not m:
+        return None, None
+    limit = None if m.group(1) == "N" else int(m.group(1))
+    in_use = int(m.group(2)) if m.group(2) else None
+    return limit, in_use
+
+
 def parse_qos():
-    """Return list of dicts: {name, prio, preempt}."""
-    text = run(["spur", "accounts", "show", "qos"])
+    """Return list of dicts: {name, prio, preempt, max_jobs_pu, max_submit_pu, node_limit}.
+
+    Uses `-P` (pipe-delimited) rather than the default space-aligned table: most
+    QoS rows leave the limit columns blank, and blanks collapse in the aligned
+    output, which shifts every later column and makes GrpTRES unparseable.
+    """
+    text = run(["spur", "accounts", "show", "qos", "-P"])
     rows = []
     for line in text.splitlines():
-        toks = line.split()
-        if len(toks) < 2 or toks[0] in ("Name", "----"):
+        if not line.strip():
             continue
+        f = [x.strip() for x in line.split("|")]
+        if f[0] in ("Name", "----"):
+            continue
+
+        def col(i):
+            return f[i] if len(f) > i else ""
+
+        # Name|Priority|PreemptMode|UsageFactor|MaxJobsPU|MaxSubmitPU|MaxWall|
+        # GrpWall|Flags|MaxTRES|MaxTRESPU|GrpTRES
         rows.append(
             {
-                "name": toks[0],
-                "prio": toks[1] if len(toks) > 1 else "",
-                "preempt": toks[2] if len(toks) > 2 else "",
+                "name": col(0),
+                "prio": col(1),
+                "preempt": col(2),
+                "max_jobs_pu": col(4),
+                "max_submit_pu": col(5),
+                "node_limit": parse_node_tres(col(11))[0],
             }
         )
     return rows
+
+
+def parse_qos_node_usage():
+    """Return dict qos -> {limit, in_use} from `scontrol show assoc_mgr`.
+
+    This is the scheduler's own accounting, so `in_use` is a DISTINCT node count:
+    two jobs of the same QoS sharing one node count once here, while summing each
+    job's NumNodes counts that node twice.
+
+    Only the leading `QOS Records` block is read. The `Association Records` block
+    that follows repeats `GrpTRES=` lines per account and per user, and would
+    otherwise be attributed to whichever QoS was seen last.
+    """
+    text = run(["scontrol", "show", "assoc_mgr"])
+    usage, cur = {}, None
+    for line in text.splitlines():
+        if line.startswith("Association Records"):
+            break
+        if line.startswith("QOS="):
+            cur = line.split()[0][len("QOS=") :]
+            continue
+        if cur and "GrpTRES=" in line:
+            tail = line.split("GrpTRES=", 1)[1].strip()
+            limit, in_use = parse_node_tres(tail.split()[0] if tail else "")
+            usage[cur] = {"limit": limit, "in_use": in_use or 0}
+            cur = None
+    return usage
+
+
+def parse_pending_reasons():
+    """Return dict jobid -> wait reason (e.g. `QOSGrpNodeLimit`) for pending jobs.
+
+    Queried separately because `%R` carries the nodelist for running jobs and the
+    wait reason for pending ones, so it cannot be mixed into the main format
+    string without making the trailing columns ambiguous.
+    """
+    text = run(["squeue", "-h", "-t", "PENDING", "-o", "%i %R"])
+    reasons = {}
+    for line in text.splitlines():
+        toks = line.split(None, 1)
+        if len(toks) == 2:
+            reasons[toks[0]] = toks[1].strip().strip("()")
+    return reasons
 
 
 def parse_nodes():
@@ -267,6 +347,8 @@ def build_report(user):
     nodes = parse_nodes()
     jobs = parse_jobs(nodes)
     resvs = parse_reservations()
+    qos_usage = parse_qos_node_usage()
+    pending_reasons = parse_pending_reasons()
 
     L = []
     L.append("# Spur Cluster Node-Allocation Report")
@@ -291,10 +373,14 @@ def build_report(user):
     L.append("")
     L.append("Global QoS (higher Prio = higher priority):")
     L.append("")
-    L.append("| QoS | Prio | Preempt |")
-    L.append("|-----|------|---------|")
+    L.append("| QoS | Prio | Preempt | Node limit | MaxJobsPU | MaxSubmitPU |")
+    L.append("|-----|------|---------|------|------|------|")
     for q in sorted(qos_rows, key=lambda x: -int(x["prio"]) if x["prio"].isdigit() else 0):
-        L.append(f"| {q['name']} | {q['prio']} | {q['preempt']} |")
+        nl = q["node_limit"] if q["node_limit"] is not None else "unlimited"
+        L.append(
+            f"| {q['name']} | {q['prio']} | {q['preempt']} | {nl} | "
+            f"{q['max_jobs_pu'] or '-'} | {q['max_submit_pu'] or '-'} |"
+        )
 
     # 2. Partitions & node states
     L.append(h("2. Partitions & Node States"))
@@ -332,8 +418,83 @@ def build_report(user):
     if bad_nodes:
         L.append(f"- **Drain/down nodes ({len(bad_nodes)})**: `{','.join(bad_nodes)}`")
 
-    # 3. Per-QoS usage
-    L.append(h("3. Node Usage by QoS (running jobs)"))
+    # 3. QoS node limits vs usage
+    L.append(h("3. QoS Node Limits vs Usage"))
+    L.append(
+        "> `Limit` is the QoS group cap (`GrpTRES=node=`); `Run nodes` is the scheduler's "
+        "own **distinct** node count, so it is lower than the sum of each job's node count "
+        "whenever two jobs of the same QoS share a node. `Blocked` counts pending jobs held "
+        "by `QOSGrpNodeLimit` - demand waiting on the cap rather than on free hardware. "
+        "Sorted by QoS name."
+    )
+    L.append("")
+    qos_run_by_name = group_usage(jobs, nodes, "qos", "RUNNING")
+    qos_pend_by_name = group_usage(jobs, nodes, "qos", "PENDING")
+    blocked_jobs, blocked_nodes = defaultdict(int), defaultdict(int)
+    for j in jobs:
+        if j["state"] == "PENDING" and pending_reasons.get(j["jobid"]) == "QOSGrpNodeLimit":
+            k = j["qos"] or "(none)"
+            blocked_jobs[k] += 1
+            blocked_nodes[k] += j["nnodes"]
+
+    limit_by_name = {q["name"]: q["node_limit"] for q in qos_rows}
+    for name, u in qos_usage.items():
+        limit_by_name.setdefault(name, u["limit"])
+    all_qos = sorted(set(limit_by_name) | set(qos_run_by_name) | set(qos_pend_by_name))
+
+    L.append(
+        "| QoS | Run jobs | Run nodes | Limit | Used % | Pend jobs | Pend nodes | "
+        "Blocked jobs | Blocked nodes | MaxSubmitPU |"
+    )
+    L.append("|-----|------|------|------|------|------|------|------|------|------|")
+    limit_sum = 0
+    for k in all_qos:
+        r = qos_run_by_name.get(k, {"jobs": 0, "nodes": set()})
+        p = qos_pend_by_name.get(k, {"jobs": 0, "node_slots": 0})
+        limit = limit_by_name.get(k)
+        # Prefer the scheduler's distinct-node count; fall back to our own set.
+        used = qos_usage.get(k, {}).get("in_use", len(r["nodes"]))
+        # A limit of None means unlimited; a limit of 0 is a real cap that pins
+        # the QoS to zero nodes, so the two must not be collapsed.
+        if limit is None:
+            limit_disp, pct = "unlimited", "-"
+        else:
+            limit_sum += limit
+            limit_disp = str(limit)
+            pct = f"{used * 100 // limit}%" if limit else "n/a"
+        msp = next((q["max_submit_pu"] for q in qos_rows if q["name"] == k), "") or "-"
+        L.append(
+            f"| {k} | {r['jobs']} | {used} | {limit_disp} | {pct} | {p['jobs']} | "
+            f"{p['node_slots']} | {blocked_jobs[k]} | {blocked_nodes[k]} | {msp} |"
+        )
+
+    usable = sum(1 for i in nodes.values() if i["state"] not in DOWN_STATES)
+    L.append("")
+    L.append(f"- **Sum of QoS node limits**: {limit_sum} vs {usable} usable nodes")
+    if usable:
+        L.append(
+            f"- **Oversubscription**: {limit_sum / usable:.1f}x - limits are deliberately "
+            "overcommitted, so a QoS below its cap can still be starved of hardware."
+        )
+    at_cap = [
+        k
+        for k in all_qos
+        if (limit_by_name.get(k) or 0) > 0 and qos_usage.get(k, {}).get("in_use", 0) >= limit_by_name[k]
+    ]
+    if at_cap:
+        L.append(f"- **QoS at their node cap ({len(at_cap)})**: {', '.join(at_cap)}")
+    zero_cap = [k for k in all_qos if limit_by_name.get(k) == 0]
+    if zero_cap:
+        L.append(f"- **QoS capped at 0 nodes (cannot run)**: {', '.join(zero_cap)}")
+    tot_blocked = sum(blocked_jobs.values())
+    if tot_blocked:
+        L.append(
+            f"- **Held by `QOSGrpNodeLimit`**: {tot_blocked} jobs / "
+            f"{sum(blocked_nodes.values())} nodes of demand"
+        )
+
+    # 4. Per-QoS usage
+    L.append(h("4. Node Usage by QoS (running jobs)"))
     L.append(
         "> Nodes can be shared (mix), so the sum of per-QoS distinct nodes may exceed the number of physically busy nodes."
     )
@@ -353,8 +514,8 @@ def build_report(user):
             f"| {k} | {r['jobs']} | {len(r['nodes'])} | {r['node_slots']} | {r['gpus']} | {p['jobs']} | {p['node_slots']} |"
         )
 
-    # 4. Per-account usage
-    L.append(h("4. Node Usage by Account (running jobs)"))
+    # 5. Per-account usage
+    L.append(h("5. Node Usage by Account (running jobs)"))
     acc_run = group_usage(jobs, nodes, "account", "RUNNING")
     acc_pend = group_usage(jobs, nodes, "account", "PENDING")
     L.append(
@@ -370,8 +531,8 @@ def build_report(user):
             f"| {k} | {r['jobs']} | {len(r['nodes'])} | {r['node_slots']} | {r['gpus']} | {p['jobs']} | {p['node_slots']} |"
         )
 
-    # 5. Reservations
-    L.append(h("5. Reservations"))
+    # 6. Reservations
+    L.append(h("6. Reservations"))
     if resvs:
         L.append("| Name | Nodes | Users | End time |")
         L.append("|-----|------|------|------|")
@@ -383,15 +544,15 @@ def build_report(user):
     else:
         L.append("No active reservations.")
 
-    # 6. Queue pressure
-    L.append(h("6. Queue Pressure"))
+    # 7. Queue pressure
+    L.append(h("7. Queue Pressure"))
     pend = [j for j in jobs if j["state"] == "PENDING"]
     run_j = [j for j in jobs if j["state"] == "RUNNING"]
     L.append(f"- **Running jobs**: {len(run_j)}")
     L.append(f"- **Pending jobs**: {len(pend)} (requesting {sum(j['nnodes'] for j in pend)} nodes total)")
 
-    # 7. My jobs
-    L.append(h("7. My Jobs (user=%s)" % user))
+    # 8. My jobs
+    L.append(h("8. My Jobs (user=%s)" % user))
     mine = [j for j in jobs if j["user"] == user]
     if mine:
         L.append("| JobID | QoS | Account | State | Nodes | Nodelist |")
@@ -403,8 +564,8 @@ def build_report(user):
     else:
         L.append("No running/pending jobs.")
 
-    # 8. Jobs by user (all users)
-    L.append(h("8. Jobs by User (all users)"))
+    # 9. Jobs by user (all users)
+    L.append(h("9. Jobs by User (all users)"))
     L.append(
         "> One row per user. `Jobs` = total (R running / P pending); `Nodes` = distinct nodes held by running jobs."
     )
@@ -432,10 +593,21 @@ def build_report(user):
 COMMANDS_APPENDIX = """```bash
 # --- Account / QoS ---
 spur accounts show user                 # all user->account rows (grep yourself)
-sacctmgr show user $(whoami)            # equivalent alias
-spur accounts show qos                  # global QoS list (Prio/Preempt)
+spur accounts show qos                  # global QoS list (Prio/Preempt/GrpTRES)
+spur accounts show qos -P                # same, pipe-delimited (blank columns keep position)
 spur accounts show account              # all accounts
 sshare -u $(whoami)                     # fair-share info
+
+# --- QoS limits and live usage (limit + distinct nodes in use) ---
+scontrol show assoc_mgr                 # QOS Records, then Association Records
+# per-QoS node cap and current usage, as `node=LIMIT(IN_USE)`:
+scontrol show assoc_mgr | awk '
+  /^Association Records/ { exit }               # stop before the per-account block
+  /^QOS=/ { q=$1; sub("QOS=","",q); next }
+  /GrpTRES=/ { match($0, /node=[0-9N]+\\([0-9]+\\)/)
+               if (RSTART) print q, substr($0, RSTART, RLENGTH) }' | column -t
+# which pending jobs are held by a QoS cap (vs waiting on hardware):
+squeue -h -t PENDING -o "%q %D %R" | grep QOSGrpNodeLimit
 
 # --- Cluster / nodes ---
 sinfo                                   # partitions + node counts per state
@@ -462,7 +634,7 @@ spur report cluster -s now-7days         # cluster utilization report
 spur health                              # node health
 ```
 
-> Spur quirks: custom `-o` delimiters render as spaces; positional filters for `show user`/`show account` are ignored (use grep/awk); `sacctmgr` policy queries are blocked; there is no `scontrol show hostnames`; the association table is empty and QoS is not enforced per account (only the account is)."""
+> Spur quirks: custom `-o` delimiters render as spaces; positional filters for `show user`/`show account` are ignored (use grep/awk); the `sacctmgr` binary is not on PATH (use `spur accounts ...`, which is the same tool); there is no `scontrol show hostnames`; QoS membership is not enforced per account (only the account is), but per-QoS `GrpTRES=node=` caps *are* enforced - see `QOSGrpNodeLimit` in the pending reasons."""
 
 
 def main():


### PR DESCRIPTION
Adds a "QoS Node Limits vs Usage" section that pairs each QoS's GrpTRES=node= cap with the nodes it currently holds, so it is possible to tell a QoS that is starved of hardware from one that is pinned by its own cap. Sorted by QoS name, and it also counts the pending jobs held by QOSGrpNodeLimit plus the cap total against usable nodes.

Three parsers back it:

- parse_qos_node_usage() reads the QOS Records block of `scontrol show assoc_mgr`, which carries both the cap and the in-use count. Parsing must stop at Association Records, whose per-account rows repeat GrpTRES= and would otherwise be attributed to the last QoS seen.
- parse_pending_reasons() queries pending reasons on their own, since %R is the nodelist for running jobs and the wait reason for pending ones.
- parse_qos() moves to `spur accounts show qos -P`; blank columns collapse in the space-aligned default output and shift GrpTRES out of position.

Also corrects two stale notes in SKILL.md. The association table is not empty (~1150 rows) and sacctmgr is not blocked -- the binary is just off PATH, while `spur accounts` is the same tool. And although QoS membership really is unenforced per account, per-QoS node caps *are* enforced, which the old wording obscured.

Records the traps found while building this: node=N means unlimited but node=0 is a real zero cap (amd-mlperf-training-qos), and the assoc_mgr in-use figure is a distinct node count, so it is lower than the sum of each job's NumNodes when jobs of one QoS share a node.