### PR TITLE
Feat/diffusion/wan21 megatron training

### DIFF
--- a/examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_local_spec.yaml
+++ b/examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_local_spec.yaml
@@ -1,0 +1,180 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+# WAN 2.1 T2V-1.3B pretraining (from scratch) on the pre-encoded PusaV1 480p
+# dataset, LOCAL spec (TE-free) + Megatron-FSDP.
+#
+# transformer_impl: "local" builds WAN attention and FFN on native Megatron
+# parallel linears plus torch nn.RMSNorm q/k norm and PrimusTurboLocalAttention
+# with unfused interleaved RoPE. No TransformerEngine required. This is the
+# WAN counterpart of Flux's transformer_impl="local".
+#
+# This config and its local_spec / local_spec_mxfp4 siblings differ ONLY in the
+# implementation and precision knobs, so their losses are directly comparable.
+#
+# Usage:
+#   EXP=examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_local_spec.yaml \
+#   bash examples/run_pretrain.sh
+
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: wan2.1_t2v_1.3b_pretrain_pusa_local_spec
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    model: diffusion/wan2.1_t2v_1.3b.yaml
+
+    trainer_class: WanPretrainTrainer
+
+    overrides:
+      model_type: diffusion_model
+
+      # ----------------------------------------------------------------------
+      # Real data (Energon pre-encoded WAN shards, 480p)
+      # ----------------------------------------------------------------------
+      mock_data: false
+      # Point PRIMUS_DIFFUSION_DATA_PATH at a prepared Energon dataset of
+      # pre-encoded WAN latents. The reference runs used PusaV1 at 480p.
+      data_path: ${PRIMUS_DIFFUSION_DATA_PATH:/path/to/energon/dataset}
+
+      # Deterministic sample order. All four knobs have to be off together, and
+      # parallel_shard_iters must be 1 once shard shuffling is disabled. This is
+      # what makes a cross-implementation loss comparison meaningful: with
+      # shuffling on, two runs draw different samples and the losses cannot be
+      # compared no matter how correct both implementations are.
+      max_samples_per_sequence: null
+      shuffle_buffer_size: null
+      shuffle_over_epochs_multiplier: null
+      parallel_shard_iters: 1
+
+      # ----------------------------------------------------------------------
+      # Local spec (TE-free)
+      # ----------------------------------------------------------------------
+      transformer_impl: "local"
+      layernorm_across_heads: true
+
+      # Inert for compute on this path (attention runs through
+      # PrimusTurboLocalAttention), but TransformerConfig still validates the
+      # field, and "auto" refuses to run under an image that pins
+      # NVTE_FLASH_ATTN=0 / NVTE_FUSED_ATTN=1.
+      attention_backend: fused
+
+      # ----------------------------------------------------------------------
+      # WAN scheduler / routing
+      # ----------------------------------------------------------------------
+      num_train_timesteps: 1000
+      # shift=3.0 is the WAN convention for 480p data. Keep train and inference
+      # shift identical.
+      scheduler_shift: 3.0
+      num_transformers: 1
+      boundary_ratio: null
+      stage: full
+
+      # Unweighted MSE. The reference implementation these runs were checked
+      # against disables the per-timestep weight, so "uniform" is what makes
+      # the two comparable; "diffsynth" is the training default.
+      loss_weighting: uniform
+
+      # ----------------------------------------------------------------------
+      # Train from scratch (random init)
+      # ----------------------------------------------------------------------
+      backbone_pretrained: null
+      backbone_subfolder: transformer
+
+      # ----------------------------------------------------------------------
+      # Batch / sequence
+      # ----------------------------------------------------------------------
+      micro_batch_size: 10
+      global_batch_size: 80
+      num_workers: 4
+      dataloader_type: external
+
+      # ----------------------------------------------------------------------
+      # Training schedule
+      # ----------------------------------------------------------------------
+      train_iters: 20
+      eval_interval: 10000
+      eval_iters: 0
+
+      log_interval: 1
+      tensorboard_dir: output/tensorboard/wan2.1_t2v_1.3b_pusa_local_spec
+      log_throughput: true
+      log_timers_to_tensorboard: true
+      log_learning_rate_to_tensorboard: true
+
+      # ----------------------------------------------------------------------
+      # Checkpointing
+      # ----------------------------------------------------------------------
+      save_interval: 1000
+      save: output/checkpoints/wan2.1_t2v_1.3b_pusa_local_spec
+      load: null
+      finetune: false
+      auto_continue_train: false
+      ckpt_format: fsdp_dtensor  # required by Megatron-FSDP
+
+      # ----------------------------------------------------------------------
+      # Precision
+      # ----------------------------------------------------------------------
+      bf16: true
+      fp16: false
+
+      # ----------------------------------------------------------------------
+      # Activation recomputation
+      # The video sequence is long (latents [16, 21, 90, 160] -> ~75k tokens
+      # after (1,2,2) patchify), so activation memory dominates. uniform with
+      # num_layers=1 recomputes every layer.
+      # ----------------------------------------------------------------------
+      recompute_granularity: full
+      recompute_method: uniform
+      recompute_num_layers: 1
+
+      # ----------------------------------------------------------------------
+      # Optimizer
+      # ----------------------------------------------------------------------
+      optimizer: adam
+      lr: 1.0e-4
+      min_lr: 1.0e-5
+      # Flow-matching DiT recipes (maxdiffusion, DiffSynth) train without weight
+      # decay; 0.0 avoids over-regularizing a from-scratch run.
+      weight_decay: 0.0
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1.0e-8
+      clip_grad: 1.0
+
+      lr_decay_style: cosine
+      lr_warmup_iters: 100
+      lr_decay_iters: 15000
+
+      # ----------------------------------------------------------------------
+      # Parallelism (TP = PP = CP = 1, DP/FSDP only)
+      # ----------------------------------------------------------------------
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      context_parallel_size: 1
+
+      # Megatron-FSDP ZeRO-3: shard optimizer states, gradients and parameters
+      # across DP ranks.
+      use_torch_fsdp2: false
+      use_megatron_fsdp: true
+      data_parallel_sharding_strategy: optim_grads_params
+
+      overlap_grad_reduce: true
+      use_flash_attn: true
+      distributed_timeout_minutes: 60
+
+      # ----------------------------------------------------------------------
+      # Primus Turbo (the local spec's TE-free flash attention). At TP=CP=1
+      # these flags mainly select the backend and its logging; the WAN local
+      # path instantiates PrimusTurboLocalAttention directly.
+      # ----------------------------------------------------------------------
+      enable_primus_turbo: true
+      use_turbo_attention: true
+
+      seed: 42
+
+      wandb_project: wan-pretrain
+      wandb_exp_name: wan2.1_t2v_1.3b_pusa_local_spec

--- a/examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_local_spec_mxfp4.yaml
+++ b/examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_local_spec_mxfp4.yaml
@@ -1,0 +1,199 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+# WAN 2.1 T2V-1.3B pretraining (from scratch) on the pre-encoded PusaV1 480p
+# dataset, LOCAL spec (TE-free) + Megatron-FSDP + MXFP4.
+#
+# transformer_impl: "local" builds WAN attention and FFN on native Megatron
+# parallel linears plus torch nn.RMSNorm q/k norm and PrimusTurboLocalAttention
+# with unfused interleaved RoPE. No TransformerEngine required. This is the
+# WAN counterpart of Flux's transformer_impl="local".
+#
+# On top of that, the attention and FFN GEMMs are swapped to per-module MXFP4
+# (Primus-Turbo): the native Megatron linears are replaced by
+# MXFP4ColumnParallelLinear / MXFP4RowParallelLinear (block-of-32 MX scaling,
+# gemm_fp4_impl). Attention itself stays BF16 flash-attn; only the linears go
+# FP4.
+#
+# Requires PRIMUS_TURBO_GEMM_BACKEND=fp4:AITER, otherwise the MXFP4 linears
+# raise on the preshuffle contract check.
+#
+# This config and its local_spec / local_spec_mxfp4 siblings differ ONLY in the
+# implementation and precision knobs, so their losses are directly comparable.
+#
+# Usage:
+#   EXP=examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_local_spec_mxfp4.yaml \
+#   bash examples/run_pretrain.sh
+
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: wan2.1_t2v_1.3b_pretrain_pusa_local_spec_mxfp4
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    model: diffusion/wan2.1_t2v_1.3b.yaml
+
+    trainer_class: WanPretrainTrainer
+
+    overrides:
+      model_type: diffusion_model
+
+      # ----------------------------------------------------------------------
+      # Real data (Energon pre-encoded WAN shards, 480p)
+      # ----------------------------------------------------------------------
+      mock_data: false
+      # Point PRIMUS_DIFFUSION_DATA_PATH at a prepared Energon dataset of
+      # pre-encoded WAN latents. The reference runs used PusaV1 at 480p.
+      data_path: ${PRIMUS_DIFFUSION_DATA_PATH:/path/to/energon/dataset}
+
+      # Deterministic sample order. All four knobs have to be off together, and
+      # parallel_shard_iters must be 1 once shard shuffling is disabled. This is
+      # what makes a cross-implementation loss comparison meaningful: with
+      # shuffling on, two runs draw different samples and the losses cannot be
+      # compared no matter how correct both implementations are.
+      max_samples_per_sequence: null
+      shuffle_buffer_size: null
+      shuffle_over_epochs_multiplier: null
+      parallel_shard_iters: 1
+
+      # ----------------------------------------------------------------------
+      # Local spec (TE-free)
+      # ----------------------------------------------------------------------
+      transformer_impl: "local"
+      layernorm_across_heads: true
+
+      # Inert for compute on this path (attention runs through
+      # PrimusTurboLocalAttention), but TransformerConfig still validates the
+      # field, and "auto" refuses to run under an image that pins
+      # NVTE_FLASH_ATTN=0 / NVTE_FUSED_ATTN=1.
+      attention_backend: fused
+
+      # MXFP4 (Primus-Turbo). fp4 / fp4_recipe are Megatron TransformerConfig
+      # fields; the mxfp4_* knobs are read by the MXFP4 local linears.
+      fp4: "mxfp4"
+      fp4_recipe: "mxfp4"
+      mxfp4_backward_precision: "mxfp4"
+      mxfp4_gradient_stochastic_rounding: false
+      # The MXFP4 linears subclass the native Megatron linears, which reject
+      # gradient accumulation fusion.
+      gradient_accumulation_fusion: false
+
+      # ----------------------------------------------------------------------
+      # WAN scheduler / routing
+      # ----------------------------------------------------------------------
+      num_train_timesteps: 1000
+      # shift=3.0 is the WAN convention for 480p data. Keep train and inference
+      # shift identical.
+      scheduler_shift: 3.0
+      num_transformers: 1
+      boundary_ratio: null
+      stage: full
+
+      # Unweighted MSE. The reference implementation these runs were checked
+      # against disables the per-timestep weight, so "uniform" is what makes
+      # the two comparable; "diffsynth" is the training default.
+      loss_weighting: uniform
+
+      # ----------------------------------------------------------------------
+      # Train from scratch (random init)
+      # ----------------------------------------------------------------------
+      backbone_pretrained: null
+      backbone_subfolder: transformer
+
+      # ----------------------------------------------------------------------
+      # Batch / sequence
+      # ----------------------------------------------------------------------
+      micro_batch_size: 10
+      global_batch_size: 80
+      num_workers: 4
+      dataloader_type: external
+
+      # ----------------------------------------------------------------------
+      # Training schedule
+      # ----------------------------------------------------------------------
+      train_iters: 20
+      eval_interval: 10000
+      eval_iters: 0
+
+      log_interval: 1
+      tensorboard_dir: output/tensorboard/wan2.1_t2v_1.3b_pusa_local_spec_mxfp4
+      log_throughput: true
+      log_timers_to_tensorboard: true
+      log_learning_rate_to_tensorboard: true
+
+      # ----------------------------------------------------------------------
+      # Checkpointing
+      # ----------------------------------------------------------------------
+      save_interval: 1000
+      save: output/checkpoints/wan2.1_t2v_1.3b_pusa_local_spec_mxfp4
+      load: null
+      finetune: false
+      auto_continue_train: false
+      ckpt_format: fsdp_dtensor  # required by Megatron-FSDP
+
+      # ----------------------------------------------------------------------
+      # Precision
+      # ----------------------------------------------------------------------
+      bf16: true
+      fp16: false
+
+      # ----------------------------------------------------------------------
+      # Activation recomputation
+      # The video sequence is long (latents [16, 21, 90, 160] -> ~75k tokens
+      # after (1,2,2) patchify), so activation memory dominates. uniform with
+      # num_layers=1 recomputes every layer.
+      # ----------------------------------------------------------------------
+      recompute_granularity: full
+      recompute_method: uniform
+      recompute_num_layers: 1
+
+      # ----------------------------------------------------------------------
+      # Optimizer
+      # ----------------------------------------------------------------------
+      optimizer: adam
+      lr: 1.0e-4
+      min_lr: 1.0e-5
+      # Flow-matching DiT recipes (maxdiffusion, DiffSynth) train without weight
+      # decay; 0.0 avoids over-regularizing a from-scratch run.
+      weight_decay: 0.0
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1.0e-8
+      clip_grad: 1.0
+
+      lr_decay_style: cosine
+      lr_warmup_iters: 100
+      lr_decay_iters: 15000
+
+      # ----------------------------------------------------------------------
+      # Parallelism (TP = PP = CP = 1, DP/FSDP only)
+      # ----------------------------------------------------------------------
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      context_parallel_size: 1
+
+      # Megatron-FSDP ZeRO-3: shard optimizer states, gradients and parameters
+      # across DP ranks.
+      use_torch_fsdp2: false
+      use_megatron_fsdp: true
+      data_parallel_sharding_strategy: optim_grads_params
+
+      overlap_grad_reduce: true
+      use_flash_attn: true
+      distributed_timeout_minutes: 60
+
+      # ----------------------------------------------------------------------
+      # Primus Turbo (the local spec's TE-free flash attention). At TP=CP=1
+      # these flags mainly select the backend and its logging; the WAN local
+      # path instantiates PrimusTurboLocalAttention directly.
+      # ----------------------------------------------------------------------
+      enable_primus_turbo: true
+      use_turbo_attention: true
+
+      seed: 42
+
+      wandb_project: wan-pretrain
+      wandb_exp_name: wan2.1_t2v_1.3b_pusa_local_spec_mxfp4

--- a/examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_te_spec.yaml
+++ b/examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_te_spec.yaml
@@ -1,0 +1,175 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+# WAN 2.1 T2V-1.3B pretraining (from scratch) on the pre-encoded PusaV1 480p
+# dataset, TransformerEngine spec + Megatron-FSDP.
+#
+# transformer_impl: "transformer_engine" builds WAN attention and FFN on the
+# Megatron-Core / TE stack (TEColumnParallelLinear / TERowParallelLinear /
+# TEDotProductAttention), the same knob Flux uses for its te_spec configs.
+#
+# This config and its local_spec / local_spec_mxfp4 siblings differ ONLY in the
+# implementation and precision knobs, so their losses are directly comparable.
+#
+# Usage:
+#   EXP=examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_te_spec.yaml \
+#   bash examples/run_pretrain.sh
+
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: wan2.1_t2v_1.3b_pretrain_pusa_te_spec
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: megatron
+    config: pre_trainer.yaml
+    model: diffusion/wan2.1_t2v_1.3b.yaml
+
+    trainer_class: WanPretrainTrainer
+
+    overrides:
+      model_type: diffusion_model
+
+      # ----------------------------------------------------------------------
+      # Real data (Energon pre-encoded WAN shards, 480p)
+      # ----------------------------------------------------------------------
+      mock_data: false
+      # Point PRIMUS_DIFFUSION_DATA_PATH at a prepared Energon dataset of
+      # pre-encoded WAN latents. The reference runs used PusaV1 at 480p.
+      data_path: ${PRIMUS_DIFFUSION_DATA_PATH:/path/to/energon/dataset}
+
+      # Deterministic sample order. All four knobs have to be off together, and
+      # parallel_shard_iters must be 1 once shard shuffling is disabled. This is
+      # what makes a cross-implementation loss comparison meaningful: with
+      # shuffling on, two runs draw different samples and the losses cannot be
+      # compared no matter how correct both implementations are.
+      max_samples_per_sequence: null
+      shuffle_buffer_size: null
+      shuffle_over_epochs_multiplier: null
+      parallel_shard_iters: 1
+
+      # ----------------------------------------------------------------------
+      # TransformerEngine spec
+      # ----------------------------------------------------------------------
+      transformer_impl: "transformer_engine"
+      layernorm_across_heads: true
+
+      # The container image pins NVTE_FLASH_ATTN=0, which the auto backend
+      # rejects; "fused" is the backend that matches that environment.
+      attention_backend: fused
+
+      # ----------------------------------------------------------------------
+      # WAN scheduler / routing
+      # ----------------------------------------------------------------------
+      num_train_timesteps: 1000
+      # shift=3.0 is the WAN convention for 480p data. Keep train and inference
+      # shift identical.
+      scheduler_shift: 3.0
+      num_transformers: 1
+      boundary_ratio: null
+      stage: full
+
+      # Unweighted MSE. The reference implementation these runs were checked
+      # against disables the per-timestep weight, so "uniform" is what makes
+      # the two comparable; "diffsynth" is the training default.
+      loss_weighting: uniform
+
+      # ----------------------------------------------------------------------
+      # Train from scratch (random init)
+      # ----------------------------------------------------------------------
+      backbone_pretrained: null
+      backbone_subfolder: transformer
+
+      # ----------------------------------------------------------------------
+      # Batch / sequence
+      # ----------------------------------------------------------------------
+      micro_batch_size: 10
+      global_batch_size: 80
+      num_workers: 4
+      dataloader_type: external
+
+      # ----------------------------------------------------------------------
+      # Training schedule
+      # ----------------------------------------------------------------------
+      train_iters: 20
+      eval_interval: 10000
+      eval_iters: 0
+
+      log_interval: 1
+      tensorboard_dir: output/tensorboard/wan2.1_t2v_1.3b_pusa_te_spec
+      log_throughput: true
+      log_timers_to_tensorboard: true
+      log_learning_rate_to_tensorboard: true
+
+      # ----------------------------------------------------------------------
+      # Checkpointing
+      # ----------------------------------------------------------------------
+      save_interval: 1000
+      save: output/checkpoints/wan2.1_t2v_1.3b_pusa_te_spec
+      load: null
+      finetune: false
+      auto_continue_train: false
+      ckpt_format: fsdp_dtensor  # required by Megatron-FSDP
+
+      # ----------------------------------------------------------------------
+      # Precision
+      # ----------------------------------------------------------------------
+      bf16: true
+      fp16: false
+
+      # ----------------------------------------------------------------------
+      # Activation recomputation
+      # The video sequence is long (latents [16, 21, 90, 160] -> ~75k tokens
+      # after (1,2,2) patchify), so activation memory dominates. uniform with
+      # num_layers=1 recomputes every layer.
+      # ----------------------------------------------------------------------
+      recompute_granularity: full
+      recompute_method: uniform
+      recompute_num_layers: 1
+
+      # ----------------------------------------------------------------------
+      # Optimizer
+      # ----------------------------------------------------------------------
+      optimizer: adam
+      lr: 1.0e-4
+      min_lr: 1.0e-5
+      # Flow-matching DiT recipes (maxdiffusion, DiffSynth) train without weight
+      # decay; 0.0 avoids over-regularizing a from-scratch run.
+      weight_decay: 0.0
+      adam_beta1: 0.9
+      adam_beta2: 0.999
+      adam_eps: 1.0e-8
+      clip_grad: 1.0
+
+      lr_decay_style: cosine
+      lr_warmup_iters: 100
+      lr_decay_iters: 15000
+
+      # ----------------------------------------------------------------------
+      # Parallelism (TP = PP = CP = 1, DP/FSDP only)
+      # ----------------------------------------------------------------------
+      tensor_model_parallel_size: 1
+      pipeline_model_parallel_size: 1
+      context_parallel_size: 1
+
+      # Megatron-FSDP ZeRO-3: shard optimizer states, gradients and parameters
+      # across DP ranks.
+      use_torch_fsdp2: false
+      use_megatron_fsdp: true
+      data_parallel_sharding_strategy: optim_grads_params
+
+      overlap_grad_reduce: true
+      use_flash_attn: true
+      distributed_timeout_minutes: 60
+
+      # ----------------------------------------------------------------------
+      # Primus Turbo (off; the TE spec uses stock TE / flash-attn kernels)
+      # ----------------------------------------------------------------------
+      enable_primus_turbo: false
+      use_turbo_attention: false
+
+      seed: 42
+
+      wandb_project: wan-pretrain
+      wandb_exp_name: wan2.1_t2v_1.3b_pusa_te_spec

--- a/examples/megatron/prepare.py
+++ b/examples/megatron/prepare.py
@@ -167,6 +167,13 @@ def prepare_dataset_if_needed(
     pre_trainer_cfg = primus_config.get_module_config("pre_trainer")
     if pre_trainer_cfg.train_data_path is not None:
         return
+    # Diffusion runs read Energon/webdataset shards straight from data_path and
+    # have no tokenizer_model at all; the bookcorpus flow below is text-only.
+    model_type = str(getattr(pre_trainer_cfg, "model_type", "") or "")
+    if model_type.startswith("diffusion") or model_type in ("flux", "wan"):
+        log_info(f"model_type={model_type!r} is a diffusion model, skipping bookcorpus tokenisation.")
+        return
+
     # SFT runs build the dataset on-the-fly (HF datasets API) inside the
     # trainer; the bookcorpus tokenisation flow below is pretrain-only.
     if getattr(pre_trainer_cfg, "stage", None) == "sft":

--- a/primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py
+++ b/primus/backends/megatron/core/extensions/primus_turbo_mxfp4_local.py
@@ -128,6 +128,137 @@ def _cdiv(a, b):
     return (a + b - 1) // b
 
 
+# ---------------------------------------------------------------------------
+# Primus-Turbo capability probes.
+#
+# Primus supports images whose Primus-Turbo predates two API changes:
+#   - PR #335 added `padding_align_size` as a positional argument of
+#     quantize_mxfp4{_dual}; before it, the C++ op takes 12 arguments.
+#   - commit 683a7de added the `preshuffled=` kwarg to gemm_fp4_impl; before
+#     it, the AITER backend decides preshuffling globally.
+# rocm/primus:v26.3 predates both, so calling the modern signatures there
+# raises. Both are probed from the registered schema rather than from
+# inspect.signature: gemm_fp4_impl is a torch CustomOpDef whose __call__ is
+# (*args, **kwargs), so a signature probe reports False on every image --
+# including modern ones, where silently dropping `preshuffled` would hand
+# unshuffled operands to a kernel expecting shuffled ones.
+# ---------------------------------------------------------------------------
+
+
+def _schema_argument_names(op) -> Tuple[str, ...]:
+    """Registered argument names of a torch operator, or () if undiscoverable."""
+    overload = getattr(op, "_opoverload", None)
+    if overload is None:
+        overloads = getattr(op, "overloads", None)
+        if callable(overloads):
+            names = overloads()
+            overload = getattr(op, names[0], None) if names else None
+    schema = getattr(overload, "_schema", None)
+    if schema is None:
+        return ()
+    return tuple(arg.name for arg in schema.arguments)
+
+
+_QUANTIZE_MXFP4_DUAL_TAKES_ALIGN = "padding_align_size" in _schema_argument_names(
+    torch.ops.primus_turbo_cpp_extension.quantize_mxfp4_dual
+)
+
+_GEMM_FP4_SUPPORTS_PRESHUFFLE = "preshuffled" in _schema_argument_names(gemm_fp4_impl)
+
+
+def _gemm_fp4(a, a_scale, trans_a, b, b_scale, trans_b, out_dtype, trans_c, preshuffle):
+    """gemm_fp4_impl, forwarding `preshuffled` only where the op accepts it.
+
+    Where it is absent the AITER backend applies its own global preshuffle
+    decision, which `_enable_preshuffle()` mirrors -- so the operand layout
+    and the kernel's expectation still agree.
+    """
+    kwargs = {"granularity": _GRAN_VALUE, "default_backend": _DEFAULT_BACKEND}
+    if _GEMM_FP4_SUPPORTS_PRESHUFFLE:
+        kwargs["preshuffled"] = preshuffle
+    return gemm_fp4_impl(a, a_scale, trans_a, b, b_scale, trans_b, out_dtype, trans_c, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# GEMM shape alignment.
+# ---------------------------------------------------------------------------
+
+# Alignment applied to any axis an FP4 GEMM reduces over. See _aligned().
+MXFP4_REDUCTION_ALIGN = 256
+
+
+def _aligned(d: int) -> int:
+    """Smallest size >= ``d`` that a reduction axis may safely take.
+
+    Two hazards force a reduction axis up to ``MXFP4_REDUCTION_ALIGN``:
+
+    - AITER's FP4 dispatcher rejects ``d % 16 != 0``.
+    - A shuffled colwise scale buffer covers ``cdiv(cdiv(d, 32), 8) * 8`` E8M0
+      blocks while the packed FP4 data covers only ``cdiv(d, 128) * 128``. When
+      ``cdiv(d, 128)`` is odd, four blocks per logical row have no backing data;
+      the quantizer never writes them and the wgrad GEMM then sums whatever the
+      allocator left behind. Training stays finite but the gradient norm jumps
+      to ~1e6 at the odd micro-batch sizes that hit this, and varies run to run.
+
+    Rounding to 256 clears both: it is a multiple of 16, and ``cdiv(256t, 128)``
+    is ``2t``, so every block is backed. Padding is not free -- it costs a full
+    ``F.pad`` copy of the operand for every GEMM -- so an axis that already
+    violates neither rule is returned untouched. WAN 1.3B's hidden dims (1536,
+    4608, 8960) and its token counts at even micro-batch sizes all pass, so the
+    common case pads nothing.
+    """
+    if d % 16 == 0 and _cdiv(d, MXFP4_PADDING_ALIGN_SIZE) % 2 == 0:
+        return d
+    return _cdiv(d, MXFP4_REDUCTION_ALIGN) * MXFP4_REDUCTION_ALIGN
+
+
+def _aligned_gemm_dims(m: int, k: int, n: int) -> Tuple[int, int, int]:
+    """Padded ``(M, K, N)`` for the three FP4 GEMMs behind one linear layer.
+
+    Each dim is the reduction axis of exactly one GEMM -- ``K`` for the forward,
+    ``N`` for dgrad, ``M`` for wgrad -- so all three have to clear the
+    dispatcher, not just the token count.
+    """
+    dims = (_aligned(m), _aligned(k), _aligned(n))
+    for label, aligned in zip(("M", "K", "N"), dims):
+        if aligned % 16:
+            raise RuntimeError(
+                f"MXFP4 reduction axis {label} is misaligned after padding: "
+                f"{aligned} (from M={m}, K={k}, N={n}). AITER's FP4 dispatcher "
+                f"needs {label} % 16 == 0."
+            )
+    return dims
+
+
+def _pad2d(t: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+    """Zero-pad a 2D tensor to ``[rows, cols]``; identity when already sized.
+
+    Zeros are exact here: a padded index either sits on a reduction axis, where
+    it contributes nothing to the sum, or on an output axis, where it is sliced
+    off before the result leaves this Function.
+    """
+    if t.shape[0] == rows and t.shape[1] == cols:
+        return t
+    return torch.nn.functional.pad(t, (0, cols - t.shape[1], 0, rows - t.shape[0]))
+
+
+# The quantize kernels take 16-bit input only, and the FP4 GEMM backends emit
+# fp16/bf16 only. Diffusion backbones can feed FP32 activations, so clamp on the
+# way in and out while leaving the surrounding activation dtype alone.
+_Q_INPUT_DTYPES = (torch.bfloat16, torch.float16)
+_GEMM_SUPPORTED_OUT_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def _to_quantizable(t: torch.Tensor) -> torch.Tensor:
+    if t.dtype in _Q_INPUT_DTYPES:
+        return t
+    return t.to(torch.bfloat16)
+
+
+def _gemm_out_dtype(dtype: torch.dtype) -> torch.dtype:
+    return dtype if dtype in _GEMM_SUPPORTED_OUT_DTYPES else torch.bfloat16
+
+
 @_custom_op("primus::quantize_mxfp4_dual", mutates_args=(), device_types="cuda")
 def _quantize_mxfp4_dual_op(
     x: torch.Tensor,
@@ -144,10 +275,11 @@ def _quantize_mxfp4_dual_op(
     shuffle_colwise_scale: bool,
     shuffle_colwise: bool,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    align = (padding_align_size,) if _QUANTIZE_MXFP4_DUAL_TAKES_ALIGN else ()
     return torch.ops.primus_turbo_cpp_extension.quantize_mxfp4_dual(
         x,
         out_dtype,
-        padding_align_size,
+        *align,
         rowwise_use_2d_block,
         rowwise_use_sr,
         rowwise_use_rht,
@@ -309,27 +441,40 @@ class MXFP4LinearFunction(torch.autograd.Function):
         fp8_backend_value,
         use_gradient_sr,
     ):
-        out_dtype = input.dtype
+        # Emit the parameter (compute) dtype -- typically bf16 under mixed
+        # precision -- rather than the raw activation dtype, since native
+        # linears run under autocast and downstream ops reject FP32.
+        gemm_out_dtype = _gemm_out_dtype(weight.dtype)
         orig_shape = input.shape
         input_2d = input.reshape(-1, input.shape[-1])
 
-        a_fp4, a_scale, a_t_fp4, a_t_scale = _quantize_input_dual(input_2d, preshuffle)
-        b_fp4, b_scale, b_t_fp4, b_t_scale = _quantize_weight_dual(weight, preshuffle)
+        m, k = input_2d.shape
+        n = weight.shape[0]
+        m_a, k_a, n_a = _aligned_gemm_dims(m, k, n)
 
-        output = gemm_fp4_impl(
+        # Quantize padded copies only: the tensors handed to the FP8-hybrid
+        # backward below must stay at their true sizes. _pad2d is the identity
+        # when the axis already clears the dispatcher, which is the usual case.
+        a_fp4, a_scale, a_t_fp4, a_t_scale = _quantize_input_dual(
+            _pad2d(_to_quantizable(input_2d), m_a, k_a), preshuffle
+        )
+        b_fp4, b_scale, b_t_fp4, b_t_scale = _quantize_weight_dual(
+            _pad2d(_to_quantizable(weight), n_a, k_a), preshuffle
+        )
+        output = _gemm_fp4(
             a_fp4,
             a_scale,
             False,
             b_fp4,
             b_scale,
             True,
-            out_dtype,
+            gemm_out_dtype,
             False,
-            granularity=_GRAN_VALUE,
-            default_backend=_DEFAULT_BACKEND,
-            preshuffled=preshuffle,
+            preshuffle,
         )
-        output = output.reshape(*orig_shape[:-1], output.shape[-1])
+        if m_a != m or n_a != n:
+            output = output[:m, :n]
+        output = output.reshape(*orig_shape[:-1], n)
 
         if backward_is_fp8:
             return output, input_2d.view_as(input_2d), weight.view_as(weight)
@@ -362,8 +507,19 @@ class MXFP4LinearFunction(torch.autograd.Function):
         ctx.preshuffle = preshuffle
         ctx.backward_is_fp8 = backward_is_fp8
         ctx.use_gradient_sr = use_gradient_sr
-        ctx.out_dtype = inputs[0].dtype
+        # grad_input must match the forward input dtype (possibly FP32), while
+        # grad_weight must match the parameter dtype (typically bf16).
+        ctx.input_dtype = inputs[0].dtype
+        ctx.weight_dtype = inputs[1].dtype
         ctx.orig_shape = inputs[0].shape
+
+        # True and FP4-aligned GEMM dims. Recomputed here rather than smuggled
+        # through the Function outputs: integer math on static shapes, so it
+        # stays out of the traced region.
+        ctx.m = inputs[0].numel() // inputs[0].shape[-1]
+        ctx.k = inputs[0].shape[-1]
+        ctx.n = inputs[1].shape[0]
+        ctx.m_a, ctx.k_a, ctx.n_a = _aligned_gemm_dims(ctx.m, ctx.k, ctx.n)
 
         if backward_is_fp8:
             _, input_2d_saved, weight_saved = output
@@ -390,10 +546,11 @@ class MXFP4LinearFunction(torch.autograd.Function):
 
         if ctx.backward_is_fp8:
             input_2d, weight = ctx.saved_tensors
+            gemm_out_dtype = _gemm_out_dtype(ctx.weight_dtype)
 
-            grad_fp8, grad_scale_inv = _quantize_fp8_tw(grad_2d, ctx.fp8_bwd_dtype)
-            a_fp8, a_scale_inv = _quantize_fp8_tw(input_2d, ctx.fp8_bwd_dtype)
-            b_fp8, b_scale_inv = _quantize_fp8_tw(weight, ctx.fp8_bwd_dtype)
+            grad_fp8, grad_scale_inv = _quantize_fp8_tw(_to_quantizable(grad_2d), ctx.fp8_bwd_dtype)
+            a_fp8, a_scale_inv = _quantize_fp8_tw(_to_quantizable(input_2d), ctx.fp8_bwd_dtype)
+            b_fp8, b_scale_inv = _quantize_fp8_tw(_to_quantizable(weight), ctx.fp8_bwd_dtype)
 
             grad_input = gemm_fp8_impl(
                 grad_fp8,
@@ -402,11 +559,13 @@ class MXFP4LinearFunction(torch.autograd.Function):
                 b_fp8,
                 b_scale_inv,
                 False,
-                ctx.out_dtype,
+                gemm_out_dtype,
                 False,
                 granularity=ctx.fp8_gran_value,
                 default_backend=ctx.fp8_backend_value,
             )
+            if grad_input.dtype != ctx.input_dtype:
+                grad_input = grad_input.to(ctx.input_dtype)
             grad_input = grad_input.reshape(ctx.orig_shape)
 
             grad_weight = gemm_fp8_impl(
@@ -416,47 +575,59 @@ class MXFP4LinearFunction(torch.autograd.Function):
                 grad_fp8,
                 grad_scale_inv,
                 False,
-                ctx.out_dtype,
+                gemm_out_dtype,
                 True,
                 granularity=ctx.fp8_gran_value,
                 default_backend=ctx.fp8_backend_value,
             )
+            if grad_weight.dtype != ctx.weight_dtype:
+                grad_weight = grad_weight.to(ctx.weight_dtype)
         else:
             a_t_fp4, a_t_scale, b_t_fp4, b_t_scale = ctx.saved_tensors
             preshuffle = ctx.preshuffle
+            gemm_out_dtype = _gemm_out_dtype(ctx.weight_dtype)
 
+            # The saved operands were quantized from padded tensors, so the
+            # gradient has to be padded to match before it can meet them.
             g_fp4, g_scale, g_t_fp4, g_t_scale = _quantize_grad_dual(
-                grad_2d, preshuffle, use_sr=ctx.use_gradient_sr
+                _pad2d(_to_quantizable(grad_2d), ctx.m_a, ctx.n_a),
+                preshuffle,
+                use_sr=ctx.use_gradient_sr,
             )
-
-            grad_input = gemm_fp4_impl(
+            grad_input = _gemm_fp4(
                 g_fp4,
                 g_scale,
                 False,
                 b_t_fp4,
                 b_t_scale,
                 True,
-                ctx.out_dtype,
+                gemm_out_dtype,
                 False,
-                granularity=_GRAN_VALUE,
-                default_backend=_DEFAULT_BACKEND,
-                preshuffled=preshuffle,
+                preshuffle,
             )
+            if ctx.m_a != ctx.m or ctx.k_a != ctx.k:
+                grad_input = grad_input[: ctx.m, : ctx.k]
+            if grad_input.dtype != ctx.input_dtype:
+                grad_input = grad_input.to(ctx.input_dtype)
             grad_input = grad_input.reshape(ctx.orig_shape)
 
-            grad_weight = gemm_fp4_impl(
+            grad_weight = _gemm_fp4(
                 g_t_fp4,
                 g_t_scale,
                 False,
                 a_t_fp4,
                 a_t_scale,
                 True,
-                ctx.out_dtype,
+                gemm_out_dtype,
                 False,
-                granularity=_GRAN_VALUE,
-                default_backend=_DEFAULT_BACKEND,
-                preshuffled=preshuffle,
+                preshuffle,
             )
+            # Slice before any dtype cast so the parameter gradient reaches FSDP
+            # and the optimizer at exactly the weight's shape.
+            if ctx.n_a != ctx.n or ctx.k_a != ctx.k:
+                grad_weight = grad_weight[: ctx.n, : ctx.k].contiguous()
+            if grad_weight.dtype != ctx.weight_dtype:
+                grad_weight = grad_weight.to(ctx.weight_dtype)
 
         return grad_input, grad_weight, None, None, None, None, None, None
 

--- a/primus/backends/megatron/core/models/diffusion/common/backend_resolution.py
+++ b/primus/backends/megatron/core/models/diffusion/common/backend_resolution.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Backend selection for the WAN layer specs.
+
+``config.transformer_impl`` plus the precision fields (``fp4`` / ``fp8``) decide
+which :class:`BackendSpecProvider` builds a model's linears, norms, and
+attention core. :func:`resolve_diffusion_backend` mirrors the ladder inlined in
+``flux/layer_spec.get_flux_layer_spec``; the two are independent copies and a
+new precision branch has to be added to both.
+
+The second return value is the provider for *sensitive* layers -- the first and
+last N blocks that stay at higher precision when ``sensitive_layers_enabled``
+is set. It is ``None`` whenever sensitive layers are off or the main backend is
+not a low-precision one.
+"""
+
+from typing import Optional, Tuple
+
+try:
+    from megatron.core.extensions.transformer_engine_spec_provider import TESpecProvider
+
+    HAVE_TE_SPEC_PROVIDER = True
+except ImportError:
+    HAVE_TE_SPEC_PROVIDER = False
+    TESpecProvider = None
+
+try:
+    from primus.backends.megatron.core.extensions.primus_turbo_local_spec import (
+        PrimusTurboFloat8LocalSpecProvider,
+        PrimusTurboLocalSpecProvider,
+    )
+
+    HAVE_PRIMUS_TURBO_LOCAL = True
+except ImportError:
+    HAVE_PRIMUS_TURBO_LOCAL = False
+    PrimusTurboLocalSpecProvider = None
+    PrimusTurboFloat8LocalSpecProvider = None
+
+# Separate guard so a missing primus_turbo_mxfp4_local does not break FP8.
+try:
+    from primus.backends.megatron.core.extensions.primus_turbo_local_spec import (
+        PrimusTurboMXFP4LocalSpecProvider,
+    )
+except ImportError:
+    PrimusTurboMXFP4LocalSpecProvider = None
+
+
+def resolve_diffusion_backend(config) -> Tuple[object, Optional[object]]:
+    """Select the spec providers for a diffusion model's layers.
+
+    Returns ``(backend, sensitive_backend)``. ``sensitive_backend`` is ``None``
+    unless the main backend is MXFP4 and ``sensitive_layer_precision`` names a
+    higher-precision provider for the first/last layers.
+    """
+    sensitive_backend = None
+
+    if config.transformer_impl == "local":
+        if config.fp4 is not None and PrimusTurboMXFP4LocalSpecProvider is not None:
+            backend = PrimusTurboMXFP4LocalSpecProvider()
+
+            sensitive_precision = getattr(config, "sensitive_layer_precision", "bf16")
+            if sensitive_precision == "tw_fp8":
+                sensitive_backend = PrimusTurboFloat8LocalSpecProvider()
+            elif sensitive_precision == "bf16":
+                sensitive_backend = PrimusTurboLocalSpecProvider()
+        elif (
+            config.fp8 is not None
+            and HAVE_PRIMUS_TURBO_LOCAL
+            and PrimusTurboFloat8LocalSpecProvider is not None
+        ):
+            backend = PrimusTurboFloat8LocalSpecProvider()
+        elif HAVE_PRIMUS_TURBO_LOCAL and PrimusTurboLocalSpecProvider is not None:
+            backend = PrimusTurboLocalSpecProvider()
+        else:
+            from megatron.core.models.backends import LocalSpecProvider
+
+            backend = LocalSpecProvider()
+    elif HAVE_TE_SPEC_PROVIDER:
+        backend = TESpecProvider()
+    else:
+        from megatron.core.models.backends import LocalSpecProvider
+
+        backend = LocalSpecProvider()
+
+    return backend, sensitive_backend
+
+
+def sensitive_layer_range(config, num_layers: int) -> Tuple[int, int]:
+    """``(num_start, num_end)`` layers to keep at the sensitive precision."""
+    if not getattr(config, "sensitive_layers_enabled", False):
+        return 0, 0
+    num_start = getattr(config, "sensitive_layers_start", 0)
+    num_end = getattr(config, "sensitive_layers_end", 0)
+    if num_start + num_end > num_layers:
+        raise ValueError(f"sensitive layers ({num_start} + {num_end}) exceed num_layers ({num_layers})")
+    return num_start, num_end
+
+
+__all__ = [
+    "resolve_diffusion_backend",
+    "sensitive_layer_range",
+    "HAVE_TE_SPEC_PROVIDER",
+    "HAVE_PRIMUS_TURBO_LOCAL",
+]

--- a/primus/backends/megatron/core/models/diffusion/wan/__init__.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/__init__.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+WAN video diffusion model components.
+
+This module provides all components needed for the WAN 2.1 / 2.2 architecture:
+- Models: Wan (single transformer), Wan2_2 (dual expert)
+- Configuration: WanConfig
+- Layers: WanRotaryPosEmbed (3D RoPE), WanConditionEmbedder
+- Attention: WanSelfAttention, WanCrossAttention
+- Layer specs: get_wan_layer_spec
+
+Quick Start - Model Creation:
+    >>> from primus.backends.megatron.core.models.diffusion.wan import Wan, WanConfig
+    >>>
+    >>> config = WanConfig.wan2_1_t2v_1_3b()
+    >>> model = Wan(config=config)
+
+WAN 2.2 dual expert:
+    >>> from primus.backends.megatron.core.models.diffusion.wan import Wan2_2, WanConfig
+    >>>
+    >>> config = WanConfig.wan2_2_t2v_a14b()
+    >>> model = Wan2_2(config=config)
+
+Per-expert training selects one side of the timestep boundary:
+    >>> config = WanConfig.wan2_2_t2v_a14b(stage="high_noise")
+    >>> config.timestep_window
+    (0.875, 1.0)
+"""
+
+from primus.backends.megatron.core.models.diffusion.wan.attention import (
+    WanCrossAttention,
+    WanCrossAttentionSubmodules,
+    WanSelfAttention,
+    WanSelfAttentionSubmodules,
+)
+from primus.backends.megatron.core.models.diffusion.wan.config import WanConfig
+from primus.backends.megatron.core.models.diffusion.wan.layer_spec import (
+    WanLayerSpec,
+    get_wan_layer_spec,
+    get_wan_transformer_spec_for_backend,
+)
+from primus.backends.megatron.core.models.diffusion.wan.layers import (
+    WanConditionEmbedder,
+    WanRotaryPosEmbed,
+)
+from primus.backends.megatron.core.models.diffusion.wan.utils import (
+    fold_patches_into_batch,
+    patch_grid,
+    unpatchify,
+)
+
+
+# LAZY IMPORT: keep the model classes out of import time so the package can be
+# imported (for configs and specs) without pulling in the full backbone stack.
+def __getattr__(name):
+    """Lazy import for the WAN model classes."""
+    if name in ("Wan", "Wan2_2", "WanTransformer3D", "build_wan_backbone"):
+        from primus.backends.megatron.core.models.diffusion.wan import model
+
+        return getattr(model, name)
+    if name == "convert_hf_checkpoint":
+        from primus.backends.megatron.core.models.diffusion.wan.checkpoint_converter import (
+            convert_hf_checkpoint,
+        )
+
+        return convert_hf_checkpoint
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+__all__ = [
+    # Models
+    "Wan",
+    "Wan2_2",
+    "WanTransformer3D",
+    "build_wan_backbone",
+    # Configuration
+    "WanConfig",
+    # Layers
+    "WanRotaryPosEmbed",
+    "WanConditionEmbedder",
+    # Attention
+    "WanSelfAttention",
+    "WanCrossAttention",
+    "WanSelfAttentionSubmodules",
+    "WanCrossAttentionSubmodules",
+    # Layer specs
+    "WanLayerSpec",
+    "get_wan_layer_spec",
+    "get_wan_transformer_spec_for_backend",
+    # Utils
+    "patch_grid",
+    "fold_patches_into_batch",
+    "unpatchify",
+    # Checkpoint conversion
+    "convert_hf_checkpoint",
+]

--- a/primus/backends/megatron/core/models/diffusion/wan/__init__.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/__init__.py
@@ -29,6 +29,8 @@ Per-expert training selects one side of the timestep boundary:
     (0.875, 1.0)
 """
 
+from typing import TYPE_CHECKING
+
 from primus.backends.megatron.core.models.diffusion.wan.attention import (
     WanCrossAttention,
     WanCrossAttentionSubmodules,
@@ -51,12 +53,28 @@ from primus.backends.megatron.core.models.diffusion.wan.utils import (
     unpatchify,
 )
 
+# The names below are resolved at runtime by __getattr__ below, which static
+# analysis cannot see; importing them under TYPE_CHECKING declares them without
+# binding anything at module scope, which would shadow __getattr__ entirely.
+if TYPE_CHECKING:
+    from primus.backends.megatron.core.models.diffusion.wan.checkpoint_converter import (
+        convert_hf_checkpoint,
+    )
+    from primus.backends.megatron.core.models.diffusion.wan.model import (
+        Wan,
+        Wan2_2,
+        WanTransformer3D,
+        build_wan_backbone,
+    )
+
+_LAZY_MODEL_EXPORTS = ("Wan", "Wan2_2", "WanTransformer3D", "build_wan_backbone")
+
 
 # LAZY IMPORT: keep the model classes out of import time so the package can be
 # imported (for configs and specs) without pulling in the full backbone stack.
 def __getattr__(name):
     """Lazy import for the WAN model classes."""
-    if name in ("Wan", "Wan2_2", "WanTransformer3D", "build_wan_backbone"):
+    if name in _LAZY_MODEL_EXPORTS:
         from primus.backends.megatron.core.models.diffusion.wan import model
 
         return getattr(model, name)

--- a/primus/backends/megatron/core/models/diffusion/wan/attention.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/attention.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Portions copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+WAN attention modules, built from backend-resolved submodule specs.
+
+WAN needs its own submodule dataclasses rather than reusing Flux's
+:class:`JointSelfAttentionSubmodules`: Flux's joint attention carries a second
+``added_*`` QKV stream for the text tokens, whereas WAN conditions on text
+through a separate cross-attention with an independent ``linear_q`` and a fused
+``linear_kv``.
+
+Both modules run sequence-major ``[S, B, dim]`` end to end, matching
+Megatron-Bridge, so AdaLN modulation, the LayerNorms, residuals, and the
+attention core all operate on the same layout and dispatch the same kernels.
+
+TE path: q/k/v are packed into the ``thd`` layout with ``cu_seqlens`` and rotated
+with the fused RoPE kernel, matching Megatron-Bridge's WAN attention exactly.
+Local path: q/k/v stay in SBHD and use unfused interleaved RoPE plus
+``PrimusTurboLocalAttention``.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+import torch
+from megatron.core.models.common.embeddings.rotary_pos_embedding import (
+    apply_rotary_pos_emb,
+)
+from megatron.core.packed_seq_params import PackedSeqParams
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.module import MegatronModule
+from megatron.core.transformer.spec_utils import ModuleSpec, build_module
+from torch import Tensor
+
+from .layers import thd_cu_seqlens, unfused_fp32_attention
+
+
+@dataclass
+class WanSelfAttentionSubmodules:
+    """Submodules of WAN self-attention (fused QKV, RoPE-rotated q/k)."""
+
+    linear_qkv: Union[ModuleSpec, type] = None
+    core_attention: Union[ModuleSpec, type] = None
+    linear_proj: Union[ModuleSpec, type] = None
+    q_layernorm: Union[ModuleSpec, type] = None
+    k_layernorm: Union[ModuleSpec, type] = None
+
+
+@dataclass
+class WanCrossAttentionSubmodules:
+    """Submodules of WAN cross-attention (split q, fused kv, no RoPE)."""
+
+    linear_q: Union[ModuleSpec, type] = None
+    linear_kv: Union[ModuleSpec, type] = None
+    core_attention: Union[ModuleSpec, type] = None
+    linear_proj: Union[ModuleSpec, type] = None
+    q_layernorm: Union[ModuleSpec, type] = None
+    k_layernorm: Union[ModuleSpec, type] = None
+
+
+class WanAttentionBase(MegatronModule):
+    """Shared plumbing for WAN self- and cross-attention.
+
+    ``config`` here is the attention config produced by
+    ``layer_spec._attention_config`` -- kv_channels, num_query_groups, biases,
+    and the RoPE/qkv-format knobs are already pinned on it. ``norm_config`` is
+    the RMSNorm clone used for the q/k norms only.
+    """
+
+    def __init__(
+        self,
+        config,
+        layer_number: int,
+        attn_mask_type: AttnMaskType,
+        norm_config=None,
+    ):
+        super().__init__(config)
+        self.layer_number = layer_number
+        self.attn_mask_type = attn_mask_type
+        self.norm_config = norm_config if norm_config is not None else config
+        self.local = config.transformer_impl == "local"
+        self.use_fp32_attention = getattr(config, "use_fp32_attention", False)
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.kv_channels
+        self.inner_dim = self.num_heads * self.head_dim
+        self.across_heads = bool(getattr(config, "layernorm_across_heads", True))
+        self.norm_size = self.inner_dim if self.across_heads else self.head_dim
+
+    def _build_norm(self, spec, hidden_size: int):
+        return build_module(
+            spec,
+            config=self.norm_config,
+            hidden_size=hidden_size,
+            eps=self.config.layernorm_epsilon,
+        )
+
+    def _apply_qk_norm(self, tensor: Tensor, norm, seq_len: int, batch: int) -> Tensor:
+        """Normalize q or k, folding heads into the feature dim when required.
+
+        The norm holds an fp32 weight, so a bf16 input comes back as fp32 while
+        ``value`` stays bf16. Flash attention rejects that mismatch, so cast
+        back to the input dtype -- computing the norm in fp32 and casting down
+        is what diffusers and Megatron-Bridge do.
+        """
+        dtype = tensor.dtype
+        if self.across_heads:
+            flat = tensor.reshape(seq_len, batch, -1)
+            if not self.local:
+                flat = flat.contiguous()
+            normed = norm(flat).view(seq_len, batch, self.num_heads, self.head_dim)
+        else:
+            normed = norm(tensor if self.local else tensor.contiguous())
+        return normed.to(dtype)
+
+    def _core(self, query, key, value, packed_seq_params=None) -> Tensor:
+        """Run the attention core, honouring the fp32 parity path."""
+        if self.use_fp32_attention and query.dtype == torch.float32:
+            return unfused_fp32_attention(query, key, value, packed_seq_params).to(query.dtype)
+        if packed_seq_params is None:
+            return self.core_attention(query, key, value, None, self.attn_mask_type)
+        return self.core_attention(
+            query,
+            key,
+            value,
+            None,
+            attn_mask_type=self.attn_mask_type,
+            packed_seq_params=packed_seq_params,
+        )
+
+
+class WanSelfAttention(WanAttentionBase):
+    """WAN self-attention: fused ``linear_qkv``, RMSNorm-ed and RoPE-rotated q/k."""
+
+    def __init__(
+        self,
+        config,
+        submodules: WanSelfAttentionSubmodules,
+        layer_number: int,
+        attn_mask_type: AttnMaskType = AttnMaskType.padding,
+        rope_config=None,
+        norm_config=None,
+    ):
+        super().__init__(config, layer_number, attn_mask_type, norm_config)
+        self.rope_config = rope_config if rope_config is not None else config
+
+        self.linear_qkv = build_module(
+            submodules.linear_qkv,
+            config.hidden_size,
+            3 * self.inner_dim,
+            config=config,
+            init_method=config.init_method,
+            gather_output=False,
+            bias=True,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="qkv",
+        )
+        self.q_layernorm = self._build_norm(submodules.q_layernorm, self.norm_size)
+        self.k_layernorm = self._build_norm(submodules.k_layernorm, self.norm_size)
+        self.core_attention = build_module(
+            submodules.core_attention,
+            config=config,
+            layer_number=layer_number,
+            attn_mask_type=attn_mask_type,
+            attention_type="self",
+        )
+        self.linear_proj = build_module(
+            submodules.linear_proj,
+            self.inner_dim,
+            config.hidden_size,
+            config=config,
+            init_method=config.output_layer_init_method,
+            bias=True,
+            input_is_parallel=True,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="proj",
+        )
+
+    def _split_qkv(self, hidden_states: Tensor) -> Tuple[Tensor, Tensor, Tensor, int, int]:
+        s, b, _ = hidden_states.shape
+        mixed_qkv, _ = self.linear_qkv(hidden_states)
+        mixed_qkv = mixed_qkv.view(s, b, self.num_heads, 3 * self.head_dim)
+        query, key, value = torch.split(mixed_qkv, [self.head_dim, self.head_dim, self.head_dim], dim=3)
+        query = self._apply_qk_norm(query, self.q_layernorm, s, b)
+        key = self._apply_qk_norm(key, self.k_layernorm, s, b)
+        return query, key, value, s, b
+
+    def forward(
+        self, hidden_states: Tensor, rotary_freqs: Optional[Tensor]
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        query, key, value, s, b = self._split_qkv(hidden_states)
+
+        if self.local:
+            if rotary_freqs is not None:
+                query = apply_rotary_pos_emb(query, rotary_freqs, config=self.rope_config)
+                key = apply_rotary_pos_emb(key, rotary_freqs, config=self.rope_config)
+            core_out = self._core(query, key, value)
+            return self.linear_proj(core_out)
+
+        # Pack the batch into the token dim BEFORE RoPE so the fused thd rotary
+        # and the fused attention kernel see Megatron-Bridge's exact layout.
+        cu_seqlens = thd_cu_seqlens(s, b, hidden_states.device)
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens,
+            cu_seqlens_kv=cu_seqlens,
+            cu_seqlens_q_padded=cu_seqlens,
+            cu_seqlens_kv_padded=cu_seqlens,
+        )
+        query = query.transpose(0, 1).reshape(b * s, self.num_heads, self.head_dim).contiguous()
+        key = key.transpose(0, 1).reshape(b * s, self.num_heads, self.head_dim).contiguous()
+        value = value.transpose(0, 1).reshape(b * s, self.num_heads, self.head_dim).contiguous()
+
+        if rotary_freqs is not None:
+            query = apply_rotary_pos_emb(query, rotary_freqs, config=self.config, cu_seqlens=cu_seqlens)
+            key = apply_rotary_pos_emb(key, rotary_freqs, config=self.config, cu_seqlens=cu_seqlens)
+
+        core_out = self._core(query, key, value, packed_seq_params)
+        core_out = core_out.reshape(b, s, -1).transpose(0, 1).contiguous()
+        return self.linear_proj(core_out)
+
+
+class WanCrossAttention(WanAttentionBase):
+    """WAN cross-attention: query from video tokens, key/value from text tokens."""
+
+    def __init__(
+        self,
+        config,
+        submodules: WanCrossAttentionSubmodules,
+        layer_number: int,
+        attn_mask_type: AttnMaskType = AttnMaskType.padding,
+        norm_config=None,
+    ):
+        super().__init__(config, layer_number, attn_mask_type, norm_config)
+
+        self.linear_q = build_module(
+            submodules.linear_q,
+            config.hidden_size,
+            self.inner_dim,
+            config=config,
+            init_method=config.init_method,
+            gather_output=False,
+            bias=True,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="q",
+        )
+        self.linear_kv = build_module(
+            submodules.linear_kv,
+            config.hidden_size,
+            2 * self.inner_dim,
+            config=config,
+            init_method=config.init_method,
+            gather_output=False,
+            bias=True,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="kv",
+        )
+        self.q_layernorm = self._build_norm(submodules.q_layernorm, self.norm_size)
+        self.k_layernorm = self._build_norm(submodules.k_layernorm, self.norm_size)
+        self.core_attention = build_module(
+            submodules.core_attention,
+            config=config,
+            layer_number=layer_number,
+            attn_mask_type=attn_mask_type,
+            attention_type="cross",
+        )
+        self.linear_proj = build_module(
+            submodules.linear_proj,
+            self.inner_dim,
+            config.hidden_size,
+            config=config,
+            init_method=config.output_layer_init_method,
+            bias=True,
+            input_is_parallel=True,
+            skip_bias_add=False,
+            is_expert=False,
+            tp_comm_buffer_name="proj",
+        )
+
+    def forward(self, hidden_states: Tensor, context: Tensor) -> Tuple[Tensor, Optional[Tensor]]:
+        sq, b, _ = hidden_states.shape
+        skv = context.shape[0]
+
+        query, _ = self.linear_q(hidden_states)
+        query = query.view(sq, b, self.num_heads, self.head_dim)
+
+        mixed_kv, _ = self.linear_kv(context)
+        mixed_kv = mixed_kv.view(skv, b, self.num_heads, 2 * self.head_dim)
+        key, value = torch.split(mixed_kv, [self.head_dim, self.head_dim], dim=3)
+
+        query = self._apply_qk_norm(query, self.q_layernorm, sq, b)
+        key = self._apply_qk_norm(key, self.k_layernorm, skv, b)
+
+        if self.local:
+            core_out = self._core(query, key, value)
+            return self.linear_proj(core_out)
+
+        # Query (video) and key/value (text) carry independent cu_seqlens.
+        cu_seqlens_q = thd_cu_seqlens(sq, b, hidden_states.device)
+        cu_seqlens_kv = thd_cu_seqlens(skv, b, hidden_states.device)
+        packed_seq_params = PackedSeqParams(
+            qkv_format="thd",
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=cu_seqlens_kv,
+            cu_seqlens_q_padded=cu_seqlens_q,
+            cu_seqlens_kv_padded=cu_seqlens_kv,
+        )
+        query = query.transpose(0, 1).reshape(b * sq, self.num_heads, self.head_dim).contiguous()
+        key = key.transpose(0, 1).reshape(b * skv, self.num_heads, self.head_dim).contiguous()
+        value = value.transpose(0, 1).reshape(b * skv, self.num_heads, self.head_dim).contiguous()
+
+        core_out = self._core(query, key, value, packed_seq_params)
+        core_out = core_out.reshape(b, sq, -1).transpose(0, 1).contiguous()
+        return self.linear_proj(core_out)
+
+
+__all__ = [
+    "WanSelfAttention",
+    "WanCrossAttention",
+    "WanSelfAttentionSubmodules",
+    "WanCrossAttentionSubmodules",
+]

--- a/primus/backends/megatron/core/models/diffusion/wan/checkpoint_converter.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/checkpoint_converter.py
@@ -1,0 +1,1064 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+"""
+HuggingFace to Primus WAN checkpoint converter.
+
+Converts HuggingFace Diffusers WAN (2.1 / 2.2) video-diffusion transformer
+checkpoints to Primus/Megatron-Core compatible format, and back.
+
+Key Conversion:
+    - HuggingFace: split ``to_q`` / ``to_k`` / ``to_v`` projections, ``to_out.0``
+    - Primus: fused ``linear_qkv`` (self-attention) / ``linear_kv`` (cross-attention)
+      in Megatron's per-head interleaved layout, ``linear_proj``
+
+    Every other parameter keeps its diffusers name (patch embedding, condition
+    embedder, ``norm2``, ``scale_shift_table``, ``proj_out``); the feed-forward
+    network is a pure rename onto Megatron-Core's ``MLP``
+    (``ffn.net.0.proj`` -> ``ffn.linear_fc1``, ``ffn.net.2`` -> ``ffn.linear_fc2``).
+
+WAN 2.2 dual-expert checkpoints are handled automatically: keys prefixed with
+``transformer.`` and ``transformer_2.`` are each converted in place.
+
+Both directions validate against the analytic key set for the target layout and
+return a :class:`ConversionReport` recording ``mapped`` / ``dropped`` /
+``missing`` keys. ``strict=True`` raises if anything is dropped or missing.
+
+Usage:
+    from primus.backends.megatron.core.models.diffusion.wan.checkpoint_converter import (
+        convert_hf_checkpoint,
+    )
+
+    primus_state_dict = convert_hf_checkpoint(
+        checkpoint_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer",
+        wan_config=config,
+        save_to="primus_wan21_t2v_1_3b.safetensors",
+    )
+
+Plus a CLI for both directions, distributed-checkpoint input, and diffusers
+directory export:
+
+    python -m primus.backends.megatron.core.models.diffusion.wan.checkpoint_converter \\
+        --direction hf2primus --input <ckpt> --output <out.safetensors>
+
+Reference:
+    - HuggingFace Diffusers ``WanTransformer3DModel``
+    - Megatron-Core fused attention (``linear_qkv`` / ``linear_kv``) layout
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple, Union
+
+import torch
+from torch import Tensor
+
+from primus.backends.megatron.core.models.diffusion.wan.config import WanConfig
+
+logger = logging.getLogger(__name__)
+
+StateDict = Dict[str, Tensor]
+
+
+# ---------------------------------------------------------------------------
+# Conversion report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConversionReport:
+    """Records exactly what happened during a conversion."""
+
+    direction: str
+    mapped: List[str] = field(default_factory=list)
+    dropped: List[str] = field(default_factory=list)
+    missing: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def add_warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+        logger.warning("[wan-convert:%s] %s", self.direction, msg)
+
+    def summary(self) -> str:
+        return (
+            f"WAN checkpoint conversion ({self.direction}): "
+            f"{len(self.mapped)} mapped, {len(self.dropped)} dropped, "
+            f"{len(self.missing)} missing, {len(self.warnings)} warnings."
+        )
+
+    def raise_if_lossy(self) -> None:
+        """Raise when keys were dropped or missing (strict mode)."""
+        if self.dropped or self.missing:
+            raise RuntimeError(
+                self.summary()
+                + " strict=True forbids lossy conversion. "
+                + f"dropped={self.dropped[:5]}... missing={self.missing[:5]}..."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Expected key sets
+#
+# The Primus WAN backbone keeps most non-attention keys identical to diffusers
+# (patch_embedding, condition_embedder, norms, scale_shift_table, proj_out) and
+# differs in the attention submodules and the feed-forward network:
+#
+#   self-attn  (attn1):
+#       to_q / to_k / to_v [inner, dim]  ->  linear_qkv [3*inner, dim]  (fused)
+#       to_out.0                         ->  linear_proj
+#       norm_q / norm_k                  ->  q_layernorm / k_layernorm
+#   cross-attn (attn2):
+#       to_q                             ->  linear_q
+#       to_k / to_v [inner, dim]         ->  linear_kv [2*inner, dim]   (fused)
+#       to_out.0                         ->  linear_proj
+#       norm_q / norm_k                  ->  q_layernorm / k_layernorm
+#   ffn (diffusers nn.Linear FeedForward -> mcore MLP; pure 1:1 rename):
+#       net.0.proj [ffn_hidden, dim]     ->  linear_fc1
+#       net.2      [dim, ffn_hidden]     ->  linear_fc2
+#
+# The fused layout is Megatron's per-head interleave: rows are grouped by head as
+# ``[q_head0(hn), k_head0(hn), v_head0(hn), q_head1(hn), ...]``, matching the
+# ``view(S, B, heads, 3*head_dim)`` split in the backbone's self-attention (and
+# ``2*head_dim`` for cross-attention ``linear_kv``). q/k RMSNorm is across-heads,
+# so its weight is ``[inner]`` and maps 1:1 with diffusers ``norm_q`` / ``norm_k``.
+# ---------------------------------------------------------------------------
+
+_SHARED_ROOT_KEYS: Tuple[str, ...] = (
+    "patch_embedding.weight",
+    "patch_embedding.bias",
+    "condition_embedder.time_embedder.linear_1.weight",
+    "condition_embedder.time_embedder.linear_1.bias",
+    "condition_embedder.time_embedder.linear_2.weight",
+    "condition_embedder.time_embedder.linear_2.bias",
+    "condition_embedder.time_proj.weight",
+    "condition_embedder.time_proj.bias",
+    "condition_embedder.text_embedder.linear_1.weight",
+    "condition_embedder.text_embedder.linear_1.bias",
+    "condition_embedder.text_embedder.linear_2.weight",
+    "condition_embedder.text_embedder.linear_2.bias",
+    "proj_out.weight",
+    "proj_out.bias",
+    "scale_shift_table",
+)
+
+_SHARED_BLOCK_SUFFIXES: Tuple[str, ...] = ("scale_shift_table",)
+
+_MCORE_BLOCK_SUFFIXES: Tuple[str, ...] = (
+    "attn1.linear_qkv.weight",
+    "attn1.linear_qkv.bias",
+    "attn1.q_layernorm.weight",
+    "attn1.k_layernorm.weight",
+    "attn1.linear_proj.weight",
+    "attn1.linear_proj.bias",
+    "attn2.linear_q.weight",
+    "attn2.linear_q.bias",
+    "attn2.linear_kv.weight",
+    "attn2.linear_kv.bias",
+    "attn2.q_layernorm.weight",
+    "attn2.k_layernorm.weight",
+    "attn2.linear_proj.weight",
+    "attn2.linear_proj.bias",
+    "ffn.linear_fc1.weight",
+    "ffn.linear_fc1.bias",
+    "ffn.linear_fc2.weight",
+    "ffn.linear_fc2.bias",
+)
+
+_DIFFUSERS_BLOCK_SUFFIXES: Tuple[str, ...] = (
+    "attn1.to_q.weight",
+    "attn1.to_q.bias",
+    "attn1.to_k.weight",
+    "attn1.to_k.bias",
+    "attn1.to_v.weight",
+    "attn1.to_v.bias",
+    "attn1.norm_q.weight",
+    "attn1.norm_k.weight",
+    "attn1.to_out.0.weight",
+    "attn1.to_out.0.bias",
+    "attn2.to_q.weight",
+    "attn2.to_q.bias",
+    "attn2.to_k.weight",
+    "attn2.to_k.bias",
+    "attn2.to_v.weight",
+    "attn2.to_v.bias",
+    "attn2.norm_q.weight",
+    "attn2.norm_k.weight",
+    "attn2.to_out.0.weight",
+    "attn2.to_out.0.bias",
+    "ffn.net.0.proj.weight",
+    "ffn.net.0.proj.bias",
+    "ffn.net.2.weight",
+    "ffn.net.2.bias",
+)
+
+
+def _build_expected_keys(config: WanConfig, block_suffixes: Tuple[str, ...]) -> Set[str]:
+    keys: Set[str] = set(_SHARED_ROOT_KEYS)
+    cross_attn_norm_suffixes = ("norm2.weight", "norm2.bias") if config.cross_attn_norm else ()
+    for n in range(config.num_dit_layers):
+        prefix = f"blocks.{n}."
+        for suffix in block_suffixes + _SHARED_BLOCK_SUFFIXES + cross_attn_norm_suffixes:
+            keys.add(prefix + suffix)
+    return keys
+
+
+def expected_mcore_keys(config: WanConfig) -> Set[str]:
+    """Analytic bare ``state_dict`` key set for one Primus WAN backbone.
+
+    Built analytically (not by instantiating the model) because the backbone
+    constructs TransformerEngine modules, which require CUDA / parallel init and
+    cannot be built on the ``meta`` device. ``_extra_state`` keys are
+    intentionally excluded (they are not real parameters).
+    """
+    return _build_expected_keys(config, _MCORE_BLOCK_SUFFIXES)
+
+
+def expected_diffusers_keys(config: WanConfig) -> Set[str]:
+    """Analytic bare ``state_dict`` key set for one diffusers ``WanTransformer3DModel``.
+
+    Covers the T2V backbone only; I2V-specific extras
+    (``condition_embedder.image_embedder.*``, ``attn2.add_k_proj``,
+    ``norm_added_k``) are deliberately excluded and are reported as dropped.
+    """
+    return _build_expected_keys(config, _DIFFUSERS_BLOCK_SUFFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Per-head fuse / split helpers
+# ---------------------------------------------------------------------------
+
+
+def _fuse_heads(tensors: List[Tensor], heads: int) -> Tensor:
+    """Interleave same-shaped per-projection tensors into the fused layout.
+
+    Each tensor is ``[inner, ...]`` (weight ``[inner, dim]`` or bias ``[inner]``)
+    where ``inner = heads * head_dim``. Returns ``[len(tensors)*inner, ...]`` with
+    rows grouped per head: ``[t0_head0, t1_head0, ..., t0_head1, ...]``.
+    """
+    heads_dim_split = []
+    tail_shape = tensors[0].shape[1:]
+    hd = tensors[0].shape[0] // heads
+    for t in tensors:
+        heads_dim_split.append(t.reshape(heads, hd, *tail_shape))
+    fused = torch.stack(heads_dim_split, dim=1)  # [heads, n, hd, ...]
+    return fused.reshape(heads * len(tensors) * hd, *tail_shape).contiguous()
+
+
+def _split_heads(fused: Tensor, heads: int, n: int) -> List[Tensor]:
+    """Inverse of :func:`_fuse_heads`: recover the ``n`` per-projection tensors."""
+    tail_shape = fused.shape[1:]
+    hd = fused.shape[0] // (heads * n)
+    x = fused.reshape(heads, n, hd, *tail_shape)
+    return [x[:, i].reshape(heads * hd, *tail_shape).contiguous() for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Distributed checkpoint (fsdp_dtensor / torch DCP) loader
+# ---------------------------------------------------------------------------
+
+
+def _normalize_wan_key(full_key: str, expected: Set[str]) -> Optional[str]:
+    """Map a DCP key to a prefixed backbone key, or ``None`` if not a backbone weight.
+
+    Training checkpoints store the WAN backbone under some wrapper (e.g.
+    ``model.transformer.*``) alongside optimizer/RNG state. We locate the
+    ``transformer.`` / ``transformer_2.`` boundary and keep the key only if the
+    remainder is an actual backbone parameter (in ``expected``). This naturally
+    excludes optimizer moments (``...weight.exp_avg``), RNG, scheduler, etc.
+    """
+    for tag in ("transformer_2.", "transformer."):
+        idx = full_key.find(tag)
+        if idx != -1:
+            bare = full_key[idx + len(tag) :]
+            if bare in expected:
+                return f"{tag}{bare}"
+    return None
+
+
+def is_distributed_checkpoint(path: Path) -> bool:
+    """True if ``path`` is a torch Distributed Checkpoint (``.metadata`` + shards)."""
+    return path.is_dir() and (path / ".metadata").exists()
+
+
+def load_distcp_backbone_state_dict(path: Path, config: WanConfig) -> StateDict:
+    """Load only the WAN backbone weights from a torch DCP (``fsdp_dtensor``) dir.
+
+    Reads the checkpoint metadata, selects just the keys that correspond to WAN
+    backbone parameters (single or dual transformer), allocates matching target
+    tensors, and loads those shards (skipping optimizer/RNG state entirely).
+
+    Key selection is name-based against :func:`expected_mcore_keys`, so
+    ``config`` must describe the model the checkpoint was trained with: a
+    mismatched depth silently keeps only the layers the two shapes happen to
+    share.
+
+    Returns a state dict keyed by ``transformer.*`` (and ``transformer_2.*`` for
+    WAN 2.2), ready for :func:`convert_primus_to_hf` / :func:`export_hf_directory`.
+    """
+    import torch.distributed.checkpoint as dcp
+
+    reader = dcp.FileSystemReader(str(path))
+    metadata = reader.read_metadata()
+    expected = expected_mcore_keys(config)
+
+    target: StateDict = {}
+    keymap: Dict[str, str] = {}
+    for full_key, tmeta in metadata.state_dict_metadata.items():
+        norm = _normalize_wan_key(full_key, expected)
+        if norm is None:
+            continue
+        size = getattr(tmeta, "size", None)
+        props = getattr(tmeta, "properties", None)
+        if size is None or props is None:
+            continue  # non-tensor metadata (bytes/RNG)
+        target[full_key] = torch.empty(tuple(size), dtype=props.dtype)
+        keymap[full_key] = norm
+
+    if not target:
+        raise RuntimeError(
+            f"No WAN backbone tensors found in DCP at {path}. The model keys did "
+            "not match the expected layout (check --config-json matches the "
+            "trained model)."
+        )
+
+    try:
+        dcp.load(target, storage_reader=reader, no_dist=True)
+    except TypeError:
+        # Older torch signatures without the ``no_dist`` kwarg.
+        dcp.load(target, storage_reader=reader)
+
+    out = {keymap[k]: v for k, v in target.items()}
+    logger.info(
+        "Loaded %d backbone tensor(s) from DCP %s (prefixes: %s)",
+        len(out),
+        path,
+        sorted({k.split(".")[0] for k in out}),
+    )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Single-backbone conversion (bare keys)
+# ---------------------------------------------------------------------------
+
+
+def _finalize_report(
+    out: StateDict,
+    src: StateDict,
+    consumed: Set[str],
+    expected: Set[str],
+    report: ConversionReport,
+) -> StateDict:
+    """Record mapped / dropped / missing for an explicit-remap conversion."""
+    report.mapped.extend(sorted(consumed))
+    dropped = [k for k in src if k not in consumed]
+    report.dropped.extend(dropped)
+    missing = [k for k in expected if k not in out]
+    report.missing.extend(missing)
+    if dropped:
+        report.add_warning(
+            f"Dropped {len(dropped)} source key(s) with no counterpart in the target "
+            f"layout (e.g. {dropped[:3]}); typically I2V-only extras or TE _extra_state."
+        )
+    if missing:
+        report.add_warning(
+            f"{len(missing)} expected key(s) not produced "
+            f"(e.g. {missing[:3]}); source checkpoint may be incomplete."
+        )
+    return out
+
+
+def _hf_to_primus_backbone(src: StateDict, config: WanConfig, report: ConversionReport) -> StateDict:
+    """Convert a bare diffusers WAN backbone state dict to the Primus fused layout."""
+    heads = config.num_attention_heads
+    out: StateDict = {}
+    consumed: Set[str] = set()
+
+    def copy(key: str) -> None:
+        if key in src:
+            out[key] = src[key].clone()
+            consumed.add(key)
+
+    for key in _SHARED_ROOT_KEYS:
+        copy(key)
+
+    for n in range(config.num_dit_layers):
+        b = f"blocks.{n}."
+
+        for wb in ("weight", "bias"):
+            q, k, v = f"{b}attn1.to_q.{wb}", f"{b}attn1.to_k.{wb}", f"{b}attn1.to_v.{wb}"
+            if q in src and k in src and v in src:
+                out[f"{b}attn1.linear_qkv.{wb}"] = _fuse_heads([src[q], src[k], src[v]], heads)
+                consumed.update({q, k, v})
+        for src_name, dst_name in (
+            (f"{b}attn1.norm_q.weight", f"{b}attn1.q_layernorm.weight"),
+            (f"{b}attn1.norm_k.weight", f"{b}attn1.k_layernorm.weight"),
+            (f"{b}attn1.to_out.0.weight", f"{b}attn1.linear_proj.weight"),
+            (f"{b}attn1.to_out.0.bias", f"{b}attn1.linear_proj.bias"),
+        ):
+            if src_name in src:
+                out[dst_name] = src[src_name].clone()
+                consumed.add(src_name)
+
+        for wb in ("weight", "bias"):
+            q = f"{b}attn2.to_q.{wb}"
+            if q in src:
+                out[f"{b}attn2.linear_q.{wb}"] = src[q].clone()
+                consumed.add(q)
+            k, v = f"{b}attn2.to_k.{wb}", f"{b}attn2.to_v.{wb}"
+            if k in src and v in src:
+                out[f"{b}attn2.linear_kv.{wb}"] = _fuse_heads([src[k], src[v]], heads)
+                consumed.update({k, v})
+        for src_name, dst_name in (
+            (f"{b}attn2.norm_q.weight", f"{b}attn2.q_layernorm.weight"),
+            (f"{b}attn2.norm_k.weight", f"{b}attn2.k_layernorm.weight"),
+            (f"{b}attn2.to_out.0.weight", f"{b}attn2.linear_proj.weight"),
+            (f"{b}attn2.to_out.0.bias", f"{b}attn2.linear_proj.bias"),
+        ):
+            if src_name in src:
+                out[dst_name] = src[src_name].clone()
+                consumed.add(src_name)
+
+        for src_name, dst_name in (
+            (f"{b}ffn.net.0.proj.weight", f"{b}ffn.linear_fc1.weight"),
+            (f"{b}ffn.net.0.proj.bias", f"{b}ffn.linear_fc1.bias"),
+            (f"{b}ffn.net.2.weight", f"{b}ffn.linear_fc2.weight"),
+            (f"{b}ffn.net.2.bias", f"{b}ffn.linear_fc2.bias"),
+        ):
+            if src_name in src:
+                out[dst_name] = src[src_name].clone()
+                consumed.add(src_name)
+
+        for key in (f"{b}norm2.weight", f"{b}norm2.bias", f"{b}scale_shift_table"):
+            copy(key)
+
+    return _finalize_report(out, src, consumed, expected_mcore_keys(config), report)
+
+
+def _primus_to_hf_backbone(src: StateDict, config: WanConfig, report: ConversionReport) -> StateDict:
+    """Convert a bare Primus fused WAN backbone state dict back to diffusers layout."""
+    heads = config.num_attention_heads
+    out: StateDict = {}
+    consumed: Set[str] = set()
+
+    def copy(key: str) -> None:
+        if key in src:
+            out[key] = src[key].clone()
+            consumed.add(key)
+
+    for key in _SHARED_ROOT_KEYS:
+        copy(key)
+
+    for n in range(config.num_dit_layers):
+        b = f"blocks.{n}."
+
+        for wb in ("weight", "bias"):
+            qkv = f"{b}attn1.linear_qkv.{wb}"
+            if qkv in src:
+                q, k, v = _split_heads(src[qkv], heads, 3)
+                out[f"{b}attn1.to_q.{wb}"] = q
+                out[f"{b}attn1.to_k.{wb}"] = k
+                out[f"{b}attn1.to_v.{wb}"] = v
+                consumed.add(qkv)
+        for src_name, dst_name in (
+            (f"{b}attn1.q_layernorm.weight", f"{b}attn1.norm_q.weight"),
+            (f"{b}attn1.k_layernorm.weight", f"{b}attn1.norm_k.weight"),
+            (f"{b}attn1.linear_proj.weight", f"{b}attn1.to_out.0.weight"),
+            (f"{b}attn1.linear_proj.bias", f"{b}attn1.to_out.0.bias"),
+        ):
+            if src_name in src:
+                out[dst_name] = src[src_name].clone()
+                consumed.add(src_name)
+
+        for wb in ("weight", "bias"):
+            q = f"{b}attn2.linear_q.{wb}"
+            if q in src:
+                out[f"{b}attn2.to_q.{wb}"] = src[q].clone()
+                consumed.add(q)
+            kv = f"{b}attn2.linear_kv.{wb}"
+            if kv in src:
+                k, v = _split_heads(src[kv], heads, 2)
+                out[f"{b}attn2.to_k.{wb}"] = k
+                out[f"{b}attn2.to_v.{wb}"] = v
+                consumed.add(kv)
+        for src_name, dst_name in (
+            (f"{b}attn2.q_layernorm.weight", f"{b}attn2.norm_q.weight"),
+            (f"{b}attn2.k_layernorm.weight", f"{b}attn2.norm_k.weight"),
+            (f"{b}attn2.linear_proj.weight", f"{b}attn2.to_out.0.weight"),
+            (f"{b}attn2.linear_proj.bias", f"{b}attn2.to_out.0.bias"),
+        ):
+            if src_name in src:
+                out[dst_name] = src[src_name].clone()
+                consumed.add(src_name)
+
+        for src_name, dst_name in (
+            (f"{b}ffn.linear_fc1.weight", f"{b}ffn.net.0.proj.weight"),
+            (f"{b}ffn.linear_fc1.bias", f"{b}ffn.net.0.proj.bias"),
+            (f"{b}ffn.linear_fc2.weight", f"{b}ffn.net.2.weight"),
+            (f"{b}ffn.linear_fc2.bias", f"{b}ffn.net.2.bias"),
+        ):
+            if src_name in src:
+                out[dst_name] = src[src_name].clone()
+                consumed.add(src_name)
+
+        for key in (f"{b}norm2.weight", f"{b}norm2.bias", f"{b}scale_shift_table"):
+            copy(key)
+
+    return _finalize_report(out, src, consumed, expected_diffusers_keys(config), report)
+
+
+# ---------------------------------------------------------------------------
+# Prefix helpers (WAN 2.2 dual-expert: transformer. / transformer_2.)
+# ---------------------------------------------------------------------------
+
+
+def _detect_backbone_prefixes(state_dict: StateDict) -> List[str]:
+    prefixes = []
+    for p in ("transformer.", "transformer_2."):
+        if any(k.startswith(p) for k in state_dict):
+            prefixes.append(p)
+    return prefixes
+
+
+def _strip_prefix(state_dict: StateDict, prefix: str) -> StateDict:
+    return {k[len(prefix) :]: v for k, v in state_dict.items() if k.startswith(prefix)}
+
+
+def _add_prefix(state_dict: StateDict, prefix: str) -> StateDict:
+    return {f"{prefix}{k}": v for k, v in state_dict.items()}
+
+
+def _convert_one_backbone(
+    bare: StateDict,
+    config: WanConfig,
+    direction: str,
+    report: ConversionReport,
+) -> StateDict:
+    """Convert a single bare backbone state dict in the requested direction."""
+    if direction == "hf->primus":
+        return _hf_to_primus_backbone(bare, config, report)
+    if direction == "primus->hf":
+        return _primus_to_hf_backbone(bare, config, report)
+    raise ValueError(f"Unknown direction={direction!r}; expected 'hf->primus' or 'primus->hf'.")
+
+
+def _convert(
+    src: StateDict,
+    config: WanConfig,
+    direction: str,
+    prefix: Optional[str],
+    strict: bool,
+) -> Tuple[StateDict, ConversionReport]:
+    """Shared driver: dispatch over the detected backbone prefixes."""
+    report = ConversionReport(direction=direction)
+    detected = _detect_backbone_prefixes(src)
+
+    if not detected:
+        out = _convert_one_backbone(src, config, direction, report)
+        if prefix:
+            out = _add_prefix(out, prefix)
+    else:
+        out = {}
+        for src_prefix in detected:
+            bare = _strip_prefix(src, src_prefix)
+            conv = _convert_one_backbone(bare, config, direction, report)
+            out.update(_add_prefix(conv, prefix or src_prefix))
+
+    logger.info("%s", report.summary())
+    if strict:
+        report.raise_if_lossy()
+    return out, report
+
+
+# ---------------------------------------------------------------------------
+# Public API: state-dict level
+# ---------------------------------------------------------------------------
+
+
+def convert_hf_to_primus(
+    hf_state_dict: StateDict,
+    config: WanConfig,
+    *,
+    prefix: Optional[str] = None,
+    strict: bool = False,
+) -> Tuple[StateDict, ConversionReport]:
+    """Convert a diffusers WAN transformer state dict to Primus format.
+
+    Args:
+        hf_state_dict: A bare backbone state dict (keys like
+            ``patch_embedding.weight``) or a full model dict prefixed with
+            ``transformer.`` / ``transformer_2.``.
+        config: ``WanConfig`` describing the target Primus model.
+        prefix: Output key prefix (e.g. ``transformer.``). ``None`` reuses the
+            detected input prefix(es); bare inputs produce bare outputs (which
+            is what the ``backbone_pretrained`` loaders expect).
+        strict: Raise if any key is dropped or missing.
+
+    Returns:
+        ``(primus_state_dict, report)``.
+    """
+    return _convert(hf_state_dict, config, "hf->primus", prefix, strict)
+
+
+def convert_primus_to_hf(
+    primus_state_dict: StateDict,
+    config: WanConfig,
+    *,
+    prefix: Optional[str] = None,
+    strict: bool = False,
+) -> Tuple[StateDict, ConversionReport]:
+    """Convert a Primus WAN state dict to diffusers ``WanTransformer3DModel`` format.
+
+    Args:
+        primus_state_dict: A bare backbone state dict or a full model dict
+            prefixed with ``transformer.`` / ``transformer_2.``.
+        config: ``WanConfig`` describing the source Primus model.
+        prefix: Output key prefix. ``None`` reuses the detected input prefix(es).
+        strict: Raise if any key is dropped or missing.
+
+    Returns:
+        ``(hf_state_dict, report)``.
+    """
+    return _convert(primus_state_dict, config, "primus->hf", prefix, strict)
+
+
+# ---------------------------------------------------------------------------
+# Public API: checkpoint (path / HuggingFace repo id) level
+# ---------------------------------------------------------------------------
+
+
+def _get_hf_token(token_file: Optional[str] = None) -> Optional[str]:
+    """Get HuggingFace token with fallback options.
+
+    Thin wrapper around the shared
+    :func:`...preprocessing.auth.setup_hf_authentication` so the token-resolution
+    priority chain (file with permission check -> HF_TOKEN env -> HF CLI login ->
+    None) lives in one place. Returns None instead of raising so the converter
+    can fall back to public-only access.
+
+    Args:
+        token_file: Optional path to token file
+
+    Returns:
+        Token string if found, None otherwise
+    """
+    from primus.backends.megatron.data.diffusion.preprocessing.auth import (
+        HFAuthError,
+        setup_hf_authentication,
+    )
+
+    try:
+        return setup_hf_authentication(token_file=token_file, use_env=True)
+    except HFAuthError:
+        # Preserve fallback-to-public behavior for the converter rather than
+        # hard-failing on a bad/insecure token file.
+        return None
+
+
+def _resolve_checkpoint_path(checkpoint_path: Union[str, Path]) -> Path:
+    """Resolve a local path, or download a HuggingFace repo id to the HF cache."""
+    checkpoint_path_str = str(checkpoint_path)
+    checkpoint_path_obj = Path(checkpoint_path)
+
+    if checkpoint_path_obj.exists():
+        return checkpoint_path_obj
+
+    # HF repo ids: don't start with /, ./, ../, and don't contain ..
+    looks_like_hf_repo = (
+        "/" in checkpoint_path_str
+        and not checkpoint_path_str.startswith("/")
+        and not checkpoint_path_str.startswith(".")
+        and ".." not in checkpoint_path_str
+    )
+    if not looks_like_hf_repo:
+        raise FileNotFoundError(
+            f"Checkpoint file or directory not found: {checkpoint_path_str}\n"
+            f"If this is a HuggingFace repo ID, ensure it follows the format 'org/repo' or "
+            f"'org/repo/subfolder'"
+        )
+
+    logger.info("Detected HuggingFace repo ID: %s", checkpoint_path_str)
+    logger.info("Downloading from HuggingFace Hub...")
+
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        raise ImportError(
+            "huggingface_hub is required for downloading checkpoints. "
+            "Install with: pip install huggingface_hub"
+        )
+
+    # Authentication: .hf_token at the repo root -> HF_TOKEN env -> HF CLI login.
+    token_file = Path(__file__).parents[7] / ".hf_token"
+    if token_file.exists():
+        logger.info("Using HuggingFace token from project root: %s", token_file)
+        hf_token = _get_hf_token(token_file=str(token_file))
+    else:
+        hf_token = _get_hf_token(token_file=None)
+
+    parts = checkpoint_path_str.split("/")
+    repo_id = "/".join(parts[:2])
+    subfolder = "/".join(parts[2:]) if len(parts) > 2 else None
+
+    cache_dir = os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface/hub"))
+
+    try:
+        local_dir = snapshot_download(
+            repo_id=repo_id,
+            allow_patterns=[f"{subfolder}/*"] if subfolder else None,
+            cache_dir=cache_dir,
+            token=hf_token,
+            resume_download=True,
+        )
+    except Exception as e:
+        logger.error("Download failed: %s", e)
+        if "401" in str(e) or "403" in str(e):
+            raise RuntimeError(
+                f"Authentication failed. Please set HuggingFace token using one of:\n"
+                f"  1. Create .hf_token file: echo 'your_token' > .hf_token && chmod 600 .hf_token\n"
+                f"  2. Set environment variable: export HF_TOKEN=your_token\n"
+                f"  3. Login via CLI: huggingface-cli login\n"
+                f"Get your token from: https://huggingface.co/settings/tokens\n"
+                f"Accept the model license at: https://huggingface.co/{repo_id}"
+            ) from e
+        raise
+
+    resolved = Path(local_dir) / subfolder if subfolder else Path(local_dir)
+    logger.info("Downloaded to: %s", resolved)
+    return resolved
+
+
+def convert_hf_checkpoint(
+    checkpoint_path: Union[str, Path],
+    wan_config: WanConfig,
+    save_to: Optional[Union[str, Path]] = None,
+    *,
+    prefix: Optional[str] = None,
+    strict: bool = False,
+) -> StateDict:
+    """Convert a HuggingFace WAN checkpoint to Primus format.
+
+    Supports both local paths and HuggingFace repo IDs. If a repo ID is provided
+    (e.g. ``"Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer"``), the checkpoint will
+    be automatically downloaded from HuggingFace Hub.
+
+    Args:
+        checkpoint_path: Path to HF checkpoint OR HuggingFace repo ID
+                        (e.g. ``"Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer"``)
+        wan_config: WanConfig instance with model architecture info
+        save_to: Optional path to save converted checkpoint
+        prefix: Optional output key prefix (e.g. ``"transformer."``)
+        strict: Raise if any key is dropped or missing
+
+    Returns:
+        Dictionary of converted state dict (Primus format)
+
+    Example:
+        >>> from primus.backends.megatron.core.models.diffusion.wan import WanConfig
+        >>> config = WanConfig(hidden_size=1536, num_attention_heads=12, num_dit_layers=30)
+        >>> primus_sd = convert_hf_checkpoint(
+        ...     "Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer",
+        ...     wan_config=config,
+        ...     save_to="primus_wan21_t2v_1_3b.safetensors",
+        ... )
+    """
+    resolved = _resolve_checkpoint_path(checkpoint_path)
+
+    logger.info("Loading HuggingFace checkpoint from: %s", resolved)
+    hf_state_dict = _load_state_dict(resolved)
+    logger.info("Loaded %d keys from HuggingFace checkpoint", len(hf_state_dict))
+
+    primus_state_dict, _ = convert_hf_to_primus(hf_state_dict, wan_config, prefix=prefix, strict=strict)
+    logger.info("Conversion complete! Primus state dict has %d keys", len(primus_state_dict))
+
+    if save_to:
+        save_to = Path(save_to)
+        logger.info("Saving to: %s", save_to)
+        _save_state_dict(primus_state_dict, save_to)
+        logger.info("Saved successfully!")
+
+    return primus_state_dict
+
+
+# ---------------------------------------------------------------------------
+# Diffusers directory export (config.json + diffusion_pytorch_model.safetensors)
+# ---------------------------------------------------------------------------
+
+
+def wan_hf_config_dict(config: WanConfig) -> Dict[str, object]:
+    """Build a diffusers ``WanTransformer3DModel`` ``config.json`` payload."""
+    return {
+        "_class_name": "WanTransformer3DModel",
+        "_diffusers_version": "0.33.0.dev0",
+        "patch_size": list(config.patch_size_3d),
+        "num_attention_heads": config.num_attention_heads,
+        "attention_head_dim": config.hidden_size // config.num_attention_heads,
+        "in_channels": config.in_channels,
+        "out_channels": config.out_channels or config.in_channels,
+        "text_dim": config.text_embed_dim,
+        "freq_dim": config.freq_dim,
+        "ffn_dim": config.ffn_hidden_size,
+        "num_layers": config.num_dit_layers,
+        "cross_attn_norm": config.cross_attn_norm,
+        "qk_norm": config.qk_norm,
+        "eps": config.layernorm_epsilon,
+        "image_dim": config.image_dim,
+        "added_kv_proj_dim": config.added_kv_proj_dim,
+        "rope_max_seq_len": config.rope_max_seq_len,
+        "pos_embed_seq_len": config.pos_embed_seq_len,
+    }
+
+
+def export_hf_directory(
+    primus_state_dict: StateDict,
+    config: WanConfig,
+    export_dir: str,
+    *,
+    config_template: Optional[str] = None,
+    strict: bool = False,
+) -> ConversionReport:
+    """Write a diffusers-loadable export directory from a Primus WAN state dict.
+
+    Produces, for each backbone present:
+
+        <export_dir>/transformer/config.json
+        <export_dir>/transformer/diffusion_pytorch_model.safetensors
+        [<export_dir>/transformer_2/...]   # WAN 2.2 dual-expert
+
+    These are exactly the files ``WanTransformer3DModel.from_pretrained(
+    export_dir, subfolder="transformer")`` expects; the rest of the pipeline
+    (vae / text_encoder / tokenizer / scheduler) is loaded from the base WAN repo.
+
+    Args:
+        primus_state_dict: Primus WAN state dict (bare or ``transformer.`` /
+            ``transformer_2.`` prefixed).
+        config: ``WanConfig`` describing the model.
+        export_dir: Output directory root.
+        config_template: Optional path to an existing diffusers ``config.json``
+            to copy verbatim (e.g. the original HF transformer config). If
+            ``None``, the config is derived from ``config``.
+        strict: Raise if any key is dropped or missing.
+
+    Returns:
+        The :class:`ConversionReport` for the export.
+    """
+    from safetensors.torch import save_file as save_safetensors
+
+    report = ConversionReport(direction="primus->hf")
+    root = Path(export_dir)
+
+    if config_template is not None:
+        cfg_json = json.loads(Path(config_template).read_text())
+    else:
+        cfg_json = wan_hf_config_dict(config)
+
+    detected = _detect_backbone_prefixes(primus_state_dict)
+    # Bare input -> single "transformer" subfolder.
+    prefixes = detected or [None]
+
+    for prefix in prefixes:
+        bare = _strip_prefix(primus_state_dict, prefix) if prefix else dict(primus_state_dict)
+        conv = _convert_one_backbone(bare, config, "primus->hf", report)
+        subfolder = prefix.rstrip(".") if prefix else "transformer"
+        sub_dir = root / subfolder
+        sub_dir.mkdir(parents=True, exist_ok=True)
+        save_safetensors(
+            {k: v.contiguous() for k, v in conv.items()},
+            str(sub_dir / "diffusion_pytorch_model.safetensors"),
+        )
+        with open(sub_dir / "config.json", "w") as f:
+            json.dump(cfg_json, f, indent=2)
+        logger.info("Wrote diffusers backbone -> %s", sub_dir)
+
+    logger.info("%s", report.summary())
+    if strict:
+        report.raise_if_lossy()
+    return report
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers + CLI
+# ---------------------------------------------------------------------------
+
+
+def _load_state_dict(path: Path) -> StateDict:
+    """Load a state dict from .safetensors, a torch file, or a directory of shards."""
+    from safetensors.torch import load_file as load_safetensors
+
+    if path.is_dir():
+        sd: StateDict = {}
+        safes = sorted(path.glob("*.safetensors"))
+        if safes:
+            for f in safes:
+                logger.info("  Loading %s...", f.name)
+                sd.update(load_safetensors(str(f)))
+            return sd
+        pts = sorted([*path.glob("*.pt"), *path.glob("*.pth"), *path.glob("*.bin")])
+        if not pts:
+            raise FileNotFoundError(f"No checkpoint files under {path}")
+        loaded = torch.load(str(pts[0]), map_location="cpu", weights_only=False)
+        return loaded.get("state_dict", loaded)
+    if path.suffix == ".safetensors":
+        return load_safetensors(str(path))
+    loaded = torch.load(str(path), map_location="cpu", weights_only=False)
+    return loaded.get("state_dict", loaded)
+
+
+def _save_state_dict(state_dict: StateDict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix == ".safetensors":
+        from safetensors.torch import save_file as save_safetensors
+
+        save_safetensors({k: v.contiguous() for k, v in state_dict.items()}, str(path))
+    else:
+        torch.save(state_dict, str(path))
+
+
+def _config_from_args(args: argparse.Namespace) -> WanConfig:
+    if args.config_json:
+        with open(args.config_json, "r") as f:
+            overrides = json.load(f)
+    else:
+        overrides = {}
+    if isinstance(overrides.get("patch_size_3d"), list):
+        overrides["patch_size_3d"] = tuple(overrides["patch_size_3d"])
+    return WanConfig(**overrides)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert WAN checkpoints between HF diffusers and Primus layouts."
+    )
+    parser.add_argument(
+        "--direction",
+        required=True,
+        choices=["hf2primus", "primus2hf"],
+        help="Conversion direction.",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Input checkpoint file, directory, distributed-checkpoint directory, "
+        "or HuggingFace repo ID (hf2primus only).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output checkpoint file (.safetensors or .pt) for a raw state-dict conversion.",
+    )
+    parser.add_argument(
+        "--hf-export-dir",
+        default=None,
+        help="(primus2hf only) Write a diffusers-loadable directory: "
+        "<dir>/transformer/{config.json,diffusion_pytorch_model.safetensors} "
+        "(+ transformer_2/ for WAN 2.2). Use this for diffusers inference.",
+    )
+    parser.add_argument(
+        "--hf-config-template",
+        default=None,
+        help="(primus2hf export) Optional existing diffusers config.json to copy "
+        "verbatim into each subfolder instead of deriving it from --config-json.",
+    )
+    parser.add_argument(
+        "--config-json",
+        default=None,
+        help="Optional JSON file with WanConfig field overrides (hidden_size, num_dit_layers, ...).",
+    )
+    parser.add_argument(
+        "--prefix",
+        default=None,
+        help="Optional output key prefix (e.g. 'transformer.').",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if any key is dropped or missing.",
+    )
+    parser.add_argument(
+        "--report-json",
+        default=None,
+        help="Optional path to write the conversion report as JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    if args.hf_export_dir and args.direction != "primus2hf":
+        parser.error("--hf-export-dir is only valid with --direction primus2hf")
+    if not args.hf_export_dir and not args.output:
+        parser.error("either --output or --hf-export-dir is required")
+
+    config = _config_from_args(args)
+
+    input_path = Path(args.input)
+    if is_distributed_checkpoint(input_path):
+        if args.direction != "primus2hf":
+            parser.error(
+                "Distributed checkpoint (fsdp_dtensor) input is only supported " "with --direction primus2hf."
+            )
+        src = load_distcp_backbone_state_dict(input_path, config)
+    else:
+        src = _load_state_dict(_resolve_checkpoint_path(input_path))
+
+    if args.hf_export_dir:
+        report = export_hf_directory(
+            src,
+            config,
+            args.hf_export_dir,
+            config_template=args.hf_config_template,
+            strict=args.strict,
+        )
+        print(report.summary())
+        print(f"Wrote diffusers export -> {args.hf_export_dir}")
+    else:
+        if args.direction == "hf2primus":
+            out, report = convert_hf_to_primus(src, config, prefix=args.prefix, strict=args.strict)
+        else:
+            out, report = convert_primus_to_hf(src, config, prefix=args.prefix, strict=args.strict)
+
+        _save_state_dict(out, Path(args.output))
+        print(report.summary())
+        print(f"Wrote {len(out)} tensors -> {args.output}")
+
+    if args.report_json:
+        report_path = Path(args.report_json)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(report_path, "w") as f:
+            json.dump(
+                {
+                    "direction": report.direction,
+                    "mapped": report.mapped,
+                    "dropped": report.dropped,
+                    "missing": report.missing,
+                    "warnings": report.warnings,
+                },
+                f,
+                indent=2,
+            )
+        print(f"Wrote conversion report -> {args.report_json}")
+
+    return 0
+
+
+__all__ = [
+    "ConversionReport",
+    "expected_mcore_keys",
+    "expected_diffusers_keys",
+    "is_distributed_checkpoint",
+    "load_distcp_backbone_state_dict",
+    "convert_hf_to_primus",
+    "convert_primus_to_hf",
+    "convert_hf_checkpoint",
+    "wan_hf_config_dict",
+    "export_hf_directory",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/primus/backends/megatron/core/models/diffusion/wan/config.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/config.py
@@ -1,0 +1,346 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Configuration for WAN (2.1 / 2.2) video diffusion models.
+
+WAN is a 3D-video DiT family. ``WanConfig`` extends :class:`BaseDiffusionConfig`
+(which itself extends Megatron-Core's ``TransformerConfig``) and adds the
+video-specific and expert-routing fields consumed by ``Wan`` / ``Wan2_2``.
+
+The precision fields (``fp8_*``, ``mxfp4_*``, ``sensitive_layers_*``) are
+inherited from :class:`BaseDiffusionConfig` and shared with Flux; this module
+only declares what is genuinely WAN-specific.
+
+Strategy A constraints, enforced in :meth:`WanConfig.validate`:
+    - ``tensor_model_parallel_size == 1``
+    - ``pipeline_model_parallel_size == 1`` (also rejected by the base class)
+    - DP / FSDP, and optionally CP, only.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch.nn as nn
+
+from ..common.config import BaseDiffusionConfig
+
+# Expert-training stages for WAN 2.2 A14B. ``full`` trains the whole schedule
+# and is what every WAN 2.1 and TI2V-5B config uses.
+WAN_STAGES = ("full", "high_noise", "low_noise")
+
+# Timestep-weighting schemes for the flow-matching loss.
+#   "diffsynth" -- the DiffSynth WAN template weight (bell curve over the
+#                  shifted schedule, normalized to mean 1). This is what the
+#                  reference WAN training recipes use.
+#   "uniform"   -- unweighted MSE; every sample weighted 1.0.
+WAN_LOSS_WEIGHTINGS = ("diffsynth", "uniform")
+
+
+@dataclass
+class WanConfig(BaseDiffusionConfig):
+    """WAN-specific configuration.
+
+    Covers WAN 2.1 (single transformer, all sizes) and WAN 2.2 (single-DiT
+    TI2V-5B with ``num_transformers=1``, dual-expert A14B with
+    ``num_transformers=2`` and a ``boundary_ratio``).
+    """
+
+    # Model identification.
+    model_type: str = "wan"
+
+    # Placeholder depth for TransformerConfig; the real depth is
+    # ``num_dit_layers`` and is mirrored into ``num_layers`` in __post_init__.
+    num_layers: int = 1
+
+    # ------------------------------------------------------------------
+    # Architecture
+    # ------------------------------------------------------------------
+    hidden_size: int = 1536
+    num_attention_heads: int = 12
+    num_dit_layers: int = 30
+    ffn_hidden_size: int = 8960
+
+    # Latent video channels.
+    in_channels: int = 16
+    out_channels: Optional[int] = 16
+
+    # 3D patchification (temporal, height, width).
+    patch_size_3d: Tuple[int, int, int] = (1, 2, 2)
+
+    # Text conditioning (UMT5).
+    text_embed_dim: int = 4096
+    text_seq_len: int = 512
+
+    # Timestep embedding sinusoidal dimension.
+    freq_dim: int = 256
+
+    # Dropout (WAN backbone attention).
+    attention_dropout: float = 0.0
+    hidden_dropout: float = 0.0
+
+    # Normalization.
+    layernorm_epsilon: float = 1e-6
+
+    # ------------------------------------------------------------------
+    # Backbone architecture (diffusers WanTransformer3DModel parity)
+    # ------------------------------------------------------------------
+    # Rotary position embedding table length (diffusers ``rope_max_seq_len``).
+    rope_max_seq_len: int = 1024
+    # Query/key normalization scheme; diffusers uses RMSNorm over the inner dim.
+    qk_norm: str = "rms_norm_across_heads"
+    # Affine LayerNorm before cross-attention (diffusers ``cross_attn_norm``).
+    cross_attn_norm: bool = True
+    # Apply q/k RMSNorm across the full inner dim (heads * head_dim) instead of
+    # per head. WAN diffusers and Megatron-Bridge both normalize across heads,
+    # so this must stay True for checkpoint parity.
+    layernorm_across_heads: bool = True
+    # AdaLN-zero init: identity blocks plus a zeroed output head.
+    adaln_zero_init: bool = True
+    # I2V-only extras; None for T2V.
+    image_dim: Optional[int] = None
+    added_kv_proj_dim: Optional[int] = None
+    pos_embed_seq_len: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # Diffusion / scheduler
+    # ------------------------------------------------------------------
+    num_train_timesteps: int = 1000
+
+    # Per-timestep weighting applied to the flow-matching loss.
+    loss_weighting: str = "diffsynth"
+
+    # ------------------------------------------------------------------
+    # WAN 2.2 expert routing
+    # ------------------------------------------------------------------
+    num_transformers: int = 1
+    boundary_ratio: Optional[float] = None
+
+    # Which expert this job trains. ``full`` covers the whole schedule;
+    # ``high_noise`` / ``low_noise`` derive the timestep window and the weight
+    # subfolder from ``boundary_ratio`` so the two cannot disagree. This mirrors
+    # the ``stage`` field of the NeMo AutoModel WAN 2.2 preset.
+    stage: str = "full"
+
+    # Explicit per-expert training window, as a fraction of the schedule.
+    # Left at the full range unless ``stage`` narrows it; setting both is an
+    # error, since the derived and explicit windows would silently disagree.
+    timestep_window_min: float = 0.0
+    timestep_window_max: float = 1.0
+
+    # ------------------------------------------------------------------
+    # Pretrained weights
+    # ------------------------------------------------------------------
+    backbone_pretrained: Optional[str] = None
+    backbone_subfolder: str = "transformer"
+    backbone_subfolder_2: str = "transformer_2"
+
+    # ------------------------------------------------------------------
+    # Attention / linear implementation
+    # ------------------------------------------------------------------
+    # Mirrors Flux's ``transformer_impl``:
+    #   - "transformer_engine": TE linears + TENorm + TEDotProductAttention
+    #     (fused THD kernel, mcore fused RoPE). Requires TransformerEngine.
+    #   - "local": TE-free. Native Megatron parallel linears (or the
+    #     Primus-Turbo MXFP4/FP8 subclasses when ``fp4``/``fp8`` is set),
+    #     ``nn.RMSNorm`` q/k norm, and ``PrimusTurboLocalAttention`` with
+    #     unfused interleaved RoPE. torch.compile-friendly; needs Primus-Turbo.
+    transformer_impl: str = "transformer_engine"
+
+    # Compute the attention core in FP32 with unfused torch ops. Only for
+    # bit-exact parity investigations against a reference stack; there is no
+    # FP32 fused-attention backend, so this is far slower.
+    use_fp32_attention: bool = False
+
+    # CPU init keeps parity with the Flux path.
+    use_cpu_initialization: bool = True
+
+    def __post_init__(self):
+        """Post-initialization processing."""
+        # Mirror the real depth into num_layers BEFORE the base class runs, so
+        # BaseDiffusionConfig can validate the sensitive-layer counts against
+        # the true depth rather than the placeholder.
+        self.num_layers = self.num_dit_layers
+
+        # Normalize patch size to a tuple (YAML gives a list).
+        if isinstance(self.patch_size_3d, list):
+            self.patch_size_3d = tuple(self.patch_size_3d)
+
+        self._resolve_stage()
+
+        super().__post_init__()
+
+        # Xavier uniform initializers (parity with Flux defaults).
+        self.init_method = nn.init.xavier_uniform_
+        self.output_layer_init_method = nn.init.xavier_uniform_
+
+    def _resolve_stage(self) -> None:
+        """Derive the timestep window and weight subfolder from ``stage``."""
+        if self.stage not in WAN_STAGES:
+            raise ValueError(f"stage must be one of {WAN_STAGES}, got {self.stage!r}")
+
+        if self.stage == "full":
+            return
+
+        if self.boundary_ratio is None:
+            raise ValueError(
+                f"stage={self.stage!r} needs boundary_ratio to derive the timestep "
+                "window (WAN 2.2 A14B ships boundary_ratio=0.875)."
+            )
+
+        explicit_window = self.timestep_window_min != 0.0 or self.timestep_window_max != 1.0
+        if explicit_window:
+            raise ValueError(
+                f"stage={self.stage!r} derives timestep_window_min/max from "
+                "boundary_ratio; do not set them explicitly as well. Use "
+                "stage='full' if you want a hand-picked window."
+            )
+
+        if self.stage == "high_noise":
+            self.timestep_window_min = float(self.boundary_ratio)
+            self.timestep_window_max = 1.0
+            self.backbone_subfolder = "transformer"
+        else:
+            self.timestep_window_min = 0.0
+            self.timestep_window_max = float(self.boundary_ratio)
+            self.backbone_subfolder = "transformer_2"
+
+    def validate(self):
+        """Validate WAN configuration, including the Strategy A guards."""
+        super().validate()
+
+        if self.num_dit_layers <= 0:
+            raise ValueError(f"num_dit_layers must be positive, got {self.num_dit_layers}")
+
+        if len(self.patch_size_3d) != 3:
+            raise ValueError(f"patch_size_3d must have 3 elements, got {self.patch_size_3d}")
+
+        if self.num_transformers not in (1, 2):
+            raise ValueError(f"num_transformers must be 1 or 2, got {self.num_transformers}")
+
+        if self.num_transformers == 2 and self.boundary_ratio is None:
+            raise ValueError("WAN 2.2 dual-expert (num_transformers=2) requires boundary_ratio")
+
+        if self.boundary_ratio is not None and not (0.0 < self.boundary_ratio < 1.0):
+            raise ValueError(f"boundary_ratio must be in (0, 1), got {self.boundary_ratio}")
+
+        if not 0.0 <= self.timestep_window_min < self.timestep_window_max <= 1.0:
+            raise ValueError(
+                "timestep_window must satisfy 0 <= min < max <= 1, got "
+                f"[{self.timestep_window_min}, {self.timestep_window_max}]"
+            )
+
+        if self.loss_weighting not in WAN_LOSS_WEIGHTINGS:
+            raise ValueError(
+                f"loss_weighting must be one of {WAN_LOSS_WEIGHTINGS}, got {self.loss_weighting!r}"
+            )
+
+        if self.transformer_impl not in ("transformer_engine", "local"):
+            raise ValueError(
+                "transformer_impl must be 'transformer_engine' or 'local', " f"got {self.transformer_impl!r}"
+            )
+
+        # MXFP4 and FP8 are only wired into the TE-free local linears.
+        if getattr(self, "fp4", None) and self.transformer_impl != "local":
+            raise ValueError("fp4 (MXFP4) on WAN requires transformer_impl='local'")
+
+        if self.use_fp32_attention and self.transformer_impl != "transformer_engine":
+            raise ValueError(
+                "use_fp32_attention replaces the TE fused attention core and is "
+                "only implemented for transformer_impl='transformer_engine'"
+            )
+
+        # Strategy A: no tensor parallelism for the WAN backbone. (PP is
+        # rejected by BaseDiffusionConfig for every diffusion model.)
+        if self.tensor_model_parallel_size != 1:
+            raise ValueError(
+                "WAN Strategy A requires tensor_model_parallel_size=1, "
+                f"got {self.tensor_model_parallel_size}"
+            )
+
+    def get_num_layers(self) -> int:
+        """Number of DiT blocks in one transformer."""
+        return self.num_dit_layers
+
+    @property
+    def boundary_timestep(self) -> Optional[float]:
+        """Routing boundary on the ``[0, num_train_timesteps]`` axis."""
+        if self.boundary_ratio is None:
+            return None
+        return float(self.boundary_ratio) * float(self.num_train_timesteps)
+
+    @property
+    def timestep_window(self) -> Tuple[float, float]:
+        """Training timestep window as a fraction of the schedule."""
+        return (self.timestep_window_min, self.timestep_window_max)
+
+    # ------------------------------------------------------------------
+    # Presets
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def wan2_1_t2v_1_3b(cls, **kwargs) -> "WanConfig":
+        """WAN 2.1 T2V-1.3B (~1.11 B parameters)."""
+        defaults = dict(
+            hidden_size=1536,
+            num_attention_heads=12,
+            num_dit_layers=30,
+            ffn_hidden_size=8960,
+            in_channels=16,
+            out_channels=16,
+            num_transformers=1,
+            boundary_ratio=None,
+        )
+        defaults.update(kwargs)
+        return cls(**defaults)
+
+    @classmethod
+    def wan2_1_t2v_14b(cls, **kwargs) -> "WanConfig":
+        """WAN 2.1 T2V-14B."""
+        defaults = dict(
+            hidden_size=5120,
+            num_attention_heads=40,
+            num_dit_layers=40,
+            ffn_hidden_size=13824,
+            in_channels=16,
+            out_channels=16,
+            num_transformers=1,
+            boundary_ratio=None,
+        )
+        defaults.update(kwargs)
+        return cls(**defaults)
+
+    @classmethod
+    def wan2_2_ti2v_5b(cls, **kwargs) -> "WanConfig":
+        """WAN 2.2 TI2V-5B (single DiT, 48-channel VAE latents)."""
+        defaults = dict(
+            hidden_size=3072,
+            num_attention_heads=24,
+            num_dit_layers=30,
+            ffn_hidden_size=14336,
+            in_channels=48,
+            out_channels=48,
+            num_transformers=1,
+            boundary_ratio=None,
+        )
+        defaults.update(kwargs)
+        return cls(**defaults)
+
+    @classmethod
+    def wan2_2_t2v_a14b(cls, **kwargs) -> "WanConfig":
+        """WAN 2.2 T2V-A14B (dual expert, canonical boundary 0.875)."""
+        defaults = dict(
+            hidden_size=5120,
+            num_attention_heads=40,
+            num_dit_layers=40,
+            ffn_hidden_size=13824,
+            in_channels=16,
+            out_channels=16,
+            num_transformers=2,
+            boundary_ratio=0.875,
+        )
+        defaults.update(kwargs)
+        return cls(**defaults)
+
+
+__all__ = ["WanConfig", "WAN_STAGES", "WAN_LOSS_WEIGHTINGS"]

--- a/primus/backends/megatron/core/models/diffusion/wan/layer_spec.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/layer_spec.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Portions copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+WAN layer specifications for Megatron-Core integration.
+
+This module is WAN's equivalent of ``flux/layer_spec.py`` and plays the same
+role: one place where the backend (TransformerEngine, local, FP8, MXFP4) is
+resolved, and one place where a DiT block declares its submodules as
+``ModuleSpec``s. Before this existed, WAN re-derived the backend independently
+inside every attention module, every q/k norm, and every FFN.
+
+Three ``TransformerConfig`` clones are produced here, because WAN's attention,
+q/k norms, and FFN each need knobs pinned that must not leak into the rest of
+the backbone:
+
+    - the attention config pins kv_channels, MHA query groups, biases,
+      interleaved RoPE, and the ``thd`` qkv format,
+    - the norm config forces RMSNorm so the backend's norm builder produces an
+      RMSNorm for q/k,
+    - the FFN config pins GELU with fused bias-activation and no gated linear
+      unit, which is what Megatron-Bridge's WAN FFN uses.
+
+Unlike Flux, WAN does not yet return ``TransformerBlockSubmodules``: its
+backbone is an ``nn.ModuleList`` of blocks, and moving to a Megatron
+``TransformerBlock`` would change the checkpoint key layout. The spec surface
+here is deliberately shaped so that migration is a later, separable change.
+"""
+
+import copy
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch.nn.functional as F
+from megatron.core.transformer.enums import AttnMaskType
+from megatron.core.transformer.mlp import MLPSubmodules
+from megatron.core.transformer.spec_utils import ModuleSpec
+
+from ..common.backend_resolution import resolve_diffusion_backend, sensitive_layer_range
+from .attention import WanCrossAttentionSubmodules, WanSelfAttentionSubmodules
+
+
+@dataclass
+class WanLayerSpec:
+    """Everything one WAN DiT block needs to build itself.
+
+    ``self_attention`` / ``cross_attention`` / ``mlp`` are ``ModuleSpec``s whose
+    submodules were resolved from a single backend provider, so a block never
+    inspects ``config.transformer_impl`` itself.
+    """
+
+    self_attention: ModuleSpec
+    cross_attention: ModuleSpec
+    mlp: MLPSubmodules
+    attention_config: object
+    ffn_config: object
+    rope_config: object
+    norm_config: object
+
+
+def _attention_config(config):
+    """Config clone tuned for the WAN attention modules.
+
+    ``apply_rope_fusion`` and ``qkv_format='thd'`` match Megatron-Bridge's WAN
+    provider: it rotates q/k with the fused kernel and dispatches attention
+    through the packed thd path. The SBHD/no-mask path selects a different
+    fused-attention variant and leaves a residual per-layer gap, so the packed
+    layout is not optional for parity.
+    """
+    acfg = copy.copy(config)
+    head_dim = config.hidden_size // config.num_attention_heads
+    acfg.kv_channels = head_dim
+    acfg.num_query_groups = config.num_attention_heads
+    acfg.attention_dropout = 0.0
+    acfg.add_bias_linear = True
+    acfg.add_qkv_bias = True
+    acfg.rotary_interleaved = True
+    acfg.apply_rope_fusion = True
+    acfg.qkv_format = "thd"
+    return acfg
+
+
+def _norm_config(config):
+    """Config clone forcing RMSNorm, used only to build the q/k norms.
+
+    WAN's block norms are LayerNorm but its q/k norms are RMSNorm, and the norm
+    modules pick between the two from ``config.normalization`` rather than from
+    a constructor flag. Without this clone the q/k norms come out as LayerNorms,
+    which both changes the math (LayerNorm re-centers) and adds ``.bias``
+    entries that no WAN checkpoint contains.
+    """
+    ncfg = copy.copy(config)
+    ncfg.normalization = "RMSNorm"
+    return ncfg
+
+
+def _rope_config(acfg):
+    """Attention-config clone for the local (unfused) RoPE path.
+
+    The local path keeps q/k in SBHD and calls the unfused interleaved rotary,
+    so fusion is off while ``rotary_interleaved`` stays on.
+    """
+    rcfg = copy.copy(acfg)
+    rcfg.apply_rope_fusion = False
+    return rcfg
+
+
+def _ffn_config(config):
+    """Config clone for the WAN feed-forward ``MLP``, matching Megatron-Bridge.
+
+    With ``activation_func=F.gelu`` + ``bias_activation_fusion=True`` +
+    ``gated_linear_unit=False`` the MLP dispatches the fused ``bias_gelu_impl``,
+    which is the tanh approximation of GELU -- exactly diffusers'
+    ``gelu-approximate``.
+    """
+    fcfg = copy.copy(config)
+    fcfg.add_bias_linear = True
+    fcfg.gated_linear_unit = False
+    fcfg.activation_func = F.gelu
+    fcfg.bias_activation_fusion = True
+    return fcfg
+
+
+def get_wan_transformer_spec_for_backend(config, backend) -> WanLayerSpec:
+    """Build one WAN DiT block's spec from a single backend provider."""
+    from .attention import WanCrossAttention, WanSelfAttention
+
+    acfg = _attention_config(config)
+    ncfg = _norm_config(acfg)
+
+    # The local path uses full non-causal flash attention with no mask; the TE
+    # path uses the packed/padding kernel to match Megatron-Bridge.
+    attn_mask_type = AttnMaskType.no_mask if config.transformer_impl == "local" else AttnMaskType.padding
+
+    qk_norm = backend.layer_norm(rms_norm=True, for_qk=True)
+    column_linear = backend.column_parallel_linear()
+    row_linear = backend.row_parallel_linear()
+    core_attention = backend.core_attention()
+
+    self_attention = ModuleSpec(
+        module=WanSelfAttention,
+        params={"attn_mask_type": attn_mask_type},
+        submodules=WanSelfAttentionSubmodules(
+            linear_qkv=column_linear,
+            core_attention=core_attention,
+            q_layernorm=qk_norm,
+            k_layernorm=qk_norm,
+            linear_proj=row_linear,
+        ),
+    )
+
+    cross_attention = ModuleSpec(
+        module=WanCrossAttention,
+        params={"attn_mask_type": attn_mask_type},
+        submodules=WanCrossAttentionSubmodules(
+            linear_q=column_linear,
+            linear_kv=column_linear,
+            core_attention=core_attention,
+            q_layernorm=qk_norm,
+            k_layernorm=qk_norm,
+            linear_proj=row_linear,
+        ),
+    )
+
+    return WanLayerSpec(
+        self_attention=self_attention,
+        cross_attention=cross_attention,
+        mlp=MLPSubmodules(linear_fc1=column_linear, linear_fc2=row_linear),
+        attention_config=acfg,
+        ffn_config=_ffn_config(config),
+        rope_config=_rope_config(acfg),
+        norm_config=ncfg,
+    )
+
+
+def get_wan_layer_spec(
+    config,
+    backend: Optional[object] = None,
+) -> List[WanLayerSpec]:
+    """Per-layer specs for a WAN backbone.
+
+    Returns one :class:`WanLayerSpec` per DiT block. All layers are identical
+    unless ``sensitive_layers_enabled`` is set, in which case the first and last
+    N blocks are built from the higher-precision sensitive backend -- the same
+    heterogeneity Flux gets from ``get_flux_layer_spec``.
+
+    Args:
+        config: ``WanConfig``.
+        backend: Explicit ``BackendSpecProvider``; resolved from the config when
+            ``None``. Passing one disables sensitive-layer heterogeneity, since
+            the caller has taken over backend choice.
+
+    Example:
+        >>> config = WanConfig.wan2_1_t2v_1_3b()
+        >>> specs = get_wan_layer_spec(config)
+        >>> len(specs) == config.num_dit_layers
+        True
+    """
+    if backend is None:
+        backend, sensitive_backend = resolve_diffusion_backend(config)
+    else:
+        sensitive_backend = None
+
+    total = config.num_dit_layers
+    num_start, num_end = sensitive_layer_range(config, total) if sensitive_backend is not None else (0, 0)
+
+    specs = []
+    for i in range(total):
+        is_sensitive = (i < num_start) or (i >= total - num_end)
+        layer_backend = sensitive_backend if is_sensitive else backend
+        specs.append(get_wan_transformer_spec_for_backend(config, layer_backend))
+    return specs
+
+
+__all__ = [
+    "WanLayerSpec",
+    "get_wan_layer_spec",
+    "get_wan_transformer_spec_for_backend",
+]

--- a/primus/backends/megatron/core/models/diffusion/wan/layers.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/layers.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Portions copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+WAN building blocks: 3D rotary position embedding and condition embedders.
+
+Flux's counterpart is ``flux/layers.py`` (``EmbedND``), but none of it is
+reusable here: Flux embeds 2D image positions plus a text stream, whereas WAN
+embeds a 3D ``(frame, height, width)`` patch grid.
+"""
+
+import math
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from ..common.embeddings import Timesteps
+
+
+class WanRotaryPosEmbed(nn.Module):
+    """WAN 3D RoPE producing mcore ``apply_rotary_pos_emb`` frequencies.
+
+    Builds per-axis angle tables, concatenates the (frame, height, width)
+    slices for the patch grid, then doubles the last dim as
+    ``(a0, a0, a1, a1, ...)`` so mcore's interleaved rotary matches diffusers'
+    ``WanAttnProcessor`` interleaving.
+
+    Output: ``[S, 1, 1, head_dim]`` angles, pre cos/sin.
+    """
+
+    def __init__(self, head_dim: int, max_seq_len: int = 1024, theta: float = 10000.0):
+        super().__init__()
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        # The temporal axis takes the remainder so t + h + w == head_dim / 2.
+        h = head_dim // 6
+        freqs = torch.cat(
+            [
+                self._rope_params(max_seq_len, head_dim - 4 * h, theta),
+                self._rope_params(max_seq_len, 2 * h, theta),
+                self._rope_params(max_seq_len, 2 * h, theta),
+            ],
+            dim=1,
+        )
+        self.register_buffer("freqs", freqs, persistent=False)
+
+    @staticmethod
+    def _rope_params(max_seq_len: int, dim: int, theta: float) -> Tensor:
+        if dim % 2 != 0:
+            raise ValueError(f"RoPE axis dim must be even, got {dim}")
+        return torch.outer(
+            torch.arange(max_seq_len, dtype=torch.float32),
+            1.0 / torch.pow(theta, torch.arange(0, dim, 2, dtype=torch.float32) / dim),
+        )
+
+    def forward(self, num_frames: int, height: int, width: int, device: torch.device) -> Tensor:
+        c = self.head_dim // 2
+        freqs = self.freqs.to(device).split([c - 2 * (c // 3), c // 3, c // 3], dim=1)
+
+        f, hgt, wid = num_frames, height, width
+        seq_len = f * hgt * wid
+        fi = torch.cat(
+            [
+                freqs[0][:f].view(f, 1, 1, -1).expand(f, hgt, wid, -1),
+                freqs[1][:hgt].view(1, hgt, 1, -1).expand(f, hgt, wid, -1),
+                freqs[2][:wid].view(1, 1, wid, -1).expand(f, hgt, wid, -1),
+            ],
+            dim=-1,
+        ).reshape(seq_len, 1, 1, -1)
+        fi = fi.unsqueeze(-1).expand(-1, -1, -1, -1, 2).reshape(seq_len, 1, 1, self.head_dim)
+        return fi.contiguous()
+
+
+class WanTimestepEmbedding(nn.Module):
+    """diffusers ``TimestepEmbedding``: linear_1 -> SiLU -> linear_2."""
+
+    def __init__(self, in_channels: int, time_embed_dim: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_channels, time_embed_dim)
+        self.act = nn.SiLU()
+        self.linear_2 = nn.Linear(time_embed_dim, time_embed_dim)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.linear_2(self.act(self.linear_1(x)))
+
+
+class WanTextProjection(nn.Module):
+    """diffusers ``PixArtAlphaTextProjection(act_fn='gelu_tanh')``."""
+
+    def __init__(self, in_features: int, hidden_size: int):
+        super().__init__()
+        self.linear_1 = nn.Linear(in_features, hidden_size)
+        self.act_1 = nn.GELU(approximate="tanh")
+        self.linear_2 = nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.linear_2(self.act_1(self.linear_1(x)))
+
+
+class WanConditionEmbedder(nn.Module):
+    """diffusers ``WanTimeTextImageEmbedding`` for T2V (no image branch).
+
+    Returns ``(temb, timestep_proj, text_ctx)`` where ``temb`` drives the final
+    AdaLN and ``timestep_proj`` (``dim * 6``) drives per-block AdaLN modulation.
+    """
+
+    def __init__(self, dim: int, time_freq_dim: int, time_proj_dim: int, text_embed_dim: int):
+        super().__init__()
+        self.timesteps_proj = Timesteps(
+            embedding_dim=time_freq_dim, flip_sin_to_cos=True, downscale_freq_shift=0
+        )
+        self.time_embedder = WanTimestepEmbedding(time_freq_dim, dim)
+        self.act_fn = nn.SiLU()
+        self.time_proj = nn.Linear(dim, time_proj_dim)
+        self.text_embedder = WanTextProjection(text_embed_dim, dim)
+
+    def forward(self, timestep: Tensor, encoder_hidden_states: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+        # ``Timesteps`` casts back to the input dtype, so feed it a float to
+        # avoid truncating the sinusoid when ``timestep`` is integer.
+        if not torch.is_floating_point(timestep):
+            timestep = timestep.float()
+        timestep = self.timesteps_proj(timestep)
+
+        weight_dtype = self.time_embedder.linear_1.weight.dtype
+        if timestep.dtype != weight_dtype:
+            timestep = timestep.to(weight_dtype)
+
+        temb = self.time_embedder(timestep).type_as(encoder_hidden_states)
+        timestep_proj = self.time_proj(self.act_fn(temb))
+        text_ctx = self.text_embedder(encoder_hidden_states)
+        return temb, timestep_proj, text_ctx
+
+
+def thd_cu_seqlens(seqlen: int, batch: int, device: torch.device) -> Tensor:
+    """Cumulative sequence lengths for ``batch`` sequences of ``seqlen`` tokens.
+
+    ``[0, seqlen, 2*seqlen, ..., batch*seqlen]`` as int32, the layout
+    ``TEDotProductAttention`` and the fused THD RoPE expect for packed
+    sequences.
+    """
+    return torch.arange(0, batch + 1, dtype=torch.int32, device=device) * int(seqlen)
+
+
+def unfused_fp32_attention(query, key, value, packed_seq_params) -> Tensor:
+    """Scaled dot-product attention over packed THD sequences in plain fp32.
+
+    ``query``/``key``/``value`` are ``[T, H, D]`` packed in THD layout, with
+    ``cu_seqlens_{q,kv}`` delimiting the individual sequences so
+    cross-attention's differing q/kv lengths work. Returns ``[T, H*D]``.
+
+    Deliberately bare ``matmul`` + ``softmax``: there is no fp32 fused
+    attention backend, and this path exists so a parity run can be bit-exact
+    against a reference stack running the same routine.
+    """
+    heads, head_dim = query.shape[1], query.shape[2]
+    scale = 1.0 / math.sqrt(head_dim)
+    cu_q = packed_seq_params.cu_seqlens_q
+    cu_kv = packed_seq_params.cu_seqlens_kv
+    outs = []
+    for i in range(cu_q.numel() - 1):
+        qs, qe = int(cu_q[i]), int(cu_q[i + 1])
+        ks, ke = int(cu_kv[i]), int(cu_kv[i + 1])
+        q = query[qs:qe].transpose(0, 1)
+        k = key[ks:ke].transpose(0, 1)
+        v = value[ks:ke].transpose(0, 1)
+        scores = torch.matmul(q, k.transpose(-1, -2)) * scale
+        probs = torch.softmax(scores, dim=-1)
+        ctx = torch.matmul(probs, v)
+        outs.append(ctx.transpose(0, 1).reshape(qe - qs, heads * head_dim))
+    return torch.cat(outs, dim=0)
+
+
+__all__ = [
+    "WanRotaryPosEmbed",
+    "WanTimestepEmbedding",
+    "WanTextProjection",
+    "WanConditionEmbedder",
+    "thd_cu_seqlens",
+    "unfused_fp32_attention",
+]

--- a/primus/backends/megatron/core/models/diffusion/wan/model.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/model.py
@@ -33,6 +33,7 @@ import torch.utils.checkpoint
 from megatron.core.process_groups_config import ProcessGroupCollection
 from megatron.core.transformer.mlp import MLP
 from megatron.core.transformer.spec_utils import build_module
+from megatron.core.transformer.transformer_layer import TransformerLayer
 from megatron.core.transformer.utils import sharded_state_dict_default
 from safetensors.torch import load_file as load_safetensors
 from torch import Tensor
@@ -56,6 +57,10 @@ class WanTransformerBlock(nn.Module):
         super().__init__()
         dim = config.hidden_size
         eps = config.layernorm_epsilon
+
+        # Carried so the block satisfies the one TransformerLayer attribute
+        # Megatron reads off an FSDP unit (see the registration below).
+        self.layer_number = layer_number
 
         self.norm1 = nn.LayerNorm(dim, eps=eps, elementwise_affine=False)
         self.attn1 = build_module(
@@ -115,6 +120,44 @@ class WanTransformerBlock(nn.Module):
         if ff_bias is not None:
             ff_out = ff_out + ff_bias
         return hidden_states + c_gate_msa * ff_out
+
+
+# Make the block a Megatron-FSDP sharding unit.
+#
+# Megatron-FSDP gathers and releases parameters at the granularity of its "FSDP
+# unit modules". When the caller passes none -- and ``megatron/training/
+# training.py`` never does, it builds the wrapper with no ``fsdp_unit_modules``
+# argument and ``DistributedDataParallelConfig`` has no field for one -- the
+# adapter falls back to ``[TransformerLayer]`` for the ``optim_grads_params``
+# strategy WAN runs under. ``WanTransformerBlock`` deliberately is not a
+# Megatron ``TransformerLayer`` (see ``layer_spec.py`` on why WAN does not build
+# on ``TransformerBlock``), so that default matched zero modules and left the
+# unit list empty.
+#
+# An empty unit list costs more than coarse sharding. The hook-registration loop
+# skips modules that live inside a registered unit; with nothing registered that
+# skip never fires, so every norm, linear and attention in all 30 blocks takes a
+# pre-forward unshard hook plus an fp8-transpose-cache post-hook that a bf16 run
+# has no use for. Any hook forces ``nn.Module._call_impl`` off its no-hook fast
+# path, so the Dynamo graph breaks at every submodule boundary inside a block
+# instead of only at the block boundary.
+#
+# Registering as a virtual subclass makes Megatron's own default match the
+# block. The alternatives were worse: Megatron-LM is an upstream submodule so
+# the argument cannot be plumbed through ``training.py``, and real inheritance
+# from ``TransformerLayer`` would change the checkpoint key layout.
+#
+# Eager trades a little step time for peak memory, because the per-block
+# all-gathers cost more collective time than one whole-model gather. Compiled
+# improves on both, as the de-fragmented graph lets Inductor drop casts it
+# previously could not elide across a break. Loss is unchanged.
+#
+# ``register`` only affects ``isinstance``. The other Megatron sites that test
+# for ``TransformerLayer`` are either unreachable for WAN (CUDA graphs, Mamba
+# and hybrid blocks, GPT callables) or keyed on ``layers.N`` parameter names,
+# and WAN's are ``blocks.N``; ``layer_number`` is set above for the one
+# attribute the FSDP-DTensor checkpoint path would read.
+TransformerLayer.register(WanTransformerBlock)
 
 
 class WanTransformer3D(nn.Module):

--- a/primus/backends/megatron/core/models/diffusion/wan/model.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/model.py
@@ -1,0 +1,497 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Portions copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+WAN (2.1 / 2.2) video diffusion models on Megatron-Core.
+
+Two model classes, selected by ``config.num_transformers``:
+
+    - :class:`Wan` -- one denoiser. Covers all of WAN 2.1 and the WAN 2.2
+      single-DiT TI2V-5B.
+    - :class:`Wan2_2` -- two denoisers with per-sample routing on the timestep
+      boundary. Covers WAN 2.2 A14B.
+
+The backbone keeps the WAN scaffolding (Conv3d patch embed, time/text condition
+embedders, ``scale_shift_table`` AdaLN modulation, output head) and builds its
+attention and FFN from the backend-resolved specs in ``layer_spec.py``.
+
+The transformer stack runs sequence-major ``[S, B, dim]`` end to end, matching
+Megatron-Bridge: AdaLN modulation, the LayerNorms, residuals, and the attention
+core all operate on that layout, so the block GEMMs dispatch identical kernels.
+Tokens are transposed into ``[S, B, dim]`` after the patch embed and back to
+``[B, S, dim]`` before the final unpatchify.
+"""
+
+import math
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import torch
+import torch.nn as nn
+import torch.utils.checkpoint
+from megatron.core.process_groups_config import ProcessGroupCollection
+from megatron.core.transformer.mlp import MLP
+from megatron.core.transformer.spec_utils import build_module
+from megatron.core.transformer.utils import sharded_state_dict_default
+from safetensors.torch import load_file as load_safetensors
+from torch import Tensor
+
+from ...common.diffusion_module.diffusion_module import DiffusionModule
+from .config import WanConfig
+from .layer_spec import WanLayerSpec, get_wan_layer_spec
+from .layers import WanConditionEmbedder, WanRotaryPosEmbed
+from .utils import fold_patches_into_batch, patch_grid, unpatchify
+
+
+class WanTransformerBlock(nn.Module):
+    """One WAN DiT block: gated self-attention, cross-attention, gated FFN.
+
+    AdaLN modulation, the LayerNorms, and the residual adds run in the tensor's
+    native dtype with plain ``nn.LayerNorm`` -- Megatron-Bridge's
+    normalize/modulate/scale-add math, not the diffusers explicit-fp32 path.
+    """
+
+    def __init__(self, config: WanConfig, spec: WanLayerSpec, layer_number: int):
+        super().__init__()
+        dim = config.hidden_size
+        eps = config.layernorm_epsilon
+
+        self.norm1 = nn.LayerNorm(dim, eps=eps, elementwise_affine=False)
+        self.attn1 = build_module(
+            spec.self_attention,
+            config=spec.attention_config,
+            submodules=spec.self_attention.submodules,
+            layer_number=layer_number,
+            rope_config=spec.rope_config,
+            norm_config=spec.norm_config,
+        )
+        self.attn2 = build_module(
+            spec.cross_attention,
+            config=spec.attention_config,
+            submodules=spec.cross_attention.submodules,
+            layer_number=layer_number,
+            norm_config=spec.norm_config,
+        )
+        self.norm2 = (
+            nn.LayerNorm(dim, eps=eps, elementwise_affine=True) if config.cross_attn_norm else nn.Identity()
+        )
+        self.ffn = MLP(
+            config=spec.ffn_config,
+            submodules=spec.mlp,
+            ffn_hidden_size=config.ffn_hidden_size,
+        )
+        self.norm3 = nn.LayerNorm(dim, eps=eps, elementwise_affine=False)
+        self.scale_shift_table = nn.Parameter(torch.randn(1, 6, dim) / dim**0.5)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        temb: Tensor,
+        rotary_freqs: Tensor,
+    ) -> Tensor:
+        # temb is [B, 6, dim]; transposing gives modulation terms of [1, B, dim]
+        # so they broadcast over the sequence-major activations.
+        mod = (self.scale_shift_table + temb).transpose(0, 1)
+        shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = mod.chunk(6, dim=0)
+
+        norm_h = self.norm1(hidden_states) * (1 + scale_msa) + shift_msa
+        attn_out, attn_bias = self.attn1(norm_h, rotary_freqs)
+        if attn_bias is not None:
+            attn_out = attn_out + attn_bias
+        hidden_states = hidden_states + gate_msa * attn_out
+
+        norm_h = self.norm2(hidden_states)
+        attn_out, attn_bias = self.attn2(norm_h, encoder_hidden_states)
+        if attn_bias is not None:
+            attn_out = attn_out + attn_bias
+        hidden_states = hidden_states + attn_out
+
+        norm_h = self.norm3(hidden_states) * (1 + c_scale_msa) + c_shift_msa
+        # The mcore MLP returns (output, fc2_bias) under skip_bias_add; diffusers
+        # folds that bias in before the gate scaling, so add it here.
+        ff_out, ff_bias = self.ffn(norm_h)
+        if ff_bias is not None:
+            ff_out = ff_out + ff_bias
+        return hidden_states + c_gate_msa * ff_out
+
+
+class WanTransformer3D(nn.Module):
+    """WAN video DiT backbone.
+
+    Input  ``hidden_states``: ``[B, C_in, T, H, W]``
+    Output velocity        : ``[B, C_out, T, H, W]``
+    """
+
+    def __init__(self, config: WanConfig):
+        super().__init__()
+        self.config = config
+        self.patch_size_3d = tuple(config.patch_size_3d)
+        self.in_channels = config.in_channels
+        self.out_channels = config.out_channels or config.in_channels
+        self.hidden_size = config.hidden_size
+
+        dim = config.hidden_size
+        head_dim = dim // config.num_attention_heads
+
+        self.rope = WanRotaryPosEmbed(head_dim, config.rope_max_seq_len)
+        self.patch_embedding = nn.Conv3d(
+            self.in_channels, dim, kernel_size=self.patch_size_3d, stride=self.patch_size_3d
+        )
+
+        self.condition_embedder = WanConditionEmbedder(
+            dim=dim,
+            time_freq_dim=config.freq_dim,
+            time_proj_dim=dim * 6,
+            text_embed_dim=config.text_embed_dim,
+        )
+
+        layer_specs = get_wan_layer_spec(config)
+        self.blocks = nn.ModuleList(
+            [WanTransformerBlock(config, spec, layer_number=i + 1) for i, spec in enumerate(layer_specs)]
+        )
+
+        self.norm_out = nn.LayerNorm(dim, eps=config.layernorm_epsilon, elementwise_affine=False)
+        self.proj_out = nn.Linear(dim, self.out_channels * math.prod(self.patch_size_3d))
+        self.scale_shift_table = nn.Parameter(torch.randn(1, 2, dim) / dim**0.5)
+
+        self.gradient_checkpointing = getattr(config, "recompute_granularity", None) == "full"
+
+        if config.adaln_zero_init:
+            self._init_adaln_zero()
+
+    def _init_adaln_zero(self) -> None:
+        """AdaLN-zero init: identity blocks plus a zeroed output head."""
+        for block in self.blocks:
+            nn.init.zeros_(block.scale_shift_table)
+        nn.init.zeros_(self.condition_embedder.time_proj.weight)
+        if self.condition_embedder.time_proj.bias is not None:
+            nn.init.zeros_(self.condition_embedder.time_proj.bias)
+        nn.init.zeros_(self.proj_out.weight)
+        if self.proj_out.bias is not None:
+            nn.init.zeros_(self.proj_out.bias)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        timestep: Tensor,
+        encoder_hidden_states: Tensor,
+        attention_kwargs: Optional[Dict[str, Any]] = None,  # noqa: ARG002
+        return_dict: bool = False,  # noqa: ARG002
+    ) -> Tensor:
+        batch_size = hidden_states.shape[0]
+        grid = patch_grid(
+            hidden_states.shape[2],
+            hidden_states.shape[3],
+            hidden_states.shape[4],
+            self.patch_size_3d,
+        )
+        ppf, pph, ppw = grid
+
+        rotary_freqs = self.rope(ppf, pph, ppw, hidden_states.device)
+
+        x = fold_patches_into_batch(hidden_states, self.in_channels, self.patch_size_3d)
+        x = self.patch_embedding(x)
+        hs = x.reshape(batch_size, ppf * pph * ppw, -1)
+        hs = hs.transpose(0, 1).contiguous()
+
+        temb, timestep_proj, enc = self.condition_embedder(timestep, encoder_hidden_states)
+        timestep_proj = timestep_proj.unflatten(1, (6, -1))
+        enc = enc.transpose(0, 1).contiguous()
+
+        if self.gradient_checkpointing and self.training and torch.is_grad_enabled():
+            for block in self.blocks:
+                hs = torch.utils.checkpoint.checkpoint(
+                    block, hs, enc, timestep_proj, rotary_freqs, use_reentrant=False
+                )
+        else:
+            for block in self.blocks:
+                hs = block(hs, enc, timestep_proj, rotary_freqs)
+
+        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).transpose(0, 1).chunk(2, dim=0)
+        hs = self.norm_out(hs) * (1 + scale) + shift
+        hs = self.proj_out(hs)
+        hs = hs.transpose(0, 1).contiguous()
+
+        return unpatchify(hs, batch_size, grid, self.patch_size_3d)
+
+
+def _load_backbone_checkpoint(
+    backbone: nn.Module, checkpoint_path: str, subfolder: Optional[str] = None
+) -> None:
+    """Load a fused-qkv WAN backbone checkpoint.
+
+    Accepts a ``.safetensors`` file, a ``.pt``/``.pth`` file, or a directory of
+    ``.safetensors`` shards. The checkpoint must already be in the fused
+    ``linear_qkv`` layout produced by ``checkpoint_converter``; a raw diffusers
+    checkpoint with split ``to_q``/``to_k``/``to_v`` will not load.
+    """
+    path = Path(checkpoint_path)
+    if subfolder:
+        path = path / subfolder
+
+    state_dict: Dict[str, Tensor] = {}
+    if path.is_dir():
+        shards = sorted(path.glob("*.safetensors"))
+        if shards:
+            for shard in shards:
+                state_dict.update(load_safetensors(str(shard)))
+        else:
+            pt_files = sorted([*path.glob("*.pt"), *path.glob("*.pth")])
+            if not pt_files:
+                raise FileNotFoundError(f"No checkpoint files found under {path}")
+            loaded = torch.load(str(pt_files[0]), map_location="cpu", weights_only=True)
+            state_dict = loaded.get("state_dict", loaded)
+    elif path.suffix == ".safetensors":
+        state_dict = load_safetensors(str(path))
+    else:
+        loaded = torch.load(str(path), map_location="cpu", weights_only=True)
+        state_dict = loaded.get("state_dict", loaded)
+
+    missing, unexpected = backbone.load_state_dict(state_dict, strict=False)
+    missing = [k for k in missing if not k.endswith("_extra_state")]
+    unexpected = [k for k in unexpected if not k.endswith("_extra_state")]
+    if missing:
+        raise RuntimeError(
+            f"WAN backbone checkpoint is missing {len(missing)} keys "
+            f"(first 5: {missing[:5]}). Expected a fused-qkv checkpoint from "
+            "convert_wan_hf_to_primus.py."
+        )
+    if unexpected:
+        raise RuntimeError(
+            f"WAN backbone checkpoint has {len(unexpected)} unexpected keys " f"(first 5: {unexpected[:5]})."
+        )
+
+
+def build_wan_backbone(config: WanConfig, subfolder: str) -> nn.Module:
+    """Build a WAN backbone and optionally load pretrained weights into it."""
+    backbone = WanTransformer3D(config)
+    if config.backbone_pretrained:
+        _load_backbone_checkpoint(backbone, checkpoint_path=config.backbone_pretrained, subfolder=subfolder)
+    return backbone
+
+
+class Wan(DiffusionModule):
+    """WAN with a single transformer denoiser.
+
+    Covers WAN 2.1 at every size and the WAN 2.2 single-DiT TI2V-5B. Both share
+    one call signature and one training objective (weighted flow matching).
+
+    Args:
+        config: ``WanConfig`` with ``num_transformers == 1``.
+        encoder_configs: Optional encoder configs (Wan VAE, UMT5). Only the
+            on-the-fly encoding path needs them; pre-encoded training does not.
+        pg_collection: Process groups for distributed training. Under Strategy A
+            this is effectively ``(DP, CP)`` with TP=PP=1.
+    """
+
+    def __init__(
+        self,
+        config: WanConfig,
+        encoder_configs: Optional[Dict[str, Any]] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ):
+        if config.num_transformers != 1:
+            raise ValueError(
+                "Wan expects num_transformers=1; use Wan2_2 for dual-expert models "
+                f"(got num_transformers={config.num_transformers})"
+            )
+
+        super().__init__(
+            config=config,
+            pg_collection=pg_collection,
+            encoder_configs=encoder_configs,
+        )
+
+        self.transformer = build_wan_backbone(config, config.backbone_subfolder)
+
+    def set_input_tensor(self, input_tensor) -> None:
+        """Accept Megatron's pipeline input tensor.
+
+        Diffusion models run with PP=1 so there is no inter-stage activation to
+        wire in, but the forward-backward schedules call this on every model
+        chunk, so the hook has to exist.
+        """
+        if isinstance(input_tensor, (list, tuple)):
+            input_tensor = input_tensor[0] if len(input_tensor) > 0 else None
+        self.input_tensor = input_tensor
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        timestep: Tensor,
+        encoder_hidden_states: Tensor,
+        *,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,  # noqa: ARG002
+    ) -> Tensor:
+        """Predict the flow-matching velocity.
+
+        Args:
+            hidden_states: ``[B, C, T, H, W]`` noisy latents.
+            timestep: ``[B]`` timesteps on the ``[0, num_train_timesteps]`` axis.
+            encoder_hidden_states: ``[B, S_txt, D_txt]`` UMT5 features.
+            attention_kwargs: Forwarded to the backbone.
+
+        Returns:
+            ``[B, C, T, H, W]`` velocity prediction.
+        """
+        return self.transformer(
+            hidden_states=hidden_states,
+            timestep=timestep,
+            encoder_hidden_states=encoder_hidden_states,
+            attention_kwargs=attention_kwargs,
+            return_dict=False,
+        )
+
+    def sharded_state_dict(
+        self,
+        prefix: str = "",
+        sharded_offsets: tuple = (),
+        metadata: Optional[dict] = None,
+    ) -> Dict[str, Any]:
+        """Sharded state dict under the diffusers-compatible ``transformer.`` prefix."""
+        sharded: Dict[str, Any] = {}
+        for name, module in self.named_children():
+            sharded.update(sharded_state_dict_default(module, f"{prefix}{name}.", sharded_offsets, metadata))
+        return sharded
+
+
+class Wan2_2(DiffusionModule):
+    """WAN 2.2 A14B: two experts routed per sample on the timestep boundary.
+
+    Samples with ``timestep >= boundary`` go to ``transformer`` (high noise),
+    the rest to ``transformer_2`` (low noise). Submodule names match the HF
+    diffusers ``Wan-AI/Wan2.2-T2V-A14B-Diffusers`` layout.
+    """
+
+    def __init__(
+        self,
+        config: WanConfig,
+        encoder_configs: Optional[Dict[str, Any]] = None,
+        pg_collection: Optional[ProcessGroupCollection] = None,
+    ):
+        if config.num_transformers != 2:
+            raise ValueError(
+                "Wan2_2 expects num_transformers=2; use Wan for single-transformer "
+                f"models (got num_transformers={config.num_transformers})"
+            )
+        if config.boundary_ratio is None:
+            raise ValueError("Wan2_2 requires boundary_ratio to route samples between experts")
+
+        super().__init__(
+            config=config,
+            pg_collection=pg_collection,
+            encoder_configs=encoder_configs,
+        )
+
+        self.default_boundary_timestep = config.boundary_timestep
+        self.transformer = build_wan_backbone(config, config.backbone_subfolder)
+        self.transformer_2 = build_wan_backbone(config, config.backbone_subfolder_2)
+
+    def set_input_tensor(self, input_tensor) -> None:
+        """Accept Megatron's pipeline input tensor (PP=1, so nothing to wire)."""
+        if isinstance(input_tensor, (list, tuple)):
+            input_tensor = input_tensor[0] if len(input_tensor) > 0 else None
+        self.input_tensor = input_tensor
+
+    def _resolve_boundary(self, timestep: Tensor, boundary_timestep: Optional[Tensor]) -> Tensor:
+        """Broadcast the routing boundary to ``[B]``."""
+        if boundary_timestep is None:
+            return torch.full_like(timestep, fill_value=self.default_boundary_timestep)
+        if isinstance(boundary_timestep, (float, int)):
+            return torch.full_like(timestep, fill_value=float(boundary_timestep))
+
+        boundary_timestep = boundary_timestep.to(device=timestep.device, dtype=timestep.dtype)
+        if boundary_timestep.shape == timestep.shape:
+            return boundary_timestep
+        try:
+            return boundary_timestep.expand_as(timestep)
+        except RuntimeError as exc:
+            raise ValueError(
+                f"boundary_timestep shape {tuple(boundary_timestep.shape)} is not "
+                f"broadcastable to timestep shape {tuple(timestep.shape)}"
+            ) from exc
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        timestep: Tensor,
+        encoder_hidden_states: Tensor,
+        *,
+        boundary_timestep: Optional[Tensor] = None,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,  # noqa: ARG002
+    ) -> Tensor:
+        """Dual-expert forward with per-sample routing.
+
+        Args:
+            hidden_states: ``[B, C, T, H, W]`` noisy latents.
+            timestep: ``[B]`` timesteps on the ``[0, num_train_timesteps]`` axis
+                (post-shift during training, matching diffusers inference).
+            encoder_hidden_states: ``[B, S_txt, D_txt]`` UMT5 features.
+            boundary_timestep: Optional ``[B]`` or scalar override of the
+                routing boundary, on the same axis as ``timestep``. Defaults to
+                ``boundary_ratio * num_train_timesteps``.
+            attention_kwargs: Forwarded to the backbones.
+
+        Returns:
+            ``[B, C, T, H, W]`` velocity prediction, reassembled in input order.
+        """
+        boundary = self._resolve_boundary(timestep, boundary_timestep)
+        high_mask = timestep >= boundary
+
+        def run(backbone, latents, ts, ctx):
+            return backbone(
+                hidden_states=latents,
+                timestep=ts,
+                encoder_hidden_states=ctx,
+                attention_kwargs=attention_kwargs,
+                return_dict=False,
+            )
+
+        if bool(torch.all(high_mask)):
+            return run(self.transformer, hidden_states, timestep, encoder_hidden_states)
+        if not bool(torch.any(high_mask)):
+            return run(self.transformer_2, hidden_states, timestep, encoder_hidden_states)
+
+        high_idx = high_mask.nonzero(as_tuple=False).squeeze(-1)
+        low_idx = (~high_mask).nonzero(as_tuple=False).squeeze(-1)
+
+        out_high = run(
+            self.transformer,
+            hidden_states.index_select(0, high_idx),
+            timestep.index_select(0, high_idx),
+            encoder_hidden_states.index_select(0, high_idx),
+        )
+        out_low = run(
+            self.transformer_2,
+            hidden_states.index_select(0, low_idx),
+            timestep.index_select(0, low_idx),
+            encoder_hidden_states.index_select(0, low_idx),
+        )
+
+        output = torch.empty_like(hidden_states)
+        output.index_copy_(0, high_idx, out_high.to(output.dtype))
+        output.index_copy_(0, low_idx, out_low.to(output.dtype))
+        return output
+
+    def sharded_state_dict(
+        self,
+        prefix: str = "",
+        sharded_offsets: tuple = (),
+        metadata: Optional[dict] = None,
+    ) -> Dict[str, Any]:
+        """Sharded state dict over both experts.
+
+        Prefixes stay ``{prefix}transformer.*`` and ``{prefix}transformer_2.*``
+        so checkpoints remain interoperable with the diffusers A14B layout.
+        """
+        sharded: Dict[str, Any] = {}
+        for name, module in self.named_children():
+            sharded.update(sharded_state_dict_default(module, f"{prefix}{name}.", sharded_offsets, metadata))
+        return sharded
+
+
+__all__ = ["Wan", "Wan2_2", "WanTransformer3D", "WanTransformerBlock", "build_wan_backbone"]

--- a/primus/backends/megatron/core/models/diffusion/wan/utils.py
+++ b/primus/backends/megatron/core/models/diffusion/wan/utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+WAN latent packing helpers.
+
+Flux's ``flux/utils.py`` packs 2D image latents into a token sequence; WAN packs
+a 5D video volume ``[B, C, T, H, W]`` into ``[B, S, C*p_t*p_h*p_w]`` over a 3D
+patch grid, so none of it carries over.
+"""
+
+from typing import Tuple
+
+from torch import Tensor
+
+
+def patch_grid(num_frames: int, height: int, width: int, patch_size_3d) -> Tuple[int, int, int]:
+    """Patch-grid extent ``(ppf, pph, ppw)`` for a latent volume."""
+    p_t, p_h, p_w = patch_size_3d
+    for name, size, patch in (
+        ("num_frames", num_frames, p_t),
+        ("height", height, p_h),
+        ("width", width, p_w),
+    ):
+        if size % patch != 0:
+            raise ValueError(f"{name}={size} is not divisible by its patch size {patch}")
+    return num_frames // p_t, height // p_h, width // p_w
+
+
+def fold_patches_into_batch(latents: Tensor, in_channels: int, patch_size_3d) -> Tensor:
+    """Reorder ``[B, C, T, H, W]`` into ``[B*S, C, p_t, p_h, p_w]``.
+
+    Each non-overlapping patch becomes its own batch element so a 1x1x1 Conv3d
+    produces the patch embedding. This is numerically identical to one strided
+    Conv3d over the whole volume, but the backward reduces over the batch
+    dimension the way Megatron-Bridge does -- under deterministic conv both
+    stacks then select the same MIOpen backward algorithm instead of splitting
+    between the strided-volume and batched implicit-GEMM paths.
+    """
+    batch_size = latents.shape[0]
+    p_t, p_h, p_w = patch_size_3d
+    ppf, pph, ppw = patch_grid(latents.shape[2], latents.shape[3], latents.shape[4], patch_size_3d)
+
+    x = latents.reshape(batch_size, in_channels, ppf, p_t, pph, p_h, ppw, p_w)
+    x = x.permute(0, 2, 4, 6, 1, 3, 5, 7).contiguous()
+    return x.reshape(-1, in_channels, p_t, p_h, p_w)
+
+
+def unpatchify(
+    hidden_states: Tensor,
+    batch_size: int,
+    grid: Tuple[int, int, int],
+    patch_size_3d,
+) -> Tensor:
+    """Reassemble ``[B, S, out*p_t*p_h*p_w]`` back into ``[B, C_out, T, H, W]``."""
+    ppf, pph, ppw = grid
+    p_t, p_h, p_w = patch_size_3d
+
+    x = hidden_states.reshape(batch_size, ppf, pph, ppw, p_t, p_h, p_w, -1)
+    x = x.permute(0, 7, 1, 4, 2, 5, 3, 6)
+    return x.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+
+__all__ = ["patch_grid", "fold_patches_into_batch", "unpatchify"]

--- a/primus/backends/megatron/data/diffusion/encoders/__init__.py
+++ b/primus/backends/megatron/data/diffusion/encoders/__init__.py
@@ -14,6 +14,8 @@ Hierarchical structure:
     - encoders/image/autoencoder_kl.py - VAE (AutoencoderKL)
     - encoders/text/t5_xxl.py - T5-XXL text encoder
     - encoders/text/clip_l.py - CLIP-L text encoder
+    - encoders/text/umt5.py - UMT5 text encoder (Wan)
+    - encoders/video/vae/wan/autoencoder_kl_wan.py - Wan video VAE (AutoencoderKLWan)
 
 Each encoder type can have multiple implementations registered
 in the ENCODER_REGISTRY for flexible configuration.
@@ -30,7 +32,10 @@ from .config import (
     FluxEncoderConfig,
     T5XXLConfig,
     TextEncoderConfig,
+    UMT5Config,
     VAEConfig,
+    WanEncoderConfig,
+    WanVAEConfig,
 )
 
 logger = logging.getLogger(__name__)
@@ -118,6 +123,9 @@ def _auto_discover_encoders():
         "primus.backends.megatron.data.diffusion.encoders.image.autoencoder_kl",
         "primus.backends.megatron.data.diffusion.encoders.text.t5_xxl",
         "primus.backends.megatron.data.diffusion.encoders.text.clip_l",
+        # Wan-family encoders
+        "primus.backends.megatron.data.diffusion.encoders.video.vae.wan.autoencoder_kl_wan",
+        "primus.backends.megatron.data.diffusion.encoders.text.umt5",
     ]
 
     for module_path in encoder_modules:
@@ -154,6 +162,9 @@ __all__ = [
     "T5XXLConfig",
     "CLIPLConfig",
     "FluxEncoderConfig",
+    "WanVAEConfig",
+    "UMT5Config",
+    "WanEncoderConfig",
     # Registry functions
     "register_encoder",
     "get_encoder",

--- a/primus/backends/megatron/data/diffusion/encoders/config.py
+++ b/primus/backends/megatron/data/diffusion/encoders/config.py
@@ -116,6 +116,91 @@ class CLIPLConfig(TextEncoderConfig):
 
 
 @dataclass
+class WanVAEConfig(EncoderConfig):
+    """Configuration for the Wan video VAE (AutoencoderKLWan).
+
+    Wan VAE is a 3D video VAE: inputs are pixel videos of shape
+    (B, C, T, H, W); latents are (B, latent_channels, T', H', W')
+    with spatial downsampling 8x and temporal downsampling 4x (Wan 2.1)
+    or 4x temporal + 4x spatial (Wan 2.2 TI2V-5B). Use this config for
+    both generations; model_path / subfolder select the variant.
+    """
+
+    type: str = "autoencoder_kl_wan"  # Wan VAE type identifier
+    scale_factor: float = 1.0  # Wan VAE has no extra scale/shift (uses per-channel mean/std)
+    shift_factor: float = 0.0
+    in_channels: int = 3  # Input video channels
+    out_channels: int = 16  # Wan VAE latent channels
+    latent_downsample_factor: int = 8  # Spatial downsampling factor (H/8, W/8)
+    temporal_downsample_factor: int = 4  # Temporal downsampling factor (T/4)
+
+    def __post_init__(self):
+        """Set encoder type and validate."""
+        if self.encoder_type is None:
+            self.encoder_type = EncoderType.IMAGE  # Video VAE belongs to the image family
+        super().__post_init__()
+
+
+@dataclass
+class UMT5Config(TextEncoderConfig):
+    """Configuration for the UMT5 text encoder used by Wan.
+
+    Wan uses a multilingual UMT5-XXL encoder (variant of T5) whose output is
+    fed directly into WanTransformer3DModel via encoder_hidden_states.
+    """
+
+    type: str = "umt5"  # UMT5 type identifier
+    max_length: int = 512  # Wan default text sequence length
+    embedding_dim: int = 4096  # UMT5-XXL hidden size
+    return_pooled: bool = False  # Wan consumes sequence features only
+
+    def __post_init__(self):
+        """Validate configuration."""
+        super().__post_init__()
+
+
+@dataclass
+class WanEncoderConfig:
+    """Configuration for all Wan encoders (Wan VAE + UMT5)."""
+
+    vae: WanVAEConfig
+    umt5: UMT5Config
+    use_preencoded: bool = True  # Whether to use pre-encoded data
+
+    @classmethod
+    def from_pretrained_wan(
+        cls,
+        vae_model_path: str = "Wan-AI/Wan2.1-T2V-14B-Diffusers",
+        umt5_model_path: str = "Wan-AI/Wan2.1-T2V-14B-Diffusers",
+        precision: str = "bf16",
+        device: str = "cuda",
+        use_preencoded: bool = True,
+        cache_dir: Optional[str] = None,
+    ):
+        """Create WanEncoderConfig from pretrained Wan model paths."""
+        return cls(
+            vae=WanVAEConfig(
+                type="autoencoder_kl_wan",
+                model_path=vae_model_path,
+                subfolder="vae",
+                precision=precision,
+                device=device,
+                cache_dir=cache_dir,
+            ),
+            umt5=UMT5Config(
+                type="umt5",
+                model_path=umt5_model_path,
+                subfolder="text_encoder",
+                tokenizer_subfolder="tokenizer",
+                precision=precision,
+                device=device,
+                cache_dir=cache_dir,
+            ),
+            use_preencoded=use_preencoded,
+        )
+
+
+@dataclass
 class FluxEncoderConfig:
     """Configuration for all Flux encoders (VAE + T5-XXL + CLIP-L)."""
 

--- a/primus/backends/megatron/data/diffusion/encoders/text/__init__.py
+++ b/primus/backends/megatron/data/diffusion/encoders/text/__init__.py
@@ -7,8 +7,10 @@ Text encoder implementations for diffusion models.
 
 from .clip_l import CLIPLEncoder
 from .t5_xxl import T5XXLEncoder
+from .umt5 import UMT5Encoder
 
 __all__ = [
     "T5XXLEncoder",
     "CLIPLEncoder",
+    "UMT5Encoder",
 ]

--- a/primus/backends/megatron/data/diffusion/encoders/text/umt5.py
+++ b/primus/backends/megatron/data/diffusion/encoders/text/umt5.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+UMT5 text encoder implementation for Wan.
+
+Wan models condition on UMT5 features (a multilingual T5 variant) instead of
+Flux's T5-XXL + CLIP-L pair. The interface mirrors ``T5XXLEncoder``: load
+weights with HuggingFace transformers, tokenize, and run the encoder.
+
+Reference:
+    https://huggingface.co/docs/diffusers/en/api/pipelines/wan
+    Wan technical report: https://arxiv.org/abs/2503.20314
+"""
+
+import logging
+import os
+from typing import List, Optional, Union
+
+import torch
+
+try:
+    # UMT5 weights are stored as a T5-style encoder, so the generic
+    # T5EncoderModel loads them; some transformers releases additionally expose
+    # an explicit UMT5EncoderModel, which is preferred when available.
+    from transformers import AutoTokenizer, T5EncoderModel
+
+    try:
+        from transformers import UMT5EncoderModel
+    except ImportError:
+        UMT5EncoderModel = None
+except ImportError:
+    AutoTokenizer = None
+    T5EncoderModel = None
+    UMT5EncoderModel = None
+
+from primus.backends.megatron.data.diffusion.encoders.base import (
+    BaseTextEncoder,
+    get_torch_dtype,
+    load_pretrained_with_subfolder_fallback,
+)
+from primus.backends.megatron.data.diffusion.encoders.config import UMT5Config
+
+logger = logging.getLogger(__name__)
+
+
+class UMT5Encoder(BaseTextEncoder):
+    """
+    UMT5 text encoder for Wan diffusion models.
+
+    This encoder uses the multilingual UMT5-XXL model from HuggingFace to
+    encode text prompts into embeddings. For Wan, the default configuration is:
+        - max_length: 512 tokens
+        - embedding_dim: 4096 (UMT5-XXL hidden size)
+        - precision: bf16
+
+    The output embeddings have shape (batch_size, seq_len, 4096).
+    """
+
+    def __init__(self, config: UMT5Config):
+        """
+        Initialize UMT5 encoder.
+
+        Args:
+            config: UMT5Config with model_path, max_length, etc.
+        """
+        super().__init__(config)
+
+        if T5EncoderModel is None or AutoTokenizer is None:
+            raise ImportError(
+                "transformers library is required for UMT5Encoder. "
+                "Install with: pip install -U transformers"
+            )
+
+        self.transformer = None  # Will be loaded in from_pretrained
+        self._tokenizer = None
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_path: str,
+        config: Optional[UMT5Config] = None,
+        subfolder: Optional[str] = None,
+    ) -> "UMT5Encoder":
+        """
+        Load UMT5 encoder from pretrained weights.
+
+        Args:
+            model_path: Path to pretrained model (local path or HuggingFace repo)
+            config: Optional UMT5Config. If None, uses defaults.
+            subfolder: Subfolder for model weights. Priority: param > config.subfolder
+
+        Returns:
+            Loaded UMT5Encoder instance
+
+        Examples:
+            >>> config = UMT5Config(
+            ...     model_path="Wan-AI/Wan2.1-T2V-14B-Diffusers",
+            ...     subfolder="text_encoder",
+            ...     tokenizer_subfolder="tokenizer",
+            ... )
+            >>> encoder = UMT5Encoder.from_pretrained(
+            ...     "Wan-AI/Wan2.1-T2V-14B-Diffusers", config=config
+            ... )
+        """
+        if config is None:
+            config = UMT5Config(
+                type="umt5",
+                model_path=model_path,
+                precision="bf16",
+            )
+
+        instance = cls(config)
+
+        # Prepare kwargs for from_pretrained calls
+        pretrained_kwargs = {}
+        if config.cache_dir:
+            pretrained_kwargs["cache_dir"] = config.cache_dir
+            logger.info(f"Using cache directory: {config.cache_dir}")
+
+        # Resolve model subfolder with priority: param > config.subfolder > error
+        model_subfolder = subfolder if subfolder is not None else getattr(config, "subfolder", None)
+
+        if model_subfolder is None and not hasattr(config, "subfolder"):
+            raise ValueError(
+                f"subfolder must be specified for UMT5Encoder with model_path='{model_path}'. "
+                f"For Wan diffusers repos (e.g., Wan-AI/Wan2.1-T2V-14B-Diffusers), use "
+                f"subfolder='text_encoder'. For standalone UMT5 checkpoints, use subfolder=None. "
+                f"Set it via config.subfolder or the subfolder parameter."
+            )
+
+        # Resolve tokenizer subfolder with priority: config.tokenizer_subfolder > model_subfolder
+        tokenizer_subfolder = getattr(config, "tokenizer_subfolder", None)
+        if tokenizer_subfolder is None:
+            tokenizer_subfolder = model_subfolder  # Use model subfolder as fallback
+
+        # Load tokenizer
+        tokenizer_path = config.tokenizer_path or model_path
+        logger.info(f"Loading UMT5 tokenizer from {tokenizer_path} (subfolder={tokenizer_subfolder})")
+
+        tokenizer_kwargs = {
+            "token": os.environ.get("HF_TOKEN"),
+            "trust_remote_code": getattr(config, "trust_remote_code", False),
+            **pretrained_kwargs,  # Merge cache_dir if provided
+        }
+        if tokenizer_subfolder:
+            tokenizer_kwargs["subfolder"] = tokenizer_subfolder
+
+        instance._tokenizer = AutoTokenizer.from_pretrained(
+            tokenizer_path,
+            **tokenizer_kwargs,
+        )
+
+        # Load model
+        torch_dtype = get_torch_dtype(config.precision)
+
+        logger.info(f"Loading UMT5 encoder from {model_path} (subfolder={model_subfolder})")
+        loader_class = UMT5EncoderModel if UMT5EncoderModel is not None else T5EncoderModel
+        instance.transformer = load_pretrained_with_subfolder_fallback(
+            loader_class,
+            model_path,
+            subfolder=model_subfolder,
+            torch_dtype=torch_dtype,
+            **pretrained_kwargs,
+        )
+
+        instance.transformer.to(instance.device)
+
+        if config.freeze_weights:
+            instance.freeze()
+            instance.transformer.eval()
+
+        logger.info(
+            f"Loaded UMT5: max_length={instance.max_length}, "
+            f"embedding_dim={instance.embedding_dim}, dtype={torch_dtype}"
+        )
+
+        return instance
+
+    @torch.no_grad()
+    def encode(
+        self,
+        texts: Union[str, List[str]],
+        max_sequence_length: Optional[int] = None,
+    ) -> torch.Tensor:
+        """
+        Encode text(s) to embeddings.
+
+        Args:
+            texts: Single text string or list of text strings
+            max_sequence_length: Optional max length override. If None, uses config max_length.
+
+        Returns:
+            Text embeddings tensor of shape (batch_size, seq_len, 4096)
+            Sequence length is padded to max_length.
+
+        Example:
+            >>> texts = ["A cat walking through tall grass"]
+            >>> embeddings = encoder.encode(texts)
+            >>> embeddings.shape
+            torch.Size([1, 512, 4096])
+        """
+        if self.transformer is None or self._tokenizer is None:
+            raise RuntimeError("UMT5 encoder not loaded. Call from_pretrained() first.")
+
+        texts = self._prepare_texts(texts)
+        max_len = max_sequence_length if max_sequence_length is not None else self.max_length
+
+        # Tokenize
+        batch_encoding = self._tokenizer(
+            texts,
+            truncation=True,
+            max_length=max_len,
+            return_length=False,
+            return_overflowing_tokens=False,
+            padding="max_length",
+            return_tensors="pt",
+        )
+
+        tokens = batch_encoding["input_ids"].to(self.device, non_blocking=True)
+        attention_mask = batch_encoding["attention_mask"].to(self.device, non_blocking=True)
+
+        # Encode
+        outputs = self.transformer(
+            input_ids=tokens,
+            attention_mask=attention_mask,
+            output_hidden_states=None,
+        )
+        embeddings = outputs.last_hidden_state
+
+        return embeddings
+
+    def forward(self, texts: Union[str, List[str]], **kwargs) -> torch.Tensor:
+        """Forward pass (alias for encode)."""
+        return self.encode(texts, **kwargs)
+
+
+# Register encoder in registry
+from primus.backends.megatron.data.diffusion.encoders import register_encoder
+
+register_encoder("umt5", UMT5Encoder)

--- a/primus/backends/megatron/data/diffusion/encoders/video/__init__.py
+++ b/primus/backends/megatron/data/diffusion/encoders/video/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Video encoder implementations for diffusion models.
+"""
+
+from primus.backends.megatron.data.diffusion.encoders.base import BaseVAE
+
+from .vae.wan import AutoencoderKLWan
+
+__all__ = [
+    "BaseVAE",
+    "AutoencoderKLWan",
+]

--- a/primus/backends/megatron/data/diffusion/encoders/video/vae/__init__.py
+++ b/primus/backends/megatron/data/diffusion/encoders/video/vae/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Video VAE implementations for diffusion models.
+"""
+
+from .wan import AutoencoderKLWan
+
+__all__ = [
+    "AutoencoderKLWan",
+]

--- a/primus/backends/megatron/data/diffusion/encoders/video/vae/wan/__init__.py
+++ b/primus/backends/megatron/data/diffusion/encoders/video/vae/wan/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""Wan VAE (AutoencoderKLWan) encoder package."""
+
+from .autoencoder_kl_wan import AutoencoderKLWan
+
+__all__ = [
+    "AutoencoderKLWan",
+]

--- a/primus/backends/megatron/data/diffusion/encoders/video/vae/wan/autoencoder_kl_wan.py
+++ b/primus/backends/megatron/data/diffusion/encoders/video/vae/wan/autoencoder_kl_wan.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Wan VAE (AutoencoderKLWan) wrapper.
+
+Provides a Primus-shaped wrapper around the diffusers ``AutoencoderKLWan``
+3D video VAE used by both WAN 2.1 and WAN 2.2. The wrapper handles:
+
+- Loading from a HuggingFace repo / local path (matching the standard Wan
+  layout, e.g. ``Wan-AI/Wan2.1-T2V-14B-Diffusers/vae``).
+- Encoding pixel videos ``(B, C, T, H, W)`` to latents
+  ``(B, latent_channels, T', H', W')``.
+- Decoding latents back to videos.
+
+The diffusers ``AutoencoderKLWan`` exposes per-channel mean / std for the
+latent normalization, so we do not need the Flux-style global
+``scale_factor`` / ``shift_factor``. Per-channel normalization is applied by
+the diffusers model itself; this wrapper just forwards encode/decode calls.
+
+Reference:
+    https://huggingface.co/docs/diffusers/en/api/models/autoencoder_kl_wan
+"""
+
+import logging
+from typing import Optional
+
+import torch
+
+try:
+    from diffusers import AutoencoderKLWan as DiffusersAutoencoderKLWan
+except ImportError:
+    DiffusersAutoencoderKLWan = None
+
+from primus.backends.megatron.data.diffusion.encoders.base import (
+    BaseVAE,
+    get_torch_dtype,
+    load_pretrained_with_subfolder_fallback,
+)
+from primus.backends.megatron.data.diffusion.encoders.config import WanVAEConfig
+
+logger = logging.getLogger(__name__)
+
+
+class AutoencoderKLWan(BaseVAE):
+    """
+    Wan 3D video VAE for WAN 2.1 / WAN 2.2 diffusion models.
+
+    Inputs / outputs (encode):
+        videos: (B, C, T, H, W) pixel videos in range [-1, 1]
+        latents: (B, latent_channels, T_lat, H_lat, W_lat)
+
+    Inputs / outputs (decode):
+        latents: (B, latent_channels, T_lat, H_lat, W_lat)
+        videos: (B, C, T, H, W) pixel videos
+
+    Spatial downsampling is 8x (Wan 2.1) and temporal downsampling is 4x.
+    """
+
+    def __init__(self, config: WanVAEConfig):
+        """
+        Initialize AutoencoderKLWan encoder.
+
+        Args:
+            config: WanVAEConfig with model_path, subfolder, precision, etc.
+        """
+        super().__init__(config)
+
+        if DiffusersAutoencoderKLWan is None:
+            raise ImportError(
+                "diffusers library is required for AutoencoderKLWan. "
+                "Install with: pip install -U diffusers"
+            )
+
+        self.temporal_downsample_factor = getattr(config, "temporal_downsample_factor", 4)
+        self.vae = None  # Will be loaded in from_pretrained
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_path: str,
+        config: Optional[WanVAEConfig] = None,
+        subfolder: Optional[str] = None,
+    ) -> "AutoencoderKLWan":
+        """
+        Load AutoencoderKLWan from pretrained weights.
+
+        Args:
+            model_path: Path to pretrained model (local path or HuggingFace repo)
+            config: Optional WanVAEConfig. If None, uses defaults.
+            subfolder: Subfolder for VAE weights. Priority: param > config.subfolder
+
+        Returns:
+            Loaded AutoencoderKLWan instance
+
+        Examples:
+            >>> config = WanVAEConfig(
+            ...     model_path="Wan-AI/Wan2.1-T2V-14B-Diffusers",
+            ...     subfolder="vae",
+            ... )
+            >>> vae = AutoencoderKLWan.from_pretrained(
+            ...     "Wan-AI/Wan2.1-T2V-14B-Diffusers", config=config
+            ... )
+        """
+        if config is None:
+            config = WanVAEConfig(
+                type="autoencoder_kl_wan",
+                model_path=model_path,
+                precision="bf16",
+            )
+
+        instance = cls(config)
+
+        # Prepare kwargs for from_pretrained calls
+        pretrained_kwargs = {}
+        if config.cache_dir:
+            pretrained_kwargs["cache_dir"] = config.cache_dir
+            logger.info(f"Using cache directory: {config.cache_dir}")
+
+        # Resolve model subfolder with priority: param > config.subfolder > error
+        model_subfolder = subfolder if subfolder is not None else getattr(config, "subfolder", None)
+
+        if model_subfolder is None and not hasattr(config, "subfolder"):
+            raise ValueError(
+                f"subfolder must be specified for AutoencoderKLWan with model_path='{model_path}'. "
+                f"For standard Wan diffusers repos (e.g., Wan-AI/Wan2.1-T2V-14B-Diffusers), "
+                f"use subfolder='vae'. Set it via config.subfolder or the subfolder parameter."
+            )
+
+        # Load VAE from diffusers
+        torch_dtype = get_torch_dtype(config.precision)
+
+        logger.info(f"Loading AutoencoderKLWan from {model_path} (subfolder={model_subfolder})")
+        instance.vae = load_pretrained_with_subfolder_fallback(
+            DiffusersAutoencoderKLWan,
+            model_path,
+            subfolder=model_subfolder,
+            torch_dtype=torch_dtype,
+            **pretrained_kwargs,
+        )
+
+        instance.vae.to(instance.device)
+
+        if config.freeze_weights:
+            instance.freeze()
+            instance.vae.eval()
+
+        logger.info(
+            f"Loaded AutoencoderKLWan: in_channels={instance.in_channels}, "
+            f"out_channels={instance.out_channels}, "
+            f"spatial_downsample={instance.latent_downsample_factor}x, "
+            f"temporal_downsample={instance.temporal_downsample_factor}x"
+        )
+
+        return instance
+
+    @torch.no_grad()
+    def encode(self, videos: torch.Tensor) -> torch.Tensor:
+        """
+        Encode pixel videos to latent representations.
+
+        Args:
+            videos: Input videos tensor of shape (B, C, T, H, W)
+                    Values should be in range [-1, 1] (normalized)
+
+        Returns:
+            Latent representations of shape (B, latent_channels, T_lat, H_lat, W_lat)
+        """
+        if self.vae is None:
+            raise RuntimeError("VAE not loaded. Call from_pretrained() first.")
+
+        videos = videos.to(device=self.device, dtype=self.dtype)
+
+        latent_dist = self.vae.encode(videos).latent_dist
+        latents = latent_dist.sample()
+
+        return latents
+
+    @torch.no_grad()
+    def decode(self, latents: torch.Tensor) -> torch.Tensor:
+        """
+        Decode latent representations to pixel videos.
+
+        Args:
+            latents: Latent representations of shape (B, latent_channels, T_lat, H_lat, W_lat)
+
+        Returns:
+            Reconstructed videos of shape (B, C, T, H, W)
+        """
+        if self.vae is None:
+            raise RuntimeError("VAE not loaded. Call from_pretrained() first.")
+
+        latents = latents.to(device=self.device, dtype=self.dtype)
+
+        videos = self.vae.decode(latents, return_dict=False)[0]
+
+        return videos
+
+    def forward(self, videos: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass: encode then decode (reconstruction).
+
+        Args:
+            videos: Input videos tensor of shape (B, C, T, H, W)
+
+        Returns:
+            Reconstructed videos of shape (B, C, T, H, W)
+        """
+        latents = self.encode(videos)
+        reconstructed = self.decode(latents)
+        return reconstructed
+
+
+# Register encoder in registry
+from primus.backends.megatron.data.diffusion.encoders import register_encoder
+
+register_encoder("autoencoder_kl_wan", AutoencoderKLWan)

--- a/primus/backends/megatron/data/diffusion/task_encoders/__init__.py
+++ b/primus/backends/megatron/data/diffusion/task_encoders/__init__.py
@@ -12,11 +12,25 @@ from .image import (
     cook_preencoded_diffusion,
     cook_raw_images,
 )
+from .video import (
+    EncodedWanTaskEncoder,
+    RawWanTaskEncoder,
+    WanSample,
+    cook_wan_preencoded,
+    cook_wan_raw,
+)
 
 __all__ = [
+    # Image / Flux family
     "DiffusionSample",
     "EncodedDiffusionTaskEncoder",
     "RawDiffusionTaskEncoder",
     "cook_preencoded_diffusion",
     "cook_raw_images",
+    # Video / Wan family
+    "WanSample",
+    "EncodedWanTaskEncoder",
+    "RawWanTaskEncoder",
+    "cook_wan_preencoded",
+    "cook_wan_raw",
 ]

--- a/primus/backends/megatron/data/diffusion/task_encoders/video.py
+++ b/primus/backends/megatron/data/diffusion/task_encoders/video.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Video TaskEncoders for Wan diffusion models using Crude Data pattern.
+
+This module provides TaskEncoder implementations for Wan video models:
+- EncodedWanTaskEncoder: Loads pre-encoded data (VAE latents, UMT5 features)
+- RawWanTaskEncoder: Loads raw frames and text (no encoding)
+
+The split mirrors EncodedDiffusionTaskEncoder / RawDiffusionTaskEncoder in
+image.py. Encoding happens in the model, not in the TaskEncoder.
+
+Use the dataset.yaml subflavors field to choose:
+    ```yaml
+    subflavors:
+      encoding: wan_preencoded  # or "wan_raw"
+    ```
+"""
+
+import io
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import torch
+from megatron.energon import (
+    Cooker,
+    DefaultTaskEncoder,
+    Sample,
+    SampleDecoder,
+    WorkerConfig,
+    basic_sample_keys,
+    stateless,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Sample Definition (with proper Sample inheritance)
+# ============================================================================
+
+
+@dataclass
+class WanSample(Sample):
+    """
+    Wan video training sample with framework-standard field names.
+
+    Inherits from megatron.energon.Sample to ensure __key__, __restore_key__,
+    and __subflavors__ are properly tracked for deterministic training resumption.
+
+    Attributes:
+        latents: Wan VAE video latents (C, T, H, W) — pre-encoded path
+        encoder_hidden_states: UMT5 text features (S_txt, D_txt) — pre-encoded path
+        frames: Raw pixel video (C, T, H, W) in range [-1, 1] — raw path
+        txt: Raw caption string — raw path
+        caption: Original text caption (optional, for debugging)
+    """
+
+    latents: Optional[torch.Tensor] = None
+    encoder_hidden_states: Optional[torch.Tensor] = None
+    frames: Optional[torch.Tensor] = None
+    txt: str = ""
+    caption: str = ""
+
+
+# ============================================================================
+# Cooker Helpers
+# ============================================================================
+
+
+def load_wan_tensor(data: Any) -> Optional[torch.Tensor]:
+    """Load a tensor from bytes, a path, or an already-decoded tensor."""
+    if data is None:
+        return None
+    if isinstance(data, (str, Path)):
+        return torch.load(data, map_location="cpu")
+    if isinstance(data, bytes):
+        return torch.load(io.BytesIO(data), map_location="cpu")
+    if isinstance(data, torch.Tensor):
+        return data
+    return data
+
+
+def decode_wan_caption(raw: Any) -> str:
+    """Decode a caption stored as bytes, a path, or a plain string."""
+    if raw is None:
+        return ""
+    if isinstance(raw, bytes):
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return ""
+    if isinstance(raw, (str, Path)):
+        path = Path(str(raw))
+        try:
+            if path.exists():
+                return path.read_text().strip()
+        except (OSError, ValueError):
+            pass
+        return str(raw)
+    return str(raw)
+
+
+# ============================================================================
+# Cooker Functions
+# ============================================================================
+
+
+@stateless
+def cook_wan_preencoded(sample: dict) -> WanSample:
+    """
+    Cooker for pre-encoded Wan features with framework-standard keys.
+
+    Loads precalculated Wan VAE latents and UMT5 text features from disk.
+
+    Required standard keys:
+        - 'latents.pth': Wan VAE video latents (C, T, H, W)
+        - 'encoder_hidden_states.pth': UMT5 text features (S_txt, D_txt)
+
+    Optional keys:
+        - 'caption.txt': Original caption (for debugging)
+
+    Args:
+        sample: Raw sample dict from WebDataset
+
+    Returns:
+        WanSample with all metadata properly forwarded
+    """
+    latents = load_wan_tensor(sample.get("latents.pth"))
+    encoder_hidden_states = load_wan_tensor(sample.get("encoder_hidden_states.pth"))
+
+    if latents is None:
+        raise ValueError(f"Wan pre-encoded sample missing 'latents.pth'. Got: {list(sample.keys())}")
+    if encoder_hidden_states is None:
+        raise ValueError(
+            f"Wan pre-encoded sample missing 'encoder_hidden_states.pth'. Got: {list(sample.keys())}"
+        )
+
+    caption = decode_wan_caption(sample.get("caption.txt"))
+
+    return WanSample(
+        **basic_sample_keys(sample),
+        latents=latents,
+        encoder_hidden_states=encoder_hidden_states,
+        caption=caption,
+    )
+
+
+@stateless
+def cook_wan_raw(sample: dict) -> WanSample:
+    """
+    Cooker for raw Wan videos - just loads data, NO ENCODING.
+
+    Encoding happens in the model's forward_step, not here.
+
+    Standard data keys:
+        - 'frames': Raw video data (tensor or serialized bytes)
+        - 'txt': Text caption
+
+    Args:
+        sample: Raw sample dict from WebDataset
+
+    Returns:
+        WanSample with raw data ready for model encoding
+    """
+    frames = sample.get("frames")
+    if isinstance(frames, bytes):
+        frames = load_wan_tensor(frames)
+
+    txt = decode_wan_caption(sample.get("txt", ""))
+
+    return WanSample(
+        **basic_sample_keys(sample),
+        frames=frames,
+        txt=txt,
+        caption=txt,
+    )
+
+
+# ============================================================================
+# TaskEncoders
+# ============================================================================
+
+
+class EncodedWanTaskEncoder(DefaultTaskEncoder[WanSample, WanSample, dict, dict]):
+    """
+    TaskEncoder for PRE-ENCODED Wan video data.
+
+    Use this when your dataset contains pre-encoded features:
+    - latents.pth (Wan VAE video latents)
+    - encoder_hidden_states.pth (UMT5 text features)
+
+    Does NOT do any encoding - just loads from disk.
+    For raw data, use RawWanTaskEncoder instead.
+
+    Outputs batch with standard keys:
+    - 'latents'
+    - 'encoder_hidden_states'
+
+    Use with dataset.yaml:
+        ```yaml
+        subflavors:
+          encoding: wan_preencoded
+        ```
+    """
+
+    decoder = SampleDecoder(image_decode="pil")
+
+    cookers = [
+        Cooker(cook_wan_preencoded, has_subflavors={"encoding": "wan_preencoded"}),
+    ]
+
+    def __init__(self, worker_config: Optional[WorkerConfig] = None):
+        """Initialize pre-encoded Wan TaskEncoder."""
+        super().__init__()
+        self.worker_config = worker_config
+        logger.info("Initialized EncodedWanTaskEncoder (wan_preencoded mode)")
+
+    def batch(self, samples: List[WanSample]) -> Dict[str, torch.Tensor]:
+        """
+        Batch pre-encoded Wan samples.
+
+        Returns:
+            Dict with keys: latents, encoder_hidden_states
+        """
+        return {
+            "latents": torch.stack([s.latents for s in samples]),
+            "encoder_hidden_states": torch.stack([s.encoder_hidden_states for s in samples]),
+        }
+
+
+class RawWanTaskEncoder(DefaultTaskEncoder):
+    """
+    TaskEncoder for RAW Wan video data (frames and text).
+
+    Use this when your dataset contains raw files:
+    - frames (raw video frames)
+    - txt (text captions)
+
+    This TaskEncoder:
+    - Loads raw frames and captions from disk
+    - Does NOT do any encoding (no Wan VAE, no UMT5)
+    - Encoding happens on-the-fly in model's forward_step
+
+    Outputs batch with standard keys:
+    - 'frames': List of video tensors
+    - 'txt': List of caption strings
+
+    Use with dataset.yaml:
+        ```yaml
+        subflavors:
+          encoding: wan_raw
+        ```
+    """
+
+    decoder = SampleDecoder(image_decode="pil")
+
+    cookers = [
+        Cooker(cook_wan_raw, has_subflavors={"encoding": "wan_raw"}),
+    ]
+
+    def __init__(self, worker_config: Optional[WorkerConfig] = None):
+        """Initialize raw Wan TaskEncoder."""
+        super().__init__()
+        self.worker_config = worker_config
+        logger.info("Initialized RawWanTaskEncoder (no encoding, passes raw data)")
+
+    def batch(self, samples: List[WanSample]) -> Dict[str, Any]:
+        """
+        Batch raw Wan samples.
+
+        Returns:
+            Dict with standard keys:
+            - 'frames': List of video tensors
+            - 'txt': List of caption strings
+        """
+        return {
+            "frames": [s.frames for s in samples],
+            "txt": [s.txt for s in samples],
+        }
+
+
+__all__ = [
+    "WanSample",
+    "EncodedWanTaskEncoder",
+    "RawWanTaskEncoder",
+    "cook_wan_preencoded",
+    "cook_wan_raw",
+    "decode_wan_caption",
+    "load_wan_tensor",
+]

--- a/primus/backends/megatron/data/diffusion/task_encoders/video.py
+++ b/primus/backends/megatron/data/diffusion/task_encoders/video.py
@@ -98,8 +98,10 @@ def decode_wan_caption(raw: Any) -> str:
         try:
             if path.exists():
                 return path.read_text().strip()
-        except (OSError, ValueError):
-            pass
+        except (OSError, ValueError) as e:
+            # Shards carry captions either inline or as a sidecar path, so an
+            # unreadable path is a caption that happens to look like one.
+            logger.debug(f"Could not read caption from path {path}: {e}")
         return str(raw)
     return str(raw)
 

--- a/primus/backends/megatron/data/energon_dataset_provider.py
+++ b/primus/backends/megatron/data/energon_dataset_provider.py
@@ -109,6 +109,13 @@ class EnergonDatasetProvider(DatasetProvider):
             virtual_epoch_length=getattr(args, "virtual_epoch_length", 1_000_000_000),
             max_samples_per_sequence=getattr(args, "max_samples_per_sequence", 100),
             shuffle_buffer_size=getattr(args, "shuffle_buffer_size", None),
+            # Defaults match Energon's own defaults. A fully deterministic sample
+            # order (WAN cross-implementation parity runs) needs all four shuffle
+            # knobs off together: max_samples_per_sequence=null, shuffle_buffer_size=null,
+            # shuffle_over_epochs_multiplier=null and parallel_shard_iters=1, the
+            # last being required once shard shuffling is disabled.
+            shuffle_over_epochs_multiplier=getattr(args, "shuffle_over_epochs_multiplier", 1),
+            parallel_shard_iters=getattr(args, "parallel_shard_iters", None),
             handler=lambda *args: None,  # Error handler (print errors but continue)
         )
 

--- a/primus/backends/megatron/data/synthetic/__init__.py
+++ b/primus/backends/megatron/data/synthetic/__init__.py
@@ -14,9 +14,11 @@ from .mock_datasets import (
     MockDiffusionDataset,
     MockFluxDataset,
     MockFluxSchnellDataset,
+    MockWanDataset,
     ModelPreset,
     PreGeneratedMockFluxDataset,
     PreGeneratedMockFluxSchnellDataset,
+    PreGeneratedMockWanDataset,
     TextEmbeddingConfig,
 )
 
@@ -26,6 +28,8 @@ __all__ = [
     "PreGeneratedMockFluxDataset",
     "MockFluxSchnellDataset",
     "PreGeneratedMockFluxSchnellDataset",
+    "MockWanDataset",
+    "PreGeneratedMockWanDataset",
     "LatentConfig",
     "TextEmbeddingConfig",
     "ModelPreset",

--- a/primus/backends/megatron/data/synthetic/mock_datasets.py
+++ b/primus/backends/megatron/data/synthetic/mock_datasets.py
@@ -535,6 +535,180 @@ class PreGeneratedMockFluxDataset(MockFluxDataset):
         return self._samples[idx]
 
 
+# ============================================================================
+# WAN (Video Diffusion) Mock Datasets
+# ============================================================================
+
+
+class MockWanDataset(Dataset):
+    """
+    Mock dataset for WAN video diffusion models.
+
+    Produces samples matching EncodedWanTaskEncoder.batch():
+        - 'latents': (C, T, H, W) Wan VAE latents (16 channels by default)
+        - 'encoder_hidden_states': (S_txt, D_txt) UMT5-XXL features (512, 4096)
+
+    WAN does not reuse the MockDiffusionDataset preset system because that
+    system emits 4D image latents under the Flux key names ('prompt_embeds',
+    'pooled_prompt_embeds'), while wan_forward_step_func reads 5D latents and
+    'encoder_hidden_states'.
+
+    Pixel dimensions follow the Wan VAE spatial downsample (factor 8). The
+    num_frames argument is the LATENT frame count after the VAE temporal
+    compression (factor 4), so the default num_frames=21 corresponds to a
+    pixel video of about 81 frames.
+
+    This dataset is purely synthetic - it loads no video and no encoder
+    weights - so it is intended for smoke tests, perf benchmarks, and CI runs
+    that exercise the WAN training loop without pre-encoded shards.
+    """
+
+    def __init__(
+        self,
+        num_samples: int = 100,
+        image_size: int = 256,
+        num_frames: int = 21,
+        latent_channels: int = 16,
+        vae_downsample: int = 8,
+        text_seq_len: int = 512,
+        text_embed_dim: int = 4096,
+        seed: Optional[int] = None,
+        dtype: torch.dtype = torch.bfloat16,
+        device: str = "cpu",
+        is_validation: bool = False,
+        **kwargs,
+    ):
+        """
+        Initialize mock WAN dataset.
+
+        Args:
+            num_samples: Number of samples in dataset
+            image_size: Pixel image size (default 256)
+            num_frames: Latent frame count T (default 21, i.e. ~81 pixel frames)
+            latent_channels: Wan VAE latent channels
+            vae_downsample: Wan VAE spatial downsampling factor
+            text_seq_len: UMT5 sequence length
+            text_embed_dim: UMT5 hidden size
+            seed: Random seed for reproducibility
+            dtype: Data type for tensors (default: torch.bfloat16)
+            device: Device to create tensors on ('cpu' or 'cuda', default: 'cpu')
+            is_validation: Whether this is a validation dataset (adds fixed timesteps)
+        """
+        super().__init__()
+        self.num_samples = num_samples
+        self.image_size = image_size
+        self.num_frames = num_frames
+        self.latent_channels = latent_channels
+        self.vae_downsample = vae_downsample
+        self.latent_size = image_size // vae_downsample
+        self.text_seq_len = text_seq_len
+        self.text_embed_dim = text_embed_dim
+        self.seed = seed if seed is not None else 0
+        self.dtype = dtype
+        self.device = torch.device(device)
+        self.is_validation = is_validation
+
+        logger.info(
+            f"Initialized MockWanDataset: {num_samples} samples, "
+            f"latent shape=[{latent_channels}, {num_frames}, {self.latent_size}, {self.latent_size}], "
+            f"text shape=[{text_seq_len}, {text_embed_dim}]"
+        )
+
+    def __len__(self) -> int:
+        """Return number of samples in dataset."""
+        return self.num_samples
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        """
+        Generate a synthetic WAN sample.
+
+        Args:
+            idx: Sample index (seeds the generator for reproducibility)
+
+        Returns:
+            Dict with 'latents' (C, T, H, W) and 'encoder_hidden_states' (S, D)
+        """
+        if idx >= self.num_samples or idx < 0:
+            raise IndexError(f"Index {idx} out of range for dataset with {self.num_samples} samples")
+
+        gen = torch.Generator(device=self.device)
+        gen.manual_seed(self.seed + idx)
+
+        latents = torch.randn(
+            self.latent_channels,
+            self.num_frames,
+            self.latent_size,
+            self.latent_size,
+            generator=gen,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        encoder_hidden_states = torch.randn(
+            self.text_seq_len,
+            self.text_embed_dim,
+            generator=gen,
+            dtype=self.dtype,
+            device=self.device,
+        )
+
+        sample: Dict[str, torch.Tensor] = {
+            "latents": latents,
+            "encoder_hidden_states": encoder_hidden_states,
+        }
+
+        if self.is_validation:
+            sample["timestep"] = torch.tensor(idx % 8)
+
+        return sample
+
+
+class PreGeneratedMockWanDataset(MockWanDataset):
+    """
+    Pre-generated mock WAN dataset for maximum training throughput.
+
+    This dataset generates all samples once during initialization and caches
+    them in memory, so __getitem__ is a plain memory lookup. Use it when the
+    cost of generating the 5D latent tensor dominates step time.
+
+    Memory usage: per sample at default shapes with bf16:
+        - Latents: 16 * 21 * 32 * 32 * 2 bytes = ~688 KB
+        - Text embeddings: 512 * 4096 * 2 bytes = ~4 MB
+        - Total: ~4.7 MB per sample (a 512-sample dataset uses ~2.4 GB)
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize and pre-generate all samples."""
+        from primus.core.utils.module_utils import log_rank_0
+
+        super().__init__(*args, **kwargs)
+
+        log_rank_0(f"Pre-generating {self.num_samples} mock WAN samples...")
+        log_rank_0(
+            f"  Latent shape: [{self.latent_channels}, {self.num_frames}, "
+            f"{self.latent_size}, {self.latent_size}]"
+        )
+        log_rank_0(f"  Text shape: [{self.text_seq_len}, {self.text_embed_dim}]")
+
+        self._samples = [MockWanDataset.__getitem__(self, i) for i in range(self.num_samples)]
+
+        sample_size = sum(
+            tensor.element_size() * tensor.numel()
+            for tensor in self._samples[0].values()
+            if hasattr(tensor, "element_size")
+        )
+        total_mb = (sample_size * self.num_samples) / (1024 * 1024)
+
+        log_rank_0(f"Pre-generation complete!")
+        log_rank_0(f"  Memory usage: {total_mb:.1f} MB")
+        log_rank_0(f"  Data loading overhead: eliminated")
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        """Return pre-generated sample (no computation)."""
+        if idx >= self.num_samples or idx < 0:
+            raise IndexError(f"Index {idx} out of range for dataset with {self.num_samples} samples")
+        return self._samples[idx]
+
+
 class MockFluxSchnellDataset(MockDiffusionDataset):
     """
     Mock dataset for FLUX.1-schnell (MLPerf Training v5.1 benchmark).
@@ -611,4 +785,6 @@ __all__ = [
     "PreGeneratedMockFluxDataset",
     "MockFluxSchnellDataset",
     "PreGeneratedMockFluxSchnellDataset",
+    "MockWanDataset",
+    "PreGeneratedMockWanDataset",
 ]

--- a/primus/backends/megatron/data/synthetic_dataset_provider.py
+++ b/primus/backends/megatron/data/synthetic_dataset_provider.py
@@ -36,6 +36,16 @@ class SyntheticDatasetProvider(DatasetProvider):
               params:
                 num_samples: 1000
                 image_size: 512
+
+    Or, to pick a default dataset by model family (e.g. for WAN video):
+        modules:
+          pre_trainer:
+            mock_data: true
+            mock_dataset:
+              family: wan
+              params:
+                num_samples: 512
+                num_frames: 21
     """
 
     DEFAULT_DATASETS = {
@@ -43,6 +53,8 @@ class SyntheticDatasetProvider(DatasetProvider):
         "flux_onthefly": "primus.backends.megatron.data.synthetic.MockFluxDataset",
         "flux_schnell": "primus.backends.megatron.data.synthetic.PreGeneratedMockFluxSchnellDataset",
         "flux_schnell_onthefly": "primus.backends.megatron.data.synthetic.MockFluxSchnellDataset",
+        "wan": "primus.backends.megatron.data.synthetic.PreGeneratedMockWanDataset",
+        "wan_onthefly": "primus.backends.megatron.data.synthetic.MockWanDataset",
     }
 
     def __init__(self, dataset_config: Optional[Dict[str, Any]] = None, model_type: str = "flux"):
@@ -59,24 +71,26 @@ class SyntheticDatasetProvider(DatasetProvider):
                         # ... other dataset params
                     }
                 }
-            model_type: Model type for default dataset selection ('flux', etc.)
-                Used when dataset_config['class'] is not specified.
+            model_type: Model type for default dataset selection ('flux', 'wan', etc.)
+                Used when dataset_config['class'] is not specified. A 'family' key
+                in dataset_config takes precedence, since the trainer collapses the
+                generic 'diffusion_model' model_type to 'flux'.
         """
         self.dataset_config = dataset_config or {}
-        self.model_type = model_type
+        self.model_type = self.dataset_config.get("family") or model_type
 
         # Determine dataset class to use
         dataset_class_from_config = self.dataset_config.get("class")
 
         # If class is None or not specified, use default for model_type
         if dataset_class_from_config is None or dataset_class_from_config == "null":
-            self.dataset_class_path = self.DEFAULT_DATASETS.get(model_type)
+            self.dataset_class_path = self.DEFAULT_DATASETS.get(self.model_type)
         else:
             self.dataset_class_path = dataset_class_from_config
 
         if not self.dataset_class_path:
             raise ValueError(
-                f"No default dataset for model_type='{model_type}'. "
+                f"No default dataset for model_type='{self.model_type}'. "
                 f"Available types: {list(self.DEFAULT_DATASETS.keys())}. "
                 f"Or specify dataset_config['class'] explicitly."
             )

--- a/primus/backends/megatron/megatron_adapter.py
+++ b/primus/backends/megatron/megatron_adapter.py
@@ -90,6 +90,7 @@ class MegatronAdapter(BackendAdapter):
         MEGATRON_TRAINERS = {
             "MegatronPretrainTrainer": "primus.backends.megatron.megatron_pretrain_trainer.MegatronPretrainTrainer",
             "FluxPretrainTrainer": "primus.backends.megatron.flux_pretrain_trainer.FluxPretrainTrainer",
+            "WanPretrainTrainer": "primus.backends.megatron.wan_pretrain_trainer.WanPretrainTrainer",
         }
 
         if trainer_class not in MEGATRON_TRAINERS:

--- a/primus/backends/megatron/patches/te_patches/hipblaslt_workspace_patches.py
+++ b/primus/backends/megatron/patches/te_patches/hipblaslt_workspace_patches.py
@@ -1,0 +1,87 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Transformer Engine hipBLASLt GEMM workspace patches.
+
+TE fixes its GEMM workspace at 64 MiB on gfx950 (32 MiB elsewhere) with no way
+to change it. That is too small for a weight-gradient GEMM whose reduction axis
+is long while its output is small and square: hipBLASLt answers such a shape
+with a split-K solution, the number of splits grows with the reduction length,
+and each split needs its own ``M x N x 4`` accumulator. Once the splits no
+longer fit, the call fails outright instead of falling back::
+
+    RuntimeError: rocm_gemm.hip:1707 in function hipblaslt_gemm: HIPBLASLT Error: 6
+
+WAN 2.1 T2V-1.3B hits this in its 1536 -> 1536 linears from roughly 70,000
+tokens up (micro_batch_size 7 at 10,920 tokens per sample); 1536 -> 8960 and
+8960 -> 1536 are unaffected because their larger outputs rule split-K out
+anyway. Seen on rocm/primus:v26.5 (TE 2.15.0.dev0).
+
+Set ``PRIMUS_TE_GEMM_WORKSPACE_MIB`` to enlarge the workspace; 128 clears the
+WAN shapes. Unset, nothing is touched, so a bigger workspace never silently
+changes hipBLASLt's solution choice for runs that do not need it.
+"""
+
+import os
+
+from primus.core.patches import PatchContext, register_patch
+from primus.core.utils.module_utils import log_rank_0
+
+ENV_VAR = "PRIMUS_TE_GEMM_WORKSPACE_MIB"
+
+
+def _requested_workspace_mib():
+    """Return the requested workspace in MiB, or None when unset/invalid."""
+    raw = os.getenv(ENV_VAR, "").strip()
+    if not raw:
+        return None
+    try:
+        requested = int(raw)
+    except ValueError:
+        return None
+    return requested if requested > 0 else None
+
+
+def _needs_te_gemm_workspace_patch(_ctx: PatchContext) -> bool:
+    if _requested_workspace_mib() is None:
+        return False
+    try:
+        from transformer_engine.pytorch.cpp_extensions import gemm as te_gemm
+    except (ImportError, ModuleNotFoundError):
+        return False
+    return hasattr(te_gemm, "get_cublas_workspace_size_bytes")
+
+
+@register_patch(
+    "megatron.te.hipblaslt_gemm_workspace",
+    backend="megatron",
+    phase="before_train",
+    description="Resize TE's hipBLASLt GEMM workspace (PRIMUS_TE_GEMM_WORKSPACE_MIB)",
+    condition=_needs_te_gemm_workspace_patch,
+)
+def patch_te_gemm_workspace_size(ctx: PatchContext):
+    """Enlarge the workspace TE hands to hipBLASLt for every GEMM."""
+    del ctx
+
+    from transformer_engine.pytorch.cpp_extensions import gemm as te_gemm
+
+    requested_bytes = _requested_workspace_mib() * 1024 * 1024
+    try:
+        previous_bytes = te_gemm.get_cublas_workspace_size_bytes()
+    except Exception:  # noqa: BLE001 - only used for the log line
+        previous_bytes = None
+
+    te_gemm.get_cublas_workspace_size_bytes = lambda: requested_bytes
+    # Already-allocated workspaces are memoized per device.
+    if hasattr(te_gemm.get_cublas_workspace, "cache_clear"):
+        te_gemm.get_cublas_workspace.cache_clear()
+
+    was = "unknown" if previous_bytes is None else f"{previous_bytes // (1024 * 1024)} MiB"
+    log_rank_0(
+        "[Patch:megatron.te.hipblaslt_gemm_workspace] TE GEMM workspace "
+        f"{was} -> {requested_bytes // (1024 * 1024)} MiB ({ENV_VAR})"
+    )

--- a/primus/backends/megatron/training/diffusion/loss_computation.py
+++ b/primus/backends/megatron/training/diffusion/loss_computation.py
@@ -89,6 +89,71 @@ def compute_flow_matching_loss(
     return loss
 
 
+def compute_weighted_flow_matching_loss(
+    prediction: Tensor,
+    target: Tensor,
+    weight: Tensor,
+    loss_mask: Optional[Tensor] = None,
+) -> Tensor:
+    """
+    Compute flow matching loss with a per-timestep weight.
+
+    Video flow matching (Wan, MovieGen) scales the squared error by a
+    timestep-dependent weight, so that noise levels contribute unevenly to
+    the gradient. Two things differ from :func:`compute_flow_matching_loss`:
+
+    1. The target is supplied by the caller rather than derived as
+       ``noise - clean_latents``, so alternative parameterizations
+       (velocity, ``noise - sample``) can reuse this helper.
+    2. The squared error is multiplied by ``weight`` before reduction.
+
+    Formula: loss = mean(((target - prediction) ** 2) * weight)
+
+    Passing ``weight=1.0`` recovers the unweighted objective, which is how
+    the ``uniform`` loss weighting mode is expressed.
+
+    Args:
+        prediction: Model output [any shape]
+        target: Training target from the scheduler [same shape as prediction]
+        weight: Per-sample weight, broadcast-compatible with target.
+                Typically [batch_size] or [batch_size, 1, 1, ...].
+        loss_mask: Optional mask for variable-length sequences [batch_size]
+                   or broadcast-compatible shape. Default None (no masking).
+
+    Returns:
+        Scalar loss value (weighted mean squared error, optionally masked).
+
+    Reference:
+        DiffSynth-Studio ``FlowMatchSFTLoss``; maxdiffusion
+        ``wan_trainer.step_optimizer``.
+
+    Example:
+        >>> pred = torch.randn(2, 16, 8, 32, 32)  # Batch of 3D latents
+        >>> target = torch.randn(2, 16, 8, 32, 32)
+        >>> weight = torch.tensor([0.8, 1.2])  # Per-sample timestep weight
+        >>> loss = compute_weighted_flow_matching_loss(pred, target, weight)
+    """
+    diff_sq = (target.float() - prediction.float()) ** 2
+
+    if weight.dim() == 1 and diff_sq.dim() > 1:
+        weight_shape = [weight.shape[0]] + [1] * (diff_sq.dim() - 1)
+        weight = weight.view(*weight_shape)
+    weight = weight.to(dtype=diff_sq.dtype, device=diff_sq.device)
+
+    weighted = diff_sq * weight
+
+    if loss_mask is None:
+        return weighted.mean()
+
+    if loss_mask.dim() == 1 and weighted.dim() > 1:
+        mask_shape = [loss_mask.shape[0]] + [1] * (weighted.dim() - 1)
+        loss_mask = loss_mask.view(*mask_shape)
+    loss_mask = loss_mask.to(dtype=weighted.dtype, device=weighted.device)
+
+    return (weighted * loss_mask).sum() / loss_mask.sum().clamp(min=1.0)
+
+
 __all__ = [
     "compute_flow_matching_loss",
+    "compute_weighted_flow_matching_loss",
 ]

--- a/primus/backends/megatron/training/diffusion/schedulers/__init__.py
+++ b/primus/backends/megatron/training/diffusion/schedulers/__init__.py
@@ -8,8 +8,12 @@ from primus.backends.megatron.training.diffusion.schedulers.base import BaseSche
 from primus.backends.megatron.training.diffusion.schedulers.flow_matching import (
     FlowMatchEulerDiscreteScheduler,
 )
+from primus.backends.megatron.training.diffusion.schedulers.wan_flow_matching import (
+    WanFlowMatchScheduler,
+)
 
 __all__ = [
     "BaseScheduler",
     "FlowMatchEulerDiscreteScheduler",
+    "WanFlowMatchScheduler",
 ]

--- a/primus/backends/megatron/training/diffusion/schedulers/wan_flow_matching.py
+++ b/primus/backends/megatron/training/diffusion/schedulers/wan_flow_matching.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Wan-template flow matching scheduler.
+
+The Wan recipe (shared by WAN 2.1 and WAN 2.2) has the same form as
+:class:`FlowMatchEulerDiscreteScheduler` but adds three pieces the training
+loop needs and the Flux scheduler does not expose:
+
+- ``training_target(latents, noise, timesteps)``: the per-sample target
+  velocity, following the maxdiffusion convention ``target = noise - sample``.
+- ``training_weight(timesteps)``: a per-timestep loss weight (bell-shaped,
+  normalized to mean 1).
+- ``sample_training_timesteps(...)``: timestep draw, optionally restricted to
+  a window so the two WAN 2.2 experts can be trained separately.
+
+Forward and inference behavior is inherited unchanged (Euler step plus the
+``shift * sigma / (1 + (shift - 1) * sigma)`` schedule).
+
+Reference:
+    DiffSynth-Studio ``diffsynth/schedulers/flow_match.py`` (Wan template).
+    maxdiffusion ``src/maxdiffusion/trainers/wan_trainer.py``.
+"""
+
+from typing import Optional, Tuple, Union
+
+import torch
+
+from primus.backends.megatron.training.diffusion.schedulers.flow_matching import (
+    FlowMatchEulerDiscreteScheduler,
+)
+
+
+class WanFlowMatchScheduler(FlowMatchEulerDiscreteScheduler):
+    """Wan template scheduler.
+
+    Args:
+        num_train_timesteps: Discrete schedule length (Wan default 1000).
+        shift: Static schedule shift. Wan default is 5.0.
+        sigma_min, sigma_max: Sigma range (Wan default ``[0, 1]``).
+        use_dynamic_shifting, base_shift, max_shift, base_image_seq_len,
+        max_image_seq_len: Inference / dynamic-shift hooks, forwarded to the
+            base scheduler.
+    """
+
+    def __init__(
+        self,
+        num_train_timesteps: int = 1000,
+        shift: float = 5.0,
+        sigma_min: float = 0.0,
+        sigma_max: float = 1.0,
+        use_dynamic_shifting: bool = False,
+        base_shift: Optional[float] = 0.5,
+        max_shift: Optional[float] = 1.15,
+        base_image_seq_len: Optional[int] = 256,
+        max_image_seq_len: Optional[int] = 4096,
+    ):
+        super().__init__(
+            num_train_timesteps=num_train_timesteps,
+            shift=shift,
+            use_dynamic_shifting=use_dynamic_shifting,
+            base_shift=base_shift,
+            max_shift=max_shift,
+            base_image_seq_len=base_image_seq_len,
+            max_image_seq_len=max_image_seq_len,
+        )
+
+        # Clip sigmas to the Wan range. The Wan defaults already match [0, 1],
+        # so this is a no-op for the default config; the knob exists to support
+        # future variants.
+        if (sigma_min, sigma_max) != (0.0, 1.0):
+            self.sigmas = self.sigmas.clamp(min=sigma_min, max=sigma_max)
+            self.sigma_min = sigma_min
+            self.sigma_max = sigma_max
+
+        self.training_weights = self._build_training_weights()
+
+    def _build_training_weights(self) -> torch.Tensor:
+        """Precompute the per-timestep loss weight table.
+
+        DiffSynth builds the table over the (post-shift) training schedule::
+
+            y = exp(-2 * ((t - N/2) / N) ** 2)
+            y = y - y.min()
+            w = y * (N / y.sum())
+
+        The subtraction makes the weight vanish at the schedule endpoint that
+        is furthest from the center, and the final scaling normalizes the table
+        to mean 1. Normalization is what keeps the weighted objective on the
+        same scale as the unweighted one, so enabling weighting does not shift
+        the loss magnitude or require re-tuning the learning rate.
+        """
+        t = self.timesteps.to(dtype=torch.float32)
+        n = float(self.num_train_timesteps)
+
+        y = torch.exp(-2.0 * ((t - n / 2.0) / n) ** 2)
+        y = y - y.min()
+
+        return y * (n / y.sum())
+
+    # ------------------------------------------------------------------
+    # Training-only helpers
+    # ------------------------------------------------------------------
+
+    def sigma_from_timestep(
+        self,
+        timesteps: Union[int, float, torch.Tensor],
+        device: Optional[torch.device] = None,
+    ) -> torch.Tensor:
+        """Map a sampled integer timestep index to its post-shift sigma.
+
+        Uses the same static shift formula as the base scheduler:
+
+            base_sigma = t / num_train_timesteps
+            sigma      = shift * base_sigma / (1 + (shift - 1) * base_sigma)
+
+        Returns a 1-D float32 tensor (no broadcasting); callers reshape as
+        needed.
+        """
+        if not isinstance(timesteps, torch.Tensor):
+            timesteps = torch.tensor(timesteps, device=device)
+        t = timesteps.to(device=device or timesteps.device, dtype=torch.float32)
+        base_sigma = t / float(self.num_train_timesteps)
+        return self.shift * base_sigma / (1.0 + (self.shift - 1.0) * base_sigma)
+
+    def conditioning_timestep(
+        self,
+        timesteps: Union[int, float, torch.Tensor],
+        device: Optional[torch.device] = None,
+    ) -> torch.Tensor:
+        """Timestep value to condition the transformer on (``sigma * N``).
+
+        This is the inference-aligned timestep. At inference the schedule feeds
+        the transformer ``sigma_shifted * num_train_timesteps``, so training
+        must condition on the same quantity rather than on the raw sampled
+        index ``t``, whose noise level is ``sigma_shifted(t)`` and not ``t / N``.
+
+        Conditioning on the raw index would teach the model a timestep->noise
+        mapping the sampler never reproduces, which lets training loss fall
+        while sample quality stalls.
+        """
+        return self.sigma_from_timestep(timesteps, device) * float(self.num_train_timesteps)
+
+    def add_noise(
+        self,
+        latents: torch.Tensor,
+        noise: torch.Tensor,
+        timesteps: Union[int, float, torch.Tensor, None] = None,
+        sigma: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Forward process: ``x_t = sigma * noise + (1 - sigma) * latents``.
+
+        Wan training samples integer timesteps uniformly over
+        ``[0, num_train_timesteps)``. Those integers are not present in
+        ``self.timesteps`` (which holds the post-shift float schedule used at
+        inference), so :meth:`scale_noise`'s schedule lookup cannot be reused.
+        Sigma is instead computed directly from the timestep, which matches
+        DiffSynth's ``FlowMatchScheduler.add_noise`` and works for any ``shift``
+        at any sampled timestep rather than only those that happen to coincide
+        with the inference schedule.
+
+        ``sigma`` may be supplied directly to bypass the timestep->sigma
+        mapping. The Megatron-Bridge parity path uses this, since it computes
+        sigma with Bridge's continuous flow-shift formula rather than the Wan
+        static-shift schedule.
+        """
+        if sigma is None:
+            sigma = self.sigma_from_timestep(timesteps, device=latents.device)
+
+        sigmas = sigma.to(device=latents.device)
+        while sigmas.dim() < latents.dim():
+            sigmas = sigmas.unsqueeze(-1)
+        sigmas = sigmas.to(dtype=latents.dtype)
+
+        return sigmas * noise + (1.0 - sigmas) * latents
+
+    def sample_bridge_style_timesteps(
+        self,
+        batch_size: int,
+        device: torch.device,
+        generator: Optional[torch.Generator] = None,
+        flow_shift: float = 2.5,
+        sampling: str = "uniform",
+        logit_mean: float = 0.0,
+        logit_std: float = 1.5,
+        sigma_min: float = 0.0,
+        sigma_max: float = 1.0,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Sample ``(timesteps, sigma)`` the Megatron-Bridge way (parity path).
+
+        Mirrors ``FlowMatchingPipeline.sample_timesteps`` in Megatron-Bridge::
+
+            u     = rand(B)                        (sampling="uniform")
+                  = sigmoid(normal(mean, std, B))  (sampling="logit_normal")
+            sigma = flow_shift * u / (1 + (flow_shift - 1) * u)
+            sigma = clamp(sigma, sigma_min, sigma_max)
+            t     = sigma * num_train_timesteps
+
+        Unlike :meth:`sample_training_timesteps` (discrete ``randint`` plus the
+        static-shift schedule), this is a continuous draw using Bridge's
+        ``flow_shift``. The returned ``sigma`` goes straight to
+        :meth:`add_noise` so the forward process uses that exact value, and
+        ``timesteps`` is what the transformer is conditioned on.
+
+        A ``generator`` makes the draw reproducible. Element-wise agreement
+        with a specific Bridge run additionally requires Bridge to seed its own
+        timestep draw, which it currently takes from the ambient RNG; without
+        that this gives algorithmic and distributional parity plus reproducible
+        values on the Primus side.
+        """
+        if sampling == "logit_normal":
+            u = torch.normal(
+                mean=logit_mean,
+                std=logit_std,
+                size=(batch_size,),
+                device=device,
+                generator=generator,
+            )
+            u = torch.sigmoid(u)
+        else:  # "uniform"
+            u = torch.rand(size=(batch_size,), device=device, generator=generator)
+
+        u = torch.clamp(u, min=1e-5)
+        sigma = flow_shift / (flow_shift + (1.0 / u - 1.0))
+        sigma = torch.clamp(sigma, sigma_min, sigma_max)
+        timesteps = sigma * float(self.num_train_timesteps)
+        return timesteps, sigma
+
+    def training_target(
+        self,
+        latents: torch.Tensor,
+        noise: torch.Tensor,
+        timesteps: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Velocity target: ``noise - latents``.
+
+        Matches maxdiffusion's ``wan_trainer.step_optimizer``. The
+        ``timesteps`` argument is accepted for interface uniformity; the Wan
+        target does not depend on it.
+        """
+        del timesteps  # Wan's target is timestep-independent.
+        return noise - latents
+
+    def training_weight(self, timesteps: torch.Tensor) -> torch.Tensor:
+        """Look up the per-sample loss weight for ``timesteps``.
+
+        ``timesteps`` are the conditioning timesteps (``sigma * N``), matching
+        the schedule the weight table is built over. Each is resolved to the
+        nearest schedule entry, as DiffSynth does.
+
+        Returns a float32 ``[B]`` tensor with values in roughly ``[0, 1.6]``
+        and mean 1 over the full schedule.
+        """
+        if not isinstance(timesteps, torch.Tensor):
+            timesteps = torch.tensor(timesteps)
+
+        t = timesteps.to(dtype=torch.float32).flatten()
+        schedule = self.timesteps.to(device=t.device, dtype=torch.float32)
+        weights = self.training_weights.to(device=t.device)
+
+        nearest = (t.unsqueeze(1) - schedule.unsqueeze(0)).abs().argmin(dim=1)
+
+        return weights[nearest]
+
+    # ------------------------------------------------------------------
+    # Timestep sampling helper
+    # ------------------------------------------------------------------
+
+    def sample_training_timesteps(
+        self,
+        batch_size: int,
+        device: torch.device,
+        timestep_window: Optional[Tuple[float, float]] = None,
+    ) -> torch.Tensor:
+        """Sample ``[B]`` integer timesteps for training.
+
+        Without ``timestep_window``: uniform over ``[0, num_train_timesteps)``.
+
+        With ``timestep_window=(lo, hi)``: uniform over
+        ``[lo, hi) * num_train_timesteps``. The DiffSynth-style per-expert
+        recipe uses this to train ``transformer`` and ``transformer_2`` in
+        separate jobs.
+        """
+        if timestep_window is None:
+            lo, hi = 0, self.num_train_timesteps
+        else:
+            lo = int(self.num_train_timesteps * timestep_window[0])
+            hi = max(lo + 1, int(self.num_train_timesteps * timestep_window[1]))
+
+        return torch.randint(
+            low=lo,
+            high=hi,
+            size=(batch_size,),
+            device=device,
+            dtype=torch.long,
+        )
+
+
+__all__ = ["WanFlowMatchScheduler"]

--- a/primus/backends/megatron/training/diffusion/wan_forward_step.py
+++ b/primus/backends/megatron/training/diffusion/wan_forward_step.py
@@ -1,0 +1,166 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Forward step for WAN (2.1 / 2.2) video diffusion training.
+
+Mirrors ``flux_forward_step_func`` but for 5D video latents, and returns the
+scheduler's training target and per-timestep weight alongside the prediction so
+the trainer can apply the weighted flow-matching loss.
+
+Random draws happen in a fixed order -- noise first, then timesteps -- because
+both come from the ambient RNG, so any reordering changes the whole stream and
+with it every loss value.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+
+
+def wan_forward_step_func(
+    data_iterator,
+    model,
+    scheduler,
+    timestep_window: Optional[Tuple[float, float]] = None,
+    boundary_timestep: Optional[float] = None,
+    loss_weighting: str = "diffsynth",
+):
+    """Run one WAN training forward pass.
+
+    Args:
+        data_iterator: Iterator yielding ``EncodedWanTaskEncoder`` batches.
+        model: ``Wan`` or ``Wan2_2`` instance.
+        scheduler: ``WanFlowMatchScheduler``.
+        timestep_window: Optional ``(lo, hi)`` in ``[0, 1]`` restricting sampled
+            timesteps to a sub-window, for training one WAN 2.2 expert per job.
+        boundary_timestep: Optional WAN 2.2 routing boundary in post-shift
+            timestep space. Ignored by single-transformer ``Wan``.
+        loss_weighting: ``"diffsynth"`` for the scheduler's per-timestep weight,
+            ``"uniform"`` for an unweighted objective.
+
+    Returns:
+        Tuple ``(noise_pred, clean_latents, noise, target, weight, loss_mask,
+        metrics, is_validation)``.
+    """
+    from megatron.core.parallel_state import (
+        get_pipeline_model_parallel_rank,
+        get_pipeline_model_parallel_world_size,
+        get_tensor_model_parallel_world_size,
+    )
+
+    pp_size = get_pipeline_model_parallel_world_size()
+    if pp_size > 1:
+        pp_rank = get_pipeline_model_parallel_rank()
+        if pp_rank not in (0, pp_size - 1):
+            # WAN enforces PP=1, but stay harmless on PP middle ranks.
+            dummy = torch.tensor(0.0, device="cuda", requires_grad=True)
+            return dummy, dummy, dummy, dummy, dummy, None, {}, False
+
+    tp_size = get_tensor_model_parallel_world_size()
+    if tp_size != 1:
+        raise RuntimeError(
+            f"WAN requires tensor_model_parallel_size=1, got tp_size={tp_size}. "
+            "WanConfig.validate() enforces this; this is a defense-in-depth check."
+        )
+
+    if model.config.bf16:
+        compute_dtype = torch.bfloat16
+    elif model.config.fp16:
+        compute_dtype = torch.float16
+    else:
+        compute_dtype = model.config.params_dtype
+
+    assert data_iterator is not None, (
+        "WAN forward step requires a data_iterator (TP=1 path). "
+        "Make sure the dataset provider sets is_distributed=True."
+    )
+
+    batch = next(data_iterator)
+    if not isinstance(batch, dict):
+        raise TypeError(f"[WanForwardStep] Expected batch to be a dict, got {type(batch)}.")
+
+    required_keys = ("latents", "encoder_hidden_states")
+    missing = [key for key in required_keys if key not in batch]
+    if missing:
+        raise KeyError(f"[WanForwardStep] Batch missing required keys: {missing}. Got: {list(batch.keys())}")
+
+    for key in list(batch.keys()):
+        if isinstance(batch[key], torch.Tensor):
+            if batch[key].is_floating_point():
+                batch[key] = batch[key].to(dtype=compute_dtype, device="cuda", non_blocking=True)
+            elif not batch[key].is_cuda:
+                batch[key] = batch[key].cuda(non_blocking=True)
+
+    latents = batch["latents"]
+    encoder_hidden_states = batch["encoder_hidden_states"]
+    loss_mask = batch.get("loss_mask")
+    is_validation = "timestep" in batch and batch.get("validation", False)
+
+    with torch.no_grad():
+        if "noise" in batch and isinstance(batch["noise"], torch.Tensor):
+            noise = batch["noise"].to(dtype=compute_dtype, device="cuda", non_blocking=True)
+        else:
+            noise = torch.randn_like(latents, dtype=compute_dtype)
+
+        if is_validation and "timestep" in batch:
+            timesteps = batch["timestep"].to(device="cuda", dtype=torch.long)
+        else:
+            timesteps = scheduler.sample_training_timesteps(
+                batch_size=latents.shape[0],
+                device=latents.device,
+                timestep_window=timestep_window,
+            )
+
+        noisy_latents = scheduler.add_noise(latents, noise, timesteps)
+        target = scheduler.training_target(latents, noise, timesteps)
+
+        # Condition on the inference-aligned post-shift timestep, which is also
+        # the axis the weight table is indexed on.
+        model_timesteps = scheduler.conditioning_timestep(timesteps, device=latents.device)
+
+        if loss_weighting == "uniform":
+            weight = torch.ones(latents.shape[0], device=latents.device, dtype=latents.dtype)
+        else:
+            weight = scheduler.training_weight(model_timesteps).to(device=latents.device, dtype=latents.dtype)
+
+    # The routing boundary is compared against the conditioned timestep, so it
+    # has to live in the same post-shift space.
+    boundary_tensor: Optional[torch.Tensor] = None
+    if boundary_timestep is not None:
+        boundary_tensor = torch.full_like(model_timesteps, fill_value=float(boundary_timestep))
+
+    with torch.amp.autocast("cuda", enabled=True, dtype=compute_dtype):
+        noise_pred = model(
+            hidden_states=noisy_latents,
+            timestep=model_timesteps,
+            encoder_hidden_states=encoder_hidden_states,
+            boundary_timestep=boundary_tensor,
+        )
+
+    metrics = {
+        "batch_size": latents.shape[0],
+        "latent_channels": latents.shape[1],
+        "latent_t": latents.shape[2],
+        "latent_h": latents.shape[3],
+        "latent_w": latents.shape[4],
+        "text_seq_len": encoder_hidden_states.shape[1],
+        "avg_timestep": timesteps.float().mean(),
+    }
+
+    return (
+        noise_pred,
+        latents,
+        noise,
+        target,
+        weight,
+        loss_mask,
+        metrics,
+        is_validation,
+    )
+
+
+__all__ = ["wan_forward_step_func"]

--- a/primus/backends/megatron/training/diffusion/wan_forward_step.py
+++ b/primus/backends/megatron/training/diffusion/wan_forward_step.py
@@ -133,7 +133,11 @@ def wan_forward_step_func(
     if boundary_timestep is not None:
         boundary_tensor = torch.full_like(model_timesteps, fill_value=float(boundary_timestep))
 
-    with torch.amp.autocast("cuda", enabled=True, dtype=compute_dtype):
+    # Autocast has nothing to do when the run is already fp32, and asking CUDA
+    # to cast float32 to float32 is only a no-op by convention.
+    autocast_enabled = compute_dtype in (torch.bfloat16, torch.float16)
+
+    with torch.amp.autocast("cuda", enabled=autocast_enabled, dtype=compute_dtype):
         noise_pred = model(
             hidden_states=noisy_latents,
             timestep=model_timesteps,

--- a/primus/backends/megatron/wan_pretrain_trainer.py
+++ b/primus/backends/megatron/wan_pretrain_trainer.py
@@ -29,48 +29,79 @@ from primus.backends.megatron.diffusion_trainer import DiffusionPretrainTrainer
 from primus.backends.megatron.training.diffusion.schedulers import WanFlowMatchScheduler
 from primus.core.utils.module_utils import log_rank_0
 
-# Primus-Turbo picks the flash-attention backward variant from this variable,
-# re-reading it on every call. Its own default is "1"; Primus' launchers override
-# that to "0" (``examples/run_pretrain.sh`` and ``runner/helpers/envs/
-# base_env.sh``, both as a conservative accuracy default).
-ATTN_ATOMIC_FP32_ENV = "PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32"
+# Both attention backends re-read the flash-attention backward variant on every
+# call, and each keeps its own copy of the choice: Primus-Turbo (local spec)
+# reads the first variable, TransformerEngine's ROCm CK backend (te_spec) the
+# second. A run uses one spec or the other, so set both rather than have the
+# trainer work out which one is live.
+#
+# Neither default is right here. Primus' launchers override Primus-Turbo's own
+# default of "1" to "0" (``examples/run_pretrain.sh`` and
+# ``runner/helpers/envs/base_env.sh``), and the release Dockerfile pins
+# ``NVTE_CK_IS_V3_ATOMIC_FP32=0``, which is the gfx950 value; on gfx942 the CK
+# v3 backward needs fp32 atomics, as ``tools/installation/env.sh`` already spells
+# out for the bare-metal path.
+ATTN_ATOMIC_FP32_ENVS = (
+    "PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32",
+    "NVTE_CK_IS_V3_ATOMIC_FP32",
+)
+
+# TE only reaches a v3 backward with this on. It is already "1" everywhere in
+# Primus; setting it stops a launcher that disabled v3 from quietly undoing the
+# atomics above.
+TE_CK_BWD_V3_ENV = "NVTE_CK_USES_BWD_V3"
 
 
-def _apply_turbo_atomic_fp32_backward(enabled: bool) -> None:
-    """Let WAN reach aiter's fp32-atomic attention backward.
+def _apply_atomic_fp32_backward(enabled: bool) -> None:
+    """Let WAN's attention backward reach the fp32-atomic ASM kernels.
 
-    With the atomic accumulator off, WAN's shapes cannot reach any aiter ASM
-    backward at all: the sequence length is not divisible by 64, so the
-    non-padded kernel family is out, and the ``psskddv`` family that would
-    otherwise serve these shapes requires the atomic. Dispatch then falls
-    through to ck_tile without saying so.
+    WAN's sequence length is not divisible by 64, which is what puts both
+    backends in the same corner: the kernel families that serve non-padded
+    shapes accumulate dQ through atomics, so with the atomic accumulator off
+    there is no ASM backward to dispatch to and both fall through to ck_tile
+    without saying so.
 
-    Turning it on replaces ck_tile's backward with
+    On the local spec that leaves Primus-Turbo on ck_tile's backward instead of
     ``aiter::fmha_bwd_hd128_bf16_a32_rtna_psskddv`` over the same call count.
-    The accumulation order is non-deterministic, so this is not free in
-    principle; over a 20-step run the loss stayed within bf16 reduction noise
-    rather than showing a behaviour change.
 
-    The opt-out is the YAML key rather than the environment variable, because
-    the launchers export the variable unconditionally (``${VAR:-0}``) and so
-    every WAN run arrives here with it already set to "0". Reading it back could
-    not tell a deliberate choice apart from that blanket default, which is the
-    bug this works around. Set ``attn_atomic_fp32: false`` to get the
-    deterministic split-dQ path back.
+    On te_spec the same thing happens one layer down. TE asks for its v3
+    backward (``NVTE_CK_USES_BWD_V3`` is "1" everywhere in Primus) but the
+    release Dockerfile pins ``NVTE_CK_IS_V3_ATOMIC_FP32=0``, the value that suits
+    gfx950, so on gfx942 v3 is unreachable and CK serves the backward from
+    ck_tile. Setting the atomics gets
+    ``aiter::fmha_bwd_hd128_bf16_a32_rtz_pssk_group`` instead over the same call
+    count, which is the pairing ``tools/installation/env.sh`` already prescribes
+    for gfx942.
+
+    So the atomic path is what reaches the ASM kernels on both specs. The
+    accumulation order is non-deterministic, so this is not free in principle;
+    over a 20-step run the loss stayed within bf16 reduction noise rather than
+    showing a behaviour change.
+
+    The opt-out is the YAML key rather than the environment variables, because
+    the launchers and the image export those unconditionally and so every WAN run
+    arrives here with them already set to "0". Reading them back could not tell a
+    deliberate choice apart from that blanket default, which is the bug this
+    works around. Set ``attn_atomic_fp32: false`` to get the deterministic
+    split-dQ path back.
     """
     value = "1" if enabled else "0"
-    previous = os.environ.get(ATTN_ATOMIC_FP32_ENV)
-    os.environ[ATTN_ATOMIC_FP32_ENV] = value
+    previous = {name: os.environ.get(name) for name in ATTN_ATOMIC_FP32_ENVS}
+    for name in ATTN_ATOMIC_FP32_ENVS:
+        os.environ[name] = value
+    if enabled:
+        os.environ[TE_CK_BWD_V3_ENV] = "1"
 
+    settings = ", ".join(f"{name}={value} (was {previous[name]!r})" for name in ATTN_ATOMIC_FP32_ENVS)
     if enabled:
         log_rank_0(
-            f"WAN trainer: {ATTN_ATOMIC_FP32_ENV}={value} (was {previous!r}) so the "
-            f"attention backward reaches aiter's fp32-atomic kernels instead of ck_tile"
+            f"WAN trainer: {settings} so the attention backward reaches the "
+            f"fp32-atomic ASM kernels instead of ck_tile"
         )
     else:
         log_rank_0(
-            f"WAN trainer: {ATTN_ATOMIC_FP32_ENV}={value} by request "
-            f"(attn_atomic_fp32: false); the attention backward will use ck_tile"
+            f"WAN trainer: {settings} by request (attn_atomic_fp32: false); "
+            f"the attention backward will use ck_tile"
         )
 
 
@@ -92,7 +123,8 @@ class WanPretrainTrainer(DiffusionPretrainTrainer):
         - ``backbone_pretrained``, ``backbone_subfolder``,
           ``backbone_subfolder_2``.
         - ``attn_atomic_fp32`` (default true): let the attention backward use
-          aiter's fp32-atomic kernels. Set false for a deterministic backward.
+          the fp32-atomic ASM kernels, on both the local spec (Primus-Turbo) and
+          te_spec (TE / CK v3). Set false for a deterministic backward.
     """
 
     def __init__(self, *args, **kwargs):
@@ -107,10 +139,10 @@ class WanPretrainTrainer(DiffusionPretrainTrainer):
 
         self.loss_weighting = getattr(params, "loss_weighting", "diffsynth")
 
-        # Before the first forward, and read per call by Primus-Turbo, so the
-        # trainer constructor is early enough.
+        # Before the first forward, and re-read per call by both backends, so
+        # the trainer constructor is early enough.
         self.attn_atomic_fp32 = bool(getattr(params, "attn_atomic_fp32", True))
-        _apply_turbo_atomic_fp32_backward(self.attn_atomic_fp32)
+        _apply_atomic_fp32_backward(self.attn_atomic_fp32)
 
         # The model config resolves stage -> window, so read the window back off
         # it rather than recomputing here and risking a disagreement.

--- a/primus/backends/megatron/wan_pretrain_trainer.py
+++ b/primus/backends/megatron/wan_pretrain_trainer.py
@@ -20,12 +20,58 @@ WAN runs at ``tensor_model_parallel_size=1`` and
 ``pipeline_model_parallel_size=1``; ``WanConfig.validate()`` enforces both.
 """
 
+import os
+
 import torch
 import torch.nn as nn
 
 from primus.backends.megatron.diffusion_trainer import DiffusionPretrainTrainer
 from primus.backends.megatron.training.diffusion.schedulers import WanFlowMatchScheduler
 from primus.core.utils.module_utils import log_rank_0
+
+# Primus-Turbo picks the flash-attention backward variant from this variable,
+# re-reading it on every call. Its own default is "1"; Primus' launchers override
+# that to "0" (``examples/run_pretrain.sh`` and ``runner/helpers/envs/
+# base_env.sh``, both as a conservative accuracy default).
+ATTN_ATOMIC_FP32_ENV = "PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32"
+
+
+def _apply_turbo_atomic_fp32_backward(enabled: bool) -> None:
+    """Let WAN reach aiter's fp32-atomic attention backward.
+
+    With the atomic accumulator off, WAN's shapes cannot reach any aiter ASM
+    backward at all: the sequence length is not divisible by 64, so the
+    non-padded kernel family is out, and the ``psskddv`` family that would
+    otherwise serve these shapes requires the atomic. Dispatch then falls
+    through to ck_tile without saying so.
+
+    Turning it on replaces ck_tile's backward with
+    ``aiter::fmha_bwd_hd128_bf16_a32_rtna_psskddv`` over the same call count.
+    The accumulation order is non-deterministic, so this is not free in
+    principle; over a 20-step run the loss stayed within bf16 reduction noise
+    rather than showing a behaviour change.
+
+    The opt-out is the YAML key rather than the environment variable, because
+    the launchers export the variable unconditionally (``${VAR:-0}``) and so
+    every WAN run arrives here with it already set to "0". Reading it back could
+    not tell a deliberate choice apart from that blanket default, which is the
+    bug this works around. Set ``attn_atomic_fp32: false`` to get the
+    deterministic split-dQ path back.
+    """
+    value = "1" if enabled else "0"
+    previous = os.environ.get(ATTN_ATOMIC_FP32_ENV)
+    os.environ[ATTN_ATOMIC_FP32_ENV] = value
+
+    if enabled:
+        log_rank_0(
+            f"WAN trainer: {ATTN_ATOMIC_FP32_ENV}={value} (was {previous!r}) so the "
+            f"attention backward reaches aiter's fp32-atomic kernels instead of ck_tile"
+        )
+    else:
+        log_rank_0(
+            f"WAN trainer: {ATTN_ATOMIC_FP32_ENV}={value} by request "
+            f"(attn_atomic_fp32: false); the attention backward will use ck_tile"
+        )
 
 
 class WanPretrainTrainer(DiffusionPretrainTrainer):
@@ -45,6 +91,8 @@ class WanPretrainTrainer(DiffusionPretrainTrainer):
           ``out_channels``, ``freq_dim``).
         - ``backbone_pretrained``, ``backbone_subfolder``,
           ``backbone_subfolder_2``.
+        - ``attn_atomic_fp32`` (default true): let the attention backward use
+          aiter's fp32-atomic kernels. Set false for a deterministic backward.
     """
 
     def __init__(self, *args, **kwargs):
@@ -58,6 +106,11 @@ class WanPretrainTrainer(DiffusionPretrainTrainer):
         self.scheduler_sigma_max = getattr(params, "scheduler_sigma_max", 1.0)
 
         self.loss_weighting = getattr(params, "loss_weighting", "diffsynth")
+
+        # Before the first forward, and read per call by Primus-Turbo, so the
+        # trainer constructor is early enough.
+        self.attn_atomic_fp32 = bool(getattr(params, "attn_atomic_fp32", True))
+        _apply_turbo_atomic_fp32_backward(self.attn_atomic_fp32)
 
         # The model config resolves stage -> window, so read the window back off
         # it rather than recomputing here and risking a disagreement.

--- a/primus/backends/megatron/wan_pretrain_trainer.py
+++ b/primus/backends/megatron/wan_pretrain_trainer.py
@@ -1,0 +1,323 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+WAN (2.1 / 2.2) Pretrain Trainer for Primus-Megatron.
+
+Mirrors :class:`FluxPretrainTrainer` but specialized for the WAN family:
+
+    - Model: :class:`Wan` (single transformer: WAN 2.1 all sizes, WAN 2.2
+      TI2V-5B) or :class:`Wan2_2` (dual-expert A14B).
+    - Scheduler: :class:`WanFlowMatchScheduler`, which adds ``training_target``
+      and ``training_weight`` to the Flux flow-matching scheduler.
+    - Loss: :func:`compute_weighted_flow_matching_loss`.
+    - Task encoder: :class:`EncodedWanTaskEncoder` for the pre-encoded path.
+
+WAN runs at ``tensor_model_parallel_size=1`` and
+``pipeline_model_parallel_size=1``; ``WanConfig.validate()`` enforces both.
+"""
+
+import torch
+import torch.nn as nn
+
+from primus.backends.megatron.diffusion_trainer import DiffusionPretrainTrainer
+from primus.backends.megatron.training.diffusion.schedulers import WanFlowMatchScheduler
+from primus.core.utils.module_utils import log_rank_0
+
+
+class WanPretrainTrainer(DiffusionPretrainTrainer):
+    """Trainer for WAN 2.1 / 2.2 video diffusion pre-training.
+
+    YAML keys consumed (under ``overrides``):
+        - ``num_train_timesteps`` (default 1000), ``scheduler_shift``
+          (default 5.0), ``scheduler_sigma_min`` / ``scheduler_sigma_max``.
+        - ``loss_weighting``: ``diffsynth`` (default) or ``uniform``.
+        - ``num_transformers`` (1 or 2) and ``boundary_ratio`` for WAN 2.2.
+        - ``stage``: ``full`` / ``high_noise`` / ``low_noise``. Narrowing the
+          stage derives the timestep window and the weight subfolder from
+          ``boundary_ratio`` so the two cannot disagree.
+        - Architecture fields (``hidden_size``, ``num_attention_heads``,
+          ``num_dit_layers``, ``ffn_hidden_size``, ``text_embed_dim``,
+          ``text_seq_len``, ``patch_size_3d``, ``in_channels``,
+          ``out_channels``, ``freq_dim``).
+        - ``backbone_pretrained``, ``backbone_subfolder``,
+          ``backbone_subfolder_2``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        params = self.backend_args
+
+        self.num_train_timesteps = getattr(params, "num_train_timesteps", 1000)
+        self.scheduler_shift = getattr(params, "scheduler_shift", 5.0)
+        self.scheduler_sigma_min = getattr(params, "scheduler_sigma_min", 0.0)
+        self.scheduler_sigma_max = getattr(params, "scheduler_sigma_max", 1.0)
+
+        self.loss_weighting = getattr(params, "loss_weighting", "diffsynth")
+
+        # The model config resolves stage -> window, so read the window back off
+        # it rather than recomputing here and risking a disagreement.
+        self.wan_config = self._build_wan_config_from_yaml()
+        self.wan_config.validate()
+
+        window = (
+            self.wan_config.timestep_window_min,
+            self.wan_config.timestep_window_max,
+        )
+        self.timestep_window = None if window == (0.0, 1.0) else window
+
+        if self.wan_config.num_transformers == 2 and self.wan_config.boundary_ratio is not None:
+            self.boundary_timestep = float(self.wan_config.boundary_ratio * self.num_train_timesteps)
+        else:
+            self.boundary_timestep = None
+
+        log_rank_0(
+            f"WAN trainer: shift={self.scheduler_shift}, "
+            f"num_train_timesteps={self.num_train_timesteps}, "
+            f"stage={self.wan_config.stage}, window={self.timestep_window}, "
+            f"num_transformers={self.wan_config.num_transformers}, "
+            f"boundary_ratio={self.wan_config.boundary_ratio}, "
+            f"loss_weighting={self.loss_weighting}"
+        )
+
+    # ------------------------------------------------------------------
+    # Forward step
+    # ------------------------------------------------------------------
+
+    def forward_step(self, data_iterator, model, return_schedule_plan=False):
+        """Run one WAN forward step and return ``(noise_pred, loss_func)``.
+
+        Overrides the Flux-flavored base step: WAN's loss needs the scheduler's
+        target and per-timestep weight, which the base step does not produce.
+        """
+        from primus.backends.megatron.training.diffusion.loss_computation import (
+            compute_weighted_flow_matching_loss,
+        )
+        from primus.backends.megatron.training.diffusion.wan_forward_step import (
+            wan_forward_step_func,
+        )
+
+        if model.training:
+            self._forward_step_count += 1
+
+        (
+            noise_pred,
+            clean_latents,
+            noise,
+            target,
+            weight,
+            loss_mask,
+            metrics,
+            is_validation,
+        ) = wan_forward_step_func(
+            data_iterator,
+            model,
+            scheduler=self.scheduler,
+            timestep_window=self.timestep_window,
+            boundary_timestep=self.boundary_timestep,
+            loss_weighting=self.loss_weighting,
+        )
+
+        self._last_clean_latents = clean_latents
+        self._last_noise = noise
+        self._last_target = target
+        self._last_weight = weight
+        self._last_loss_mask = loss_mask
+
+        if hasattr(self, "runtime_state") and self.runtime_state:
+            self.runtime_state.update_metrics(metrics)
+
+        if is_validation:
+
+            def val_loss_func(output_tensor, non_loss_data=False):
+                if non_loss_data:
+                    return output_tensor
+                loss = compute_weighted_flow_matching_loss(
+                    output_tensor,
+                    self._last_target,
+                    self._last_weight,
+                    self._last_loss_mask,
+                )
+                sample_count = torch.tensor(output_tensor.shape[0], dtype=loss.dtype, device=loss.device)
+                return loss, {"loss": (loss.detach(), sample_count.detach())}
+
+            return noise_pred, val_loss_func
+
+        def wan_loss_func(output_tensor, non_loss_data=False):
+            if non_loss_data:
+                return output_tensor
+
+            loss = compute_weighted_flow_matching_loss(
+                output_tensor,
+                self._last_target,
+                self._last_weight,
+                self._last_loss_mask,
+            )
+            return loss, {"reduced_train_loss": loss.detach().clone()}
+
+        return noise_pred, wan_loss_func
+
+    # ------------------------------------------------------------------
+    # Model construction
+    # ------------------------------------------------------------------
+
+    def create_model(self, pre_process=True, post_process=True):
+        """Build a Wan / Wan2_2 model from the YAML configuration."""
+        from primus.backends.megatron.core.models.diffusion.wan.model import Wan, Wan2_2
+
+        log_rank_0("=" * 80)
+        log_rank_0("Creating WAN model from YAML config")
+
+        config = self.wan_config
+
+        if config.num_transformers == 2:
+            model = Wan2_2(config=config)
+            log_rank_0(
+                "WAN 2.2 dual-expert model created "
+                f"(boundary_ratio={config.boundary_ratio}, "
+                f"boundary_timestep={self.boundary_timestep})"
+            )
+        else:
+            model = Wan(config=config)
+            log_rank_0("WAN single-transformer model created")
+
+        total_params = sum(p.numel() for p in model.parameters())
+        log_rank_0(f"Total parameters: {total_params / 1e9:.2f}B")
+        log_rank_0("=" * 80)
+        return model
+
+    def _build_wan_config_from_yaml(self):
+        """Build :class:`WanConfig` from ``backend_args``.
+
+        Mirrors ``FluxPretrainTrainer._build_flux_config_from_yaml``.
+        """
+        from primus.backends.megatron.core.models.diffusion.wan.config import WanConfig
+
+        params = self.backend_args
+
+        cfg: dict = {
+            "hidden_size": getattr(params, "hidden_size", 1536),
+            "num_attention_heads": getattr(params, "num_attention_heads", 12),
+            "num_dit_layers": getattr(params, "num_dit_layers", 30),
+            "ffn_hidden_size": getattr(params, "ffn_hidden_size", 8960),
+            "in_channels": getattr(params, "in_channels", 16),
+            "out_channels": getattr(params, "out_channels", 16),
+            "patch_size_3d": tuple(getattr(params, "patch_size_3d", (1, 2, 2))),
+            "text_embed_dim": getattr(params, "text_embed_dim", 4096),
+            "text_seq_len": getattr(params, "text_seq_len", 512),
+            "freq_dim": getattr(params, "freq_dim", 256),
+            "num_train_timesteps": getattr(params, "num_train_timesteps", 1000),
+            "loss_weighting": getattr(params, "loss_weighting", "diffsynth"),
+            "num_transformers": getattr(params, "num_transformers", 1),
+            "boundary_ratio": getattr(params, "boundary_ratio", None),
+            "stage": getattr(params, "stage", "full"),
+            "transformer_impl": getattr(params, "transformer_impl", "transformer_engine"),
+            # TransformerConfig defaults this to AttnBackend.auto, which TE
+            # refuses to run under an image that pins NVTE_FLASH_ATTN /
+            # NVTE_FUSED_ATTN, so the resolved value has to be threaded in.
+            "attention_backend": getattr(params, "attention_backend", None),
+            "layernorm_across_heads": getattr(params, "layernorm_across_heads", True),
+            "adaln_zero_init": getattr(params, "adaln_zero_init", True),
+            "backbone_pretrained": getattr(params, "backbone_pretrained", None),
+            "init_method": nn.init.xavier_uniform_,
+            "output_layer_init_method": nn.init.xavier_uniform_,
+        }
+
+        # Only forward an explicit window when the stage did not derive one;
+        # WanConfig rejects setting both.
+        if getattr(params, "stage", "full") == "full":
+            cfg["timestep_window_min"] = getattr(params, "timestep_window_min", 0.0)
+            cfg["timestep_window_max"] = getattr(params, "timestep_window_max", 1.0)
+            cfg["backbone_subfolder"] = getattr(params, "backbone_subfolder", "transformer")
+        cfg["backbone_subfolder_2"] = getattr(params, "backbone_subfolder_2", "transformer_2")
+
+        if cfg["attention_backend"] is None:
+            del cfg["attention_backend"]
+
+        cfg.update(
+            {
+                "bf16": getattr(params, "bf16", True),
+                "fp16": getattr(params, "fp16", False),
+                "params_dtype": getattr(params, "params_dtype", torch.float32),
+            }
+        )
+
+        cfg.update(
+            {
+                "recompute_granularity": getattr(params, "recompute_granularity", None),
+                "recompute_method": getattr(params, "recompute_method", None),
+                "recompute_num_layers": getattr(params, "recompute_num_layers", None),
+                "recompute_modules": getattr(params, "recompute_modules", None),
+            }
+        )
+
+        # FP4 / MXFP4, local transformer_impl only. ``fp4`` / ``fp4_recipe`` are
+        # Megatron TransformerConfig fields; the mxfp4_* knobs are read by the
+        # Primus-Turbo MXFP4 local linears.
+        if getattr(params, "fp4", None):
+            fp4_recipe = getattr(params, "fp4_recipe", None)
+            if not fp4_recipe:
+                raise ValueError(
+                    "fp4_recipe must be set explicitly in YAML when fp4 is enabled "
+                    "(use fp4_recipe: 'mxfp4' for AMD FP4 GEMM)."
+                )
+            cfg.update(
+                {
+                    "fp4": True,
+                    "fp4_recipe": fp4_recipe,
+                    "mxfp4_backward_precision": getattr(params, "mxfp4_backward_precision", "mxfp4"),
+                    "mxfp4_gradient_stochastic_rounding": getattr(
+                        params, "mxfp4_gradient_stochastic_rounding", False
+                    ),
+                    # The MXFP4 local linears subclass the native Megatron
+                    # linears, which reject grad-accum fusion.
+                    "gradient_accumulation_fusion": False,
+                }
+            )
+
+        if getattr(params, "use_fsdp2_fp32_param_optimizer", False):
+            cfg["params_dtype"] = torch.float32
+            cfg["pipeline_dtype"] = torch.bfloat16
+
+        cfg["tensor_model_parallel_size"] = getattr(params, "tensor_model_parallel_size", 1)
+        cfg["pipeline_model_parallel_size"] = getattr(params, "pipeline_model_parallel_size", 1)
+        cfg["context_parallel_size"] = getattr(params, "context_parallel_size", 1)
+
+        return WanConfig(**cfg)
+
+    # ------------------------------------------------------------------
+    # Scheduler
+    # ------------------------------------------------------------------
+
+    def create_scheduler(self):
+        """Create the WAN flow matching scheduler."""
+        log_rank_0(
+            f"Creating WanFlowMatchScheduler: num_train_timesteps={self.num_train_timesteps}, "
+            f"shift={self.scheduler_shift}, "
+            f"sigma_range=[{self.scheduler_sigma_min}, {self.scheduler_sigma_max}]"
+        )
+
+        return WanFlowMatchScheduler(
+            num_train_timesteps=self.num_train_timesteps,
+            shift=self.scheduler_shift,
+            sigma_min=self.scheduler_sigma_min,
+            sigma_max=self.scheduler_sigma_max,
+        )
+
+    # ------------------------------------------------------------------
+    # TaskEncoder
+    # ------------------------------------------------------------------
+
+    def get_task_encoder(self):
+        """Return :class:`EncodedWanTaskEncoder` for the pre-encoded path."""
+        from primus.backends.megatron.data.diffusion.task_encoders import (
+            EncodedWanTaskEncoder,
+        )
+
+        encoder = EncodedWanTaskEncoder(worker_config=None)
+        log_rank_0("Created EncodedWanTaskEncoder for pre-encoded WAN data")
+        return encoder

--- a/primus/configs/models/megatron/diffusion/wan2.1_t2v_1.3b.yaml
+++ b/primus/configs/models/megatron/diffusion/wan2.1_t2v_1.3b.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+# WAN 2.1 T2V-1.3B configuration.
+#
+# The small WAN 2.1 variant, sized for single-node iteration and smoke tests.
+# Reference checkpoint: Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+
+extends:
+  - wan_base.yaml
+
+hidden_size: 1536
+num_attention_heads: 12
+num_dit_layers: 30
+num_layers: 30             # Megatron validate_args reads this; == num_dit_layers
+ffn_hidden_size: 8960
+
+num_transformers: 1
+boundary_ratio: null

--- a/primus/configs/models/megatron/diffusion/wan_base.yaml
+++ b/primus/configs/models/megatron/diffusion/wan_base.yaml
@@ -51,6 +51,17 @@ num_train_timesteps: 1000
 loss_weighting: diffsynth
 
 # ==============================================================================
+# Attention backward kernel
+# ==============================================================================
+
+# Let the attention backward use aiter's fp32-atomic accumulation. WAN's
+# sequence length is not divisible by 64, so with this off no aiter ASM backward
+# is reachable and dispatch falls silently through to the slower ck_tile path.
+# Set false for a deterministic backward; accumulation order is
+# non-deterministic when this is on.
+attn_atomic_fp32: true
+
+# ==============================================================================
 # WAN 2.2 dual-expert routing (single-transformer by default)
 # ==============================================================================
 

--- a/primus/configs/models/megatron/diffusion/wan_base.yaml
+++ b/primus/configs/models/megatron/diffusion/wan_base.yaml
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+# WAN Base Configuration
+# Common parameters for all WAN variants (2.1 1.3B/14B, 2.2 TI2V-5B/A14B).
+# Size-specific variants override hidden_size / num_attention_heads /
+# num_dit_layers / ffn_hidden_size / num_transformers / boundary_ratio.
+
+extends:
+  - ../diffusion_model.yaml
+
+# ==============================================================================
+# Core Architecture (set by variant)
+# ==============================================================================
+
+hidden_size: null            # 1536 (1.3B), 3072 (TI2V-5B), 5120 (14B/A14B)
+num_attention_heads: null    # 12 (1.3B), 24 (TI2V-5B), 40 (14B/A14B)
+num_dit_layers: null         # 30 (1.3B, TI2V-5B), 40 (14B/A14B)
+ffn_hidden_size: null        # 8960 (1.3B), 14336 (TI2V-5B), 13824 (14B/A14B)
+
+# ==============================================================================
+# Latent video channels + 3D patchification
+# ==============================================================================
+
+in_channels: 16
+out_channels: 16
+patch_size_3d: [1, 2, 2]     # (temporal, height, width)
+
+# ==============================================================================
+# Text conditioning (UMT5)
+# ==============================================================================
+
+text_embed_dim: 4096
+text_seq_len: 512
+
+# ==============================================================================
+# Timestep embedding
+# ==============================================================================
+
+freq_dim: 256
+
+# ==============================================================================
+# Diffusion / scheduler
+# ==============================================================================
+
+num_train_timesteps: 1000
+
+# Per-timestep loss weighting:
+#   diffsynth - DiffSynth's bell curve, normalized to mean 1 over the schedule
+#   uniform   - unweighted MSE, identical to Flux's compute_flow_matching_loss
+loss_weighting: diffsynth
+
+# ==============================================================================
+# WAN 2.2 dual-expert routing (single-transformer by default)
+# ==============================================================================
+
+num_transformers: 1
+boundary_ratio: null         # set in (0, 1) for WAN 2.2 A14B dual-expert
+
+# Which expert this job trains: full | high_noise | low_noise. Anything other
+# than full derives the timestep window and the weight subfolder from
+# boundary_ratio, so setting an explicit window as well is an error.
+stage: full
+
+timestep_window_min: 0.0
+timestep_window_max: 1.0
+
+# ==============================================================================
+# Backbone weights
+# ==============================================================================
+
+# q/k RMSNorm across the full inner dim (heads * head_dim) rather than per head;
+# diffusers and Megatron-Bridge both do this, so it must stay true for
+# checkpoint parity.
+layernorm_across_heads: true
+backbone_pretrained: null
+backbone_subfolder: transformer
+backbone_subfolder_2: transformer_2
+
+# ==============================================================================
+# Transformer numerics
+# ==============================================================================
+
+layernorm_epsilon: 1.0e-6
+hidden_dropout: 0.0
+attention_dropout: 0.0

--- a/primus/configs/models/megatron/diffusion/wan_base.yaml
+++ b/primus/configs/models/megatron/diffusion/wan_base.yaml
@@ -54,11 +54,12 @@ loss_weighting: diffsynth
 # Attention backward kernel
 # ==============================================================================
 
-# Let the attention backward use aiter's fp32-atomic accumulation. WAN's
-# sequence length is not divisible by 64, so with this off no aiter ASM backward
-# is reachable and dispatch falls silently through to the slower ck_tile path.
-# Set false for a deterministic backward; accumulation order is
-# non-deterministic when this is on.
+# Let the attention backward use fp32-atomic accumulation. WAN's sequence length
+# is not divisible by 64, so with this off no ASM backward is reachable on either
+# spec and dispatch falls silently through to the slower ck_tile path, and on
+# te_spec the CK v3 backward is unreachable because the image pins the gfx950
+# value of NVTE_CK_IS_V3_ATOMIC_FP32. Set false for a deterministic backward;
+# accumulation order is non-deterministic when this is on.
 attn_atomic_fp32: true
 
 # ==============================================================================

--- a/primus/configs/models/megatron/diffusion_model.yaml
+++ b/primus/configs/models/megatron/diffusion_model.yaml
@@ -103,6 +103,12 @@ tp_comm_bulk_dgrad: true
 # Optimization flags
 gradient_accumulation_fusion: true  # Should be disabled for FSDP2
 
+# Attention backend for the TransformerEngine path: auto | flash | fused |
+# unfused | local. Declared here so diffusion configs can override it; "auto"
+# refuses to run when the environment forces a backend via NVTE_FLASH_ATTN /
+# NVTE_FUSED_ATTN, so an image that pins those needs an explicit choice.
+attention_backend: auto
+
 # Other compatibility fields
 fused_padded_mla_attention: false
 

--- a/tests/unit_tests/backends/megatron/diffusion/data/test_synthetic_datasets.py
+++ b/tests/unit_tests/backends/megatron/diffusion/data/test_synthetic_datasets.py
@@ -124,6 +124,50 @@ class TestSyntheticDatasetProviderLookup(PrimusUT):
         assert cls is not None
         assert cls.__name__ == "PreGeneratedMockFluxSchnellDataset"
 
+    # Note: PrimusUT is a unittest.TestCase, which pytest cannot parametrize,
+    # so the two families are spelled out rather than swept.
+
+    def test_family_key_selects_pregenerated_wan_dataset(self):
+        """A 'family' key reaches the Wan defaults that model_type cannot.
+
+        The trainer collapses the generic 'diffusion_model' model_type to
+        'flux' before the provider is built, so without this key no config
+        could select a Wan mock dataset at all.
+        """
+        provider = SyntheticDatasetProvider(dataset_config={"family": "wan"})
+        assert provider._import_dataset_class().__name__ == "PreGeneratedMockWanDataset"
+
+    def test_family_key_selects_onthefly_wan_dataset(self):
+        provider = SyntheticDatasetProvider(dataset_config={"family": "wan_onthefly"})
+        assert provider._import_dataset_class().__name__ == "MockWanDataset"
+
+    def test_family_key_overrides_model_type(self):
+        """'family' wins over model_type, which is the point of the key."""
+        provider = SyntheticDatasetProvider(dataset_config={"family": "wan"}, model_type="flux")
+        assert provider.model_type == "wan"
+        assert provider._import_dataset_class().__name__ == "PreGeneratedMockWanDataset"
+
+    def test_absent_family_key_preserves_model_type(self):
+        """Configs that do not set 'family' behave exactly as before."""
+        provider = SyntheticDatasetProvider(dataset_config={}, model_type="flux_schnell")
+        assert provider.model_type == "flux_schnell"
+        assert provider._import_dataset_class().__name__ == "PreGeneratedMockFluxSchnellDataset"
+
+    def test_explicit_class_still_wins_over_family(self):
+        """An explicit 'class' outranks the family default."""
+        provider = SyntheticDatasetProvider(
+            dataset_config={
+                "family": "wan",
+                "class": "primus.backends.megatron.data.synthetic.MockFluxDataset",
+            }
+        )
+        assert provider._import_dataset_class().__name__ == "MockFluxDataset"
+
+    def test_unknown_family_names_the_resolved_type(self):
+        """The error reports the family that was resolved, not the raw model_type."""
+        with pytest.raises(ValueError, match="model_type='nope'"):
+            SyntheticDatasetProvider(dataset_config={"family": "nope"}, model_type="flux")
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit_tests/backends/megatron/diffusion/test_wan_attn_atomic_fp32.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_wan_attn_atomic_fp32.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for Wan's attention-backward kernel selection.
+
+The ``attn_atomic_fp32`` model key exists because both attention backends
+re-read their fp32-atomic setting from the environment on every call, and
+both arrive at the trainer already forced to "0" -- Primus' launchers export
+Primus-Turbo's variable that way, and the release image pins TE's. Reading
+either variable back therefore cannot distinguish a deliberate opt-out from
+that blanket default, so the trainer writes both from the YAML key instead.
+
+These tests pin that plumbing, which is otherwise only observable by reading
+kernel names out of a profile.
+"""
+
+import os
+
+import pytest
+
+
+def _trainer_module():
+    """Import lazily so collection does not depend on the trainer's imports."""
+    from primus.backends.megatron import wan_pretrain_trainer
+
+    return wan_pretrain_trainer
+
+
+@pytest.fixture(autouse=True)
+def isolate_attention_env(monkeypatch):
+    """Give every variable the helper writes a restore point for teardown."""
+    module = _trainer_module()
+    for name in (*module.ATTN_ATOMIC_FP32_ENVS, module.TE_CK_BWD_V3_ENV):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_both_backend_variables_are_covered():
+    """One key has to reach Primus-Turbo and TransformerEngine alike.
+
+    A run uses the local spec or te_spec, not both, so the trainer sets both
+    variables rather than working out which backend is live. Dropping either
+    name silently leaves that spec on ck_tile.
+    """
+    module = _trainer_module()
+
+    assert set(module.ATTN_ATOMIC_FP32_ENVS) == {
+        "PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32",
+        "NVTE_CK_IS_V3_ATOMIC_FP32",
+    }
+
+
+def test_enabling_sets_both_backend_variables():
+    module = _trainer_module()
+
+    module._apply_atomic_fp32_backward(True)
+
+    for name in module.ATTN_ATOMIC_FP32_ENVS:
+        assert os.environ[name] == "1", name
+
+
+def test_enabling_forces_the_te_v3_backward():
+    """TE only reaches a v3 backward with this on, so enabling pins it.
+
+    Without it, a launcher that disabled v3 would quietly undo the atomics.
+    """
+    module = _trainer_module()
+
+    module._apply_atomic_fp32_backward(True)
+
+    assert os.environ[module.TE_CK_BWD_V3_ENV] == "1"
+
+
+def test_enabling_overrides_the_launcher_blanket_default():
+    """The pre-set "0" is exactly the state this helper exists to correct."""
+    module = _trainer_module()
+    for name in module.ATTN_ATOMIC_FP32_ENVS:
+        os.environ[name] = "0"
+
+    module._apply_atomic_fp32_backward(True)
+
+    for name in module.ATTN_ATOMIC_FP32_ENVS:
+        assert os.environ[name] == "1", name
+
+
+def test_disabling_sets_both_backend_variables_to_zero():
+    module = _trainer_module()
+
+    module._apply_atomic_fp32_backward(False)
+
+    for name in module.ATTN_ATOMIC_FP32_ENVS:
+        assert os.environ[name] == "0", name
+
+
+def test_disabling_leaves_the_te_v3_setting_alone():
+    """Opting out of the atomics is not a request to disable v3 as well."""
+    module = _trainer_module()
+    os.environ[module.TE_CK_BWD_V3_ENV] = "1"
+
+    module._apply_atomic_fp32_backward(False)
+
+    assert os.environ[module.TE_CK_BWD_V3_ENV] == "1"
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_helper_is_idempotent(enabled):
+    module = _trainer_module()
+
+    module._apply_atomic_fp32_backward(enabled)
+    first = {name: os.environ[name] for name in module.ATTN_ATOMIC_FP32_ENVS}
+    module._apply_atomic_fp32_backward(enabled)
+
+    assert {name: os.environ[name] for name in module.ATTN_ATOMIC_FP32_ENVS} == first
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit_tests/backends/megatron/diffusion/test_wan_layer_spec.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_wan_layer_spec.py
@@ -78,6 +78,43 @@ def test_qk_norm_uses_backend_native_kernel(transformer_impl):
         assert origin.startswith("torch."), origin
 
 
+def test_block_is_a_virtual_transformer_layer():
+    """The block answers isinstance(TransformerLayer) without inheriting it.
+
+    Megatron-FSDP takes its unit granularity from a default list of
+    ``[TransformerLayer]`` and matches it with isinstance, and nothing plumbs
+    an explicit list through for Wan. The virtual registration is what makes
+    that default match, so an empty unit list does not silently hook all 600
+    submodules instead of the blocks.
+    """
+    from megatron.core.transformer.transformer_layer import TransformerLayer
+
+    from primus.backends.megatron.core.models.diffusion.wan.model import (
+        WanTransformerBlock,
+    )
+
+    assert issubclass(WanTransformerBlock, TransformerLayer)
+
+    # Virtual only: real inheritance would change the checkpoint key layout.
+    assert TransformerLayer not in WanTransformerBlock.__mro__
+
+    # This is the exact shape of the check Megatron-FSDP performs.
+    model, _ = _build_on_meta(WanConfig.wan2_1_t2v_1_3b, "local")
+    block = model.blocks[0]
+    assert isinstance(block, tuple([TransformerLayer]))
+
+
+def test_block_carries_layer_number():
+    """The FSDP-DTensor checkpoint path reads ``layer_number`` off the block.
+
+    Numbered from 1, following Megatron's own convention for the attribute.
+    """
+    model, _ = _build_on_meta(WanConfig.wan2_1_t2v_1_3b, "local")
+
+    for index, block in enumerate(model.blocks):
+        assert block.layer_number == index + 1
+
+
 @pytest.mark.parametrize("transformer_impl", BACKENDS)
 @pytest.mark.parametrize("variant_name,ctor", VARIANTS, ids=[v[0] for v in VARIANTS])
 def test_state_dict_matches_converter_key_table(variant_name, ctor, transformer_impl):

--- a/tests/unit_tests/backends/megatron/diffusion/test_wan_layer_spec.py
+++ b/tests/unit_tests/backends/megatron/diffusion/test_wan_layer_spec.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Unit tests for the Wan layer spec.
+
+Covers two invariants that are easy to break silently:
+
+- The q/k norms must be RMSNorm, not LayerNorm. Wan's block norms are
+  LayerNorm, so ``config.normalization`` says ``"LayerNorm"`` and the norm
+  modules read that field rather than a constructor flag. The spec therefore
+  hands the q/k norms a dedicated RMSNorm config clone. Getting this wrong
+  changes the math (LayerNorm re-centers) and adds ``.bias`` entries that no
+  Wan checkpoint contains.
+- The backbone's state dict keys must equal the checkpoint converter's
+  analytic key table, since the loader rejects missing or unexpected keys.
+"""
+
+import argparse
+
+import pytest
+import torch
+
+from primus.backends.megatron.core.models.diffusion.wan.checkpoint_converter import (
+    expected_mcore_keys,
+)
+from primus.backends.megatron.core.models.diffusion.wan.config import WanConfig
+from primus.backends.megatron.core.models.diffusion.wan.model import WanTransformer3D
+
+BACKENDS = ["local", "transformer_engine"]
+VARIANTS = [
+    ("wan2_1_t2v_1_3b", WanConfig.wan2_1_t2v_1_3b),
+    ("wan2_1_t2v_14b", WanConfig.wan2_1_t2v_14b),
+    ("wan2_2_ti2v_5b", WanConfig.wan2_2_ti2v_5b),
+    ("wan2_2_t2v_a14b", WanConfig.wan2_2_t2v_a14b),
+]
+
+
+def _build_on_meta(ctor, transformer_impl):
+    """Instantiate a backbone on the meta device (structure only, no weights)."""
+    from megatron.training.global_vars import set_args
+
+    # PrimusTurboLocalAttention reads Megatron's global args at construction.
+    set_args(argparse.Namespace(enable_turbo_attention_float8=False))
+
+    config = ctor()
+    config.transformer_impl = transformer_impl
+    # Both would try to materialize real weights, which meta tensors cannot back.
+    config.use_cpu_initialization = False
+    config.perform_initialization = False
+
+    with torch.device("meta"):
+        return WanTransformer3D(config), config
+
+
+@pytest.mark.parametrize("transformer_impl", BACKENDS)
+def test_qk_norm_is_rms_norm_without_bias(transformer_impl):
+    """q/k norms are RMSNorm and carry a weight but no bias."""
+    model, _ = _build_on_meta(WanConfig.wan2_1_t2v_1_3b, transformer_impl)
+
+    for attn_name in ("attn1", "attn2"):
+        attn = getattr(model.blocks[0], attn_name)
+        for norm in (attn.q_layernorm, attn.k_layernorm):
+            assert type(norm).__name__ == "RMSNorm", f"{attn_name}: got {type(norm).__name__}"
+            params = {name for name, _ in norm.named_parameters()}
+            assert params == {"weight"}, f"{attn_name}: unexpected params {params}"
+
+
+@pytest.mark.parametrize("transformer_impl", BACKENDS)
+def test_qk_norm_uses_backend_native_kernel(transformer_impl):
+    """The TE backend uses TE's RMSNorm; the local backend uses torch's."""
+    model, _ = _build_on_meta(WanConfig.wan2_1_t2v_1_3b, transformer_impl)
+    origin = type(model.blocks[0].attn1.q_layernorm).__module__
+
+    if transformer_impl == "transformer_engine":
+        assert origin.startswith("transformer_engine"), origin
+    else:
+        assert origin.startswith("torch."), origin
+
+
+@pytest.mark.parametrize("transformer_impl", BACKENDS)
+@pytest.mark.parametrize("variant_name,ctor", VARIANTS, ids=[v[0] for v in VARIANTS])
+def test_state_dict_matches_converter_key_table(variant_name, ctor, transformer_impl):
+    """The backbone's keys equal the converter's analytic mcore key table."""
+    model, config = _build_on_meta(ctor, transformer_impl)
+
+    # TE linears carry _extra_state entries, which are not weights.
+    actual = {key for key in model.state_dict() if not key.endswith("_extra_state")}
+    expected = expected_mcore_keys(config)
+
+    assert actual == expected, (
+        f"{variant_name}/{transformer_impl}: "
+        f"missing={sorted(expected - actual)[:8]} unexpected={sorted(actual - expected)[:8]}"
+    )

--- a/tests/unit_tests/backends/megatron/diffusion/training/test_loss_computation.py
+++ b/tests/unit_tests/backends/megatron/diffusion/training/test_loss_computation.py
@@ -16,6 +16,7 @@ skip_if_no_cuda()
 
 from primus.backends.megatron.training.diffusion.loss_computation import (
     compute_flow_matching_loss,
+    compute_weighted_flow_matching_loss,
 )
 from tests.utils import PrimusUT
 
@@ -54,3 +55,87 @@ class TestFlowMatchingLoss(PrimusUT):
         loss_without_mask = compute_flow_matching_loss(prediction, clean, noise)
 
         assert not torch.allclose(loss_with_mask, loss_without_mask)
+
+
+class TestWeightedFlowMatchingLoss(PrimusUT):
+    """Tests for the per-timestep weighted flow matching loss.
+
+    The weighted helper exists alongside the unweighted one rather than
+    replacing it, so the load-bearing property is that weight=1 reproduces
+    the unweighted objective exactly. If that drifts, every Wan run silently
+    optimizes a different loss than the Flux runs it is compared against.
+    """
+
+    @staticmethod
+    def _fixture():
+        torch.manual_seed(0)
+        prediction = torch.randn(2, 16, 8, 32, 32)
+        clean = torch.randn(2, 16, 8, 32, 32)
+        noise = torch.randn(2, 16, 8, 32, 32)
+        # The unweighted helper derives this target internally.
+        return prediction, clean, noise, noise - clean
+
+    def test_unit_weight_recovers_unweighted_loss(self):
+        """weight=1 per sample is exactly the unweighted objective."""
+        prediction, clean, noise, target = self._fixture()
+
+        weighted = compute_weighted_flow_matching_loss(prediction, target, torch.ones(2))
+        unweighted = compute_flow_matching_loss(prediction, clean, noise)
+
+        assert torch.allclose(weighted, unweighted)
+        assert weighted.dim() == 0
+
+    def test_scalar_unit_weight_recovers_unweighted_loss(self):
+        """A 0-dim weight broadcasts without the [batch] reshape path."""
+        prediction, clean, noise, target = self._fixture()
+
+        weighted = compute_weighted_flow_matching_loss(prediction, target, torch.tensor(1.0))
+        unweighted = compute_flow_matching_loss(prediction, clean, noise)
+
+        assert torch.allclose(weighted, unweighted)
+
+    def test_unit_weight_recovers_unweighted_loss_under_mask(self):
+        """The equivalence also holds on the masked reduction path."""
+        prediction, clean, noise, target = self._fixture()
+        loss_mask = torch.tensor([1.0, 0.0])
+
+        weighted = compute_weighted_flow_matching_loss(prediction, target, torch.ones(2), loss_mask)
+        unweighted = compute_flow_matching_loss(prediction, clean, noise, loss_mask)
+
+        assert torch.allclose(weighted, unweighted)
+
+    def test_uniform_weight_scales_the_loss(self):
+        """A constant weight scales the squared error linearly."""
+        prediction, _, _, target = self._fixture()
+        batch = prediction.shape[0]
+
+        base = compute_weighted_flow_matching_loss(prediction, target, torch.ones(batch))
+        scaled = compute_weighted_flow_matching_loss(prediction, target, torch.full((batch,), 2.0))
+
+        assert torch.allclose(scaled, base * 2.0)
+
+    def test_per_sample_weight_broadcasts_over_latent_dims(self):
+        """A [batch] weight applies per sample, not per element."""
+        prediction, _, _, target = self._fixture()
+        weight = torch.tensor([0.0, 1.0])
+
+        actual = compute_weighted_flow_matching_loss(prediction, target, weight)
+
+        # Zeroing the first sample leaves the second sample's error, averaged
+        # over the whole tensor -- so half the second sample's own mean.
+        second = ((target[1].float() - prediction[1].float()) ** 2).mean()
+        assert torch.allclose(actual, second / 2.0)
+
+    def test_caller_supplied_target_is_not_rederived(self):
+        """The target comes from the caller, unlike the unweighted helper."""
+        prediction, clean, noise, _ = self._fixture()
+        batch = prediction.shape[0]
+
+        # A target that is deliberately not noise - clean.
+        alt_target = torch.zeros_like(prediction)
+
+        with_alt = compute_weighted_flow_matching_loss(prediction, alt_target, torch.ones(batch))
+        with_derived = compute_weighted_flow_matching_loss(prediction, noise - clean, torch.ones(batch))
+
+        assert not torch.allclose(with_alt, with_derived)
+        assert torch.allclose(with_alt, (prediction.float() ** 2).mean())

--- a/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
+++ b/tests/unit_tests/backends/megatron/test_primus_turbo_mxfp4_local.py
@@ -338,3 +338,172 @@ class TestMXFP4LinearGuard(PrimusUT):
                 skip_bias_add=False,
                 is_expert=False,
             )
+
+
+# ---------------------------------------------------------------------------
+# Reduction-axis alignment
+# ---------------------------------------------------------------------------
+
+
+def _mxfp4_module():
+    """The extension module, skipped where Primus-Turbo's FP4 ops are absent."""
+    return pytest.importorskip(
+        "primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local",
+        reason="Requires the Primus-Turbo MXFP4 extension",
+    )
+
+
+class TestMXFP4ReductionAlignment:
+    """Integer-math tests for the FP4 reduction-axis padding rules.
+
+    A shuffled colwise scale buffer covers ``cdiv(cdiv(d, 32), 8) * 8`` E8M0
+    blocks while the packed FP4 data covers only ``cdiv(d, 128) * 128``. When
+    ``cdiv(d, 128)`` is odd, some blocks have no backing data and the wgrad
+    GEMM sums uninitialized memory -- finite, but a gradient norm that varies
+    run to run. Padding is what closes that, and it is conditional because a
+    full operand copy at every FP4 linear is not free, so both halves of the
+    rule need holding down: pad when either invariant fails, and pad nothing
+    when both already hold.
+    """
+
+    def test_padding_alignment_is_a_multiple_of_the_block_size(self):
+        module = _mxfp4_module()
+
+        assert module.MXFP4_REDUCTION_ALIGN % module.MXFP4_PADDING_ALIGN_SIZE == 0
+        assert module.MXFP4_REDUCTION_ALIGN % 16 == 0
+
+    @pytest.mark.parametrize("dim", [256, 512, 1536, 4608, 8960])
+    def test_already_conforming_axis_is_returned_untouched(self, dim):
+        """Wan 1.3B's hidden dims pay no copy: this is the common case."""
+        module = _mxfp4_module()
+
+        assert module._aligned(dim) == dim
+
+    @pytest.mark.parametrize(
+        "dim,expected",
+        [
+            (128, 256),  # 16-aligned, but cdiv(128, 128) == 1 is odd
+            (384, 512),  # cdiv(384, 128) == 3 is odd
+            (640, 768),  # cdiv(640, 128) == 5 is odd
+            (100, 256),  # not a multiple of 16 at all
+            (1, 256),
+        ],
+    )
+    def test_offending_axis_is_padded_up(self, dim, expected):
+        module = _mxfp4_module()
+
+        assert module._aligned(dim) == expected
+
+    def test_padded_axis_always_satisfies_both_invariants(self):
+        """Whatever comes out clears AITER's dispatcher and backs every block."""
+        module = _mxfp4_module()
+        block = module.MXFP4_PADDING_ALIGN_SIZE
+
+        for dim in range(1, 4097):
+            aligned = module._aligned(dim)
+
+            assert aligned >= dim, dim
+            assert aligned % 16 == 0, dim
+            assert module._cdiv(aligned, block) % 2 == 0, dim
+
+    def test_each_gemm_axis_is_aligned_independently(self):
+        """M, K and N are each the reduction axis of one of the three GEMMs."""
+        module = _mxfp4_module()
+
+        # M offends, K and N do not.
+        assert module._aligned_gemm_dims(128, 256, 512) == (256, 256, 512)
+        # Nothing offends.
+        assert module._aligned_gemm_dims(256, 1536, 8960) == (256, 1536, 8960)
+        # All three offend.
+        assert module._aligned_gemm_dims(128, 384, 100) == (256, 512, 256)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_pad2d_is_identity_at_the_requested_size(self):
+        """The usual case must not copy, so identity is returned by object."""
+        module = _mxfp4_module()
+
+        tensor = torch.randn(256, 512, dtype=torch.bfloat16, device="cuda")
+
+        assert module._pad2d(tensor, 256, 512) is tensor
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+    def test_pad2d_appends_zeros_and_preserves_the_original_block(self):
+        module = _mxfp4_module()
+
+        tensor = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+        padded = module._pad2d(tensor, 256, 256)
+
+        assert padded.shape == (256, 256)
+        assert torch.equal(padded[:128], tensor)
+        assert not padded[128:].any()
+
+
+class TestMXFP4UnpaddedShape(PrimusUT):
+    """Cross-validation at a shape that pads nothing.
+
+    Every other numeric test in this file runs at 128 rows, which the
+    alignment rule pads to 256, so without this the unpadded fast path is
+    never exercised against the reference at all.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_parallel(self, init_parallel_state):
+        pass
+
+    @requires_mxfp4
+    def test_forward_matches_reference_without_padding(self):
+        from primus_turbo.pytorch.core.low_precision import Float4QuantConfig
+        from primus_turbo.pytorch.ops.gemm_fp4 import FP4GemmMXFunction
+
+        from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
+            MXFP4LinearFunction,
+            _aligned_gemm_dims,
+            _enable_preshuffle,
+        )
+
+        # Guard the premise: this shape must reach the GEMM unpadded.
+        assert _aligned_gemm_dims(256, 256, 512) == (256, 256, 512)
+
+        torch.manual_seed(42)
+        x = torch.randn(256, 256, dtype=torch.bfloat16, device="cuda")
+        w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda")
+        preshuffle = _enable_preshuffle()
+
+        our_output = MXFP4LinearFunction.apply(x, w, preshuffle, False, None, 0, 0, False)[0]
+
+        config = Float4QuantConfig(use_preshuffle=preshuffle)
+        ref_output = FP4GemmMXFunction.apply(
+            x.clone(),
+            w.clone(),
+            None,
+            None,
+            False,
+            True,
+            x.dtype,
+            config,
+        )
+
+        assert torch.equal(our_output, ref_output), (
+            f"Forward outputs differ. Max abs diff: " f"{(our_output - ref_output).abs().max().item():.6e}"
+        )
+
+    @requires_mxfp4
+    def test_padded_shape_returns_unpadded_output(self):
+        """A padded M must be sliced back off before the result is returned."""
+        from primus.backends.megatron.core.extensions.primus_turbo_mxfp4_local import (
+            MXFP4LinearFunction,
+            _aligned_gemm_dims,
+            _enable_preshuffle,
+        )
+
+        # Guard the premise: this shape must be padded on M.
+        assert _aligned_gemm_dims(128, 256, 512)[0] == 256
+
+        torch.manual_seed(42)
+        x = torch.randn(128, 256, dtype=torch.bfloat16, device="cuda")
+        w = torch.randn(512, 256, dtype=torch.bfloat16, device="cuda")
+
+        output = MXFP4LinearFunction.apply(x, w, _enable_preshuffle(), False, None, 0, 0, False)[0]
+
+        assert output.shape == (128, 512)
+        assert torch.isfinite(output.float()).all()

--- a/tools/checkpoint_conversion/convert_wan_hf_to_primus.py
+++ b/tools/checkpoint_conversion/convert_wan_hf_to_primus.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the Apache License, Version 2.0.
+
+"""
+Convert HuggingFace WAN checkpoint to Primus format.
+
+This tool converts HuggingFace Diffusers WAN (2.1 / 2.2) video-diffusion
+transformer checkpoints to Primus/Megatron-Core compatible format. It handles:
+- QKV weight fusion into Megatron's per-head interleaved layout
+  (self-attention ``linear_qkv``, cross-attention ``linear_kv``)
+- Key mapping from HF to Primus naming conventions
+- Feed-forward rename onto Megatron-Core's MLP (linear_fc1 / linear_fc2)
+- Multi-file safetensors loading
+
+WAN 2.2 A14B is a dual-expert model: run the tool once per expert subfolder
+(``transformer`` and ``transformer_2``).
+
+Usage:
+    # Convert Wan2.1-T2V-1.3B checkpoint
+    python tools/checkpoint_conversion/convert_wan_hf_to_primus.py \\
+        --input Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer \\
+        --output checkpoints/primus_wan21_t2v_1_3b.safetensors \\
+        --variant wan2.1_t2v_1.3b
+
+    # Convert with custom architecture
+    python tools/checkpoint_conversion/convert_wan_hf_to_primus.py \\
+        --input path/to/checkpoint \\
+        --output checkpoints/primus_custom.safetensors \\
+        --variant custom \\
+        --hidden-size 1536 \\
+        --num-attention-heads 12 \\
+        --num-dit-layers 30 \\
+        --ffn-hidden-size 8960
+
+Example:
+    $ python tools/checkpoint_conversion/convert_wan_hf_to_primus.py \\
+        --input Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer \\
+        --output checkpoints/primus_wan21_t2v_1_3b.safetensors \\
+        --variant wan2.1_t2v_1.3b
+
+    Converting wan2.1_t2v_1.3b checkpoint
+      Input: Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer
+      Output: checkpoints/primus_wan21_t2v_1_3b.safetensors
+      Architecture: 30 layers, hidden 1536, 12 heads, ffn 8960
+    Loading HuggingFace checkpoint from: ...
+    ...
+    Conversion complete!
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Add primus to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from primus.backends.megatron.core.models.diffusion.wan import (
+    WanConfig,
+    convert_hf_checkpoint,
+)
+
+# CLI variant name -> WanConfig preset classmethod.
+WAN_VARIANTS = {
+    "wan2.1_t2v_1.3b": "wan2_1_t2v_1_3b",
+    "wan2.1_t2v_14b": "wan2_1_t2v_14b",
+    "wan2.2_ti2v_5b": "wan2_2_ti2v_5b",
+    "wan2.2_t2v_a14b": "wan2_2_t2v_a14b",
+}
+
+CUSTOM_ARGS = ("hidden_size", "num_attention_heads", "num_dit_layers", "ffn_hidden_size")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert HuggingFace WAN checkpoint to Primus format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Convert Wan2.1-T2V-1.3B
+  %(prog)s --input Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer \\
+           --output checkpoints/primus_wan21_t2v_1_3b.safetensors \\
+           --variant wan2.1_t2v_1.3b
+
+  # Convert local checkpoint directory
+  %(prog)s --input /path/to/wan/checkpoint \\
+           --output primus_wan.safetensors \\
+           --variant wan2.1_t2v_14b
+
+  # Convert both WAN 2.2 A14B experts (dual-expert model, one run each)
+  %(prog)s --input Wan-AI/Wan2.2-T2V-A14B-Diffusers/transformer \\
+           --output primus_wan22_a14b_high_noise.safetensors \\
+           --variant wan2.2_t2v_a14b
+  %(prog)s --input Wan-AI/Wan2.2-T2V-A14B-Diffusers/transformer_2 \\
+           --output primus_wan22_a14b_low_noise.safetensors \\
+           --variant wan2.2_t2v_a14b
+
+  # Convert with custom architecture
+  %(prog)s --input /path/to/checkpoint \\
+           --output primus_custom.safetensors \\
+           --variant custom \\
+           --hidden-size 1536 \\
+           --num-attention-heads 12 \\
+           --num-dit-layers 30 \\
+           --ffn-hidden-size 8960
+        """,
+    )
+
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="Path to HF checkpoint (file, directory, or HF model ID like "
+        "'Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer')",
+    )
+    parser.add_argument("--output", required=True, help="Output path for Primus checkpoint (.safetensors)")
+    parser.add_argument(
+        "--variant",
+        choices=[*WAN_VARIANTS, "custom"],
+        default="wan2.1_t2v_1.3b",
+        help="WAN variant (determines architecture). Default: wan2.1_t2v_1.3b",
+    )
+    parser.add_argument("--hidden-size", type=int, help="Hidden size (only with --variant custom)")
+    parser.add_argument(
+        "--num-attention-heads", type=int, help="Number of attention heads (only with --variant custom)"
+    )
+    parser.add_argument("--num-dit-layers", type=int, help="Number of DiT layers (only with custom variant)")
+    parser.add_argument("--ffn-hidden-size", type=int, help="FFN hidden size (only with --variant custom)")
+    parser.add_argument("--prefix", default=None, help="Optional output key prefix (e.g. 'transformer.')")
+    parser.add_argument("--strict", action="store_true", help="Fail if any key is dropped or missing")
+
+    args = parser.parse_args()
+
+    # Validate custom variant arguments
+    custom_values = {name: getattr(args, name) for name in CUSTOM_ARGS}
+    if args.variant == "custom":
+        missing = [name for name, value in custom_values.items() if not value]
+        if missing:
+            flags = ", ".join("--" + name.replace("_", "-") for name in missing)
+            parser.error(f"{flags} required with --variant custom")
+        config = WanConfig(**custom_values)
+    else:
+        if any(custom_values.values()):
+            flags = ", ".join("--" + name.replace("_", "-") for name in CUSTOM_ARGS)
+            parser.error(f"{flags} can only be used with --variant custom")
+        config = getattr(WanConfig, WAN_VARIANTS[args.variant])()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    # Print conversion info
+    print("=" * 80)
+    print(f"Converting {args.variant} checkpoint")
+    print(f"  Input:  {args.input}")
+    print(f"  Output: {args.output}")
+    print(
+        f"  Architecture: {config.num_dit_layers} layers, hidden {config.hidden_size}, "
+        f"{config.num_attention_heads} heads, ffn {config.ffn_hidden_size}"
+    )
+    print("=" * 80)
+    print()
+
+    # Convert checkpoint
+    try:
+        convert_hf_checkpoint(
+            checkpoint_path=args.input,
+            wan_config=config,
+            save_to=args.output,
+            prefix=args.prefix,
+            strict=args.strict,
+        )
+
+        print()
+        print("=" * 80)
+        print("✓ Conversion complete!")
+        print(f"Primus checkpoint saved to: {args.output}")
+        print("=" * 80)
+
+        return 0
+
+    except Exception as e:
+        print()
+        print("=" * 80)
+        print(f"✗ Conversion failed: {e}")
+        print("=" * 80)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wan_train.sh
+++ b/wan_train.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+###############################################################################
+# WAN 2.1 / 2.2 training launcher (Primus-Megatron).
+#
+# Usage:
+#   bash wan_train.sh                                  # default EXP below
+#   EXP=<path/to/config.yaml> bash wan_train.sh        # pick an arm
+#   GPUS_PER_NODE=8 bash wan_train.sh                  # 8-GPU single node
+#
+# Expects PRIMUS_DIFFUSION_DATA_PATH (prepared Energon dataset) and HF_HOME
+# (cache holding the VAE and UMT5 weights) to be set in the environment.
+###############################################################################
+
+set -euo pipefail
+
+PRIMUS_ROOT="${PRIMUS_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+export EXP="${EXP:-examples/megatron/configs/MI355X/diffusion/wan2.1_t2v_1.3b_pretrain_pusa_te_spec.yaml}"
+
+export GPUS_PER_NODE="${GPUS_PER_NODE:-8}"
+export PYTHONPATH="${PRIMUS_ROOT}:${PYTHONPATH:-}"
+
+# Long video sequences fragment the allocator badly without this.
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+# Force AITER for the FP4 matmuls. The HipBLASLt/rocRoller FP4 path runs a
+# per-shape CPU-bound solution search that stalls on WAN's long-sequence shapes.
+# Harmless for non-FP4 runs, since only the FP4 dispatcher consults it.
+export PRIMUS_TURBO_GEMM_BACKEND="${PRIMUS_TURBO_GEMM_BACKEND:-fp4:AITER}"
+
+# run_pretrain.sh pins MIOPEN_FIND_MODE=2 (Fast), which is inert for LLMs but
+# ruinous here: WAN's Conv3d patch embed is the only convolution in the model,
+# and Fast mode resolves its backward to a naive im2col path -- a per-tile GEMM
+# launch per patch -- instead of the fused Composable Kernel wgrad solver, which
+# on its own dominates the step. Mode 5 (DynamicHybrid) is MIOpen's own default;
+# it searches once per new conv shape, so only the first iteration pays.
+export MIOPEN_FIND_MODE="${MIOPEN_FIND_MODE:-5}"
+
+# Set HF_HOME and PRIMUS_DIFFUSION_DATA_PATH in the environment to point at the
+# HuggingFace cache holding the VAE / UMT5 weights and at the prepared Energon
+# dataset; the configs read the latter with a placeholder default.
+
+if [[ "${WAN_DEBUG:-0}" == "1" ]]; then
+  export NCCL_DEBUG="${NCCL_DEBUG:-INFO}"
+  export TORCH_DISTRIBUTED_DEBUG="${TORCH_DISTRIBUTED_DEBUG:-DETAIL}"
+  export TORCH_SHOW_CPP_STACKTRACES="${TORCH_SHOW_CPP_STACKTRACES:-1}"
+fi
+
+mkdir -p "${PRIMUS_ROOT}/output"
+LOG_FILE="${LOG_FILE:-${PRIMUS_ROOT}/output/wan_train_$(hostname).log}"
+
+echo "EXP=${EXP}"
+echo "GPUS_PER_NODE=${GPUS_PER_NODE}"
+echo "LOG_FILE=${LOG_FILE}"
+
+cd "${PRIMUS_ROOT}"
+exec bash examples/run_pretrain.sh "$@" |& tee -a "${LOG_FILE}"

--- a/wan_train.sh
+++ b/wan_train.sh
@@ -36,6 +36,14 @@ export PRIMUS_TURBO_GEMM_BACKEND="${PRIMUS_TURBO_GEMM_BACKEND:-fp4:AITER}"
 # it searches once per new conv shape, so only the first iteration pays.
 export MIOPEN_FIND_MODE="${MIOPEN_FIND_MODE:-5}"
 
+# TE pins its hipBLASLt workspace at 64 MiB, which is not enough for the
+# 1536 -> 1536 wgrad GEMM once WAN's token count passes ~70k (micro_batch_size
+# 7+): hipBLASLt picks split-K, the splits outgrow the workspace, and the call
+# fails with "HIPBLASLT Error: 6" instead of falling back. 128 MiB clears every
+# WAN shape. Read by primus/backends/megatron/patches/te_patches/
+# hipblaslt_workspace_patches.py; unset it and TE's own default applies.
+export PRIMUS_TE_GEMM_WORKSPACE_MIB="${PRIMUS_TE_GEMM_WORKSPACE_MIB:-128}"
+
 # Set HF_HOME and PRIMUS_DIFFUSION_DATA_PATH in the environment to point at the
 # HuggingFace cache holding the VAE / UMT5 weights and at the prepared Energon
 # dataset; the configs read the latter with a placeholder default.


### PR DESCRIPTION
# WAN 2.1 / 2.2 video DiT training on Megatron-Core

## What this adds

End-to-end training support for the WAN video diffusion transformer on
Megatron-Core, covering the model, the data path, the trainer, runnable example
configs, and a checkpoint conversion CLI. Along the way it fixes three defects
that WAN surfaced but that are not WAN-specific, and adds unit coverage for the
invariants the new code depends on.

Validated by training WAN 2.1 T2V 1.3B on a pre-encoded PusaV1 dataset across
three precision arms — TransformerEngine, Primus-Turbo local bf16, and MXFP4 —
which differ only in their precision block so they can be diffed against each
other.

## Layout

The 11 commits are grouped so each can be reviewed on its own; the history is
bisectable.

| Commits | Area |
| --- | --- |
| `fbab4c4` | The `WanTransformerBlock` / DiT backbone on Megatron-Core |
| `e10fb93`, `55bb06f` | Data: Energon shards, UMT5 / VAE encoders, synthetic providers |
| `97f2576` | Trainer, forward step, flow-matching scheduler and loss |
| `f1e1d15` | Example configs, `wan_train.sh`, HF→Primus conversion CLI |
| `55f98c4`, `13663e9` | Two fixes outside WAN (MXFP4 local spec, TE hipBLASLt workspace) |
| `c02e66b`, `b850687`, `a194ccc` | Three performance fixes in the WAN path |
| `df2d5d7` | Unit tests |

## Points worth a reviewer's attention

**`WanTransformerBlock` is registered as a virtual subclass of
`TransformerLayer` (`c02e66b`).** Megatron-FSDP shards at the granularity of its
"FSDP unit modules", but nothing passes that list for WAN — `training.py` builds
the wrapper with no `fsdp_unit_modules` and `DistributedDataParallelConfig` has
no field for one, so the adapter falls back to its default of
`[TransformerLayer]`. WAN's block deliberately is not a Megatron
`TransformerLayer`, so that default matched nothing and the unit list came out
empty, which is worse than coarse sharding: the hook-registration loop skips
modules inside a registered unit, and with nothing registered that skip never
fires, so every norm, linear and attention takes an unshard hook plus an
fp8-transpose post-hook a bf16 run has no use for. `ABCMeta.register` affects
`isinstance` only and leaves the checkpoint key layout alone. The alternatives
were worse — Megatron-LM is an upstream submodule, so plumbing the argument
through `training.py` means forking it, and real inheritance would change
checkpoint keys.

**One YAML key drives two backends' attention kernel selection (`b850687`,
`a194ccc`).** WAN's sequence length is not divisible by 64, which puts both
Primus-Turbo and TE's ROCm CK backend in the same corner: the kernel families
serving non-padded shapes accumulate dQ through atomics, so with the fp32