### PR TITLE
[Fix] add support for amd-smi

### DIFF
--- a/runner/helpers/envs/primus-env.sh
+++ b/runner/helpers/envs/primus-env.sh
@@ -36,24 +36,26 @@ LOG_INFO_RANK0 "=== Loading Primus Environment Configuration ==="
 # 2. Detect GPU model and load device-specific configuration
 
 # GPU detection function
+# Prefer amd-smi (new ROCm SDK, e.g. the pip _rocm_sdk_devel layout where rocm-smi
+# is no longer shipped); fall back to rocm-smi for older images. amd-smi reports
+# the model as "MARKET_NAME: AMD Instinct MI355X".
 detect_gpu_model() {
     local gpu_model
     gpu_model="unknown"
 
-    # Check if rocm-smi is available
-    if ! command -v rocm-smi &> /dev/null; then
-        echo "Warning: rocm-smi not found; set PRIMUS_GPU_MODEL (e.g. MI355X) for GPU env overrides." >&2
+    local product_name=""
+    if command -v amd-smi &> /dev/null; then
+        # e.g. "        MARKET_NAME: AMD Instinct MI355X"
+        product_name=$(amd-smi static --asic 2>/dev/null | grep -i "MARKET_NAME" | head -n1)
+    elif command -v rocm-smi &> /dev/null; then
+        product_name=$(rocm-smi --showproductname 2>/dev/null | grep -i "Card series" | head -n1 | awk '{print $NF}')
+        if [[ -z "$product_name" ]]; then
+            product_name=$(rocm-smi --showproductname 2>/dev/null | grep -oP 'MI\d+[A-Z]*' | head -n1)
+        fi
+    else
+        echo "Error: neither amd-smi nor rocm-smi found. Is ROCm installed?" >&2
         echo "unknown"
         return 0
-    fi
-
-    # Get product name from rocm-smi
-    local product_name
-    product_name=$(rocm-smi --showproductname 2>/dev/null | grep -i "Card series" | head -n1 | awk '{print $NF}')
-
-    # If that doesn't work, try alternative method
-    if [[ -z "$product_name" ]]; then
-        product_name=$(rocm-smi --showproductname 2>/dev/null | grep -oP 'MI\d+[A-Z]*' | head -n1)
     fi
 
     # Extract model identifier (MI300, MI355, etc.)

--- a/runner/lib/common.sh
+++ b/runner/lib/common.sh
@@ -498,13 +498,18 @@ print_system_info() {
     PRINT_INFO_RANK0 "    Memory: $(get_memory_gb) GB"
     PRINT_INFO_RANK0 "    Container: $(is_container && echo 'Yes' || echo 'No')"
     PRINT_INFO_RANK0 "    Slurm Job: $(is_slurm_job && echo 'Yes' || echo 'No')"
-    if command -v rocm-smi &>/dev/null; then
+    if command -v amd-smi &>/dev/null; then
+        local gpu_count
+        gpu_count=$(amd-smi list 2>/dev/null | grep -c '^GPU:' || echo "0")
+        PRINT_INFO_RANK0 "    GPUs: $gpu_count"
+        PRINT_DEBUG "amd-smi available, GPU count: $gpu_count"
+    elif command -v rocm-smi &>/dev/null; then
         local gpu_count
         gpu_count=$(rocm-smi --showid | grep 'GUID' | sort -u | wc -l || echo "0")
         PRINT_INFO_RANK0 "    GPUs: $gpu_count"
         PRINT_DEBUG "ROCm SMI available, GPU count: $gpu_count"
     else
-        PRINT_DEBUG "ROCm SMI not available"
+        PRINT_DEBUG "Neither amd-smi nor rocm-smi available"
     fi
 }
 


### PR DESCRIPTION
`rocm-smi` is getting deprecated. The new command is going to be `amd-smi`. Adding support got using `amd-smi` in newer rocm versions.