### PR TITLE
Fix system validation link

### DIFF
--- a/docs/02-user-guide/jax-maxtext-training.md
+++ b/docs/02-user-guide/jax-maxtext-training.md
@@ -69,7 +69,7 @@ The following models are pre-optimized for performance on the AMD Instinct MI300
 
 ## System validation
 
-If you have already validated your system, skip this step. Otherwise, complete the [system validation and optimization steps](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/prerequisite-system-validation.html#train-a-model-system-validation) to set up your system before starting training.
+If you have already validated your system, skip this step. Otherwise, complete the [system validation and optimization steps](https://rocm.docs.amd.com/projects/ai-ecosystem/en/latest/system-setup/prerequisite-system-validation.html#prerequisite-system-validation-before-running-ai-workloads) to set up your system before starting training.
 
 ---
 

--- a/docs/02-user-guide/megatron-lm-training.md
+++ b/docs/02-user-guide/megatron-lm-training.md
@@ -111,7 +111,7 @@ The following models are pre-optimized for performance on the AMD Instinct MI300
 
 ## System validation steps
 
-If you have already validated your system, skip this step. Otherwise, complete the [system validation and optimization steps](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/prerequisite-system-validation.html) to set up your system before starting training.
+If you have already validated your system, skip this step. Otherwise, complete the [system validation and optimization steps](https://rocm.docs.amd.com/projects/ai-ecosystem/en/latest/system-setup/prerequisite-system-validation.html#prerequisite-system-validation-before-running-ai-workloads) to set up your system before starting training.
 
 ### Disable NUMA auto-balancing
 

--- a/docs/02-user-guide/torchtitan-training.md
+++ b/docs/02-user-guide/torchtitan-training.md
@@ -59,7 +59,7 @@ Examples of the following models are pre-optimized for performance on the AMD In
 
 ## System validation steps
 
-If you have already validated your system, skip this step. Otherwise, complete the [system validation and optimization steps](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/training/prerequisite-system-validation.html) to set up your system before starting training.
+If you have already validated your system, skip this step. Otherwise, complete the [system validation and optimization steps](https://rocm.docs.amd.com/projects/ai-ecosystem/en/latest/system-setup/prerequisite-system-validation.html#prerequisite-system-validation-before-running-ai-workloads) to set up your system before starting training.
 
 ### Disable NUMA auto-balancing
 

--- a/docs/06-developer-guide/cli-architecture.md
+++ b/docs/06-developer-guide/cli-architecture.md
@@ -421,7 +421,7 @@ primus-cli direct -- train pretrain --config deepseek_v2.yaml
 - 🏛 **System Architecture**: [architecture.md](./architecture.md)
 - 🔧 **Quick Start**: `primus-cli --help`
 - 💬 **Issue Reporting**: GitHub Issues
-- 🌐 **ROCm Ecosystem**: [rocm.github.io](https://rocm.github.io)
+- 🌐 **ROCm Ecosystem**: [github.com/ROCm](https://github.com/ROCm)
 
 ---
 


### PR DESCRIPTION
The system validation page has moved to "https://rocm.docs.amd.com/projects/ai-ecosystem/en/latest/system-setup/prerequisite-system-validation.html#prerequisite-system-validation-before-running-ai-workloads". This needs to be updated everywhere,