### PR TITLE
[CP] Dev/jax maxtext v26.6 primus cli (#1095)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,23 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+
+  # Version updates stay disabled here (open-pull-requests-limit: 0) to keep the
+  # GitHub-Actions-only policy above; this entry exists so the ignore rule below
+  # also applies to security updates, which are enabled repo-wide and would
+  # otherwise bypass this file. Note that `ignore.update-types` does NOT apply to
+  # security updates, but `ignore.versions` does.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      # requirements-maxdiffusion.txt is the only root manifest pinning
+      # transformers, and MaxDiffusion is Flax-based: transformers 5.0 removed all
+      # Flax classes, so a 5.x bump breaks `import maxdiffusion` at module load.
+      # Trade-off: a CVE fixed only in 5.x will not raise a PR here, so a
+      # transformers advisory has to be handled by hand until MaxDiffusion moves
+      # off Flax.
+      - dependency-name: "transformers"
+        versions: [">=5.0.0"]

--- a/examples/maxdiffusion/configs/MI300X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/flux_dev-pretrain.yaml
@@ -74,10 +74,11 @@ modules:
       output_dir: "./output/flux_dev-pretrain"
       base_output_directory: "./output/flux_dev-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image default
-      # log_period=100 emits nothing at 20 steps, so perf comes back empty and
-      # madengine silently reuses a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON metrics
       # here (max_utils.write_metrics_locally). This is the reliable perf source; the

--- a/examples/maxdiffusion/configs/MI300X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/wan2.1_1.3b-pretrain.yaml
@@ -84,10 +84,11 @@ modules:
       output_dir: "./output/wan2.1_1.3b-pretrain"
       base_output_directory: "./output/wan2.1_1.3b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image default
-      # log_period=100 emits nothing at 20 steps, so perf comes back empty and
-      # madengine silently reuses a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON metrics
       # here (max_utils.write_metrics_locally). This is the reliable perf source; the

--- a/examples/maxdiffusion/configs/MI300X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI300X/wan2.1_14b-pretrain.yaml
@@ -70,10 +70,11 @@ modules:
       output_dir: "./output/wan2.1_14b-pretrain"
       base_output_directory: "./output/wan2.1_14b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image default
-      # log_period=100 emits nothing at 20 steps, so perf comes back empty and
-      # madengine silently reuses a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON metrics
       # here (max_utils.write_metrics_locally). This is the reliable perf source; the

--- a/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/flux_dev-pretrain.yaml
@@ -73,10 +73,11 @@ modules:
       output_dir: "./output/flux_dev-pretrain"
       base_output_directory: "./output/flux_dev-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
-      # default log_period=100 emits nothing at 20 steps, so perf came back empty
-      # and madengine silently reused a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
       # metrics here (max_utils.write_metrics_locally). This is the reliable perf

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_1.3b-pretrain.yaml
@@ -76,10 +76,11 @@ modules:
       output_dir: "./output/wan2.1_1.3b-pretrain"
       base_output_directory: "./output/wan2.1_1.3b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
-      # default log_period=100 emits nothing at 20 steps, so perf came back empty
-      # and madengine silently reused a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
       # metrics here (max_utils.write_metrics_locally). This is the reliable perf

--- a/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
+++ b/examples/maxdiffusion/configs/MI355X/wan2.1_14b-pretrain.yaml
@@ -78,10 +78,11 @@ modules:
       output_dir: "./output/wan2.1_14b-pretrain"
       base_output_directory: "./output/wan2.1_14b-pretrain"
       max_train_steps: ${MAX_STEPS:20}
-      # Log throughput every step: the perf extractor parses the per-step
-      # "completed step: N, seconds: X, TFLOP/s/device: Y" line. The image
-      # default log_period=100 emits nothing at 20 steps, so perf came back empty
-      # and madengine silently reused a stale CSV.
+      # TensorBoard flush cadence only. The per-step "completed step: ..." line
+      # the perf extractor parses is emitted every step regardless of this value
+      # (primus/backends/maxdiffusion/patches/throughput_patches.py), so keeping
+      # it at 1 only means a 20-step run that is killed early still leaves a
+      # complete event file behind.
       log_period: 1
       # Bound to run.sh's PERF_METRICS_FILE: the trainer writes per-step JSON
       # metrics here (max_utils.write_metrics_locally). This is the reliable perf

--- a/examples/maxdiffusion/setup_maxdiffusion_env.sh
+++ b/examples/maxdiffusion/setup_maxdiffusion_env.sh
@@ -5,22 +5,33 @@
 # See LICENSE for license information.
 ###############################################################################
 #
-# Install + patch the MaxDiffusion (JAX) runtime from the vendored submodule.
+# Install the MaxDiffusion (JAX) runtime from the vendored submodule.
 #
-# When is this needed?
+# Used ONLY by examples/run_pretrain.sh (BACKEND=maxdiffusion). primus-cli does
+# not call this script: it installs deps through the regular per-backend hook,
+# runner/helpers/hooks/train/pretrain/maxdiffusion/00_install_requirements.sh,
+# the same way maxtext / megatron / torchtitan do.
+#
+# What it does:
 #   - Python deps (requirements-maxdiffusion.txt) are ALWAYS installed to ensure
 #     Primus core deps like loguru are present before the runtime starts.
 #   - If the container ALREADY ships maxdiffusion (e.g. the MAD primus_maxdiffusion
 #     image or the unified docker), the script installs deps then exits early.
 #     Setting PRIMUS_SKIP_PIP=1 skips calling it entirely.
 #   - If the container does NOT have maxdiffusion (e.g. a bare rocm/jax-training
-#     maxtext image), this script installs everything from the Primus checkout:
-#     torch (ROCm wheels), editable submodule install, and 4 site-package patches.
+#     maxtext image), this script installs from the Primus checkout: torch (ROCm
+#     wheels), editable submodule install, and the site-package patches below.
 #     Requires `third_party/maxdiffusion` to be initialized
 #     (git submodule update --init).
 #
-# Invoked by examples/run_pretrain.sh when BACKEND=maxdiffusion (unless
-# PRIMUS_SKIP_PIP=1). Idempotent: safe to re-run.
+# NOTE on the early exit: it tests whether `maxdiffusion` is importable, which on
+# the MaxText image succeeds against the image's own /workspace/maxdiffusion even
+# when a vendored checkout exists. The Primus adapter prepends the vendored
+# checkout to sys.path, so the copy that gets imported at train time is not
+# necessarily the one this check found. That is why runtime fixes must not live
+# here as source edits -- see primus/backends/maxdiffusion/patches/.
+#
+# Idempotent: safe to re-run.
 set -euo pipefail
 
 PRIMUS_PATH="${PRIMUS_PATH:-$(realpath "$(dirname "$0")/../..")}"
@@ -66,8 +77,15 @@ log "pip install -e maxdiffusion (--no-deps)"
 pip install -e "$MAXDIFFUSION_PATH" --no-deps --quiet
 
 # 3) Patches (idempotent). These were previously baked into
-#    docker/primus_maxdiffusion.ubuntu.amd.Dockerfile; here they target the
-#    vendored submodule + the venv site-packages.
+#    docker/primus_maxdiffusion.ubuntu.amd.Dockerfile; here they target the venv
+#    site-packages.
+#
+#    Only site-package patches remain. The two that used to rewrite the vendored
+#    submodule (TensorFlow preload in train_utils.py, Shardy in attention_flax.py)
+#    are now Primus patches under primus/backends/maxdiffusion/patches/. Both
+#    launch paths end in `primus/cli/main.py train pretrain`, so the patch phases
+#    run for run_pretrain.sh and primus-cli alike -- and unlike a sed, they cannot
+#    be undone by a git checkout of third_party/maxdiffusion.
 SP="$(python -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')"
 
 # 4a) transformers Flax T5 (FLUX text encoder): jnp.clip a_min/a_max -> min/max.
@@ -78,23 +96,7 @@ else
   log "transformers T5 patch: not needed"
 fi
 
-# 4b) preload tensorflow before Transformer Engine (import order segfault fix).
-TU="$MAXDIFFUSION_PATH/src/maxdiffusion/train_utils.py"
-if [ -f "$TU" ] && ! grep -q "preload before Transformer Engine" "$TU"; then
-  sed -i '/from transformer_engine.jax.sharding import global_shard_guard, MeshResource/i\    import tensorflow  # noqa: F401 preload before Transformer Engine to avoid segfault' "$TU"
-  log "patched maxdiffusion train_utils (TF preload)"
-else
-  log "train_utils TF-preload patch: already applied / n/a"
-fi
-
-# 4c) keep Shardy enabled for the GSPMD fallback path (cudnn_flash_te).
-AF="$MAXDIFFUSION_PATH/src/maxdiffusion/models/attention_flax.py"
-if [ -f "$AF" ]; then
-  sed -i 's/jax.config.update("jax_use_shardy_partitioner", False)/jax.config.update("jax_use_shardy_partitioner", True)/g' "$AF"
-  log "ensured Shardy on in attention_flax"
-fi
-
-# 4d) TE fused-attn partitioner: treat empty context-parallel axis as size 1.
+# 4b) TE fused-attn partitioner: treat empty context-parallel axis as size 1.
 TE="$SP/transformer_engine/jax/sharding.py"
 if [ -f "$TE" ] && ! grep -q "if not axis:" "$TE"; then
   sed -i 's|    assert axis in mesh.shape, f"{axis} is not a axis of the given mesh {mesh.shape}"|    if not axis:\n        return 1\n    assert axis in mesh.shape, f"{axis} is not a axis of the given mesh {mesh.shape}"|' "$TE"

--- a/examples/maxtext/configs/MI325X/deepseek_v2_16B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/deepseek_v2_16B-bf16-pretrain.yaml
@@ -1,0 +1,49 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2_16B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v2_16B.yaml
+    overrides:
+      run_name: "deepseek_v2_16b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      megablox: false
+      capacity_factor: 1.25
+      sparse_matmul: false
+      sharding_tolerance: 0.05
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 219.2/230.4 GB, pdbs 15 OOMs.
+      per_device_batch_size: 14
+      remat_policy: "minimal_flash"

--- a/examples/maxtext/configs/MI325X/deepseek_v2_16B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/deepseek_v2_16B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,58 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:deepseek_v2_16B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: deepseek_v2_16B.yaml
+    overrides:
+      run_name: "deepseek_v2_16b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      megablox: false
+      capacity_factor: 1.25
+      sparse_matmul: false
+      sharding_tolerance: 0.05
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 219.3/230.4 GB, pdbs 15 OOMs.
+      per_device_batch_size: 14
+      remat_policy: "minimal_flash"
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"
+
+      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
+      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
+      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
+      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
+      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI325X/gemma4_26B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_26B-bf16-pretrain.yaml
@@ -1,0 +1,43 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_26B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_26B.yaml
+    overrides:
+      run_name: "gemma4_26b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy (MoE: shard experts)
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      attention: "cudnn_flash_te"
+      max_target_length: 4096
+      per_device_batch_size: 16
+      remat_policy: "full"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1

--- a/examples/maxtext/configs/MI325X/gemma4_26B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_26B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,47 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_26B-fp8-pretrain}
+workspace: ./output
+
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_26B.yaml
+    overrides:
+      run_name: "gemma4_26b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy (MoE: shard experts)
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      attention: "cudnn_flash_te"
+      max_target_length: 4096
+      per_device_batch_size: 16
+      remat_policy: "full"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+
+      # nanoo_fp8 for AMD MI300X/MI325X (uses e4m3fnuz/e5m2fnuz types)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/gemma4_31B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_31B-bf16-pretrain.yaml
@@ -1,0 +1,39 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_31B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_31B.yaml
+    overrides:
+      run_name: "gemma4_31b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_tensor_sequence_parallelism: -1
+
+      remat_policy: "full"
+      attention: "cudnn_flash_te"
+      max_target_length: 8192
+      per_device_batch_size: 6

--- a/examples/maxtext/configs/MI325X/gemma4_31B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/gemma4_31B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,43 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:gemma4_31B-fp8-pretrain}
+workspace: ./output
+
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: gemma4_31B.yaml
+    overrides:
+      run_name: "gemma4_31b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_tensor_sequence_parallelism: -1
+
+      remat_policy: "full"
+      attention: "cudnn_flash_te"
+      max_target_length: 8192
+      per_device_batch_size: 4
+
+      # nanoo_fp8 for AMD MI300X/MI325X (uses e4m3fnuz/e5m2fnuz types)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/grok1-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/grok1-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,85 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:grok1-pretrain}
+workspace: ./output
+
+# STATUS (MI325X / gfx942, 1 node x 8 GPU, maxtext release/v26.6): DOES NOT FIT.
+# grok1 is a 316.489B-parameter MoE (8 experts, top-2). With ici_expert_parallelism=8
+# only the expert weights shard; the ~7B non-expert params and the optimizer state are
+# replicated, leaving ~46B params per GPU. Measured on 2026-09-05 at seq 4096 / pdbs 2:
+#
+#   state (params + Adam moments)  221.1 GB   <- 92.9% of the 238 GB budget
+#   temp (mostly the grad buffer)   94.3 GB   <- the allocation that fails
+#   budget @ MEM_FRACTION .97      248.3 GB
+#
+# Neither per_device_batch_size nor max_target_length closes this: halving the sequence
+# from 8192 to 4096 cut temp by only 15.3 GB (14%), because temp is dominated by the
+# ~92 GB bf16 gradient buffer for the local param shard, which is independent of both.
+#
+# optimizer_memory_host_offload: true does move the moments out (state drops to 73.7 GB,
+# needs XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB well above its 64 GB default), but temp then
+# grows to 217.7 GB because the moments have to be staged back into HBM for the update --
+# still 43 GB over budget. Both directions fail, for opposite reasons.
+#
+# 316B params with Adam wants ~2.5 TB; this node has ~2 TB of HBM. Run grok1 multi-node
+# (the dcn_* axes below are already set up for it) rather than tuning single-node.
+#
+# NOTE: shardy must stay true. The MI300X copy of this config sets shardy: false, which
+# aborts in ~50 s on this JAX 0.11 / TE stack: TransformerEngine's fused attention is
+# registered via custom_partitioning with Shardy rules only, so GSPMD lowering raises
+# "does not support GSPMD sharding propagation rules".
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: grok1.yaml
+    overrides:
+      run_name: "grok1_training"
+      base_output_directory: "./output"
+      steps: 50
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: 8
+
+      per_device_batch_size: 4
+
+      profiler: ""
+      upload_all_profiler_results: true
+      skip_first_n_steps_for_profiler: 3
+      profiler_steps: 1
+
+      remat_policy: "full"
+      use_iota_embed: true
+      scan_layers: true
+
+      logits_dot_in_fp32: false
+      dtype: "bfloat16"
+      quantization: "nanoo_fp8"
+      quantize_kvcache: false
+      kv_quant_axis: "heads_and_dkv"
+      kv_quant_dtype: "int8"
+      weight_dtype: "bfloat16"
+      checkpoint_is_quantized: false
+      shardy: true
+
+      sparse_matmul: false # ValueError("Sparse matmul doesn't support using expert and pipeline parallelism together.")
+      megablox: false
+      max_target_length: 8192           # Increased from 4096
+      capacity_factor: 1

--- a/examples/maxtext/configs/MI325X/llama2_70B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_70B-bf16-pretrain.yaml
@@ -1,0 +1,45 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_70B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_70B.yaml
+    overrides:
+      run_name: "llama2_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 226.7/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a slightly larger value may fit.
+      per_device_batch_size: 22

--- a/examples/maxtext/configs/MI325X/llama2_70B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_70B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,48 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_70B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_70B.yaml
+    overrides:
+      run_name: "llama2_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 225.0/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a slightly larger value may fit.
+      per_device_batch_size: 22
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/llama2_7B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_7B-bf16-pretrain.yaml
@@ -1,0 +1,38 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_7B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_7B.yaml
+    overrides:
+      run_name: "llama2_7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 225.4/230.4 GB, pdbs 19 OOMs.
+      per_device_batch_size: 18

--- a/examples/maxtext/configs/MI325X/llama2_7B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama2_7B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,41 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama2_7B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama2_7B.yaml
+    overrides:
+      run_name: "llama2_7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 222.6/230.4 GB, pdbs 19 OOMs.
+      per_device_batch_size: 18
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/llama3.3_70B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3.3_70B-bf16-pretrain.yaml
@@ -1,0 +1,44 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3.3_70B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3.3_70B.yaml
+    overrides:
+      run_name: "llama3.3_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 229.7/230.4 GB, pdbs 12 OOMs.
+      per_device_batch_size: 11

--- a/examples/maxtext/configs/MI325X/llama3_70B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3_70B-bf16-pretrain.yaml
@@ -1,0 +1,44 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_70B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3_70B.yaml
+    overrides:
+      run_name: "llama3_70b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+      dcn_pipeline_parallelism: 1
+      dcn_tensor_parallelism: 1
+      dcn_sequence_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+      ici_sequence_parallelism: 1
+      ici_tensor_parallelism: 1
+      ici_pipeline_parallelism: 1
+
+      remat_policy: "full"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 229.7/230.4 GB, pdbs 12 OOMs.
+      per_device_batch_size: 11

--- a/examples/maxtext/configs/MI325X/llama3_8B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3_8B-bf16-pretrain.yaml
@@ -1,0 +1,38 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_8B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3_8B.yaml
+    overrides:
+      run_name: "llama3_8b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 224.4/230.4 GB, pdbs 9 OOMs.
+      per_device_batch_size: 8

--- a/examples/maxtext/configs/MI325X/llama3_8B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/llama3_8B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,41 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:llama3_8B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: llama3_8B.yaml
+    overrides:
+      run_name: "llama3_8b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      remat_policy: "minimal_flash"
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 224.4/230.4 GB, pdbs 9 OOMs.
+      per_device_batch_size: 8
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/mixtral_8x22B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/mixtral_8x22B-bf16-pretrain.yaml
@@ -1,0 +1,42 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x22B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: mixtral_8x22B.yaml
+    overrides:
+      run_name: "mixtral_8x22b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+      max_target_length: 4096
+      # MI325X (256GB HBM): largest 3-step run; peak 219.8/230.4 GB, pdbs 7 OOMs.
+      per_device_batch_size: 6
+      remat_policy: "save_dot_with_context_except_mlp"

--- a/examples/maxtext/configs/MI325X/mixtral_8x7B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/mixtral_8x7B-bf16-pretrain.yaml
@@ -1,0 +1,43 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x7B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: mixtral_8x7B.yaml
+    overrides:
+      run_name: "mixtral_8x7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 217.6/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a larger value may fit.
+      per_device_batch_size: 27
+      remat_policy: "save_dot_with_context_except_mlp"

--- a/examples/maxtext/configs/MI325X/mixtral_8x7B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/mixtral_8x7B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,52 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:mixtral_8x7B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: mixtral_8x7B.yaml
+    overrides:
+      run_name: "mixtral_8x7b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 219.9/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), so a larger value may fit.
+      per_device_batch_size: 29
+      remat_policy: "save_dot_with_context_except_mlp"
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"
+
+      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
+      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
+      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
+      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
+      pure_nnx_decoder: false

--- a/examples/maxtext/configs/MI325X/qwen3_14B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_14B-bf16-pretrain.yaml
@@ -1,0 +1,39 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_14B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_14B.yaml
+    overrides:
+      run_name: "qwen3_14b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      # training
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 214.2/230.4 GB, pdbs 6 OOMs.
+      per_device_batch_size: 5
+      remat_policy: "minimal_flash"

--- a/examples/maxtext/configs/MI325X/qwen3_14B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_14B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,42 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_14B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_14B.yaml
+    overrides:
+      run_name: "qwen3_14b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 8
+      ici_data_parallelism: 1
+
+      # training
+      max_target_length: 8192
+      # MI325X (256GB HBM): largest 3-step run; peak 214.2/230.4 GB, pdbs 6 OOMs.
+      per_device_batch_size: 5
+      remat_policy: "minimal_flash"
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"

--- a/examples/maxtext/configs/MI325X/qwen3_30B_A3B-bf16-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_30B_A3B-bf16-pretrain.yaml
@@ -1,0 +1,44 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_30B_A3B-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_30B_A3B.yaml
+    overrides:
+      run_name: "qwen3_30b_a3b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 227.9/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), but little headroom is left.
+      per_device_batch_size: 10
+      remat_policy: "minimal"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1

--- a/examples/maxtext/configs/MI325X/qwen3_30B_A3B-nanoo_fp8-pretrain.yaml
+++ b/examples/maxtext/configs/MI325X/qwen3_30B_A3B-nanoo_fp8-pretrain.yaml
@@ -1,0 +1,53 @@
+work_group: ${PRIMUS_TEAM:amd}
+user_name: ${PRIMUS_USER:root}
+exp_name: ${PRIMUS_EXP_NAME:qwen3_30B_A3B-nanoo_fp8-pretrain}
+workspace: ./output
+
+modules:
+  pre_trainer:
+    framework: maxtext
+    config: pre_trainer.yaml
+
+    # model to run
+    model: qwen3_30B_A3B.yaml
+    overrides:
+      run_name: "qwen3_30b_a3b_training"
+      base_output_directory: "./output"
+      steps: 50
+      profiler: ""
+
+      # data
+      dataset_type: "synthetic"
+      hf_access_token: ${HF_TOKEN:""}
+
+      # checkpoint
+      enable_checkpointing: false
+      async_checkpointing: false
+
+      # inter-node parallelism strategy
+      dcn_data_parallelism: -1
+      dcn_fsdp_parallelism: 1
+
+      # intra-node parallelism strategy
+      ici_fsdp_parallelism: 1
+      ici_data_parallelism: 1
+      ici_expert_parallelism: -1
+
+      # training
+      max_target_length: 4096
+      # MI325X (256GB HBM): verified 3-step run at peak 227.9/230.4 GB. Not OOM-pinned
+      # (the sweep stopped at its attempt cap), but little headroom is left.
+      per_device_batch_size: 10
+      remat_policy: "minimal"
+      sparse_matmul: false
+      megablox: false
+      capacity_factor: 1
+
+      # quantization (nanoo_fp8)
+      quantization: "nanoo_fp8"
+
+      # v26.6 fp8-MoE fix: the legacy per-module linen Fp8Einsum requires an active
+      # Linen binding scope. v26.6 flipped base.yml pure_nnx_decoder false->true, which
+      # runs the decoder in pure-NNX and invokes Fp8Einsum unbound -> crash. Pinning the
+      # decoder back to the bridged path restores the v26.5 fp8-MoE behavior.
+      pure_nnx_decoder: false

--- a/primus/backends/maxdiffusion/patches/shardy_patches.py
+++ b/primus/backends/maxdiffusion/patches/shardy_patches.py
@@ -1,0 +1,95 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion Shardy Patch
+
+MaxDiffusion turns the Shardy partitioner off wherever it builds a
+``cudnn_flash_te`` attention layer (two call sites in
+``src/maxdiffusion/models/attention_flax.py``)::
+
+    if attention_kernel == "cudnn_flash_te":
+      from transformer_engine.jax.flax.transformer import DotProductAttention
+      jax.config.update("jax_use_shardy_partitioner", False)
+
+TransformerEngine's fused attention is registered through
+``custom_partitioning`` with Shardy sharding rules only, so with Shardy off JAX
+falls back to GSPMD and lowering aborts before the first step::
+
+    NotImplementedError: Custom-partitioned function 'impl at
+    transformer_engine/jax/cpp_extensions/attention.py:563' does not support
+    GSPMD sharding propagation rules.
+
+Every WAN and FLUX config Primus ships sets ``attention: cudnn_flash_te``, so
+this is on the path of every MaxDiffusion run.
+
+This was previously repaired by a ``sed`` in
+``examples/maxdiffusion/setup_maxdiffusion_env.sh`` that rewrote both call sites
+in the vendored submodule. That fix only survived while the submodule working
+tree kept the edit -- a ``git restore``, ``git checkout`` or ``submodule update``
+in ``third_party/maxdiffusion`` reverted it -- and the script could not re-apply
+it, because it exits early whenever MaxDiffusion is already importable (true on
+the MaxText image, which ships its own copy at ``/workspace/maxdiffusion``).
+Guarding the config setter here keeps the behavior in tracked, reviewable code
+and independent of the submodule's working-tree state.
+"""
+
+from primus.core.patches import PatchContext, register_patch
+from primus.core.utils.module_utils import error_rank_0, log_rank_0, warning_rank_0
+
+_SHARDY_FLAG = "jax_use_shardy_partitioner"
+
+_suppression_logged = False
+
+
+@register_patch(
+    patch_id="maxdiffusion.shardy",
+    backend="maxdiffusion",
+    phase="before_train",
+    description="Keep the Shardy partitioner enabled for TransformerEngine fused attention",
+    condition=lambda ctx: True,  # Always enabled
+)
+def patch_maxdiffusion_shardy(ctx: PatchContext) -> None:
+    """Ignore attempts to disable Shardy, which TE fused attention requires."""
+    del ctx
+
+    try:
+        import jax
+    except ImportError as exc:  # noqa: BLE001 - never abort a run over a config guard
+        error_rank_0(f"[Patch:maxdiffusion.shardy] Failed to import jax: {exc!r}")
+        return
+
+    upstream_update = jax.config.update
+    if getattr(upstream_update, "_primus_shardy_guard", False):
+        return
+
+    global _suppression_logged
+    _suppression_logged = False
+
+    def update(name, value, *args, **kwargs):
+        # Only the disable is refused; every other config update passes through
+        # untouched, including an explicit re-enable.
+        if name == _SHARDY_FLAG and not value:
+            global _suppression_logged
+            if not _suppression_logged:
+                _suppression_logged = True
+                # One layer per transformer block reaches this, so report once.
+                warning_rank_0(
+                    "[Patch:maxdiffusion.shardy] Ignoring MaxDiffusion's attempt to disable "
+                    "Shardy: TransformerEngine fused attention registers Shardy partitioning "
+                    "rules only, and GSPMD lowering fails for it."
+                )
+            return None
+        return upstream_update(name, value, *args, **kwargs)
+
+    update._primus_shardy_guard = True
+    jax.config.update = update
+
+    # Assert the value once through the unwrapped setter: an attention layer built
+    # before this patch landed would have left Shardy off.
+    upstream_update(_SHARDY_FLAG, True)
+
+    log_rank_0("[Patch:maxdiffusion.shardy] Shardy partitioner pinned on.")

--- a/primus/backends/maxdiffusion/patches/te_preload_patches.py
+++ b/primus/backends/maxdiffusion/patches/te_preload_patches.py
@@ -1,0 +1,87 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion TransformerEngine preload patch
+
+``transformer_engine_context`` in ``maxdiffusion.train_utils`` imports
+TransformerEngine as its first statement. On this ROCm/JAX stack that import
+segfaults unless TensorFlow has already been loaded in the process.
+
+This was previously repaired by a ``sed`` in
+``examples/maxdiffusion/setup_maxdiffusion_env.sh`` that inserted
+``import tensorflow`` immediately above the TE import in the vendored submodule.
+That edit had the same durability problem as the Shardy ``sed``: any
+``git restore`` / ``checkout`` / ``submodule update`` in
+``third_party/maxdiffusion`` drops it, and the setup script then skips the
+patch section because MaxDiffusion is already importable.
+
+This patch does the equivalent from tracked Primus code:
+
+1. Import TensorFlow at ``setup``, before ``before_train`` (which imports JAX)
+   and before ``train()`` (which enters ``transformer_engine_context``).
+2. Wrap ``transformer_engine_context`` so a later TE import still preloads TF
+   even if something else imported TransformerEngine first through a different
+   path.
+
+The intended process-wide order is tensorflow -> jax -> transformer_engine.
+"""
+
+from contextlib import contextmanager
+
+from primus.core.patches import PatchContext, register_patch
+from primus.core.utils.module_utils import error_rank_0, log_rank_0, warning_rank_0
+
+
+def _preload_tensorflow() -> bool:
+    """Import TensorFlow if it is not already in the process. Return success."""
+    try:
+        import tensorflow  # noqa: F401
+    except ImportError as exc:  # noqa: BLE001 - a missing TF must not abort training
+        warning_rank_0(
+            f"[Patch:maxdiffusion.te_preload] tensorflow is not importable ({exc!r}); "
+            "TransformerEngine may segfault on import."
+        )
+        return False
+    return True
+
+
+@register_patch(
+    patch_id="maxdiffusion.te_preload",
+    backend="maxdiffusion",
+    phase="setup",
+    description="Preload TensorFlow before TransformerEngine to avoid an import-order segfault",
+    condition=lambda ctx: True,  # Always enabled
+    priority=10,  # Before other setup work; logger is independent
+)
+def patch_maxdiffusion_te_preload(ctx: PatchContext) -> None:
+    """Load TensorFlow, then wrap MaxDiffusion's TE context so it always preloads."""
+    del ctx
+
+    if not _preload_tensorflow():
+        return
+
+    try:
+        from maxdiffusion import train_utils
+    except ImportError as exc:  # noqa: BLE001 - TF is already loaded; TE import is still safer
+        error_rank_0(f"[Patch:maxdiffusion.te_preload] Failed to import maxdiffusion.train_utils: {exc!r}")
+        log_rank_0("[Patch:maxdiffusion.te_preload] tensorflow preloaded; TE context wrap skipped.")
+        return
+
+    upstream = train_utils.transformer_engine_context
+    if getattr(upstream, "_primus_tf_preload", False):
+        return
+
+    @contextmanager
+    def transformer_engine_context():
+        _preload_tensorflow()
+        with upstream() as result:
+            yield result
+
+    transformer_engine_context._primus_tf_preload = True  # type: ignore[attr-defined]
+    train_utils.transformer_engine_context = transformer_engine_context
+
+    log_rank_0("[Patch:maxdiffusion.te_preload] tensorflow preloaded; TE context wrapped.")

--- a/primus/backends/maxdiffusion/patches/throughput_patches.py
+++ b/primus/backends/maxdiffusion/patches/throughput_patches.py
@@ -1,0 +1,288 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+MaxDiffusion Throughput Patch
+
+MaxDiffusion's per-step line reports step time, FLOP rate and loss, but nothing
+that says how much *data* a step moved::
+
+    completed step: 18, seconds: 11.722, TFLOP/s/device: 348.548, loss: 1.540
+
+This patch adds throughput to that line and to the metrics stream::
+
+    completed step: 18, seconds: 11.722, TFLOP/s/device: 348.548,
+    Tokens/s/device: 6756.526, Samples/s/device: 0.0853,
+    Frames/s/device: 7.251, loss: 1.540
+
+Everything is per device, like the ``TFLOP/s/device`` it sits next to:
+
+``Samples/s/device``
+    Videos (or images) per second per GPU. Defined for every model family.
+``Frames/s/device``
+    Video frames per second per GPU, i.e. ``Samples/s/device * num_frames``.
+    Only emitted for families whose config describes frames.
+``Tokens/s/device``
+    Patchified latent tokens per second per GPU: 79,200 tokens for a
+    720x1280x85 WAN video, 1,024 for a 512px FLUX image. Derived from the same
+    shape ``calculate_{wan,flux}_tflops`` feeds its FLOP count, so token rate
+    and FLOP rate always describe the same work, and unlike samples or frames
+    it stays comparable across resolutions and clip lengths. Omitted for the
+    UNet families (SD 1.x/2.x, SDXL, DreamBooth), which have no equivalent
+    notion of a token.
+
+The ``Tokens/s/device`` name matches MaxText's step line on purpose:
+``parse_metrics_for_maxtext`` in ``tools/daily/daily_report.py`` then works
+unchanged on MaxDiffusion logs.
+
+The same numbers are written into ``metrics["scalar"]`` as ``perf/*`` entries
+before any consumer runs, so they also reach TensorBoard and ``metrics_file``
+alongside the upstream perf scalars, together with the cluster-wide
+``perf/samples_per_second``, ``perf/frames_per_second`` and
+``perf/tokens_per_second`` totals.
+"""
+
+from typing import Any, Dict, Optional
+
+from primus.core.patches import PatchContext, register_patch
+from primus.core.utils.module_utils import error_rank_0, log_rank_0, warning_rank_0
+
+# WAN and FLUX both encode with a VAE that downsamples 8x in H and W and then
+# patchify the latents 2x2 before the transformer blocks; WAN additionally
+# compresses 4x along time.
+_VAE_SCALE_FACTOR_SPATIAL = 8
+_WAN_VAE_SCALE_FACTOR_TEMPORAL = 4
+_TRANSFORMER_PATCH_SIZE = 2
+
+# Model families whose sample -> token expansion is known. UNet families
+# (SD 1.x/2.x, SDXL, DreamBooth) have no comparable token count, and LTX-Video
+# uses a different VAE geometry, so they report samples only.
+_WAN_MODEL_NAMES = frozenset({"wan2.1", "wan2.2"})
+_FLUX_MODEL_NAMES = frozenset({"flux", "flux-dev", "flux-schnell"})
+
+_work_per_step: Dict[str, float] = {}
+_enabled = True
+_tensorboard_hint_logged = False
+
+
+def _config_keys(config: Any) -> Dict[str, Any]:
+    """Return the config as a plain dict.
+
+    ``HyperParameters.__getattr__`` raises ``ValueError`` (not
+    ``AttributeError``) for unknown keys, so ``getattr(config, k, default)``
+    is not safe here; MaxDiffusion configs differ per model family.
+    """
+    return config.get_keys()
+
+
+def _effective_video_dims(keys: Dict[str, Any]) -> Dict[str, Any]:
+    """Frame geometry the data iterator actually produces.
+
+    ``get_wan_dimension`` honours ``synthetic_override_{height,width,num_frames}``
+    -- and only those three -- when the synthetic iterator builds a batch, while
+    ``WanTrainer.calculate_tflops`` always reads the plain config keys. Rates are
+    reported for the shape that is really trained on, and a divergence is worth
+    flagging because it means the upstream TFLOP/s number describes a different
+    video than the one in the batch.
+    """
+    synthetic = keys.get("dataset_type") == "synthetic"
+    dims = {}
+    mismatched = []
+    for name in ("height", "width", "num_frames"):
+        configured = keys.get(name)
+        override = keys.get(f"synthetic_override_{name}") if synthetic else None
+        dims[name] = override or configured
+        if override and configured and override != configured:
+            mismatched.append(f"{name}: data={override} vs config={configured}")
+
+    if mismatched:
+        warning_rank_0(
+            "[Patch:maxdiffusion.throughput] Synthetic data shape differs from the config shape "
+            f"({', '.join(mismatched)}). Throughput follows the data; TFLOP/s/device does not."
+        )
+    return dims
+
+
+def _tokens_per_sample(keys: Dict[str, Any], dims: Dict[str, Any]) -> Optional[int]:
+    """Transformer tokens one sample expands into, or None where undefined.
+
+    Both branches rebuild the latent sequence length that the data iterator and
+    ``calculate_{wan,flux}_tflops`` use, so Tokens/s and TFLOP/s describe the
+    same work. Text-conditioning tokens are excluded: they are a fixed
+    per-sample cost that does not scale with resolution or clip length.
+    """
+    if keys.get("model_name") in _WAN_MODEL_NAMES:
+        height, width, num_frames = dims["height"], dims["width"], dims["num_frames"]
+        if not height or not width or not num_frames:
+            return None
+
+        latent_frames = (num_frames - 1) // _WAN_VAE_SCALE_FACTOR_TEMPORAL + 1
+        latent_positions = (
+            (height // _VAE_SCALE_FACTOR_SPATIAL) * (width // _VAE_SCALE_FACTOR_SPATIAL) * latent_frames
+        )
+        return int(latent_positions // _TRANSFORMER_PATCH_SIZE**2)
+
+    if keys.get("flux_name") in _FLUX_MODEL_NAMES:
+        resolution = keys.get("resolution")
+        if not resolution:
+            return None
+
+        latent_side = resolution // (_VAE_SCALE_FACTOR_SPATIAL * _TRANSFORMER_PATCH_SIZE)
+        return int(latent_side * latent_side)
+
+    return None
+
+
+def _resolve_work_per_step(config: Any) -> Dict[str, float]:
+    """Samples/tokens/frames one training step consumes. Constant, so cached."""
+    if _work_per_step:
+        return _work_per_step
+
+    import jax
+
+    keys = _config_keys(config)
+    per_device_samples = float(keys.get("per_device_batch_size") or 0.0)
+    if per_device_samples <= 0:
+        # Raise rather than report zeros; the caller disables the patch.
+        raise ValueError(f"unusable per_device_batch_size={keys.get('per_device_batch_size')!r}")
+
+    # data_sharding spreads the batch over every mesh axis, so a step trains
+    # per_device_batch_size samples on each of jax.device_count() devices --
+    # the same normalization calculate_tflops uses for TFLOP/s/device.
+    global_samples = float(
+        keys.get("global_batch_size_to_train_on") or per_device_samples * jax.device_count()
+    )
+
+    work = {"per_device_samples": per_device_samples, "global_samples": global_samples}
+
+    dims = _effective_video_dims(keys)
+    tokens_per_sample = _tokens_per_sample(keys, dims)
+    if tokens_per_sample:
+        work["per_device_tokens"] = tokens_per_sample * per_device_samples
+        work["global_tokens"] = tokens_per_sample * global_samples
+
+    num_frames = dims["num_frames"]
+    if num_frames:
+        work["per_device_frames"] = float(num_frames) * per_device_samples
+        work["global_frames"] = float(num_frames) * global_samples
+
+    _work_per_step.update(work)
+    log_rank_0(
+        f"[Patch:maxdiffusion.throughput] Per step: {global_samples:g} samples "
+        f"({per_device_samples:g}/device), {work.get('per_device_frames', 0):g} frames/device, "
+        f"{work.get('per_device_tokens', 0):g} tokens/device"
+    )
+    return _work_per_step
+
+
+def _throughput_scalars(config: Any, step_time_seconds: float) -> Dict[str, float]:
+    if step_time_seconds <= 0:
+        return {}
+
+    work = _resolve_work_per_step(config)
+    scalars = {
+        "perf/samples_per_second": work["global_samples"] / step_time_seconds,
+        "perf/samples_per_second_per_device": work["per_device_samples"] / step_time_seconds,
+    }
+    if "per_device_tokens" in work:
+        scalars["perf/tokens_per_second"] = work["global_tokens"] / step_time_seconds
+        scalars["perf/tokens_per_second_per_device"] = work["per_device_tokens"] / step_time_seconds
+    if "per_device_frames" in work:
+        scalars["perf/frames_per_second"] = work["global_frames"] / step_time_seconds
+        scalars["perf/frames_per_second_per_device"] = work["per_device_frames"] / step_time_seconds
+    return scalars
+
+
+def _format_step_line(scalars: Dict[str, Any], step: Any) -> str:
+    """Upstream's step line, widened with whichever throughput metrics exist."""
+    message = "completed step: {}, seconds: {:.3f}, TFLOP/s/device: {:.3f}".format(
+        step,
+        scalars["perf/step_time_seconds"],
+        scalars["perf/per_device_tflops_per_sec"],
+    )
+    if "perf/tokens_per_second_per_device" in scalars:
+        message += ", Tokens/s/device: {:.3f}".format(scalars["perf/tokens_per_second_per_device"])
+    if "perf/samples_per_second_per_device" in scalars:
+        message += ", Samples/s/device: {:.4f}".format(scalars["perf/samples_per_second_per_device"])
+    if "perf/frames_per_second_per_device" in scalars:
+        message += ", Frames/s/device: {:.3f}".format(scalars["perf/frames_per_second_per_device"])
+    return message + ", loss: {:.3f}".format(float(scalars["learning/loss"]))
+
+
+@register_patch(
+    patch_id="maxdiffusion.throughput",
+    backend="maxdiffusion",
+    phase="before_train",
+    description="Report sample/token throughput in MaxDiffusion step metrics",
+    condition=lambda ctx: True,  # Always enabled
+)
+def patch_maxdiffusion_throughput(ctx: PatchContext) -> None:
+    """Add throughput to ``train_utils`` metric recording and step logging."""
+    del ctx
+
+    try:
+        from maxdiffusion import max_logging, pyconfig, train_utils
+    except ImportError as exc:  # noqa: BLE001 - never abort a run over metrics
+        error_rank_0(f"[Patch:maxdiffusion.throughput] Failed to import maxdiffusion.train_utils: {exc!r}")
+        return
+
+    # Reset in case a previous run in this process left state behind.
+    global _enabled, _tensorboard_hint_logged
+    _enabled = True
+    _tensorboard_hint_logged = False
+    _work_per_step.clear()
+
+    upstream_record_scalar_metrics = train_utils.record_scalar_metrics
+    upstream_write_metrics_to_tensorboard = train_utils.write_metrics_to_tensorboard
+
+    def record_scalar_metrics(metrics, step_time_delta, per_device_tflops, lr):
+        upstream_record_scalar_metrics(metrics, step_time_delta, per_device_tflops, lr)
+
+        # pyconfig.config is only populated once pyconfig.initialize() has run,
+        # which happens after this patch is installed.
+        global _enabled
+        if not _enabled or pyconfig.config is None:
+            return
+        try:
+            metrics["scalar"].update(_throughput_scalars(pyconfig.config, step_time_delta.total_seconds()))
+        except Exception as exc:  # noqa: BLE001 - a metric must not kill training
+            _enabled = False
+            warning_rank_0(f"[Patch:maxdiffusion.throughput] Disabled after error: {exc!r}")
+
+    def write_metrics_to_tensorboard(writer, metrics, step, config):
+        """Upstream ``train_utils.write_metrics_to_tensorboard`` with a wider step line."""
+        import jax
+        import numpy as np
+
+        try:
+            step_line = _format_step_line(metrics["scalar"], step)
+        except (KeyError, TypeError, ValueError) as exc:  # unexpected metric set
+            warning_rank_0(f"[Patch:maxdiffusion.throughput] Falling back to upstream step line: {exc!r}")
+            upstream_write_metrics_to_tensorboard(writer, metrics, step, config)
+            return
+
+        global _tensorboard_hint_logged
+        if jax.process_index() == 0:
+            max_logging.log(step_line)
+            for metric_name in metrics.get("scalar", []):
+                writer.add_scalar(metric_name, np.array(metrics["scalar"][metric_name]), step)
+            for metric_name in metrics.get("scalars", []):
+                writer.add_scalars(metric_name, metrics["scalars"][metric_name], step)
+
+            # Upstream reprints the tensorboard hint on every log_period, which
+            # at log_period=1 doubles the length of the step log to repeat a
+            # string that never changes.
+            if not _tensorboard_hint_logged:
+                _tensorboard_hint_logged = True
+                max_logging.log(f"To see full metrics 'tensorboard --logdir={config.tensorboard_dir}'")
+
+            if step % config.log_period == 0:
+                writer.flush()
+
+    train_utils.record_scalar_metrics = record_scalar_metrics
+    train_utils.write_metrics_to_tensorboard = write_metrics_to_tensorboard
+
+    log_rank_0("[Patch:maxdiffusion.throughput] MaxDiffusion throughput metrics patched successfully.")

--- a/requirements-maxdiffusion.txt
+++ b/requirements-maxdiffusion.txt
@@ -6,6 +6,11 @@
 # torch/torchvision are installed separately (ROCm wheel index) by
 # examples/maxdiffusion/setup_maxdiffusion_env.sh, because they need
 # --find-links/--no-index which cannot be mixed with a PyPI resolve here.
+#
+# MUST stay on transformers 4.x: MaxDiffusion is a Flax codebase and imports
+# FlaxCLIPTextModel/FlaxT5EncoderModel at module load (src/maxdiffusion/max_utils.py).
+# transformers 5.0 removed every Flax and TensorFlow class, so any 5.x resolve
+# breaks `import maxdiffusion` outright. Upstream pins 4.48.1 for the same reason.
 transformers==4.57.3
 scikit-image
 imageio-ffmpeg

--- a/runner/helpers/hooks/train/pretrain/maxdiffusion/00_install_requirements.sh
+++ b/runner/helpers/hooks/train/pretrain/maxdiffusion/00_install_requirements.sh
@@ -5,19 +5,22 @@
 # See LICENSE for license information.
 ###############################################################################
 #
-# Install the MaxDiffusion (JAX) runtime for primus-cli launches.
+# Install the MaxDiffusion (JAX) Python dependencies for primus-cli launches.
 #
-# The MaxText sibling hook pip-installs its requirements inline, but MaxDiffusion
-# additionally needs torch from the ROCm wheel index and four source patches, so
-# this delegates to examples/maxdiffusion/setup_maxdiffusion_env.sh -- the same
-# idempotent script examples/run_pretrain.sh uses. Both launch paths therefore
-# share one definition of the environment instead of drifting apart.
+# Same shape as the maxtext / megatron / torchtitan siblings: this hook only
+# installs packages. The other two concerns are split the same way they are for
+# every other backend:
+#   - backend path + launcher env (RUN_MODE, JAX coordinator, NVTE_FRAMEWORK)
+#     are emitted by this directory's prepare.py
+#   - runtime behavior (Shardy partitioner, TensorFlow preload) lives in
+#     primus/backends/maxdiffusion/patches/
+# so nothing here has to mutate the vendored third_party/maxdiffusion checkout.
 #
-# Container launches start from a clean image every time, so this runs on every
-# launch. Pointing pip at a cache under DATA_PATH (inside the bind-mounted Primus
-# checkout) keeps repeat runs off the network.
+# requirements-maxdiffusion.txt is deliberately separate from requirements-jax.txt
+# (which MaxText installs): it pins transformers 4.x for MaxDiffusion's Flax code,
+# and that pin must not be forced onto MaxText runs.
 #
-# PRIMUS_SKIP_PIP=1 skips the whole step, for images that already ship the stack.
+# PRIMUS_SKIP_PIP=1 skips this step, for images that already ship the stack.
 ###############################################################################
 set -euo pipefail
 
@@ -41,24 +44,36 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Load shared logging so output honors PRIMUS_LOG_LEVEL (DEBUG/INFO/WARN/ERROR).
+# When invoked through primus-cli the LOG_* functions are already exported, but
+# sourcing here keeps the hook usable standalone and under `set -u`.
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../../../../hook_common.sh"
+
 if [[ "${PRIMUS_SKIP_PIP:-0}" == "1" ]]; then
-  echo "[INFO] PRIMUS_SKIP_PIP=1: skipping MaxDiffusion env setup (deps from image)"
+  LOG_INFO "PRIMUS_SKIP_PIP=1: skipping MaxDiffusion dependency install (deps from image)"
   exit 0
 fi
 
 DATA_PATH="${DATA_PATH:-${PRIMUS_ROOT}/data}"
 PIP_CACHE_DIR="${PIP_CACHE_DIR:-${DATA_PATH}/pip_cache}"
-export PIP_CACHE_DIR
 
-echo "[INFO] Using pip cache: ${PIP_CACHE_DIR}"
+# Match pip verbosity to the active log level so WARN/ERROR runs stay quiet
+# (suppresses the "Requirement already satisfied" wall) while DEBUG/INFO keep it.
+PIP_FLAGS=()
+case "${PRIMUS_LOG_LEVEL:-INFO}" in
+  WARN|ERROR) PIP_FLAGS+=(-q -q) ;;
+esac
+
+LOG_INFO "Using pip cache: ${PIP_CACHE_DIR}"
 mkdir -p "${PIP_CACHE_DIR}"
 
-SETUP_SCRIPT="${PRIMUS_ROOT}/examples/maxdiffusion/setup_maxdiffusion_env.sh"
-if [[ ! -f "${SETUP_SCRIPT}" ]]; then
-  echo "[ERROR] Missing MaxDiffusion setup script: ${SETUP_SCRIPT}" >&2
+REQ_FILE="${PRIMUS_ROOT}/requirements-maxdiffusion.txt"
+if [[ ! -f "${REQ_FILE}" ]]; then
+  LOG_ERROR "Missing required MaxDiffusion requirements file: ${REQ_FILE}"
   exit 1
 fi
 
-echo "[+] Setting up MaxDiffusion environment (deps + source patches)..."
-PRIMUS_PATH="${PRIMUS_ROOT}" bash "${SETUP_SCRIPT}"
-echo "[OK] MaxDiffusion environment ready"
+LOG_INFO "Installing MaxDiffusion dependencies..."
+pip install "${PIP_FLAGS[@]}" --cache-dir="${PIP_CACHE_DIR}" -r "${REQ_FILE}"
+LOG_SUCCESS "MaxDiffusion dependencies installed"


### PR DESCRIPTION
Cherry-pick of the 10 commits from PR #1095 (merged to main as 78d56a37).

MaxDiffusion + primus-cli
  Stop mutating third_party/maxdiffusion from the install hook. The hook is now
  a plain `pip install -r requirements-maxdiffusion.txt`, matching the maxtext /
  megatron / torchtitan siblings (hook_common.sh logging, PIP_CACHE_DIR,
  log-level-aware PIP_FLAGS, PRIMUS_SKIP_PIP). The two submodule seds it used to
  rely on could never run on the documented flow -- setup_maxdiffusion_env.sh
  exits early whenever `import maxdiffusion` succeeds, which on
  rocm/jax-training:maxtext-v26.6 is always true because the image ships its own
  copy at /workspace/maxdiffusion -- so the fixes now live in tracked patches
  under primus/backends/maxdiffusion/patches/:
    - keep the Shardy partitioner enabled (TE fused attention registers Shardy rules only, so GSPMD lowering aborts before the first step)
    - preload TensorFlow before TransformerEngine (ROCm/JAX TE import segfault) Also: pin transformers back to 4.57.3 with a Dependabot ignore so security updates cannot walk it to 5.x again, and report Samples/s/device, Frames/s/device and Tokens/s/device in the step line and TensorBoard, with the TensorBoard hint printed once per run instead of once per log_period.

MaxText MI325X
  Add the examples/maxtext/configs/MI325X/ suite, copied from MI300X with
  per_device_batch_size tuned on an 8x MI325X node, then align gemma4 / grok1
  with the current MI300X settings (cudnn_flash_te, Shardy on for grok1) and
  record measured on-node status in the configs.

Cherry-pick note: requirements-maxdiffusion.txt conflicted because release/v26.6 was already at transformers==4.57.3 (via #1018) while main had drifted to 5.10.1 through two Dependabot security bumps. Resolved by keeping 4.57.3 and taking the new explanatory comment block, so this branch gains only the comment. Every other file applied cleanly and the resulting tree is identical to the PR head for all 35 files it touches.

Squashed from:
  402ce499 maxtext: add MI325X configs with per_device_batch_size tuned on-node
  669eef82 feat(maxdiffusion): report per-device throughput in step metrics
  64bcc8ab fix(maxdiffusion): log the tensorboard hint once per run
  108ff8d6 docs(maxdiffusion): correct the log_period rationale in the configs
  bd767ff5 style(maxdiffusion): wrap the global_samples line to the 110-column limit
  7c8f3105 fix(maxdiffusion): pin transformers back to 4.57.3
  5df0585c fix(maxdiffusion): keep Shardy on from Primus instead of patching the submodule
  30851c28 fix(maxdiffusion): preload tensorflow before TransformerEngine from Primus
  1bb22e73 refactor(maxdiffusion): align the primus-cli hook with the other backends
  cb05b3e0 maxtext(MI325X): align gemma4/grok1 configs with MI300X and record measured status