### PR TITLE
feat(logging): add VERBOSE log level support to _info_enabled

### DIFF
--- a/primus/pretrain.py
+++ b/primus/pretrain.py
@@ -24,7 +24,7 @@ def _info_enabled() -> bool:
     Mirrors the level gating in runner/lib/common.sh so informational prints are
     silenced when the user sets PRIMUS_LOG_LEVEL=WARN/ERROR.
     """
-    return os.environ.get("PRIMUS_LOG_LEVEL", "INFO").upper() in ("DEBUG", "INFO")
+    return os.environ.get("PRIMUS_LOG_LEVEL", "INFO").upper() in ("DEBUG", "INFO", "VERBOSE")
 
 
 def setup_backend_path(framework: str, backend_path=None, verbose: bool = True):


### PR DESCRIPTION
Extend `PRIMUS_LOG_LEVEL` handling to recognise `VERBOSE` as an info-level value, consistent with logging frameworks that use VERBOSE as a level between DEBUG and INFO.